### PR TITLE
refactor(create-webpack-config-for-*): correct naming of color-mod, change order of execution

### DIFF
--- a/packages/mc-scripts/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-development.js
@@ -9,7 +9,7 @@ const postcssPresetEnv = require('postcss-preset-env');
 const postcssReporter = require('postcss-reporter');
 const postcssCustomProperties = require('postcss-custom-properties');
 const postcssCustomMediaQueries = require('postcss-custom-media');
-const postcssPostcssColorModFunction = require('postcss-color-mod-function');
+const postcssColorModFunction = require('postcss-color-mod-function');
 const browserslist = require('./browserslist');
 
 const defaultToggleFlags = {
@@ -234,11 +234,11 @@ module.exports = ({
                   browsers: browserslist.development,
                   autoprefixer: { grid: true },
                 }),
+                postcssCustomMediaQueries(),
                 postcssCustomProperties({
                   preserve: false,
                 }),
-                postcssCustomMediaQueries(),
-                postcssPostcssColorModFunction(),
+                postcssColorModFunction(),
                 postcssReporter(),
               ],
             },
@@ -273,11 +273,11 @@ module.exports = ({
                       browsers: browserslist.development,
                       autoprefixer: { grid: true },
                     }),
+                    postcssCustomMediaQueries(),
                     postcssCustomProperties({
                       preserve: false,
                     }),
-                    postcssCustomMediaQueries(),
-                    postcssPostcssColorModFunction(),
+                    postcssColorModFunction(),
                     postcssReporter(),
                   ],
                 },

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -18,7 +18,7 @@ const postcssPresetEnv = require('postcss-preset-env');
 const postcssReporter = require('postcss-reporter');
 const postcssCustomProperties = require('postcss-custom-properties');
 const postcssCustomMediaQueries = require('postcss-custom-media');
-const postcssPostcssColorModFunction = require('postcss-color-mod-function');
+const postcssColorModFunction = require('postcss-color-mod-function');
 const FinalStatsWriterPlugin = require('../webpack-plugins/final-stats-writer-plugin');
 const browserslist = require('./browserslist');
 
@@ -322,11 +322,11 @@ module.exports = ({
                   browsers: browserslist.production,
                   autoprefixer: { grid: true },
                 }),
+                postcssColorModFunction(),
                 postcssCustomProperties({
                   preserve: false,
                 }),
                 postcssCustomMediaQueries(),
-                postcssPostcssColorModFunction(),
                 postcssReporter(),
               ],
             },
@@ -363,11 +363,11 @@ module.exports = ({
                       browsers: browserslist.production,
                       autoprefixer: { grid: true },
                     }),
+                    postcssCustomMediaQueries(),
                     postcssCustomProperties({
                       preserve: false,
                     }),
-                    postcssCustomMediaQueries(),
-                    postcssPostcssColorModFunction(),
+                    postcssColorModFunction(),
                     postcssReporter(),
                   ],
                 },


### PR DESCRIPTION
#### Summary

- changes the order of execution based on [this](https://github.com/csstools/postcss-preset-env/blob/master/lib/ids-by-execution-order.js) to avoid confusion
- `postcssPostcssColorModFunction -> postcssColorModFunction`