### PR TITLE
chore(navbar/feature-toggles): remove PRODUCT_TYPE_ADMINISTRATION

### DIFF
--- a/packages/application-shell/src/components/navbar/config.js
+++ b/packages/application-shell/src/components/navbar/config.js
@@ -3,7 +3,6 @@ import { MCSupportFormURL } from '../../constants';
 import {
   CUSTOMER_GROUPS,
   PIM_SEARCH,
-  PRODUCT_TYPES_ADMINISTRATION,
   DEVELOPER_SETTINGS,
   CAN_VIEW_CATEGORIES,
   CAN_VIEW_PRODUCTS,
@@ -202,7 +201,6 @@ const itemsProjectSettings = {
     },
     {
       key: 'Product types',
-      featureToggle: PRODUCT_TYPES_ADMINISTRATION,
       labelKey: 'NavBar.ProductTypes.title',
       uriPath: 'settings/product-types',
       permissions: [

--- a/packages/application-shell/src/components/navbar/feature-toggles.js
+++ b/packages/application-shell/src/components/navbar/feature-toggles.js
@@ -30,8 +30,6 @@ export const DISCOUNTS_BULK_SELECTION_STATUS =
 
 export const PIM_SEARCH = 'pimSearch';
 export const PRICE_TIERS = 'productPriceTiers';
-// This is a shared toggle. It is also used in application-project-settings
-export const PRODUCT_TYPES_ADMINISTRATION = 'productTypesAdministration';
 
 export const DEVELOPER_SETTINGS = 'developerSettings';
 export const PROJECT_EXTENSIONS = 'projectExtensions';


### PR DESCRIPTION
#### Summary

- removes `PRODUCT_TYPES_ADMINISTRATION ` feature toggle

#### Description

I will remove the LD config once this is merged/released
