### PR TITLE
fix(nav-bar): widen expanded navbar to fit spanish support text

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -269,7 +269,7 @@
 
 .list-item.item__active .item-icon-text {
   position: absolute;
-  width: 150px;
+  width: 175px;
 }
 
 :global(.body__menu-open) .list-item.item__active .item-icon-text {


### PR DESCRIPTION
#### Summary

Right now, when in Spanish mode, you get this behaviour because the active item isn't wide enough. (because the text is Support - in english) instead of just support

![bug](https://user-images.githubusercontent.com/33861468/47068847-be012300-d1ed-11e8-94cb-43da7934f0e6.gif)

#### Approach

Make active item wider so that this doesn't happen.

![fix](https://user-images.githubusercontent.com/2425013/47075239-733ad780-d1fc-11e8-8883-5ade981578c2.gif)


cc @mariabarrena 