### PR TITLE
refactor(app-state): rename to ApplicationContextProvider

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/README.md
+++ b/packages/application-shell-connectors/src/components/application-context/README.md
@@ -1,14 +1,14 @@
-# Connectors for `applicationState`
+# Connectors for `applicationContext`
 
-This component exposes getters/setters to set and retrieve the `applicationState`.
+This component exposes getters/setters to set and retrieve the `applicationContext`.
 
-> It uses the new React Context API, so it needs the `ApplicationStateProvider` up in the tree. This is done within the AppShell.
+> It uses the new React Context API, so it needs the `ApplicationContextProvider` up in the tree. This is done within the AppShell.
 
-Additionally it provides a HOC to inject the `applicationState`.
+Additionally it provides a HOC to inject the `applicationContext`.
 
-Use this component to access information about the `user`, `project` and application `environment`.
+Use this component to access information about `user`, `project` and `environment`.
 
-#### `user` fields
+#### `user`
 
 - `id`
 - `email`
@@ -17,7 +17,7 @@ Use this component to access information about the `user`, `project` and applica
 - `locale`
 - `timeZone`
 
-#### `project` fields
+#### `project`
 
 - `key`
 - `version`
@@ -25,10 +25,16 @@ Use this component to access information about the `user`, `project` and applica
 - `countries`
 - `currencies`
 - `languages`
-- `permissions`: an object containing boolean flags about the permissions of the logged in user for the selected project (e.g. `{ canViewProducts: true, canManageOrders: false, ... }`)
-- `dataLocale`: the selected project **locale** (from the locale switcher in the AppBar) used to render a localized field of the project data. The available values are based on the `project.languages`
 
-#### `environment` fields
+#### `permissions`
+
+An object containing boolean flags about the permissions of the logged in user for the selected project (e.g. `{ canViewProducts: true, canManageOrders: false, ... }`)
+
+#### `dataLocale`
+
+The selected project **locale** (from the locale switcher in the AppBar) used to render a localized field of the project data. The available values are based on the `project.languages`
+
+#### `environment`
 
 This object contains application specific environment information defined in the `env.json`. The object will then be available on runtime from `window.app`. However, to avoid accessing those values globally, we inject this object into the application context.
 
@@ -45,30 +51,33 @@ The following are common fields defined in `env.json`. However, each application
 
 ```js
 /* In the AppShell */
-<ApplicationStateProvider {{ /* props */ }}>
+<ApplicationContextProvider {{ /* props */ }}>
   <div>
     {/* ... */}
     {/* In the application specific code */}
-    <GetApplicationState
+    <GetApplicationContext
       render={({ user, project, environment }) => (
-        <div>{...}</div>
+        <div>
+          <h2>{`Hello ${user.firstName}`}</h2>
+          <p>{`You are currently in project "${project.key}"`}</p>
+        </div>
       )}
     />
   </div>
-</ApplicationStateProvider>
+</ApplicationContextProvider>
 ```
 
