### PR TITLE
refactor(app-shell): pass userId to getCorrelationId to avoid circular dependency

### DIFF
--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -1,6 +1,10 @@
 import { ApolloLink } from 'apollo-link';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { getCorrelationId, selectProjectKeyFromUrl } from '../utils';
+import {
+  getCorrelationId,
+  selectProjectKeyFromUrl,
+  selectUserId,
+} from '../utils';
 
 const isKnownTarget = target => Object.values(GRAPHQL_TARGETS).includes(target);
 
@@ -13,8 +17,6 @@ const headerLink = new ApolloLink((operation, forward) => {
       `GraphQL target "${target}" is missing or is not supported`
     );
 
-  const { cache } = operation.getContext();
-
   /**
    * NOTE:
    *   The project key is read from the url in a project related appliation context.
@@ -25,12 +27,13 @@ const headerLink = new ApolloLink((operation, forward) => {
    */
   const projectKey =
     operation.variables.projectKey || selectProjectKeyFromUrl();
+  const userId = selectUserId({ apolloCache: operation.getContext().cache });
 
   // NOTE: keep header names with capital letters to avoid possible conflicts or problems with nginx.
   operation.setContext({
     headers: {
       'X-Project-Key': projectKey,
-      'X-Correlation-Id': getCorrelationId(cache),
+      'X-Correlation-Id': getCorrelationId({ userId }),
       'X-Graphql-Target': target,
     },
   });

--- a/packages/application-shell/src/apollo-links/header-link.spec.js
+++ b/packages/application-shell/src/apollo-links/header-link.spec.js
@@ -2,11 +2,13 @@ import { ApolloLink, execute, Observable } from 'apollo-link';
 import gql from 'graphql-tag';
 import waitFor from 'wait-for-observables';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import { getCorrelationId } from '../utils';
 import headerLink from './header-link';
 
 jest.mock('../utils/', () => ({
-  getCorrelationId: () => 'test-correlation-id',
+  getCorrelationId: jest.fn(() => 'test-correlation-id'),
   selectProjectKeyFromUrl: jest.fn(() => 'project-1'),
+  selectUserId: jest.fn(() => 'user-1'),
 }));
 
 describe('headerLink', () => {
@@ -74,6 +76,10 @@ describe('with valid target', () => {
         'X-Correlation-Id': 'test-correlation-id',
       })
     );
+  });
+
+  it('should pass "userId" param to "getCorrelationId"', () => {
+    expect(getCorrelationId).toHaveBeenCalledWith({ userId: 'user-1' });
   });
 
   describe('with project key in variables', () => {

--- a/packages/application-shell/src/configure-store.js
+++ b/packages/application-shell/src/configure-store.js
@@ -21,7 +21,17 @@ import loggerMiddleware, { actionTransformer } from './middleware/logger';
 import sentryTrackingMiddleware from './middleware/sentry-tracking';
 import { activePluginReducer } from './components/inject-reducer';
 import { requestsInFlightReducer } from './components/requests-in-flight-loader';
-import { getCorrelationId, selectProjectKeyFromUrl } from './utils';
+import apolloClient from './configure-apollo';
+import {
+  getCorrelationId,
+  selectProjectKeyFromUrl,
+  selectUserId,
+} from './utils';
+
+const patchedGetCorrelationId = () =>
+  getCorrelationId({
+    userId: selectUserId({ apolloCache: apolloClient }),
+  });
 
 // We use a factory as it's more practicable for tests
 // The application can import the configured store (the default export)
@@ -29,7 +39,7 @@ export const createReduxStore = (
   preloadedState = { requestsInFlight: null }
 ) => {
   const sdkMiddleware = createSdkMiddleware({
-    getCorrelationId,
+    getCorrelationId: patchedGetCorrelationId,
     getProjectKey: selectProjectKeyFromUrl,
   });
 

--- a/packages/application-shell/src/utils/get-correlation-id/__snapshots__/get-correlation-id.spec.js.snap
+++ b/packages/application-shell/src/utils/get-correlation-id/__snapshots__/get-correlation-id.spec.js.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`getCorrelationId should match snapshot 1`] = `"mc/test-project-key/test-user-id/test-uuid"`;
-
-exports[`getCorrelationId without \`userId\` should match snapshot 1`] = `"mc/test-project-key/test-uuid"`;

--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
@@ -1,8 +1,8 @@
 import uuid from 'uuid/v4';
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
-import selectUserId from '../select-user-id';
 
-export default cache =>
-  ['mc', selectProjectKeyFromUrl(), selectUserId(cache), uuid()]
+export default function getCorrelationId({ userId } = {}) {
+  return ['mc', selectProjectKeyFromUrl(), userId, uuid()]
     .filter(Boolean)
     .join('/');
+}

--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.spec.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.spec.js
@@ -1,12 +1,10 @@
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
-import selectUserId from '../select-user-id';
 import getCorrelationId from './get-correlation-id';
 
 jest.mock('uuid/v4', () => () => 'test-uuid');
 jest.mock('../select-project-key-from-url', () =>
   jest.fn(() => 'test-project-key')
 );
-jest.mock('../select-user-id', () => jest.fn(() => 'test-user-id'));
 
 describe('getCorrelationId', () => {
   let correlationId;
@@ -15,26 +13,32 @@ describe('getCorrelationId', () => {
     correlationId = getCorrelationId();
   });
 
-  it('should match snapshot', () => {
-    expect(correlationId).toMatchSnapshot();
-  });
-
-  it('should invoke `selectUserId`', () => {
-    expect(selectUserId).toHaveBeenCalled();
-  });
-
   it('should invoke `selectProjectKeyFromUrl`', () => {
     expect(selectProjectKeyFromUrl).toHaveBeenCalled();
   });
 
+  describe('with `userId`', () => {
+    beforeEach(() => {
+      correlationId = getCorrelationId({ userId: 'user-1' });
+    });
+
+    it('should build correlation id', () => {
+      expect(correlationId).toBe('mc/test-project-key/user-1/test-uuid');
+    });
+
+    it('should not contain `null`', () => {
+      // NOTE: `'null'` would be stringified.
+      expect(correlationId).not.toEqual(expect.stringContaining('null'));
+    });
+  });
+
   describe('without `userId`', () => {
     beforeEach(() => {
-      selectUserId.mockReturnValue(null);
       correlationId = getCorrelationId();
     });
 
-    it('should match snapshot', () => {
-      expect(correlationId).toMatchSnapshot();
+    it('should build correlation id', () => {
+      expect(correlationId).toBe('mc/test-project-key/test-uuid');
     });
 
     it('should not contain `null`', () => {

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.js
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.js
@@ -1,8 +1,8 @@
 import UserIdQuery from './select-user-id.graphql';
 
-export default cache => {
+export default function selectUserId({ apolloCache }) {
   try {
-    const queryResult = cache.readQuery({
+    const queryResult = apolloCache.readQuery({
       query: UserIdQuery,
     });
 
@@ -14,4 +14,4 @@ export default cache => {
   }
 
   return null;
-};
+}

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.spec.js
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.spec.js
@@ -1,16 +1,16 @@
 import selectUserId from './select-user-id';
 
-const cache = {
+const apolloCache = {
   readQuery: jest.fn(),
 };
 
 describe('selectUserId', () => {
   describe('when `readQuery` throws', () => {
     beforeEach(() => {
-      cache.readQuery.mockReturnValueOnce(new Error('Test Error'));
+      apolloCache.readQuery.mockReturnValueOnce(new Error('Test Error'));
     });
     it('should return `null`', () => {
-      expect(selectUserId(cache)).toBeNull();
+      expect(selectUserId({ apolloCache })).toBeNull();
     });
   });
 
@@ -23,19 +23,19 @@ describe('selectUserId', () => {
 
     describe('with `user`', () => {
       beforeEach(() => {
-        cache.readQuery.mockReturnValueOnce(queryResult);
+        apolloCache.readQuery.mockReturnValueOnce(queryResult);
       });
       it('should return the `id`', () => {
-        expect(selectUserId(cache)).toEqual(queryResult.user.id);
+        expect(selectUserId({ apolloCache })).toEqual(queryResult.user.id);
       });
     });
 
     describe('without `user`', () => {
       beforeEach(() => {
-        cache.readQuery.mockReturnValueOnce({});
+        apolloCache.readQuery.mockReturnValueOnce({});
       });
       it('should return `null`', () => {
-        expect(selectUserId(cache)).toBeNull();
+        expect(selectUserId({ apolloCache })).toBeNull();
       });
     });
   });

--- a/packages/sdk/middleware/middleware.js
+++ b/packages/sdk/middleware/middleware.js
@@ -30,7 +30,10 @@ const actionToUri = (action, projectKey) => {
   return service.build();
 };
 
-export default ({ getCorrelationId, getProjectKey }) => {
+export default function createSdkMiddleware({
+  getCorrelationId,
+  getProjectKey,
+}) {
   const client = createClient({ getCorrelationId });
 
   return ({ dispatch }) => next => action => {
@@ -69,7 +72,7 @@ export default ({ getCorrelationId, getProjectKey }) => {
           Accept: 'application/json',
           ...(action.payload.headers || {}),
           ...(shouldRenewToken ? { 'X-Force-Token': 'true' } : {}),
-          ...{ 'X-Project-Key': projectKey },
+          'X-Project-Key': projectKey,
         };
         const body =
           action.payload.method === 'POST' ? action.payload.payload : undefined;
@@ -128,4 +131,4 @@ export default ({ getCorrelationId, getProjectKey }) => {
     }
     return next(action);
   };
-};
+}


### PR DESCRIPTION
Branches off #62 (to make the diff a bit more clear)

We now explicitly pass `userId` to the `getCorrelationId` function and `selectUserId` requires the apollo client/cache to be injected.