### PR TITLE
fix(application-shell): to use expiry not expired in project list

### DIFF
--- a/packages/application-shell/src/components/project-switcher/project-switcher-fragments.graphql
+++ b/packages/application-shell/src/components/project-switcher/project-switcher-fragments.graphql
@@ -4,5 +4,7 @@ fragment projectFragment on Project {
   suspension {
     isActive
   }
-  expired
+  expiry {
+    isActive
+  }
 }


### PR DESCRIPTION
#### Summary

This pull request fixes the GraphQL query to use expiry over expired.

#### Description

Expired is a deprecated field and expiry should be used instead. The project list component itself already uses expiry.isActive. I am not sure how this slipped in again but it should be fixed with the next release.
