### PR TITLE
fix: cjs for test-utils instead of es

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -28,12 +28,13 @@
     "README.md"
   ],
   "scripts": {
-    "prebuild": "rimraf dist/**",
-    "build": "npm run build:es && npm run build:cjs && npm run build:test-utils:es",
+    "prebuild": "rimraf dist/** test-utils/**",
+    "build": "npm run build:es && npm run build:cjs && npm run build:test-utils:cjs",
     "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].cjs.js --entryFileNames application-shell-[name].cjs.js --experimentalCodeSplitting",
     "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].es.js --entryFileNames application-shell-[name].es.js --experimentalCodeSplitting",
     "build:es:watch": "npm run build:es -- -w",
-    "build:test-utils:es": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js  -f es ./src/test-utils/index.js --o ./test-utils/index.js"
+    "build:test-utils:cjs": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js  -f cjs ./src/test-utils/index.js --o ./test-utils/index.js"
+
   },
   "dependencies": {
     "@babel/runtime": "7.1.5",


### PR DESCRIPTION
Build cjs version of test utils in app-shell instead of es version.