### PR TITLE
QuickAccess: allow opening in new tab by cmd+click or cmd+enter

### DIFF
--- a/packages/application-shell/src/components/quick-access/create-commands.js
+++ b/packages/application-shell/src/components/quick-access/create-commands.js
@@ -277,11 +277,11 @@ export default ({
       id: 'go/support',
       text: intl.formatMessage(messages.openSupport),
       keywords: ['Go to support'],
-      action: () =>
-        window.open(
-          `https://jira.commercetools.com/servicedesk/customer/portal/1/create/99`,
-          '_blank'
-        ),
+      action: {
+        type: 'go',
+        to:
+          'https://jira.commercetools.com/servicedesk/customer/portal/1/create/99',
+      },
     },
     {
       id: 'go/account-profile',
@@ -293,9 +293,7 @@ export default ({
       id: 'go/privacy-policy',
       text: intl.formatMessage(messages.showPrivacyPolicy),
       keywords: ['Open Privacy Policy'],
-      action: () => {
-        window.open('https://commercetools.com/privacy', '_blank');
-      },
+      action: { type: 'go', to: 'https://commercetools.com/privacy' },
     },
     {
       id: 'go/logout',

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -261,10 +261,15 @@ class QuickAccess extends React.Component {
     }
   };
 
-  executeCommand = command => {
+  executeCommand = (command, meta) => {
     if (typeof command.action === 'object') {
       if (command.action.type === 'go') {
-        this.props.history.push(command.action.to);
+        // open in new window
+        if (meta.openInNewTab) {
+          open(command.action.to, '_blank');
+        } else {
+          this.props.history.push(command.action.to);
+        }
       }
     }
     if (typeof command.action === 'function') {

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -47,6 +47,7 @@ const createTestProps = custom => ({
 describe('QuickAccess', () => {
   beforeEach(() => {
     gtm.track.mockReset();
+    global.open = jest.fn();
   });
 
   it('should open when pressing "f" on document body', async () => {
@@ -207,6 +208,86 @@ describe('QuickAccess', () => {
     fireEvent.keyUp(searchInput, { key: 'Enter' });
     expect(props.history.push).toHaveBeenCalledWith(
       '/test-with-big-data-44/dashboard'
+    );
+
+    // should close quick access
+    expect(container).toBeEmpty();
+  });
+
+  it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+enter', async () => {
+    const mocks = [createMatchlessSearchMock('Open dshbrd')];
+    const props = createTestProps();
+    const { getByTestId, container, getByText } = render(
+      <QuickAccess {...props} />,
+      { mocks }
+    );
+
+    // open quick-access
+    fireEvent.keyDown(document.body, { key: 'f' });
+    await waitForElement(() => getByTestId('quick-access-search-input'));
+
+    const searchInput = getByTestId('quick-access-search-input');
+    fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+    await waitForElement(() => getByText('Open Dashboard'));
+    fireEvent.keyDown(searchInput, { key: 'Enter', metaKey: true });
+    fireEvent.keyUp(searchInput, { key: 'Enter', metaKey: true });
+
+    expect(global.open).toHaveBeenCalledWith(
+      '/test-with-big-data-44/dashboard',
+      '_blank'
+    );
+
+    // should close quick access
+    expect(container).toBeEmpty();
+  });
+
+  it('should open dashboard in new tab when chosing the "Open Dashboard" command by click', async () => {
+    const mocks = [createMatchlessSearchMock('Open dshbrd')];
+    const props = createTestProps();
+    const { getByTestId, container, getByText } = render(
+      <QuickAccess {...props} />,
+      { mocks }
+    );
+
+    // open quick-access
+    fireEvent.keyDown(document.body, { key: 'f' });
+    await waitForElement(() => getByTestId('quick-access-search-input'));
+
+    const searchInput = getByTestId('quick-access-search-input');
+    fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+    await waitForElement(() => getByText('Open Dashboard'));
+    fireEvent.click(getByTestId('quick-access-result(go/dashboard)'));
+
+    expect(props.history.push).toHaveBeenCalledWith(
+      '/test-with-big-data-44/dashboard'
+    );
+
+    // should close quick access
+    expect(container).toBeEmpty();
+  });
+
+  it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+click', async () => {
+    const mocks = [createMatchlessSearchMock('Open dshbrd')];
+    const props = createTestProps();
+    const { getByTestId, container, getByText } = render(
+      <QuickAccess {...props} />,
+      { mocks }
+    );
+
+    // open quick-access
+    fireEvent.keyDown(document.body, { key: 'f' });
+    await waitForElement(() => getByTestId('quick-access-search-input'));
+
+    const searchInput = getByTestId('quick-access-search-input');
+    fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+    await waitForElement(() => getByText('Open Dashboard'));
+    fireEvent.click(getByTestId('quick-access-result(go/dashboard)'), {
+      metaKey: true,
+    });
+
+    expect(global.open).toHaveBeenCalledWith(
+      '/test-with-big-data-44/dashboard',
+      '_blank'
     );
 
     // should close quick access

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -214,31 +214,131 @@ describe('QuickAccess', () => {
     expect(container).toBeEmpty();
   });
 
-  it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+enter', async () => {
-    const mocks = [createMatchlessSearchMock('Open dshbrd')];
-    const props = createTestProps();
-    const { getByTestId, container, getByText } = render(
-      <QuickAccess {...props} />,
-      { mocks }
-    );
+  describe('on MacOS', () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'appVersion', {
+        value:
+          '5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36',
+        configurable: true,
+      });
+    });
+    it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+enter', async () => {
+      const mocks = [createMatchlessSearchMock('Open dshbrd')];
+      const props = createTestProps();
+      const { getByTestId, container, getByText } = render(
+        <QuickAccess {...props} />,
+        { mocks }
+      );
 
-    // open quick-access
-    fireEvent.keyDown(document.body, { key: 'f' });
-    await waitForElement(() => getByTestId('quick-access-search-input'));
+      // open quick-access
+      fireEvent.keyDown(document.body, { key: 'f' });
+      await waitForElement(() => getByTestId('quick-access-search-input'));
 
-    const searchInput = getByTestId('quick-access-search-input');
-    fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
-    await waitForElement(() => getByText('Open Dashboard'));
-    fireEvent.keyDown(searchInput, { key: 'Enter', metaKey: true });
-    fireEvent.keyUp(searchInput, { key: 'Enter', metaKey: true });
+      const searchInput = getByTestId('quick-access-search-input');
+      fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+      await waitForElement(() => getByText('Open Dashboard'));
+      fireEvent.keyDown(searchInput, { key: 'Enter', metaKey: true });
+      fireEvent.keyUp(searchInput, { key: 'Enter', metaKey: true });
 
-    expect(global.open).toHaveBeenCalledWith(
-      '/test-with-big-data-44/dashboard',
-      '_blank'
-    );
+      expect(global.open).toHaveBeenCalledWith(
+        '/test-with-big-data-44/dashboard',
+        '_blank'
+      );
 
-    // should close quick access
-    expect(container).toBeEmpty();
+      // should close quick access
+      expect(container).toBeEmpty();
+    });
+
+    it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+click', async () => {
+      const mocks = [createMatchlessSearchMock('Open dshbrd')];
+      const props = createTestProps();
+      const { getByTestId, container, getByText } = render(
+        <QuickAccess {...props} />,
+        { mocks }
+      );
+
+      // open quick-access
+      fireEvent.keyDown(document.body, { key: 'f' });
+      await waitForElement(() => getByTestId('quick-access-search-input'));
+
+      const searchInput = getByTestId('quick-access-search-input');
+      fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+      await waitForElement(() => getByText('Open Dashboard'));
+      fireEvent.click(getByTestId('quick-access-result(go/dashboard)'), {
+        metaKey: true,
+      });
+
+      expect(global.open).toHaveBeenCalledWith(
+        '/test-with-big-data-44/dashboard',
+        '_blank'
+      );
+
+      // should close quick access
+      expect(container).toBeEmpty();
+    });
+  });
+
+  describe('on Windows', () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'appVersion', {
+        value: 'Windows Holzkiste',
+        configurable: true,
+      });
+    });
+    it('should open dashboard in new tab when chosing the "Open Dashboard" command by ctrl+enter', async () => {
+      const mocks = [createMatchlessSearchMock('Open dshbrd')];
+      const props = createTestProps();
+      const { getByTestId, container, getByText } = render(
+        <QuickAccess {...props} />,
+        { mocks }
+      );
+
+      // open quick-access
+      fireEvent.keyDown(document.body, { key: 'f' });
+      await waitForElement(() => getByTestId('quick-access-search-input'));
+
+      const searchInput = getByTestId('quick-access-search-input');
+      fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+      await waitForElement(() => getByText('Open Dashboard'));
+      fireEvent.keyDown(searchInput, { key: 'Enter', ctrlKey: true });
+      fireEvent.keyUp(searchInput, { key: 'Enter', ctrlKey: true });
+
+      expect(global.open).toHaveBeenCalledWith(
+        '/test-with-big-data-44/dashboard',
+        '_blank'
+      );
+
+      // should close quick access
+      expect(container).toBeEmpty();
+    });
+
+    it('should open dashboard in new tab when chosing the "Open Dashboard" command by ctrl+click', async () => {
+      const mocks = [createMatchlessSearchMock('Open dshbrd')];
+      const props = createTestProps();
+      const { getByTestId, container, getByText } = render(
+        <QuickAccess {...props} />,
+        { mocks }
+      );
+
+      // open quick-access
+      fireEvent.keyDown(document.body, { key: 'f' });
+      await waitForElement(() => getByTestId('quick-access-search-input'));
+
+      const searchInput = getByTestId('quick-access-search-input');
+      fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+      await waitForElement(() => getByText('Open Dashboard'));
+      fireEvent.click(getByTestId('quick-access-result(go/dashboard)'), {
+        ctrlKey: true,
+      });
+
+      expect(global.open).toHaveBeenCalledWith(
+        '/test-with-big-data-44/dashboard',
+        '_blank'
+      );
+
+      // should close quick access
+      expect(container).toBeEmpty();
+    });
   });
 
   it('should open dashboard in new tab when chosing the "Open Dashboard" command by click', async () => {
@@ -260,34 +360,6 @@ describe('QuickAccess', () => {
 
     expect(props.history.push).toHaveBeenCalledWith(
       '/test-with-big-data-44/dashboard'
-    );
-
-    // should close quick access
-    expect(container).toBeEmpty();
-  });
-
-  it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+click', async () => {
-    const mocks = [createMatchlessSearchMock('Open dshbrd')];
-    const props = createTestProps();
-    const { getByTestId, container, getByText } = render(
-      <QuickAccess {...props} />,
-      { mocks }
-    );
-
-    // open quick-access
-    fireEvent.keyDown(document.body, { key: 'f' });
-    await waitForElement(() => getByTestId('quick-access-search-input'));
-
-    const searchInput = getByTestId('quick-access-search-input');
-    fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
-    await waitForElement(() => getByText('Open Dashboard'));
-    fireEvent.click(getByTestId('quick-access-result(go/dashboard)'), {
-      metaKey: true,
-    });
-
-    expect(global.open).toHaveBeenCalledWith(
-      '/test-with-big-data-44/dashboard',
-      '_blank'
     );
 
     // should close quick access


### PR DESCRIPTION
This adds a feature requested by @antonboyko to QuickAccess which allows opening the result in a new tab by pressing either <kbd>cmd+click</kbd> or by using <kbd>cmd+enter</kbd> when on the selected result. On windows the combination is <kbd>ctrl+click</kbd> or <kbd>ctrl+enter</kbd>.

This also gets rid of the behaviour where Privacy and Help were opened in a new tab/window by default.