### PR TITLE
chore: refactor i18n for better code splitting

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -5,6 +5,7 @@ Supported languages:
 
 - `en`
 - `de`
+- `es`
 
 ## Install
 

--- a/packages/i18n/load-i18n.js
+++ b/packages/i18n/load-i18n.js
@@ -2,57 +2,36 @@ import { addLocaleData } from 'react-intl';
 import { getMatchingMomentCode } from './utils';
 
 const getReactIntlChunkImport = lang => {
-  let chunkImport;
   switch (lang) {
-    case 'en':
-      chunkImport = import(/* webpackChunkName: "react-intl-data-en" */ 'react-intl/locale-data/en');
-      break;
     case 'de':
-      chunkImport = import(/* webpackChunkName: "react-intl-data-de" */ 'react-intl/locale-data/de');
-      break;
+      return import(/* webpackChunkName: "react-intl-data-de" */ 'react-intl/locale-data/de');
     case 'es':
-      chunkImport = import(/* webpackChunkName: "react-intl-data-es" */ 'react-intl/locale-data/es');
-      break;
+      return import(/* webpackChunkName: "react-intl-data-es" */ 'react-intl/locale-data/es');
     default:
-      chunkImport = import(/* webpackChunkName: "react-intl-data-en" */ 'react-intl/locale-data/en');
+      return import(/* webpackChunkName: "react-intl-data-en" */ 'react-intl/locale-data/en');
   }
-  return chunkImport;
 };
 
 const getMomentChunkImport = momentLocaleCode => {
-  let chunkImport;
   switch (momentLocaleCode) {
-    case 'en':
-      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-en-gb" */ 'moment/locale/en-gb');
-      break;
     case 'de':
-      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-de" */ 'moment/locale/de');
-      break;
+      return import(/* webpackChunkName: "i18n-moment-locale-de" */ 'moment/locale/de');
     case 'es':
-      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-es" */ 'moment/locale/es');
-      break;
+      return import(/* webpackChunkName: "i18n-moment-locale-es" */ 'moment/locale/es');
     default:
-      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-en-gb" */ 'moment/locale/en-gb');
+      return import(/* webpackChunkName: "i18n-moment-locale-en-gb" */ 'moment/locale/en-gb');
   }
-  return chunkImport;
 };
 
 const getLocalizedStringsChunkImport = lang => {
-  let chunkImport;
   switch (lang) {
-    case 'en':
-      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-en" */ './data/en.json');
-      break;
     case 'de':
-      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-de" */ './data/de.json');
-      break;
+      return import(/* webpackChunkName: "react-intl-localized-strings-de" */ './data/de.json');
     case 'es':
-      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-es" */ './data/es.json');
-      break;
+      return import(/* webpackChunkName: "react-intl-localized-strings-es" */ './data/es.json');
     default:
-      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-en" */ './data/en.json');
+      return import(/* webpackChunkName: "react-intl-localized-strings-en" */ './data/en.json');
   }
-  return chunkImport;
 };
 
 export default function loadI18n(lang) {

--- a/packages/i18n/load-i18n.js
+++ b/packages/i18n/load-i18n.js
@@ -1,24 +1,73 @@
 import { addLocaleData } from 'react-intl';
 import { getMatchingMomentCode } from './utils';
 
+const getReactIntlChunkImport = lang => {
+  let chunkImport;
+  switch (lang) {
+    case 'en':
+      chunkImport = import(/* webpackChunkName: "react-intl-data-en" */ 'react-intl/locale-data/en');
+      break;
+    case 'de':
+      chunkImport = import(/* webpackChunkName: "react-intl-data-de" */ 'react-intl/locale-data/de');
+      break;
+    case 'es':
+      chunkImport = import(/* webpackChunkName: "react-intl-data-es" */ 'react-intl/locale-data/es');
+      break;
+    default:
+      chunkImport = import(/* webpackChunkName: "react-intl-data-en" */ 'react-intl/locale-data/en');
+  }
+  return chunkImport;
+};
+
+const getMomentChunkImport = momentLocaleCode => {
+  let chunkImport;
+  switch (momentLocaleCode) {
+    case 'en':
+      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-en-gb" */ 'moment/locale/en-gb');
+      break;
+    case 'de':
+      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-de" */ 'moment/locale/de');
+      break;
+    case 'es':
+      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-es" */ 'moment/locale/es');
+      break;
+    default:
+      chunkImport = import(/* webpackChunkName: "i18n-moment-locale-en-gb" */ 'moment/locale/en-gb');
+  }
+  return chunkImport;
+};
+
+const getLocalizedStringsChunkImport = lang => {
+  let chunkImport;
+  switch (lang) {
+    case 'en':
+      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-en" */ './data/en.json');
+      break;
+    case 'de':
+      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-de" */ './data/de.json');
+      break;
+    case 'es':
+      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-es" */ './data/es.json');
+      break;
+    default:
+      chunkImport = import(/* webpackChunkName: "react-intl-localized-strings-en" */ './data/en.json');
+  }
+  return chunkImport;
+};
+
 export default function loadI18n(lang) {
   // Use default (lazy) so that we will receive one chunk per
   // locale. https://webpack.js.org/api/module-methods/#import-
 
+  const reactIntlChunkImport = getReactIntlChunkImport(lang);
+
   const momentLocaleCode = getMatchingMomentCode(lang);
-
-  const reactIntlChunkImport = import(/* webpackChunkName: "react-intl-data-[request]" */
-  /* webpackMode: "lazy" */
-  `./locale-data/${lang}`);
-
-  const momentChunkImport = import(/* webpackChunkName: "i18n-moment-locale-[request]" */
-  `./moment-data/${momentLocaleCode}`);
+  const momentChunkImport = getMomentChunkImport(momentLocaleCode);
 
   const localeDataPromises = [reactIntlChunkImport, momentChunkImport];
 
   return Promise.all(localeDataPromises).then(response => {
     addLocaleData([...response[0].default]);
-    return import(/* webpackChunkName: "react-intl-localized-strings-[request]" */
-    `./data/${lang}.json`);
+    return getLocalizedStringsChunkImport(lang);
   });
 }

--- a/packages/i18n/locale-data/de.js
+++ b/packages/i18n/locale-data/de.js
@@ -1,3 +1,0 @@
-import de from 'react-intl/locale-data/de';
-
-export default de;

--- a/packages/i18n/locale-data/en.js
+++ b/packages/i18n/locale-data/en.js
@@ -1,3 +1,0 @@
-import en from 'react-intl/locale-data/en';
-
-export default en;

--- a/packages/i18n/locale-data/es.js
+++ b/packages/i18n/locale-data/es.js
@@ -1,3 +1,0 @@
-import es from 'react-intl/locale-data/es';
-
-export default es;

--- a/packages/i18n/moment-data/de.js
+++ b/packages/i18n/moment-data/de.js
@@ -1,3 +1,0 @@
-import de from 'moment/locale/de';
-
-export default de;

--- a/packages/i18n/moment-data/en-gb.js
+++ b/packages/i18n/moment-data/en-gb.js
@@ -1,3 +1,0 @@
-import enGb from 'moment/locale/en-gb';
-
-export default enGb;

--- a/packages/i18n/moment-data/es.js
+++ b/packages/i18n/moment-data/es.js
@@ -1,3 +1,0 @@
-import es from 'moment/locale/es';
-
-export default es;


### PR DESCRIPTION
#### Summary

We can't use dynamic code splitting in rollup like we were in webpack. This is more explicit. The downside, is we can't define something like "supportedLanguages" in one place. The upside, is we don't need to care about the location of the files, as rollup will split on them.

I'm going to do the same thing in l10n as preparation for the rollup PR as well.