### PR TITLE
chore(http-server): trigger cloudbuild on each tag/release

### DIFF
--- a/packages/mc-http-server/Dockerfile
+++ b/packages/mc-http-server/Dockerfile
@@ -1,14 +1,7 @@
 #### Release process
 #
 # We use Google Cloud Container Registry to build and store the Docker image, using a Build trigger connected to our GitHub repo.
-#
-# - the trigger is configured to be executed based on the git tag matching the regex `http-server-[0-9].[0-9].[0-9]`
-#   - the reason is to avoid triggering the build on every push/commit on e.g. `master`, instead we need to explicitly "tag a release"
-#   - whenever we push some changes for the dockerfile, we should create a new tag `git tag -m "Http server: 2.0.0" http-server-2.0.0 && git push --tags`, obviously using a proper semver
-# - remember to bump the version in the following places:
-#   - `_PKG_VERSION` in `cloudbuild.yaml`
-#   - `image.tag` in the `values.yaml` of the related K8s chart
-# - the Google Cloud project used for the registry is called `ct-images`
+# The build is triggered on each tag, so whenever we do a new release.
 
 FROM node:10-alpine
 

--- a/packages/mc-http-server/README.md
+++ b/packages/mc-http-server/README.md
@@ -10,6 +10,14 @@ This package contains the HTTP server to run a MC application in production.
 $ npm install --save @commercetools-frontend/mc-http-server
 ```
 
+### Docker image
+
+We also provide a docker image to run the server:
+
+```bash
+$ docker run -p 3001:3001 eu.gcr.io/ct-images/mc-http-server:v0.0.0 mc-http-server --config="$(pwd)/env.json"
+```
+
 ## Why do we need an HTTP Server?
 
 Since a SPA consists of mainly JS bundles and CSS, it's usually not necessary to have an actual HTTP server running.

--- a/packages/mc-http-server/cloudbuild.yaml
+++ b/packages/mc-http-server/cloudbuild.yaml
@@ -1,16 +1,14 @@
-substitutions:
-  _PKG_VERSION: 5.3.3
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     args:
       [
         'build',
         '-t',
-        'eu.gcr.io/$PROJECT_ID/mc-http-server:${_PKG_VERSION}',
+        'eu.gcr.io/$PROJECT_ID/mc-http-server:$TAG_NAME',
         '-t',
         'eu.gcr.io/$PROJECT_ID/mc-http-server:latest',
         './packages/mc-http-server',
       ]
 images:
-  - 'eu.gcr.io/$PROJECT_ID/mc-http-server:${_PKG_VERSION}'
+  - 'eu.gcr.io/$PROJECT_ID/mc-http-server:$TAG_NAME'
   - 'eu.gcr.io/$PROJECT_ID/mc-http-server:latest'


### PR DESCRIPTION
No more manual trigger. Now when we cut a new release, a new tag is created and the image is built with the same version as the release tag.