### PR TITLE
refactor(http-server): configure cloudbuilder to wait for 30s before building the docker image

### DIFF
--- a/packages/mc-http-server/cloudbuild.yaml
+++ b/packages/mc-http-server/cloudbuild.yaml
@@ -1,4 +1,13 @@
 steps:
+  # As this build gets triggered during a release cycle,
+  # lerna will push the git tag before publishing the packages
+  # to npm, which causes the docker build to fail to install
+  # the dependencies (as they are not been fully published yet).
+  # Therefore, we try to wait for about 30s before building
+  # the docker image, which should give enough time for
+  # the lerna release to finish.
+  - name: 'ubuntu'
+    args: ['sleep', '30']
   - name: 'gcr.io/cloud-builders/docker'
     args:
       [


### PR DESCRIPTION
When we release with `lerna`, a commit with the updated versions and a git tag are created and the packages are published to npm (in that order).

We also configured our Google Cloudbuilder to be triggered every time there is a git tag (which corresponds to a release). However, because the git tag is created/pushed before the packages are published to npm, the docker build fails because it can't find the dependencies in the npm registry.

I just noticed this recently and I had to retrigger those builds manually. To try to avoid this issue, we can wait for e.g. `30s` before actually building the docker image. I think this should give us enough time for the packages to be released.