### PR TITLE
fix: circular dependency fix

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -25,6 +25,7 @@
     "npm": ">=5"
   },
   "dependencies": {
+    "@babel/runtime": "7.1.2",
     "@commercetools-frontend/actions-global": "1.0.0-rc.3",
     "@commercetools-frontend/application-shell-connectors": "1.0.0-rc.3",
     "@commercetools-frontend/browser-history": "1.0.0-rc.3",
@@ -86,7 +87,8 @@
     "redux-thunk": "2.3.0",
     "reselect": "3.0.1",
     "unfetch": "3.1.1",
-    "uuid": "3.3.2"
+    "uuid": "3.3.2",
+    "warning": "4.0.2"
   },
   "devDependencies": {
     "@commercetools-frontend/ui-kit": "2.0.0-rc.11",

--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -1,6 +1,10 @@
 import { ApolloLink } from 'apollo-link';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { getCorrelationId, selectProjectKeyFromUrl } from '../utils';
+import {
+  getCorrelationId,
+  selectProjectKeyFromUrl,
+  selectUserId,
+} from '../utils';
 
 const isKnownTarget = target => Object.values(GRAPHQL_TARGETS).includes(target);
 
@@ -13,8 +17,6 @@ const headerLink = new ApolloLink((operation, forward) => {
       `GraphQL target "${target}" is missing or is not supported`
     );
 
-  const { cache } = operation.getContext();
-
   /**
    * NOTE:
    *   The project key is read from the url in a project related appliation context.
@@ -25,12 +27,13 @@ const headerLink = new ApolloLink((operation, forward) => {
    */
   const projectKey =
     operation.variables.projectKey || selectProjectKeyFromUrl();
+  const userId = selectUserId({ apolloCache: operation.getContext().cache });
 
   // NOTE: keep header names with capital letters to avoid possible conflicts or problems with nginx.
   operation.setContext({
     headers: {
       'X-Project-Key': projectKey,
-      'X-Correlation-Id': getCorrelationId(cache),
+      'X-Correlation-Id': getCorrelationId({ userId }),
       'X-Graphql-Target': target,
     },
   });

--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -13,6 +13,8 @@ const headerLink = new ApolloLink((operation, forward) => {
       `GraphQL target "${target}" is missing or is not supported`
     );
 
+  const { cache } = operation.getContext();
+
   /**
    * NOTE:
    *   The project key is read from the url in a project related appliation context.
@@ -28,7 +30,7 @@ const headerLink = new ApolloLink((operation, forward) => {
   operation.setContext({
     headers: {
       'X-Project-Key': projectKey,
-      'X-Correlation-Id': getCorrelationId(),
+      'X-Correlation-Id': getCorrelationId(cache),
       'X-Graphql-Target': target,
     },
   });

--- a/packages/application-shell/src/apollo-links/header-link.spec.js
+++ b/packages/application-shell/src/apollo-links/header-link.spec.js
@@ -2,11 +2,13 @@ import { ApolloLink, execute, Observable } from 'apollo-link';
 import gql from 'graphql-tag';
 import waitFor from 'wait-for-observables';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import { getCorrelationId } from '../utils';
 import headerLink from './header-link';
 
 jest.mock('../utils/', () => ({
-  getCorrelationId: () => 'test-correlation-id',
+  getCorrelationId: jest.fn(() => 'test-correlation-id'),
   selectProjectKeyFromUrl: jest.fn(() => 'project-1'),
+  selectUserId: jest.fn(() => 'user-1'),
 }));
 
 describe('headerLink', () => {
@@ -74,6 +76,10 @@ describe('with valid target', () => {
         'X-Correlation-Id': 'test-correlation-id',
       })
     );
+  });
+
+  it('should pass "userId" param to "getCorrelationId"', () => {
+    expect(getCorrelationId).toHaveBeenCalledWith({ userId: 'user-1' });
   });
 
   describe('with project key in variables', () => {

--- a/packages/application-shell/src/configure-store.js
+++ b/packages/application-shell/src/configure-store.js
@@ -21,7 +21,17 @@ import loggerMiddleware, { actionTransformer } from './middleware/logger';
 import sentryTrackingMiddleware from './middleware/sentry-tracking';
 import { activePluginReducer } from './components/inject-reducer';
 import { requestsInFlightReducer } from './components/requests-in-flight-loader';
-import { getCorrelationId, selectProjectKeyFromUrl } from './utils';
+import apolloClient from './configure-apollo';
+import {
+  getCorrelationId,
+  selectProjectKeyFromUrl,
+  selectUserId,
+} from './utils';
+
+const patchedGetCorrelationId = () =>
+  getCorrelationId({
+    userId: selectUserId({ apolloCache: apolloClient }),
+  });
 
 // We use a factory as it's more practicable for tests
 // The application can import the configured store (the default export)
@@ -29,7 +39,7 @@ export const createReduxStore = (
   preloadedState = { requestsInFlight: null }
 ) => {
   const sdkMiddleware = createSdkMiddleware({
-    getCorrelationId,
+    getCorrelationId: patchedGetCorrelationId,
     getProjectKey: selectProjectKeyFromUrl,
   });
 

--- a/packages/application-shell/src/utils/get-correlation-id/__snapshots__/get-correlation-id.spec.js.snap
+++ b/packages/application-shell/src/utils/get-correlation-id/__snapshots__/get-correlation-id.spec.js.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`getCorrelationId should match snapshot 1`] = `"mc/test-project-key/test-user-id/test-uuid"`;
-
-exports[`getCorrelationId without \`userId\` should match snapshot 1`] = `"mc/test-project-key/test-uuid"`;

--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
@@ -1,8 +1,8 @@
 import uuid from 'uuid/v4';
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
-import selectUserId from '../select-user-id';
 
-export default cache =>
-  ['mc', selectProjectKeyFromUrl(), selectUserId(cache), uuid()]
+export default function getCorrelationId({ userId } = {}) {
+  return ['mc', selectProjectKeyFromUrl(), userId, uuid()]
     .filter(Boolean)
     .join('/');
+}

--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
@@ -2,7 +2,7 @@ import uuid from 'uuid/v4';
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
 import selectUserId from '../select-user-id';
 
-export default () =>
-  ['mc', selectProjectKeyFromUrl(), selectUserId(), uuid()]
+export default cache =>
+  ['mc', selectProjectKeyFromUrl(), selectUserId(cache), uuid()]
     .filter(Boolean)
     .join('/');

--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.spec.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.spec.js
@@ -1,12 +1,10 @@
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
-import selectUserId from '../select-user-id';
 import getCorrelationId from './get-correlation-id';
 
 jest.mock('uuid/v4', () => () => 'test-uuid');
 jest.mock('../select-project-key-from-url', () =>
   jest.fn(() => 'test-project-key')
 );
-jest.mock('../select-user-id', () => jest.fn(() => 'test-user-id'));
 
 describe('getCorrelationId', () => {
   let correlationId;
@@ -15,26 +13,32 @@ describe('getCorrelationId', () => {
     correlationId = getCorrelationId();
   });
 
-  it('should match snapshot', () => {
-    expect(correlationId).toMatchSnapshot();
-  });
-
-  it('should invoke `selectUserId`', () => {
-    expect(selectUserId).toHaveBeenCalled();
-  });
-
   it('should invoke `selectProjectKeyFromUrl`', () => {
     expect(selectProjectKeyFromUrl).toHaveBeenCalled();
   });
 
+  describe('with `userId`', () => {
+    beforeEach(() => {
+      correlationId = getCorrelationId({ userId: 'user-1' });
+    });
+
+    it('should build correlation id', () => {
+      expect(correlationId).toBe('mc/test-project-key/user-1/test-uuid');
+    });
+
+    it('should not contain `null`', () => {
+      // NOTE: `'null'` would be stringified.
+      expect(correlationId).not.toEqual(expect.stringContaining('null'));
+    });
+  });
+
   describe('without `userId`', () => {
     beforeEach(() => {
-      selectUserId.mockReturnValue(null);
       correlationId = getCorrelationId();
     });
 
-    it('should match snapshot', () => {
-      expect(correlationId).toMatchSnapshot();
+    it('should build correlation id', () => {
+      expect(correlationId).toBe('mc/test-project-key/test-uuid');
     });
 
     it('should not contain `null`', () => {

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.js
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.js
@@ -1,9 +1,8 @@
-import apolloClient from '../../configure-apollo';
 import UserIdQuery from './select-user-id.graphql';
 
-export default () => {
+export default cache => {
   try {
-    const queryResult = apolloClient.readQuery({
+    const queryResult = cache.readQuery({
       query: UserIdQuery,
     });
 

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.js
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.js
@@ -1,8 +1,8 @@
 import UserIdQuery from './select-user-id.graphql';
 
-export default cache => {
+export default function selectUserId({ apolloCache }) {
   try {
-    const queryResult = cache.readQuery({
+    const queryResult = apolloCache.readQuery({
       query: UserIdQuery,
     });
 
@@ -14,4 +14,4 @@ export default cache => {
   }
 
   return null;
-};
+}

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.spec.js
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.spec.js
@@ -1,17 +1,16 @@
-import apolloClient from '../../configure-apollo';
 import selectUserId from './select-user-id';
 
-jest.mock('../../configure-apollo', () => ({
+const cache = {
   readQuery: jest.fn(),
-}));
+};
 
 describe('selectUserId', () => {
   describe('when `readQuery` throws', () => {
     beforeEach(() => {
-      apolloClient.readQuery.mockReturnValueOnce(new Error('Test Error'));
+      cache.readQuery.mockReturnValueOnce(new Error('Test Error'));
     });
     it('should return `null`', () => {
-      expect(selectUserId()).toBeNull();
+      expect(selectUserId(cache)).toBeNull();
     });
   });
 
@@ -24,19 +23,19 @@ describe('selectUserId', () => {
 
     describe('with `user`', () => {
       beforeEach(() => {
-        apolloClient.readQuery.mockReturnValueOnce(queryResult);
+        cache.readQuery.mockReturnValueOnce(queryResult);
       });
       it('should return the `id`', () => {
-        expect(selectUserId()).toEqual(queryResult.user.id);
+        expect(selectUserId(cache)).toEqual(queryResult.user.id);
       });
     });
 
     describe('without `user`', () => {
       beforeEach(() => {
-        apolloClient.readQuery.mockReturnValueOnce({});
+        cache.readQuery.mockReturnValueOnce({});
       });
       it('should return `null`', () => {
-        expect(selectUserId()).toBeNull();
+        expect(selectUserId(cache)).toBeNull();
       });
     });
   });

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.spec.js
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.spec.js
@@ -1,16 +1,16 @@
 import selectUserId from './select-user-id';
 
-const cache = {
+const apolloCache = {
   readQuery: jest.fn(),
 };
 
 describe('selectUserId', () => {
   describe('when `readQuery` throws', () => {
     beforeEach(() => {
-      cache.readQuery.mockReturnValueOnce(new Error('Test Error'));
+      apolloCache.readQuery.mockReturnValueOnce(new Error('Test Error'));
     });
     it('should return `null`', () => {
-      expect(selectUserId(cache)).toBeNull();
+      expect(selectUserId({ apolloCache })).toBeNull();
     });
   });
 
@@ -23,19 +23,19 @@ describe('selectUserId', () => {
 
     describe('with `user`', () => {
       beforeEach(() => {
-        cache.readQuery.mockReturnValueOnce(queryResult);
+        apolloCache.readQuery.mockReturnValueOnce(queryResult);
       });
       it('should return the `id`', () => {
-        expect(selectUserId(cache)).toEqual(queryResult.user.id);
+        expect(selectUserId({ apolloCache })).toEqual(queryResult.user.id);
       });
     });
 
     describe('without `user`', () => {
       beforeEach(() => {
-        cache.readQuery.mockReturnValueOnce({});
+        apolloCache.readQuery.mockReturnValueOnce({});
       });
       it('should return `null`', () => {
-        expect(selectUserId(cache)).toBeNull();
+        expect(selectUserId({ apolloCache })).toBeNull();
       });
     });
   });

--- a/packages/sdk/middleware/middleware.js
+++ b/packages/sdk/middleware/middleware.js
@@ -30,7 +30,10 @@ const actionToUri = (action, projectKey) => {
   return service.build();
 };
 
-export default ({ getCorrelationId, getProjectKey }) => {
+export default function createSdkMiddleware({
+  getCorrelationId,
+  getProjectKey,
+}) {
   const client = createClient({ getCorrelationId });
 
   return ({ dispatch }) => next => action => {
@@ -69,7 +72,7 @@ export default ({ getCorrelationId, getProjectKey }) => {
           Accept: 'application/json',
           ...(action.payload.headers || {}),
           ...(shouldRenewToken ? { 'X-Force-Token': 'true' } : {}),
-          ...{ 'X-Project-Key': projectKey },
+          'X-Project-Key': projectKey,
         };
         const body =
           action.payload.method === 'POST' ? action.payload.payload : undefined;
@@ -128,4 +131,4 @@ export default ({ getCorrelationId, getProjectKey }) => {
     }
     return next(action);
   };
-};
+}


### PR DESCRIPTION
![2e5a77bc32a7eaae461f16e900e91d24b9fb25fce5d1dfec57f422e5f3f0b842](https://user-images.githubusercontent.com/2425013/48127145-4fab0000-e283-11e8-81ce-31e17d992a39.jpg)

#### Summary

Currently, in our `header-link`, we are using apolloClient to read query to get the user id. This causes a circular dependency that looks something like


```(!) Circular dependency: src/configure-apollo.js -> src/apollo-links/index.js -> src/apollo-links/header-link.js -> src/utils/index.js -> src/utils/select-user-id/index.js -> src/utils/select-user-id/select-user-id.js -> src/configure-apollo.js```

#### Approach

Instead of importing `apolloClient` in `select-user-id`, we pass in the cache, which we can get inside of the headerLink using `getContext()`. Then we execute getQuery on the cache. Also added two missing deps to `application-shell/package.json`

