### PR TITLE
fix(application-shell): expose test-utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ typings/
 # Build
 dist
 public
+packages/application-shell/test-utils
 
 # Editor/IDE
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.0.2](https://github.com/commercetools/merchant-center-application-kit/compare/v2.0.1...v2.0.2) (2018-11-13)
+
+#### 🐛 Type: Bug
+
+- `application-shell`
+
+  - [#91](https://github.com/commercetools/merchant-center-application-kit/pull/93) fix(application-shell): expose test-utils ([@dferber90](https://github.com/dferber90))
+
 ## [2.0.1](https://github.com/commercetools/merchant-center-application-kit/compare/v2.0.0...v2.0.1) (2018-11-13)
 
 #### 🐛 Type: Bug

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -22,6 +22,7 @@
   "module": "dist/application-shell-index.es.js",
   "files": [
     "dist",
+    "test-utils",
     "package.json",
     "LICENSE",
     "README.md"
@@ -32,7 +33,7 @@
     "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].cjs.js --entryFileNames application-shell-[name].cjs.js --experimentalCodeSplitting",
     "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].es.js --entryFileNames application-shell-[name].es.js --experimentalCodeSplitting",
     "build:es:watch": "npm run build:es -- -w",
-    "build:test-utils:es": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js  -f es ./src/test-utils/index.js --o ./dist/test-utils/index.js"
+    "build:test-utils:es": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js  -f es ./src/test-utils/index.js --o ./test-utils/index.js"
   },
   "dependencies": {
     "@babel/runtime": "7.1.5",


### PR DESCRIPTION
We were exposing `test-utils` from the `dist` folder by accident which is inconvenient for consumers, and not what we explain in our docs.


After this PR importing `test-utils` will work as documented:
```diff
- import { render } from '@commercetools-frontend/application-shell/dist/test-utils';
+ import { render } from '@commercetools-frontend/application-shell/test-utils'; 
```