### PR TITLE
feat(quick-access): support opening quick access when link has focus

### DIFF
--- a/packages/application-shell/src/components/quick-access/index.js
+++ b/packages/application-shell/src/components/quick-access/index.js
@@ -47,7 +47,9 @@ export default class QuickAccessTrigger extends React.Component {
       // react-modal uses it for example. We want to treat those elements
       // similar to document.body.
       // See https://stackoverflow.com/a/32912224
-      event.target.getAttribute('tabindex') !== '-1'
+      event.target.getAttribute('tabindex') !== '-1' &&
+      // Do not prevent Quick Access from opening when a link has focus
+      event.target.nodeName !== 'A'
     )
       return;
 


### PR DESCRIPTION
Quick Access not opening was reported as a bug:

![image](https://user-images.githubusercontent.com/1765075/47096759-2c66d500-d230-11e8-8701-e18deabf976a.png)

So far it was not possible to open Quick Access by pressing `f` while a link had focus.

This PR enables that by exempting links from the early return we are doing. This early return is what stops Quick Access from opening while a user types into a form input for example.

I think it's a fair assumption to open Butler while a link has focus.

