### PR TITLE
fix(app-shell/quick-access): missing dep, log if component cannot be loaded

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -53,6 +53,7 @@
     "lodash.camelcase": "4.3.0",
     "lodash.has": "4.5.2",
     "lodash.isnil": "4.0.0",
+    "lodash.last": "3.0.0",
     "lodash.omit": "4.5.0",
     "lodash.once": "4.1.1",
     "moment": "2.22.2",

--- a/packages/application-shell/src/components/quick-access/butler-container/butler-container.js
+++ b/packages/application-shell/src/components/quick-access/butler-container/butler-container.js
@@ -3,20 +3,38 @@ import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import styles from './butler-container.mod.css';
 
-const ButlerContainer = props =>
-  // render no overlay in case of loding error, just show nothing then
-  props.timedOut || props.error ? null : (
-    <div
-      className={styles.container}
-      tabIndex="-1"
-      // omit props of react-loadable
-      {...omit(props, ['error', 'timedOut', 'pastDelay', 'isLoading', 'retry'])}
-    />
-  );
-ButlerContainer.displayName = 'ButlerContainer';
-ButlerContainer.propTypes = {
-  timedOut: PropTypes.bool,
-  error: PropTypes.any,
-};
+class ButlerContainer extends React.Component {
+  static displayName = 'ButlerContainer';
+  static propTypes = {
+    timedOut: PropTypes.bool,
+    error: PropTypes.any,
+  };
+
+  componentDidUpdate() {
+    if (this.props.error) {
+      console.error('Failed to load component', this.props.error);
+    }
+  }
+
+  render() {
+    // render no overlay in case of loding error, just show nothing then
+    if (this.props.timedOut || this.props.error) return null;
+
+    return (
+      <div
+        className={styles.container}
+        tabIndex="-1"
+        // omit this.props of react-loadable
+        {...omit(this.props, [
+          'error',
+          'timedOut',
+          'pastDelay',
+          'isLoading',
+          'retry',
+        ])}
+      />
+    );
+  }
+}
 
 export default ButlerContainer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7566,6 +7566,10 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.last@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.last/-/lodash.last-3.0.0.tgz#242f663112dd4c6e63728c60a3c909d1bdadbd4c"
+
 lodash.mapvalues@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"


### PR DESCRIPTION
Before, the error was swallowed by the component, now we log an error in case react loadable has the `error` prop.

<img width="1217" alt="image" src="https://user-images.githubusercontent.com/1110551/46660552-883db800-cbb7-11e8-8fd7-9b3610a4dba3.png">
