### PR TITLE
fix(components/notification-kinds): do not report error to sentry for `invalid_scope`

### DIFF
--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.js
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.js
@@ -104,10 +104,16 @@ export const ApiErrorMessage = props => {
   const message = messages[props.error.code];
   if (!message) {
     // This error is not mapped / translated yet,
-    // we log / report it and show the original error.
+    // we log, report it to sentry and show the original error, unless `error.code` is `invalid_scope`
+    // which an error code emitted for expired project(s)
     // NOTE this is a side-effect within the render function, which is bad!
     // This should be moved to componentDidMount
-    reportErrorToSentry(new Error('Unmapped error'), { extra: props.error });
+    if (
+      props.error.code !== 'invalid_scope' &&
+      !props.error.message.includes('has expired')
+    ) {
+      reportErrorToSentry(new Error('Unmapped error'), { extra: props.error });
+    }
 
     return (
       <div>

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.js
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.js
@@ -133,6 +133,23 @@ describe('render', () => {
     it('should report the error', () => {
       expect(reportErrorToSentry).toHaveBeenCalledTimes(1);
     });
+    describe('when `error.code` is `invalid_scope`', () => {
+      describe('with project expired', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            error: {
+              code: 'invalid_scope',
+              message: 'has expired',
+            },
+          });
+          reportErrorToSentry.mockReset();
+          wrapper = shallow(<ApiErrorMessage {...props} />);
+        });
+        it('should not report to sentry', () => {
+          expect(reportErrorToSentry).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
   });
 
   describe('DuplicateSlug', () => {


### PR DESCRIPTION
#### Summary

- does not report to sentry when error `code=invalid_scope` and message contains `has expired`

#### Description

When a project expires, the API responds with an [invalid_scope](https://tools.ietf.org/html/rfc6749#section-5.2) error.
For the moment, we receive logs from Sentry about this. However these are not helpful since they are not actionable.
Instead, I propose that whenever there is an invalid_scope in conjunction with a project being expired, we do nothing..

Why invalid_scope for expired projects?

When a project is expired, the token for the project is expired as well along with its api-clients, so this error code does make sense if we look into the specification of OAuth, however not helpful nor actionable at all in the UI code.

I've initiated a discussion with a couple of backends on what we could do to provide a richer error response when this occurs, and so far the least harmful solution would be for the API to provide a header.

Although this could be a solution, the effort is not worth to implementing considering that it is only one client (namely MC) that needs this.

For now; let's live with inspecting the error message itself.
ref: [sentry error](https://sentry.io/commercetools/mcng/issues/711119876/?query=is:unresolved)

