### PR TITLE
fix(quick-access): fix cart-discount-list route

### DIFF
--- a/packages/application-shell/src/components/quick-access/create-commands.js
+++ b/packages/application-shell/src/components/quick-access/create-commands.js
@@ -142,7 +142,7 @@ export default ({
         {
           id: 'go/discounts/carts/list',
           text: intl.formatMessage(messages.openCartDiscountsList),
-          action: { type: 'go', to: `/${project.key}/discounts/products` },
+          action: { type: 'go', to: `/${project.key}/discounts/carts` },
         },
         {
           id: 'go/discounts/codes/list',


### PR DESCRIPTION
Make `Cart Discount List` redirect to `<project>/discounts/carts` instead of `<project>/discounts/products`.

Rephrased bug report:

> Morning, I found a small bug in regards of quick-access functionality. The `Cart Discount List` option goes to `Product Discount List` page.