### PR TITLE
fix(navbar): adds Scrollable and FixedMenu

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -13,6 +13,7 @@
 /* Left Nav */
 
 .left-navigation {
+  display: flex;
   flex-grow: 1;
   width: var(--width-leftNavigation);
   z-index: 19999;
@@ -22,8 +23,16 @@
 .list {
   margin: 0;
   padding: 0;
-  top: 0;
-  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 0;
+}
+
+:global(.body__menu-open) .scrollable-menu {
+  flex: 1 1 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .list-item {
@@ -74,8 +83,6 @@
 
 .expander {
   height: var(--expander-height);
-  bottom: 0;
-  position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -319,4 +326,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.scrollable-menu {
+  flex: 1 1 0;
+}
+
+.fixed-menu {
+  flex: 0 0 0;
 }

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -363,7 +363,7 @@ describe('rendering', () => {
         });
         describe('when item is active', () => {
           beforeEach(() => {
-            wrapper.setState({ activeItemIndex: 0 });
+            wrapper.setState({ activeItemIndex: 'scrollable-0' });
           });
           it('should render active icon', () => {
             expect(wrapper.find('CustomerFilledIcon')).toHaveProp(
@@ -460,7 +460,7 @@ describe('rendering', () => {
         });
         describe('when item is active', () => {
           beforeEach(() => {
-            wrapper.setState({ activeItemIndex: 0 });
+            wrapper.setState({ activeItemIndex: 'scrollable-0' });
           });
           it('should pass isActive as prop', () => {
             expect(wrapper.find('MenuGroup').at(1)).toHaveProp(
@@ -1153,11 +1153,11 @@ describe('instance methods', () => {
     describe('handleToggleItem', () => {
       describe('if activeItemIndex is not the same as the given index', () => {
         beforeEach(() => {
-          wrapper.setState({ activeItemIndex: 1 });
-          wrapper.instance().handleToggleItem(0);
+          wrapper.setState({ activeItemIndex: 'fixed-1' });
+          wrapper.instance().handleToggleItem('fixed', 0);
         });
         it('should update activeItemIndex with the new index', () => {
-          expect(wrapper).toHaveState('activeItemIndex', 0);
+          expect(wrapper).toHaveState('activeItemIndex', 'fixed-0');
         });
       });
     });
@@ -1189,7 +1189,7 @@ describe('instance methods', () => {
     describe('handleToggleMenu', () => {
       describe('if menu is open and activeItemIndex is not null', () => {
         beforeEach(() => {
-          wrapper.setState({ isMenuOpen: true, activeItemIndex: 0 });
+          wrapper.setState({ isMenuOpen: true, activeItemIndex: 'fixed-0' });
           wrapper.instance().handleToggleMenu();
         });
         it('should unset activeItemIndex', () => {


### PR DESCRIPTION
#### Summary

The "absolute" positioned items in the NavBar, covered other items when the menu got expanded in smaller height screens

#### Description

This PR adds a FixedMenu and a ScrollableMenu so **if the screen gets smaller** it will add a scrolling bar inside the items which gets rendered inside the `ScrollableMenu` section

#### Cross-Browser

* [x] Chrome
* [x] Firefox
* [ ] Safari - couldn't test on safari locally since I can't login in this browse, issue needs to be reported
* [ ] (IE/Edge)

#### Tests
* Components
  * [x] Rendered elements (also different states)

#### Technical debt & future

The NavBar is being refactored, so this is a quick fix for the problem

**Before**
![bug-1](https://user-images.githubusercontent.com/14938754/46813041-4149f100-cd76-11e8-9d21-57e722f3f146.gif)

**After**
![bug-2](https://user-images.githubusercontent.com/14938754/46813054-47d86880-cd76-11e8-94e9-b0fba2983677.gif)


**SUPPORT LINK**
https://jira.commercetools.com/browse/SUPPORT-3996