### PR TITLE
[application-shell]: Allow passing project key as variable on operation

### DIFF
--- a/packages/application-shell/src/apollo-links/__snapshots__/header-link.spec.js.snap
+++ b/packages/application-shell/src/apollo-links/__snapshots__/header-link.spec.js.snap
@@ -9,3 +9,13 @@ Object {
   },
 }
 `;
+
+exports[`with valid target without project key in url with project key in variables should set headers matching snapshot 1`] = `
+Object {
+  "headers": Object {
+    "X-Correlation-Id": "test-correlation-id",
+    "X-Graphql-Target": "mc",
+    "X-Project-Key": "test-project-key",
+  },
+}
+`;

--- a/packages/application-shell/src/apollo-links/__snapshots__/header-link.spec.js.snap
+++ b/packages/application-shell/src/apollo-links/__snapshots__/header-link.spec.js.snap
@@ -10,7 +10,7 @@ Object {
 }
 `;
 
-exports[`with valid target without project key in url with project key in variables should set headers matching snapshot 1`] = `
+exports[`with valid target with project key in variables should set headers matching snapshot 1`] = `
 Object {
   "headers": Object {
     "X-Correlation-Id": "test-correlation-id",

--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -13,9 +13,18 @@ const headerLink = new ApolloLink((operation, forward) => {
       `GraphQL target "${target}" is missing or is not supported`
     );
 
-  const projectKey = selectProjectKeyFromUrl();
-  // NOTE: keep header names with capital letters to avoid possible conflicts
-  // or problems with nginx.
+  /**
+   * NOTE:
+   *   The project key is read from the url in a project related appliation context.
+   *   This holds for most applications like `application-categories`, `application-discounts` etc.
+   *   However, the `application-account` does not run with the project key being part of the url.
+   *   As a result we allow passing the project key as a variable on the operation allowing
+   *   it to be the fallback.
+   */
+  const projectKey =
+    selectProjectKeyFromUrl() || operation.variables.projectKey;
+
+  // NOTE: keep header names with capital letters to avoid possible conflicts or problems with nginx.
   operation.setContext({
     headers: {
       'X-Project-Key': projectKey,

--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -22,7 +22,7 @@ const headerLink = new ApolloLink((operation, forward) => {
    *   it to be the fallback.
    */
   const projectKey =
-    selectProjectKeyFromUrl() || operation.variables.projectKey;
+    operation.variables.projectKey || selectProjectKeyFromUrl();
 
   // NOTE: keep header names with capital letters to avoid possible conflicts or problems with nginx.
   operation.setContext({

--- a/packages/application-shell/src/apollo-links/header-link.spec.js
+++ b/packages/application-shell/src/apollo-links/header-link.spec.js
@@ -2,7 +2,6 @@ import { ApolloLink, execute, Observable } from 'apollo-link';
 import gql from 'graphql-tag';
 import waitFor from 'wait-for-observables';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { selectProjectKeyFromUrl } from '../utils';
 import headerLink from './header-link';
 
 jest.mock('../utils/', () => ({
@@ -77,37 +76,31 @@ describe('with valid target', () => {
     );
   });
 
-  describe('without project key in url', () => {
-    beforeEach(() => {
-      selectProjectKeyFromUrl.mockImplementation(() => undefined);
+  describe('with project key in variables', () => {
+    const projectKey = 'test-project-key';
+
+    beforeEach(async () => {
+      await waitFor(
+        execute(link, {
+          query,
+          variables: {
+            target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+            projectKey,
+          },
+        })
+      );
     });
 
-    describe('with project key in variables', () => {
-      const projectKey = 'test-project-key';
+    it('should set headers matching snapshot', () => {
+      expect(context).toMatchSnapshot();
+    });
 
-      beforeEach(async () => {
-        await waitFor(
-          execute(link, {
-            query,
-            variables: {
-              target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
-              projectKey,
-            },
-          })
-        );
-      });
-
-      it('should set headers matching snapshot', () => {
-        expect(context).toMatchSnapshot();
-      });
-
-      it('should set `X-Project-Key`-Header', () => {
-        expect(context.headers).toEqual(
-          expect.objectContaining({
-            'X-Project-Key': projectKey,
-          })
-        );
-      });
+    it('should set `X-Project-Key`-Header', () => {
+      expect(context.headers).toEqual(
+        expect.objectContaining({
+          'X-Project-Key': projectKey,
+        })
+      );
     });
   });
 });

--- a/packages/application-shell/src/apollo-links/header-link.spec.js
+++ b/packages/application-shell/src/apollo-links/header-link.spec.js
@@ -2,11 +2,12 @@ import { ApolloLink, execute, Observable } from 'apollo-link';
 import gql from 'graphql-tag';
 import waitFor from 'wait-for-observables';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import { selectProjectKeyFromUrl } from '../utils';
 import headerLink from './header-link';
 
 jest.mock('../utils/', () => ({
   getCorrelationId: () => 'test-correlation-id',
-  selectProjectKeyFromUrl: () => 'project-1',
+  selectProjectKeyFromUrl: jest.fn(() => 'project-1'),
 }));
 
 describe('headerLink', () => {
@@ -74,5 +75,39 @@ describe('with valid target', () => {
         'X-Correlation-Id': 'test-correlation-id',
       })
     );
+  });
+
+  describe('without project key in url', () => {
+    beforeEach(() => {
+      selectProjectKeyFromUrl.mockImplementation(() => undefined);
+    });
+
+    describe('with project key in variables', () => {
+      const projectKey = 'test-project-key';
+
+      beforeEach(async () => {
+        await waitFor(
+          execute(link, {
+            query,
+            variables: {
+              target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+              projectKey,
+            },
+          })
+        );
+      });
+
+      it('should set headers matching snapshot', () => {
+        expect(context).toMatchSnapshot();
+      });
+
+      it('should set `X-Project-Key`-Header', () => {
+        expect(context.headers).toEqual(
+          expect.objectContaining({
+            'X-Project-Key': projectKey,
+          })
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
#### Summary

The project key is read from the url in a project related appliation context.
This holds for most applications like `application-categories`, `application-discounts` etc. However, the `application-account` does not run with the project key being part of the url. As a result we allow passing the project key as a variable on the operation allowing it to be the fallback.