### PR TITLE
fix: use commonjs for jest preset

### DIFF
--- a/packages/jest-preset-mc-app/setup-test-framework.js
+++ b/packages/jest-preset-mc-app/setup-test-framework.js
@@ -1,11 +1,11 @@
-import 'jest-enzyme';
-import 'jest-dom/extend-expect';
-import 'react-testing-library/cleanup-after-each';
-import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-import ShallowWrapper from 'enzyme/ShallowWrapper';
-import configureEnzymeExtensions from '@commercetools/enzyme-extensions';
-import * as commerceToolsEnzymeMatchers from '@commercetools/jest-enzyme-matchers';
+require('jest-enzyme');
+require('jest-dom/extend-expect');
+require('react-testing-library/cleanup-after-each');
+const Enzyme = require('enzyme');
+const Adapter = require('enzyme-adapter-react-16');
+const ShallowWrapper = require('enzyme/ShallowWrapper');
+const configureEnzymeExtensions = require('@commercetools/enzyme-extensions');
+const commerceToolsEnzymeMatchers = require('@commercetools/jest-enzyme-matchers');
 
 Enzyme.configure({ adapter: new Adapter(), disableLifecycleMethods: true });
 

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-import colors from 'colors/safe';
-import pkgDir from 'pkg-dir';
+const fs = require('fs');
+const path = require('path');
+const colors = require('colors/safe');
+const pkgDir = require('pkg-dir');
 
 global.window.app = {
   mcApiUrl: 'http://localhost:8080',


### PR DESCRIPTION
This way we don't need to transpile this when we run jest.