-You can also use the HOC `withApplicationState` that will inject a `applicationState` prop.
+You can also use the HOC `withApplicationContext` that will inject a `applicationContext` prop.
 
 ```js
-withApplicationState()(MyComponent);
+withApplicationContext()(MyComponent);
 ```
 
 ...or pass a mapping function as the first argument to return custom shape of the injected props
 
 ```js
-withApplicationState(applicationState => ({
-  projectKey: applicationState.project && applicationState.project.key,
-  userEmail: applicationState.user && applicationState.user.email,
+withApplicationContext(applicationContext => ({
+  projectKey: applicationContext.project && applicationContext.project.key,
+  userEmail: applicationContext.user && applicationContext.user.email,
 }))(MyComponent);
 ```

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.js
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ApplicationStateProvider } from './application-state';
+import { ApplicationContextProvider } from './application-context';
 
 describe('rendering', () => {
   let wrapper;
@@ -8,7 +8,7 @@ describe('rendering', () => {
   describe('Provider', () => {
     beforeEach(() => {
       wrapper = shallow(
-        <ApplicationStateProvider
+        <ApplicationContextProvider
           user={{
             id: 'u1',
             email: 'foo@bar.com',
@@ -45,7 +45,7 @@ describe('rendering', () => {
           }}
         >
           <div />
-        </ApplicationStateProvider>
+        </ApplicationContextProvider>
       );
     });
     it('should pass mapped user to Provider', () => {
@@ -74,9 +74,23 @@ describe('rendering', () => {
             countries: expect.any(Array),
             currencies: expect.any(Array),
             languages: expect.any(Array),
-            permissions: expect.any(Object),
-            dataLocale: expect.any(String),
           },
+        })
+      );
+    });
+    it('should pass mapped permissions to Provider', () => {
+      expect(wrapper).toHaveProp(
+        'value',
+        expect.objectContaining({
+          permissions: expect.any(Object),
+        })
+      );
+    });
+    it('should pass mapped dataLocale to Provider', () => {
+      expect(wrapper).toHaveProp(
+        'value',
+        expect.objectContaining({
+          dataLocale: expect.any(String),
         })
       );
     });

--- a/packages/application-shell-connectors/src/components/application-context/index.js
+++ b/packages/application-shell-connectors/src/components/application-context/index.js
@@ -1,0 +1,5 @@
+export { default } from './application-context';
+export {
+  ApplicationContextProvider,
+  withApplicationContext,
+} from './application-context';

--- a/packages/application-shell-connectors/src/components/application-state/index.js
+++ b/packages/application-shell-connectors/src/components/application-state/index.js
@@ -1,5 +1,0 @@
-export { default } from './application-state';
-export {
-  ApplicationStateProvider,
-  withApplicationState,
-} from './application-state';

--- a/packages/application-shell-connectors/src/index.js
+++ b/packages/application-shell-connectors/src/index.js
@@ -1,8 +1,8 @@
 export {
-  default as GetApplicationState,
-  ApplicationStateProvider,
-  withApplicationState,
-} from './components/application-state';
+  default as GetApplicationContext,
+  ApplicationContextProvider,
+  withApplicationContext,
+} from './components/application-context';
 
 export {
   default as GetProjectExtensionImageRegex,

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -11,7 +11,7 @@ import {
   reportErrorToSentry,
   SentryUserTracker,
 } from '@commercetools-frontend/sentry';
-import { ApplicationStateProvider } from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import { getSupportedLanguage } from '@commercetools-frontend/l10n';
@@ -96,7 +96,7 @@ export const RestrictedApplication = props => (
       }
 
       return (
-        <ApplicationStateProvider user={user} environment={props.environment}>
+        <ApplicationContextProvider user={user} environment={props.environment}>
           {/*
             NOTE: we do not want to load the locale data as long as we do not
             know the user setting. This is important in order to avoid flashing
@@ -173,7 +173,7 @@ export const RestrictedApplication = props => (
                                       locales={project.languages}
                                     >
                                       {({ locale, setProjectDataLocale }) => (
-                                        <ApplicationStateProvider
+                                        <ApplicationContextProvider
                                           user={user}
                                           project={project}
                                           projectDataLocale={locale}
@@ -188,7 +188,7 @@ export const RestrictedApplication = props => (
                                             history={routeProps.history}
                                             user={user}
                                           />
-                                        </ApplicationStateProvider>
+                                        </ApplicationContextProvider>
                                       )}
                                     </ProjectDataLocale>
                                   );
@@ -230,7 +230,7 @@ export const RestrictedApplication = props => (
                                   return <LoadingNavBar />;
 
                                 return (
-                                  <ApplicationStateProvider
+                                  <ApplicationContextProvider
                                     user={user}
                                     project={project}
                                     environment={props.environment}
@@ -242,7 +242,7 @@ export const RestrictedApplication = props => (
                                         props.INTERNAL__isApplicationFallback
                                       }
                                     />
-                                  </ApplicationStateProvider>
+                                  </ApplicationContextProvider>
                                 );
                               }}
                             </FetchProject>
@@ -334,7 +334,7 @@ export const RestrictedApplication = props => (
               </ConfigureIntlProvider>
             )}
           </AsyncLocaleData>
-        </ApplicationStateProvider>
+        </ApplicationContextProvider>
       );
     }}
   </FetchUser>
@@ -419,7 +419,7 @@ export default class ApplicationShell extends React.Component {
   }
   render() {
     return (
-      <ApplicationStateProvider environment={this.props.environment}>
+      <ApplicationContextProvider environment={this.props.environment}>
         <ApolloProvider client={apolloClient}>
           <React.Fragment>
             {/* <VersionCheckSubscriber /> */}
@@ -480,7 +480,7 @@ export default class ApplicationShell extends React.Component {
             </Router>
           </React.Fragment>
         </ApolloProvider>
-      </ApplicationStateProvider>
+      </ApplicationContextProvider>
     );
   }
 }

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -4,7 +4,7 @@ import { ReconfigureFlopFlip } from '@flopflip/react-broadcast';
 import { DOMAINS } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
-import { ApplicationStateProvider } from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import * as appShellUtils from '../../utils';
 import ConfigureIntlProvider from '../configure-intl-provider';
 import ProjectContainer from '../project-container';
@@ -74,8 +74,8 @@ describe('rendering', () => {
     wrapper = shallow(<ApplicationShell {...props} />);
   });
   describe('providers', () => {
-    it('should pass "environment" to <ApplicationStateProvider>', () => {
-      expect(wrapper.find(ApplicationStateProvider)).toHaveProp(
+    it('should pass "environment" to <ApplicationContextProvider>', () => {
+      expect(wrapper.find(ApplicationContextProvider)).toHaveProp(
         'environment',
         props.environment
       );
@@ -205,14 +205,14 @@ describe('<RestrictedApplication>', () => {
       it('should pass "locale" as undefined to <AsyncLocaleData>', () => {
         expect(wrapper.find(AsyncLocaleData)).toHaveProp('locale', undefined);
       });
-      it('should pass "user" as undefined to <ApplicationStateProvider>', () => {
-        expect(wrapper.find(ApplicationStateProvider)).toHaveProp(
+      it('should pass "user" as undefined to <ApplicationContextProvider>', () => {
+        expect(wrapper.find(ApplicationContextProvider)).toHaveProp(
           'user',
           undefined
         );
       });
-      it('should pass "environment" to <ApplicationStateProvider>', () => {
-        expect(wrapper.find(ApplicationStateProvider)).toHaveProp(
+      it('should pass "environment" to <ApplicationContextProvider>', () => {
+        expect(wrapper.find(ApplicationContextProvider)).toHaveProp(
           'environment',
           props.environment
         );
@@ -226,14 +226,14 @@ describe('<RestrictedApplication>', () => {
           .find(FetchUser)
           .renderProp('children', userData);
       });
-      it('should pass "user" to <ApplicationStateProvider>', () => {
-        expect(wrapper.find(ApplicationStateProvider)).toHaveProp(
+      it('should pass "user" to <ApplicationContextProvider>', () => {
+        expect(wrapper.find(ApplicationContextProvider)).toHaveProp(
           'user',
           userData.user
         );
       });
-      it('should pass "environment" to <ApplicationStateProvider>', () => {
-        expect(wrapper.find(ApplicationStateProvider)).toHaveProp(
+      it('should pass "environment" to <ApplicationContextProvider>', () => {
+        expect(wrapper.find(ApplicationContextProvider)).toHaveProp(
           'environment',
           props.environment
         );
@@ -300,8 +300,8 @@ describe('<RestrictedApplication>', () => {
           })
         );
       });
-      it('should not render <ApplicationStateProvider>', () => {
-        expect(wrapper).not.toRender(ApplicationStateProvider);
+      it('should not render <ApplicationContextProvider>', () => {
+        expect(wrapper).not.toRender(ApplicationContextProvider);
       });
     });
 
@@ -367,20 +367,20 @@ describe('<RestrictedApplication>', () => {
               project,
             });
         });
-        it('should pass "user" to <ApplicationStateProvider>', () => {
-          expect(wrapperAside.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "user" to <ApplicationContextProvider>', () => {
+          expect(wrapperAside.find(ApplicationContextProvider)).toHaveProp(
             'user',
             userData.user
           );
         });
-        it('should pass "project" to <ApplicationStateProvider>', () => {
-          expect(wrapperAside.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "project" to <ApplicationContextProvider>', () => {
+          expect(wrapperAside.find(ApplicationContextProvider)).toHaveProp(
             'project',
             project
           );
         });
-        it('should pass "environment" to <ApplicationStateProvider>', () => {
-          expect(wrapperAside.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "environment" to <ApplicationContextProvider>', () => {
+          expect(wrapperAside.find(ApplicationContextProvider)).toHaveProp(
             'environment',
             props.environment
           );

--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -80,13 +80,13 @@ export { ProjectQuery, FetchProject };
 // Exports with deprecated warnings
 const DeprecatedFetchProject = deprecateComponent({
   message:
-    'The "FetchProject" component has been deprecated and will be removed in the next major release. Please use "GetApplicationState" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
+    'The "FetchProject" component has been deprecated and will be removed in the next major release. Please use "GetApplicationContext" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
 })(FetchProjectData);
 const deprecatedWithProject = mapDataToProps => Component => {
   const WrappedComponent = withProject(mapDataToProps)(Component);
   return deprecateComponent({
     message:
-      'The "withProject" HOC has been deprecated and will be removed in the next major release. Please use "withApplicationState" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
+      'The "withProject" HOC has been deprecated and will be removed in the next major release. Please use "withApplicationContext" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
   })(WrappedComponent);
 };
 export { DeprecatedFetchProject, deprecatedWithProject };

--- a/packages/application-shell/src/components/fetch-user/fetch-user.js
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.js
@@ -79,13 +79,13 @@ export { LoggedInUserQuery, FetchUser };
 // Exports with deprecated warnings
 const DeprecatedFetchUser = deprecateComponent({
   message:
-    'The "FetchUser" component has been deprecated and will be removed in the next major release. Please use "GetApplicationState" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
+    'The "FetchUser" component has been deprecated and will be removed in the next major release. Please use "GetApplicationContext" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
 })(FetchLoggedInUser);
 const deprecatedWithUser = mapDataToProps => Component => {
   const WrappedComponent = withUser(mapDataToProps)(Component);
   return deprecateComponent({
     message:
-      'The "withUser" HOC has been deprecated and will be removed in the next major release. Please use "withApplicationState" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
+      'The "withUser" HOC has been deprecated and will be removed in the next major release. Please use "withApplicationContext" from `@commercetools-frontend/application-shell-connectors` to access "user" and "project" information.',
   })(WrappedComponent);
 };
 export { DeprecatedFetchUser, deprecatedWithUser };

--- a/packages/application-shell/src/components/login-locked/__snapshots__/login-locked.spec.js.snap
+++ b/packages/application-shell/src/components/login-locked/__snapshots__/login-locked.spec.js.snap
@@ -44,7 +44,7 @@ exports[`LockedAccount rendering rendering should match snapshot 1`] = `
 `;
 
 exports[`ResetPasswordLink rendering rendering should match snapshot 1`] = `
-<GetApplicationState
+<GetApplicationContext
   render={[Function]}
 />
 `;

--- a/packages/application-shell/src/components/login-locked/login-locked.js
+++ b/packages/application-shell/src/components/login-locked/login-locked.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { GetApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { GetApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { Text } from '@commercetools-frontend/ui-kit';
 import { ProjectSuspendedSVG } from '@commercetools-frontend/assets';
 import ServicePageResponseLayout from '../../from-core/service-page-response-layout';
@@ -16,7 +16,7 @@ export const HelpDeskLink = () => (
 HelpDeskLink.displayName = 'HelpDeskLink';
 
 export const ResetPasswordLink = () => (
-  <GetApplicationState
+  <GetApplicationContext
     render={({ environment }) => (
       <a href={`${environment.adminCenterUrl}/reset-password`} target="_blank">
         <FormattedMessage {...messages.resetPasswordLink} />

--- a/packages/application-shell/src/components/login/login.js
+++ b/packages/application-shell/src/components/login/login.js
@@ -8,7 +8,7 @@ import { actions as sdkActions } from '@commercetools-frontend/sdk';
 import { Spacings, PrimaryButton } from '@commercetools-frontend/ui-kit';
 import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import * as storage from '@commercetools-frontend/storage';
-import { withApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { Notification } from '@commercetools-frontend/react-notifications';
 import InfoDialog from '../../from-core/info-dialog';
 import Title from '../../from-core/title';
@@ -316,8 +316,8 @@ const mapDispatchToProps = dispatch => ({
 
 export default compose(
   injectIntl,
-  withApplicationState(applicationState => ({
-    adminCenterUrl: applicationState.environment.adminCenterUrl,
+  withApplicationContext(({ environment }) => ({
+    adminCenterUrl: environment.adminCenterUrl,
   })),
   connect(
     null,

--- a/packages/application-shell/src/components/navbar/__snapshots__/navbar.spec.js.snap
+++ b/packages/application-shell/src/components/navbar/__snapshots__/navbar.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering <ToggledWithPermissions> <RestrictedByPermissions> when permissions are defined should match snapshot 1`] = `
-<withApplicationState(RestrictedByPermissions)
+<withApplicationContext(RestrictedByPermissions)
   permissions={
     Array [
       "ViewProducts",
@@ -10,5 +10,5 @@ exports[`rendering <ToggledWithPermissions> <RestrictedByPermissions> when permi
   shouldMatchSomePermissions={true}
 >
   <ItemChild />
-</withApplicationState(RestrictedByPermissions)>
+</withApplicationContext(RestrictedByPermissions)>
 `;

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -7,7 +7,7 @@ import isNil from 'lodash.isnil';
 import { DOMAINS } from '@commercetools-frontend/constants';
 import * as storage from '@commercetools-frontend/storage';
 import { Notifier } from '@commercetools-frontend/react-notifications';
-import { ApplicationStateProvider } from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { STORAGE_KEYS, SUSPENSION_REASONS } from '../../constants';
 import ApplicationLoader from '../application-loader';
@@ -134,7 +134,7 @@ export class ProjectContainer extends React.Component {
           return (
             <ProjectDataLocale locales={project.languages}>
               {({ locale, setProjectDataLocale }) => (
-                <ApplicationStateProvider
+                <ApplicationContextProvider
                   user={this.props.user}
                   project={project}
                   projectDataLocale={locale}
@@ -174,7 +174,7 @@ export class ProjectContainer extends React.Component {
                      */}
                     {this.props.render()}
                   </React.Fragment>
-                </ApplicationStateProvider>
+                </ApplicationContextProvider>
               )}
             </ProjectDataLocale>
           );

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 import { shallow } from 'enzyme';
 import * as storage from '@commercetools-frontend/storage';
 import { Notifier } from '@commercetools-frontend/react-notifications';
-import { ApplicationStateProvider } from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import ProjectExpired from '../project-expired';
 import ProjectNotFound from '../project-not-found';
 import ProjectSuspended from '../project-suspended';
@@ -275,26 +275,26 @@ describe('rendering', () => {
               setProjectDataLocale: jest.fn(),
             });
         });
-        it('should pass "user" to <ApplicationStateProvider>', () => {
-          expect(wrapperDataLocale.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "user" to <ApplicationContextProvider>', () => {
+          expect(wrapperDataLocale.find(ApplicationContextProvider)).toHaveProp(
             'user',
             props.user
           );
         });
-        it('should pass "project" to <ApplicationStateProvider>', () => {
-          expect(wrapperDataLocale.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "project" to <ApplicationContextProvider>', () => {
+          expect(wrapperDataLocale.find(ApplicationContextProvider)).toHaveProp(
             'project',
             project
           );
         });
-        it('should pass "projectDataLocale" to <ApplicationStateProvider>', () => {
-          expect(wrapperDataLocale.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "projectDataLocale" to <ApplicationContextProvider>', () => {
+          expect(wrapperDataLocale.find(ApplicationContextProvider)).toHaveProp(
             'projectDataLocale',
             'de'
           );
         });
-        it('should pass "environment" to <ApplicationStateProvider>', () => {
-          expect(wrapperDataLocale.find(ApplicationStateProvider)).toHaveProp(
+        it('should pass "environment" to <ApplicationContextProvider>', () => {
+          expect(wrapperDataLocale.find(ApplicationContextProvider)).toHaveProp(
             'environment',
             props.environment
           );

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.js
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
-import { withApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import PageNotFound from '../../from-core/page-not-found';
 
 export class ForcePageReload extends React.PureComponent {
@@ -53,6 +53,6 @@ export class RouteCatchAll extends React.PureComponent {
   }
 }
 
-export default withApplicationState(applicationState => ({
-  servedByProxy: applicationState.environment.servedByProxy,
+export default withApplicationContext(({ environment }) => ({
+  servedByProxy: environment.servedByProxy,
 }))(RouteCatchAll);

--- a/packages/application-shell/src/components/version-check-subscriber/version-check-subscriber.js
+++ b/packages/application-shell/src/components/version-check-subscriber/version-check-subscriber.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { compose, setDisplayName } from 'recompose';
 import { connect } from 'react-redux';
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
-import { withApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 
 export class VersionCheckSubscriber extends React.PureComponent {
   static displayName = 'VersionCheckSubscriber';
 
   static propTypes = {
-    applicationState: PropTypes.shape({
+    applicationContext: PropTypes.shape({
       environment: PropTypes.shape({
         revision: PropTypes.string,
       }).isRequired,
@@ -23,7 +23,8 @@ export class VersionCheckSubscriber extends React.PureComponent {
         this.props.fetchServerVersion().then(
           data => {
             if (
-              data.revision !== this.props.applicationState.environment.revision
+              data.revision !==
+              this.props.applicationContext.environment.revision
             )
               // TODO: notify the user that a new version is available
               // Possible options:
@@ -61,7 +62,7 @@ const mapDispatchToProps = dispatch => ({
 
 export default compose(
   setDisplayName('VersionCheckSubscriber'),
-  withApplicationState(),
+  withApplicationContext(),
   connect(
     null,
     mapDispatchToProps

--- a/packages/application-shell/src/components/version-check-subscriber/version-check-subscriber.spec.js
+++ b/packages/application-shell/src/components/version-check-subscriber/version-check-subscriber.spec.js
@@ -5,7 +5,7 @@ import { VersionCheckSubscriber } from './version-check-subscriber';
 
 const createTestProps = props => ({
   fetchServerVersion: jest.fn(),
-  applicationState: {
+  applicationContext: {
     environment: {
       revision: '123',
     },

--- a/packages/application-shell/src/test-utils.js
+++ b/packages/application-shell/src/test-utils.js
@@ -12,7 +12,7 @@ import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
 import { MockedProvider as ApolloMockProvider } from 'react-apollo/test-utils';
 import memoryAdapter from '@flopflip/memory-adapter';
 import { Provider as StoreProvider } from 'react-redux';
-import { ApplicationStateProvider } from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { createReduxStore } from './configure-store';
 
 // Reset memoryAdapter after each test, so that the next test accepts the
@@ -48,8 +48,9 @@ const defaultProject = {
   countries: ['de', 'en'],
   currencies: ['EUR', 'GBP'],
   languages: ['de', 'en-GB'],
-  permissions: { canManageProject: true },
 };
+
+const defaultPermissions = { canManageProject: true };
 
 // Allow consumers of `render` to extend the defaults by passing an object
 // or to completely omit the value by passing `null`
@@ -81,11 +82,12 @@ const render = (
     // flopflip
     adpater = memoryAdapter,
     flags = {},
-    // application-state
-    dataLocale = 'en',
+    // application-context
     environment,
     user,
     project,
+    permissions = defaultPermissions,
+    dataLocale = 'en',
     // forwarding to react-testing-library
     ...renderOptions
   } = {}
@@ -98,14 +100,14 @@ const render = (
       <IntlProvider locale={locale}>
         <ApolloMockProvider mocks={mocks} addTypename={addTypename}>
           <ConfigureFlopFlip adapter={adpater} defaultFlags={flags}>
-            <ApplicationStateProvider
+            <ApplicationContextProvider
               user={mergedUser}
-              project={mergedProject}
+              project={{ ...mergedProject, permissions }}
               environment={mergedEnvironment}
               projectDataLocale={dataLocale}
             >
               <Router history={history}>{ui}</Router>
-            </ApplicationStateProvider>
+            </ApplicationContextProvider>
           </ConfigureFlopFlip>
         </ApolloMockProvider>
       </IntlProvider>,
@@ -116,11 +118,13 @@ const render = (
     // this to test implementation details).
     history,
     // Adding user, project & environment so tests know about the merge results
-    // Note that these objects do not resemble the application state, they are
+    // Note that these objects do not resemble the application context, they are
     // only intended to communicate the test setup back to the tests.
     user: mergedUser,
     project: mergedProject,
     environment: mergedEnvironment,
+    permissions,
+    dataLocale,
   };
 };
 

--- a/packages/application-shell/src/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils.spec.js
@@ -9,7 +9,7 @@ import { injectIntl } from 'react-intl';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import { injectFeatureToggle } from '@flopflip/react-broadcast';
-import { GetApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { GetApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { Switch, Route } from 'react-router';
 import { render, wait } from './test-utils';
@@ -80,16 +80,11 @@ describe('FlopFlip', () => {
   });
 });
 
-describe('ApplicationState', () => {
+describe('ApplicationContext', () => {
   describe('user', () => {
     const TestComponent = () => (
-      <GetApplicationState
-        render={applicationState =>
-          [
-            applicationState.user.firstName,
-            applicationState.user.lastName,
-          ].join(' ')
-        }
+      <GetApplicationContext
+        render={({ user }) => [user.firstName, user.lastName].join(' ')}
       />
     );
 
@@ -127,17 +122,13 @@ describe('ApplicationState', () => {
 
   describe('project', () => {
     const TestComponent = () => (
-      <GetApplicationState
-        render={applicationState =>
-          [applicationState.project.key, applicationState.project.name].join(
-            ' '
-          )
-        }
+      <GetApplicationContext
+        render={({ project }) => [project.key, project.name].join(' ')}
       />
     );
 
     it('should render with defaults', () => {
-      const { container, project } = render(<TestComponent />);
+      const { container, project, permissions } = render(<TestComponent />);
       expect(container).toHaveTextContent(
         'test-with-big-data Test with big data'
       );
@@ -148,13 +139,13 @@ describe('ApplicationState', () => {
         key: 'test-with-big-data',
         languages: ['de', 'en-GB'],
         name: 'Test with big data',
-        permissions: { canManageProject: true },
         version: 43,
       });
+      expect(permissions).toEqual({ canManageProject: true });
     });
 
     it('should respect user overwrites', () => {
-      const { container, project } = render(<TestComponent />, {
+      const { container, project, permissions } = render(<TestComponent />, {
         project: { name: 'Geek' },
       });
       // shows that data gets merged and overwrites have priority
@@ -166,9 +157,9 @@ describe('ApplicationState', () => {
         key: 'test-with-big-data',
         languages: ['de', 'en-GB'],
         name: 'Geek',
-        permissions: { canManageProject: true },
         version: 43,
       });
+      expect(permissions).toEqual({ canManageProject: true });
     });
   });
 
@@ -186,7 +177,7 @@ describe('ApplicationState', () => {
     });
     it('should allow overwriting permissions', () => {
       const { container } = render(<TestComponent />, {
-        project: { permissions: {} },
+        permissions: { canManageProducts: false },
       });
       expect(container).toHaveTextContent('Not allowed');
     });
@@ -194,9 +185,7 @@ describe('ApplicationState', () => {
 
   describe('dataLocale', () => {
     const TestComponent = () => (
-      <GetApplicationState
-        render={applicationState => applicationState.project.dataLocale}
-      />
+      <GetApplicationContext render={({ dataLocale }) => dataLocale} />
     );
     it('should add the locale to the project', () => {
       const { container } = render(<TestComponent />, { dataLocale: 'de' });
@@ -206,12 +195,9 @@ describe('ApplicationState', () => {
 
   describe('environment', () => {
     const TestComponent = () => (
-      <GetApplicationState
-        render={applicationState =>
-          [
-            applicationState.environment.location,
-            applicationState.environment.env,
-          ].join(' ')
+      <GetApplicationContext
+        render={({ environment }) =>
+          [environment.location, environment.env].join(' ')
         }
       />
     );

--- a/packages/permissions/src/components/authorized/authorized.js
+++ b/packages/permissions/src/components/authorized/authorized.js
@@ -5,7 +5,7 @@ import { defaultMemoize } from 'reselect';
 import warning from 'warning';
 import camelCase from 'lodash.camelcase';
 import upperFirst from 'lodash.upperfirst';
-import { GetApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { GetApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   hasSomePermissions,
   hasEveryPermissions,
@@ -72,12 +72,12 @@ const injectAuthorized = (
   propName = 'isAuthorized'
 ) => Component => {
   const WrappedComponent = props => (
-    <GetApplicationState
-      render={applicationState => (
+    <GetApplicationContext
+      render={applicationContext => (
         <Authorized
           shouldMatchSomePermissions={options.shouldMatchSomePermissions}
           demandedPermissions={demandedPermissions}
-          actualPermissions={applicationState.project.permissions}
+          actualPermissions={applicationContext.permissions}
           render={isAuthorized => (
             <Component {...props} {...{ [propName]: isAuthorized }} />
           )}

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.js
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash.isnil';
-import { withApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { permissions } from '../../constants';
 import Authorized from '../authorized';
 
@@ -34,10 +34,8 @@ export class RestrictedByPermissions extends React.Component {
     render: PropTypes.func,
 
     // Injected
-    applicationState: PropTypes.shape({
-      project: PropTypes.shape({
-        permissions: PropTypes.objectOf(PropTypes.bool).isRequired,
-      }).isRequired,
+    applicationContext: PropTypes.shape({
+      permissions: PropTypes.objectOf(PropTypes.bool).isRequired,
     }).isRequired,
   };
 
@@ -46,7 +44,7 @@ export class RestrictedByPermissions extends React.Component {
       <Authorized
         shouldMatchSomePermissions={this.props.shouldMatchSomePermissions}
         demandedPermissions={this.props.permissions}
-        actualPermissions={this.props.applicationState.project.permissions}
+        actualPermissions={this.props.applicationContext.permissions}
         render={isAuthorized => {
           if (typeof this.props.children === 'function')
             return this.props.children({
@@ -73,4 +71,4 @@ export class RestrictedByPermissions extends React.Component {
   }
 }
 
-export default withApplicationState()(RestrictedByPermissions);
+export default withApplicationContext()(RestrictedByPermissions);

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.js
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.js
@@ -9,12 +9,10 @@ const createTestProps = custom => ({
     { mode: 'view', resource: 'products' },
     { mode: 'view', resource: 'orders' },
   ],
-  applicationState: {
-    project: {
-      permissions: {
-        canViewProducts: true,
-        canViewOrders: true,
-      },
+  applicationContext: {
+    permissions: {
+      canViewProducts: true,
+      canViewOrders: true,
     },
   },
   ...custom,

--- a/playground/src/components/channels-list/channels-list.js
+++ b/playground/src/components/channels-list/channels-list.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { withApplicationState } from '@commercetools-frontend/application-shell-connectors';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   LoadingSpinner,
   Table,
@@ -36,10 +36,8 @@ export class ChannelsList extends React.Component {
   static propTypes = {
     projectKey: PropTypes.string.isRequired,
     // injected
-    applicationState: PropTypes.shape({
-      project: PropTypes.shape({
-        dataLocale: PropTypes.string.isRequired,
-      }).isRequired,
+    applicationContext: PropTypes.shape({
+      dataLocale: PropTypes.string.isRequired,
     }).isRequired,
   };
   measurementCache = null;
@@ -54,8 +52,7 @@ export class ChannelsList extends React.Component {
         return value ? (
           <Constraints.Horizontal constraint="m">
             <Text.Wrap>
-              {value[this.props.applicationState.project.dataLocale] ||
-                NO_VALUE_FALLBACK}
+              {value[this.props.dataLocale] || NO_VALUE_FALLBACK}
             </Text.Wrap>
           </Constraints.Horizontal>
         ) : (
@@ -109,4 +106,4 @@ export class ChannelsList extends React.Component {
   }
 }
 
-export default withApplicationState()(ChannelsList);
+export default withApplicationContext()(ChannelsList);

--- a/playground/src/components/channels-list/channels-list.spec.js
+++ b/playground/src/components/channels-list/channels-list.spec.js
@@ -6,10 +6,8 @@ import { ChannelsList } from './channels-list';
 
 const createTestProps = props => ({
   projectKey: 'test-1',
-  applicationState: {
-    project: {
-      dataLocale: 'en',
-    },
+  applicationContext: {
+    dataLocale: 'en',
   },
   ...props,
 });


### PR DESCRIPTION
Following the discussion in #68 we want to keep the application provide flexible, which is why we decided to rename it to `ApplicationContextProvider` (so ~~`State`~~ `Context`).

Furthermore, we decided to also "move up" `permissions` and `dataLocale` from the `project`.

Eventually we can have something like this:

```js
<GetApplicationContext
  render={({
    environment,
    user,
    project,
    permissions,
    dataLocale,
    // as follow ups
    track,
    notifications,
    showNotification,
  }) => ()}
/>
```