### PR TITLE
refactor(navbar): remnove `CAN_VIEW_PRODUCTS` feature toggle

### DIFF
--- a/packages/application-shell/src/components/navbar/config.js
+++ b/packages/application-shell/src/components/navbar/config.js
@@ -5,7 +5,6 @@ import {
   PIM_SEARCH,
   DEVELOPER_SETTINGS,
   CAN_VIEW_CATEGORIES,
-  CAN_VIEW_PRODUCTS,
   CAN_VIEW_ORDERS,
   CAN_VIEW_DISCOUNTS,
 } from './feature-toggles';
@@ -147,7 +146,6 @@ const itemsProducts = {
   uriPath: 'products',
   labelKey: 'NavBar.Products.title',
   icon: 'BoxProductIcon',
-  featureToggle: CAN_VIEW_PRODUCTS,
   permissions: [permissions.ViewProducts, permissions.ManageProducts],
   submenu: [
     {

--- a/packages/application-shell/src/components/navbar/feature-toggles.js
+++ b/packages/application-shell/src/components/navbar/feature-toggles.js
@@ -16,7 +16,6 @@
 export const CAN_VIEW_DASHBOARD = 'canViewDashboard';
 export const CAN_VIEW_ORDERS = 'canViewOrders';
 export const CAN_VIEW_CATEGORIES = 'canViewCategories';
-export const CAN_VIEW_PRODUCTS = 'canViewProducts';
 export const CAN_VIEW_DISCOUNTS = 'canViewDiscounts';
 
 export const CUSTOMER_GROUPS = 'customerGroups';


### PR DESCRIPTION
#### Summary

Let's clean up these feature toggles.
This was introduced in conjunction with issues that we faced with multi-cloud. I'd like to release this upon merge. any objections?