### PR TITLE
chore: fix this undefined due to malformed react components

### DIFF
--- a/packages/application-shell/src/components/project-expired/__snapshots__/project-expired.spec.js.snap
+++ b/packages/application-shell/src/components/project-expired/__snapshots__/project-expired.spec.js.snap
@@ -10,11 +10,9 @@ exports[`rendering outputs correct tree 1`] = `
       id="ProjectExpired.paragraph1"
       values={
         Object {
-          "mailto": <a
-            href="mailto:sales@commercetools.com"
-          >
-            sales@commercetools.com
-          </a>,
+          "mailto": <EmailLink
+            email="sales@commercetools.com"
+          />,
         }
       }
     />

--- a/packages/application-shell/src/components/project-expired/project-expired.js
+++ b/packages/application-shell/src/components/project-expired/project-expired.js
@@ -6,14 +6,19 @@ import ServicePageProjectSwitcher from '../service-page-project-switcher';
 import messages from './messages';
 
 const salesEmail = 'sales@commercetools.com';
-const mailto = <a href={`mailto:${salesEmail}`}>{salesEmail}</a>;
+
+const EmailLink = () => <a href={`mailto:${salesEmail}`}>{salesEmail}</a>;
+EmailLink.displayName = 'EmailLink';
 
 const ProjectExpired = () => (
   <ServicePageResponseLayout
     imageSrc={ProjectExpiredSvg}
     title={<FormattedMessage {...messages.title} />}
     paragraph1={
-      <FormattedMessage {...messages.paragraph1} values={{ mailto }} />
+      <FormattedMessage
+        {...messages.paragraph1}
+        values={{ mailto: <EmailLink email={salesEmail} /> }}
+      />
     }
     bodyContent={<ServicePageProjectSwitcher />}
   />

--- a/packages/application-shell/src/from-core/page-not-found/__snapshots__/page-not-found.spec.js.snap
+++ b/packages/application-shell/src/from-core/page-not-found/__snapshots__/page-not-found.spec.js.snap
@@ -4,6 +4,7 @@ exports[`rendering outputs correct tree 1`] = `
 <div
   className="container"
 >
+  here
   <ServicePageResponseLayout
     imageSrc="test-file-stub"
     paragraph1={
@@ -14,16 +15,7 @@ Please contact your system administrator or the commercetools {link} if you have
         id="PageNotFound.paragraph1"
         values={
           Object {
-            "link": <a
-              href="https://support.commercetools.com"
-              target="_blank"
-            >
-              <FormattedMessage
-                defaultMessage="Help Desk"
-                id="PageNotFound.helpDesk"
-                values={Object {}}
-              />
-            </a>,
+            "link": <Link />,
           }
         }
       />

--- a/packages/application-shell/src/from-core/page-not-found/page-not-found.js
+++ b/packages/application-shell/src/from-core/page-not-found/page-not-found.js
@@ -5,18 +5,25 @@ import ServicePageResponseLayout from '../service-page-response-layout';
 import messages from './messages';
 import styles from './page-not-found.mod.css';
 
-const link = (
+const Link = () => (
   <a href={'https://support.commercetools.com'} target="_blank">
     <FormattedMessage {...messages.helpDesk} />
   </a>
 );
+
+Link.displayName = 'Link';
+
 const PageNotFound = () => (
   <div className={styles.container}>
+    here
     <ServicePageResponseLayout
       imageSrc={PageNotFoundSVG}
       title={<FormattedMessage {...messages.title} />}
       paragraph1={
-        <FormattedMessage {...messages.paragraph1} values={{ link }} />
+        <FormattedMessage
+          {...messages.paragraph1}
+          values={{ link: <Link /> }}
+        />
       }
     />
   </div>


### PR DESCRIPTION
#### Summary

In `project-not-found` and `project-expired`, we have a few warnings due to the babel transformation / rollup.

```js
https://rollupjs.org/guide/en#error-this-is-undefined
src/from-core/page-not-found/page-not-found.js
13:     lineNumber: 9
14:   },
15:   __self: this
              ^
16: }, React.createElement(FormattedMessage, Object.assign({}, messages.helpDesk, {
17:   __source: {
...and 1 other occurrence
src/components/project-expired/project-expired.js
13:     lineNumber: 9
14:   },
15:   __self: this
              ^
16: }, salesEmail);
```

The issue was that we were creating React components for the links, but we weren't creating them as class or functional components. So this was undefined.

The compiled code looked like

```js
var salesEmail = 'sales@commercetools.com';
var mailto = React.createElement("a", {
  href: "mailto:".concat(salesEmail),
  __source: {
    fileName: _jsxFileName,
    lineNumber: 9
  },
  __self: undefined
}, salesEmail);
```

and now it looks like

```js

var salesEmail = 'sales@commercetools.com';

var EmailLink = function EmailLink(email) {
  return React.createElement("a", {
    href: "mailto:".concat(email),
    __source: {
      fileName: _jsxFileName,
      lineNumber: 11
    },
    __self: this
  }, salesEmail);
};

EmailLink.propTypes = {
  email: PropTypes.string.isRequired
};
EmailLink.displayName = 'EmailLink';
```