### PR TITLE
chore: don't mix named and default exports on code splitting

### DIFF
--- a/packages/application-shell/src/components/login-locked/async.js
+++ b/packages/application-shell/src/components/login-locked/async.js
@@ -2,6 +2,6 @@ import Loadable from 'react-loadable';
 import AsyncChunkLoader from '../async-chunk-loader';
 
 export default Loadable({
-  loader: () => import('./login-locked' /* webpackChunkName: "login-locked" */),
+  loader: () => import('./index' /* webpackChunkName: "login-locked" */),
   loading: AsyncChunkLoader,
 });

--- a/packages/application-shell/src/components/login-sso-callback/async.js
+++ b/packages/application-shell/src/components/login-sso-callback/async.js
@@ -2,7 +2,6 @@ import Loadable from 'react-loadable';
 import AsyncChunkLoader from '../async-chunk-loader';
 
 export default Loadable({
-  loader: () =>
-    import('./login-sso-callback' /* webpackChunkName: "login-sso-callback" */),
+  loader: () => import('./index' /* webpackChunkName: "login-sso-callback" */),
   loading: AsyncChunkLoader,
 });

--- a/packages/application-shell/src/components/login-sso/async.js
+++ b/packages/application-shell/src/components/login-sso/async.js
@@ -2,6 +2,6 @@ import Loadable from 'react-loadable';
 import AsyncChunkLoader from '../async-chunk-loader';
 
 export default Loadable({
-  loader: () => import('./login-sso' /* webpackChunkName: "login-sso" */),
+  loader: () => import('./index' /* webpackChunkName: "login-sso" */),
   loading: AsyncChunkLoader,
 });

--- a/packages/application-shell/src/components/login/async.js
+++ b/packages/application-shell/src/components/login/async.js
@@ -2,6 +2,6 @@ import Loadable from 'react-loadable';
 import AsyncChunkLoader from '../async-chunk-loader';
 
 export default Loadable({
-  loader: () => import('./login' /* webpackChunkName: "login" */),
+  loader: () => import('./index' /* webpackChunkName: "login" */),
   loading: AsyncChunkLoader,
 });

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -23,7 +23,7 @@ const containsMatchByProductKey = data => Boolean(data.productByKey);
 const containsMatchByVariantKey = data => Boolean(data.productByVariantKey);
 const containsMatchByVariantSku = data => Boolean(data.productByVariantSku);
 
-export class QuickAccess extends React.Component {
+class QuickAccess extends React.Component {
   static displayName = 'QuickAccess';
   static propTypes = {
     project: PropTypes.shape({


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Currently, we have a few places where a new chunk contains mixed exports. This isn't great for CJS builds.

This will help remove some rollup warnings and shouldn't have any effects on consumers, as they would have to be directly importing from these code split components to be effected.

<!-- provide some context -->
