### PR TITLE
chore: prefer named imports

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -7,7 +7,7 @@ import { graphql } from 'react-apollo';
 import { ToggleFeature, injectFeatureToggle } from '@flopflip/react-broadcast';
 import { compose, withProps } from 'recompose';
 import classnames from 'classnames';
-import oneLineTrim from 'common-tags/lib/oneLineTrim';
+import { oneLineTrim } from 'common-tags';
 import { Icons } from '@commercetools-frontend/ui-kit';
 import * as storage from '@commercetools-frontend/storage';
 import {

--- a/packages/application-shell/src/components/quick-access/create-commands.js
+++ b/packages/application-shell/src/components/quick-access/create-commands.js
@@ -1,4 +1,4 @@
-import oneLineTrim from 'common-tags/lib/oneLineTrim';
+import { oneLineTrim } from 'common-tags';
 import messages from './messages';
 
 const hasPermission = (permission, allPermissions) =>

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -4,7 +4,7 @@ import { compose } from 'recompose';
 import { injectIntl } from 'react-intl';
 import { injectFeatureToggles } from '@flopflip/react-broadcast';
 import { withApollo } from 'react-apollo';
-import oneLineTrim from 'common-tags/lib/oneLineTrim';
+import { oneLineTrim } from 'common-tags';
 import debounce from 'debounce-async';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import Butler from './butler';

--- a/packages/application-shell/src/components/quick-access/sub-commands.js
+++ b/packages/application-shell/src/components/quick-access/sub-commands.js
@@ -1,4 +1,4 @@
-import oneLineTrim from 'common-tags/lib/oneLineTrim';
+import { oneLineTrim } from 'common-tags';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import QuickAccessProductQuery from './quick-access-product.graphql';
 import messages from './messages';


### PR DESCRIPTION
Will fix some warnings with rollup.

Besides, let's used the named export instead of depending on their directory structure remaining static 🤷‍♂️ 