### PR TITLE
Add ApplicationState to test-utils

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,5 +1,6 @@
----
-extends: "@commercetools-frontend/eslint-config-mc-app"
+extends: '@commercetools-frontend/eslint-config-mc-app'
 settings:
   react:
     version: '^16.0'
+  import/ignore:
+    - test-utils.js$

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { fireEvent, waitForElement } from 'react-testing-library';
-import { render } from '../../test-utils';
+import { render, fireEvent, waitForElement } from '../../test-utils';
 import QuickAccessQuery from './quick-access.graphql';
 import * as gtm from '../../utils/gtm';
 import QuickAccess from './index';

--- a/packages/application-shell/src/test-utils.js
+++ b/packages/application-shell/src/test-utils.js
@@ -31,7 +31,7 @@ afterEach(memoryAdapter.reset);
 // Inspired by
 // https://github.com/kentcdodds/react-testing-library-course/blob/2a5b1560656790bb1d9c055fba3845780b2c2c97/src/__tests__/react-router-03.js
 // eslint-disable-next-line import/prefer-default-export
-export const render = (
+const render = (
   ui,
   {
     // react-intl
@@ -68,7 +68,7 @@ export const render = (
 // Test setup for rendering with Redux
 // We expose a sophisticated function because we plan to get rid of Redux
 // Use this function only when your test actually needs Redux
-export const renderWithRedux = (
+const renderWithRedux = (
   ui,
   {
     // Consuemrs of renderWithRedux can use
@@ -84,3 +84,12 @@ export const renderWithRedux = (
   // this to test implementation details).
   store,
 });
+
+// re-export everything
+export * from 'react-testing-library';
+
+export {
+  // override render method of react-testing-library
+  render,
+  renderWithRedux,
+};

--- a/packages/application-shell/src/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils.spec.js
@@ -261,13 +261,11 @@ describe('router', () => {
   it('should render fallback when no route is provided', () => {
     const { container } = render(<TestComponent />);
     expect(container).not.toHaveTextContent('Foo');
-    expect(container).not.toHaveTextContent('Bar');
     expect(container).toHaveTextContent('None');
   });
   it('should render allow routing', () => {
     const { container } = render(<TestComponent />, { route: '/foo' });
     expect(container).toHaveTextContent('Foo');
-    expect(container).not.toHaveTextContent('Bar');
     expect(container).not.toHaveTextContent('None');
   });
   it('should return a history object', () => {

--- a/packages/application-shell/src/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils.spec.js
@@ -1,0 +1,258 @@
+// This file tests our test-utils file #inception
+//
+// The TestComponents are expected to work. We run the tests to ensure that
+// the `render` method sets up the tests correctly.
+// This is a bit different from our usual tests, as we are testing our testing
+// tools here instead of actual components.
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import { injectFeatureToggle } from '@flopflip/react-broadcast';
+import { Switch, Route } from 'react-router';
+import { render, wait } from './test-utils';
+import { GetApplicationState } from '../../application-shell-connectors';
+
+describe('Intl', () => {
+  const TestComponent = injectIntl(props => props.intl.locale);
+  it('should have intl', () => {
+    const { container } = render(<TestComponent />);
+    expect(container).toHaveTextContent('en');
+  });
+  it('should be possible to overwrite', () => {
+    const { container } = render(<TestComponent />, {
+      locale: 'de',
+    });
+    expect(container).toHaveTextContent('de');
+  });
+});
+
+describe('ApolloMockProvider', () => {
+  const SomeQuery = gql`
+    query Wow {
+      foo {
+        name
+      }
+    }
+  `;
+  const TestComponent = () => (
+    <Query query={SomeQuery} variables={{ target: 'ctp' }}>
+      {payload => {
+        if (!payload || !payload.data || !payload.data.foo) return 'loading';
+        return payload.data.foo.name;
+      }}
+    </Query>
+  );
+  it('should be possible to fake GraphQL requests', async () => {
+    const { container } = render(<TestComponent />, {
+      mocks: [
+        {
+          request: {
+            query: SomeQuery,
+            variables: { target: 'ctp' },
+          },
+          result: { data: { foo: { name: 'Snoop Dogg' } } },
+        },
+      ],
+    });
+    expect(container).toHaveTextContent('loading');
+    await wait(() => {
+      expect(container).toHaveTextContent('Snoop Dogg');
+    });
+  });
+});
+
+describe('FlopFlip', () => {
+  const FEATURE_NAME = 'foo-bar';
+  const TestComponent = injectFeatureToggle(FEATURE_NAME, 'isFooBarEnabled')(
+    props => (props.isFooBarEnabled ? 'enabled' : 'disabled')
+  );
+  it('should not have feature toggles by default', () => {
+    const { container } = render(<TestComponent />);
+    expect(container).toHaveTextContent('disabled');
+  });
+  it('should be possible to provide feature toggles', () => {
+    const { container } = render(<TestComponent />, {
+      flags: { [FEATURE_NAME]: true },
+    });
+    expect(container).toHaveTextContent('enabled');
+  });
+});
+
+describe('ApplicationState', () => {
+  describe('user', () => {
+    const TestComponent = () => (
+      <GetApplicationState
+        render={applicationState =>
+          [
+            applicationState.user.firstName,
+            applicationState.user.lastName,
+          ].join(' ')
+        }
+      />
+    );
+
+    it('should render with defaults', () => {
+      const { container, user } = render(<TestComponent />);
+      expect(container).toHaveTextContent('Sheldon Cooper');
+      // the user should be returned from "render"
+      expect(user).toEqual({
+        email: 'sheldon.cooper@caltech.edu',
+        firstName: 'Sheldon',
+        id: 'user-id-1',
+        language: 'en',
+        lastName: 'Cooper',
+        timeZone: 'Etc/UTC',
+      });
+    });
+
+    it('should respect user overwrites', () => {
+      const { container, user } = render(<TestComponent />, {
+        user: { firstName: 'Leonard' },
+      });
+      // shows that data gets merged and overwrites have priority
+      expect(container).toHaveTextContent('Leonard Cooper');
+      // the merged user should be returned from "render"
+      expect(user).toEqual({
+        email: 'sheldon.cooper@caltech.edu',
+        firstName: 'Leonard',
+        id: 'user-id-1',
+        language: 'en',
+        lastName: 'Cooper',
+        timeZone: 'Etc/UTC',
+      });
+    });
+  });
+
+  describe('project', () => {
+    const TestComponent = () => (
+      <GetApplicationState
+        render={applicationState =>
+          [applicationState.project.key, applicationState.project.name].join(
+            ' '
+          )
+        }
+      />
+    );
+
+    it('should render with defaults', () => {
+      const { container, project } = render(<TestComponent />);
+      expect(container).toHaveTextContent(
+        'test-with-big-data Test with big data'
+      );
+      // the project should be returned from "render"
+      expect(project).toEqual({
+        countries: ['de', 'en'],
+        currencies: ['EUR', 'GBP'],
+        key: 'test-with-big-data',
+        languages: ['de', 'en-GB'],
+        name: 'Test with big data',
+        permissions: {
+          canManageProject: true,
+        },
+        version: 43,
+      });
+    });
+
+    it('should respect user overwrites', () => {
+      const { container, project } = render(<TestComponent />, {
+        project: { name: 'Geek' },
+      });
+      // shows that data gets merged and overwrites have priority
+      expect(container).toHaveTextContent('test-with-big-data Geek');
+      // the merged project should be returned from "render"
+      expect(project).toEqual({
+        countries: ['de', 'en'],
+        currencies: ['EUR', 'GBP'],
+        key: 'test-with-big-data',
+        languages: ['de', 'en-GB'],
+        name: 'Geek',
+        permissions: { canManageProject: true },
+        version: 43,
+      });
+    });
+  });
+
+  describe('dataLocale', () => {
+    const TestComponent = () => (
+      <GetApplicationState
+        render={applicationState => applicationState.project.dataLocale}
+      />
+    );
+    it('should add the locale to the project', () => {
+      const { container } = render(<TestComponent />, { dataLocale: 'de' });
+      expect(container).toHaveTextContent('de');
+    });
+  });
+
+  describe('environment', () => {
+    const TestComponent = () => (
+      <GetApplicationState
+        render={applicationState =>
+          [
+            applicationState.environment.location,
+            applicationState.environment.env,
+          ].join(' ')
+        }
+      />
+    );
+
+    it('should render with defaults', () => {
+      const { container, environment } = render(<TestComponent />);
+      // shows that data gets merged and overwrites have priority
+      expect(container).toHaveTextContent('eu production');
+      // the project should be returned from "render"
+      expect(environment).toEqual({
+        frontendHost: 'localhost:3001',
+        mcApiUrl: 'https://mc-api.commercetools.com',
+        location: 'eu',
+        env: 'production',
+        cdnUrl: 'http://localhost:3001',
+        servedByProxy: false,
+      });
+    });
+
+    it('should respect user overwrites', () => {
+      const { container, environment } = render(<TestComponent />, {
+        environment: { location: 'us' },
+      });
+      // shows that data gets merged and overwrites have priority
+      expect(container).toHaveTextContent('us production');
+      // the merged project should be returned from "render"
+      expect(environment).toEqual({
+        frontendHost: 'localhost:3001',
+        mcApiUrl: 'https://mc-api.commercetools.com',
+        location: 'us',
+        env: 'production',
+        cdnUrl: 'http://localhost:3001',
+        servedByProxy: false,
+      });
+    });
+  });
+});
+
+describe('router', () => {
+  const TestComponent = () => (
+    <Switch>
+      <Route path="/foo" render={() => 'Foo'} />
+      {/* Define a catch-all route */}
+      <Route render={() => 'None'} />
+    </Switch>
+  );
+  it('should render fallback when no route is provided', () => {
+    const { container } = render(<TestComponent />);
+    expect(container).not.toHaveTextContent('Foo');
+    expect(container).not.toHaveTextContent('Bar');
+    expect(container).toHaveTextContent('None');
+  });
+  it('should render allow routing', () => {
+    const { container } = render(<TestComponent />, { route: '/foo' });
+    expect(container).toHaveTextContent('Foo');
+    expect(container).not.toHaveTextContent('Bar');
+    expect(container).not.toHaveTextContent('None');
+  });
+  it('should return a history object', () => {
+    const { history } = render(<TestComponent />, { route: '/foo' });
+    expect(history.location.pathname).toBe('/foo');
+  });
+});

--- a/packages/application-shell/src/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils.spec.js
@@ -9,10 +9,10 @@ import { injectIntl } from 'react-intl';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import { injectFeatureToggle } from '@flopflip/react-broadcast';
+import { GetApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { Switch, Route } from 'react-router';
 import { render, wait } from './test-utils';
-import { GetApplicationState } from '../../application-shell-connectors';
-import { RestrictedByPermissions } from '../../permissions';
 
 describe('Intl', () => {
   const TestComponent = injectIntl(props => props.intl.locale);

--- a/packages/application-shell/src/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils.spec.js
@@ -12,6 +12,7 @@ import { injectFeatureToggle } from '@flopflip/react-broadcast';
 import { Switch, Route } from 'react-router';
 import { render, wait } from './test-utils';
 import { GetApplicationState } from '../../application-shell-connectors';
+import { RestrictedByPermissions } from '../../permissions';
 
 describe('Intl', () => {
   const TestComponent = injectIntl(props => props.intl.locale);
@@ -147,9 +148,7 @@ describe('ApplicationState', () => {
         key: 'test-with-big-data',
         languages: ['de', 'en-GB'],
         name: 'Test with big data',
-        permissions: {
-          canManageProject: true,
-        },
+        permissions: { canManageProject: true },
         version: 43,
       });
     });
@@ -170,6 +169,26 @@ describe('ApplicationState', () => {
         permissions: { canManageProject: true },
         version: 43,
       });
+    });
+  });
+
+  describe('permissions', () => {
+    const TestComponent = () => (
+      <RestrictedByPermissions
+        permissions={[{ mode: 'manage', resource: 'products' }]}
+      >
+        {({ isAuthorized }) => (isAuthorized ? 'Authorized' : 'Not allowed')}
+      </RestrictedByPermissions>
+    );
+    it('should have all permissions by default', () => {
+      const { container } = render(<TestComponent />);
+      expect(container).toHaveTextContent('Authorized');
+    });
+    it('should allow overwriting permissions', () => {
+      const { container } = render(<TestComponent />, {
+        project: { permissions: {} },
+      });
+      expect(container).toHaveTextContent('Not allowed');
     });
   });
 


### PR DESCRIPTION
This enhances the capabilities of our `test-utils`.

The application-kit exports `render` (and a bunch of other `react-testing-library` functions) from `@commercetools-frontend/application-shell/src/test-utils`. The `test-utils` file contains a `render` function which can be used to render any component as-if it was rendered by `AppShell`. The `render` function sets up the context providers for the component-under-test. It accepts some options which influence what that context looks like.

The context includes:
- `IntlProvider`
- `ApolloProvider`
- `ConfigureFlopFlip`
- `ApplicationStateProvider`
- `Router`
- permissions


Tests in applications can now test their components using this `render` function like so:

```jsx
// The component under test

// A dumb component which prints the users first and last name
const Username = () => (
  <GetApplicationState
    render={applicationState =>
      [
        applicationState.user.firstName,
        applicationState.user.lastName,
      ].join(' ')
    }
  />
);
export default Username
```

```jsx
// a test
import { render } from '@commercetools-frontend/application-shell/src/test-utils'
import Username from './username'

describe('Username', () => {
  it('should print the user name', () => {
    const { container } = render(<Username />);
    expect(container).toHaveTextContent('Sheldon Cooper');
  });

  // it is also possible to overwrite the default values
  it('should be possible to overwrite', () => {
    const { container } = render(<Username />, {
      user: { firstName: 'Leonard', lastName: 'Hofstadter' }
    });
    expect(container).toHaveTextContent('Leonard Hofstadter');
  });

  // it is even possible to access the defaults because the "render" method returns them
  it('should be possible to overwrite', () => {
    const { container, user } = render(<Username />, {
      user: { firstName: 'Leonard', lastName: 'Hofstadter' }
    });
    expect(container).toHaveTextContent(user.firstName + ' ' + user.lastName);
  });
});
```

This also works for feature flags, permissions, projects and so on. See the `test-utils.spec.js` file of this PR to find out which providers `test-utils` influences.
