### PR TITLE
refactor: self contained styles

### DIFF
--- a/packages/application-shell/src/components/application-shell/global-style-imports.js
+++ b/packages/application-shell/src/components/application-shell/global-style-imports.js
@@ -1,3 +1,3 @@
 // Global MC styles
-import '@commercetools-frontend/ui-kit/materials/grid.mod.css';
-import '@commercetools-frontend/ui-kit/materials/reset.mod.css';
+import './grid.mod.css';
+import './reset.mod.css';

--- a/packages/application-shell/src/components/application-shell/grid.mod.css
+++ b/packages/application-shell/src/components/application-shell/grid.mod.css
@@ -1,0 +1,45 @@
+/*
+  Global styles for the responsive grid layout.
+  TODO: implement a proper layout system with components, or simply use css-grid.
+ */
+
+:global(.row) {
+  clear: both;
+  float: left;
+  width: 100%;
+}
+
+:global(.col-3) {
+  float: left;
+  width: 25%;
+}
+
+:global(.col-4) {
+  float: left;
+  width: 33.333%;
+}
+
+:global(.col-5) {
+  float: left;
+  width: 41.666%;
+}
+
+:global(.col-6) {
+  float: left;
+  width: 50%;
+}
+
+:global(.col-7) {
+  float: left;
+  width: 58.333%;
+}
+
+:global(.col-8) {
+  float: left;
+  width: 66.666%;
+}
+
+:global(.col-12) {
+  float: left;
+  width: 100%;
+}

--- a/packages/application-shell/src/components/application-shell/reset.mod.css
+++ b/packages/application-shell/src/components/application-shell/reset.mod.css
@@ -1,0 +1,46 @@
+@import '@commercetools-frontend/ui-kit/materials/colors/base-colors.mod.css';
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+html,
+body {
+  color: var(--color-black);
+  font-family: 'Open Sans', sans-serif;
+  font-size: 13px;
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: var(--color-green);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s ease-in;
+}
+
+p {
+  color: var(--color-black);
+  margin: 0;
+}


### PR DESCRIPTION
#### Summary

`ui-kit` is moving it's styles internally, and the `grid.mod.css` and `reset.mod.css` files are (in the next release) located inside of `materials/internal` and could be removed in a later release.. [ref](https://github.com/commercetools/ui-kit/issues/185)

I propose we move `grid.mod.css` and `reset.mod.css` into the app-shell.

* Closes #26 