### PR TITLE
refactor(login-sso): avoid query params in authorize url, use session storage and state nonce

### DIFF
--- a/packages/application-shell/src/components/login-sso-callback/login-sso-callback.js
+++ b/packages/application-shell/src/components/login-sso-callback/login-sso-callback.js
@@ -28,12 +28,10 @@ export class LoginSSOCallback extends React.PureComponent {
     const fragments = qs.parse(this.props.location.hash.substring(1));
     const idToken = fragments.id_token;
     const decodedIdToken = jwtDecode(idToken);
-    const sessionState = storage.get(
-      `${STORAGE_KEYS.NONCE}_${decodedIdToken.nonce}`,
-      { storage: window.sessionStorage }
-    );
+    const nonceKey = `${STORAGE_KEYS.NONCE}_${decodedIdToken.nonce}`;
+    const sessionState = window.sessionStorage.getItem(nonceKey);
     // Clear the nonce, we don't need it anymore
-    storage.remove(STORAGE_KEYS.NONCE, { storage: window.sessionStorage });
+    window.sessionStorage.removeItem(nonceKey);
 
     if (!sessionState) {
       this.setAuthenticationFailed(true);

--- a/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
+++ b/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import * as storage from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 import FailedAuthentication from '../failed-authentication';
 import { LoginSSOCallback } from './login-sso-callback';
@@ -58,7 +57,7 @@ describe('lifecylcle', () => {
 
     describe('when nonce is correct', () => {
       beforeEach(() => {
-        storage.get.mockReturnValue({ organizationId: 'o1' });
+        window.sessionStorage.getItem.mockReturnValue({ organizationId: 'o1' });
         wrapper.instance().componentDidMount();
       });
       it('should call requestAccessToken with idToken', () => {
@@ -79,7 +78,7 @@ describe('lifecylcle', () => {
             ),
           });
           wrapper = shallow(<LoginSSOCallback {...props} />);
-          storage.put(`${STORAGE_KEYS.NONCE}_EY`, {
+          window.sessionStorage.setItem(`${STORAGE_KEYS.NONCE}_EY`, {
             organizationId: 'o1',
           });
           wrapper.instance().componentDidMount();
@@ -94,7 +93,9 @@ describe('lifecylcle', () => {
             requestAccessToken: jest.fn(() => Promise.reject(new Error())),
           });
           wrapper = shallow(<LoginSSOCallback {...props} />);
-          storage.get.mockReturnValue({ organizationId: 'o1' });
+          window.sessionStorage.getItem.mockReturnValue({
+            organizationId: 'o1',
+          });
           wrapper.instance().componentDidMount();
         });
         it('should set hasAuthenticationFailed to true', () => {
@@ -108,7 +109,7 @@ describe('lifecylcle', () => {
 
     describe('when nonce is wrong', () => {
       beforeEach(() => {
-        storage.get.mockReturnValue(null);
+        window.sessionStorage.getItem.mockReturnValue(null);
         wrapper.instance().componentDidMount();
       });
       it('should set hasAuthenticationFailed to true', () => {

--- a/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
+++ b/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
@@ -10,7 +10,6 @@ jest.mock('@commercetools-frontend/storage');
 
 const createTestProps = props => ({
   location: {
-    query: { organizationId: 'o1' },
     hash: '#id_token=111',
   },
   redirectTo: jest.fn(),
@@ -59,7 +58,7 @@ describe('lifecylcle', () => {
 
     describe('when nonce is correct', () => {
       beforeEach(() => {
-        storage.get.mockReturnValue('EY');
+        storage.get.mockReturnValue({ organizationId: 'o1' });
         wrapper.instance().componentDidMount();
       });
       it('should call requestAccessToken with idToken', () => {
@@ -80,7 +79,9 @@ describe('lifecylcle', () => {
             ),
           });
           wrapper = shallow(<LoginSSOCallback {...props} />);
-          storage.put(STORAGE_KEYS.NONCE, 'EY');
+          storage.put(`${STORAGE_KEYS.NONCE}_EY`, {
+            organizationId: 'o1',
+          });
           wrapper.instance().componentDidMount();
         });
         it('should redirect to /', () => {
@@ -93,7 +94,7 @@ describe('lifecylcle', () => {
             requestAccessToken: jest.fn(() => Promise.reject(new Error())),
           });
           wrapper = shallow(<LoginSSOCallback {...props} />);
-          storage.get.mockReturnValue('EY');
+          storage.get.mockReturnValue({ organizationId: 'o1' });
           wrapper.instance().componentDidMount();
         });
         it('should set hasAuthenticationFailed to true', () => {
@@ -107,7 +108,7 @@ describe('lifecylcle', () => {
 
     describe('when nonce is wrong', () => {
       beforeEach(() => {
-        storage.get.mockReturnValue(STORAGE_KEYS.NONCE, 'BAD');
+        storage.get.mockReturnValue(null);
         wrapper.instance().componentDidMount();
       });
       it('should set hasAuthenticationFailed to true', () => {

--- a/packages/application-shell/src/components/login-sso/login-sso.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.js
@@ -12,7 +12,6 @@ import {
 } from '@commercetools-frontend/url-utils';
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
 import { connect } from 'react-redux';
-import * as storage from '@commercetools-frontend/storage';
 import { Notification } from '@commercetools-frontend/react-notifications';
 import { ORGANIZATION_GENERAL_ERROR, STORAGE_KEYS } from '../../constants';
 import LabelField from '../../from-core/label-field';
@@ -40,9 +39,7 @@ function generateAndCacheNonceWithState(state) {
   // the id_token and, once validated, we can retrieve and use
   // the state object.
   // https://auth0.com/docs/protocols/oauth2/oauth-state#how-to-use-the-parameter-to-restore-application-state
-  storage.put(`${STORAGE_KEYS.NONCE}_${nonce}`, state, {
-    storage: window.sessionStorage,
-  });
+  window.sessionStorage.setItem(`${STORAGE_KEYS.NONCE}_${nonce}`, state);
   return nonce;
 }
 

--- a/packages/application-shell/src/components/login-sso/login-sso.spec.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Formik } from 'formik';
 import { PrimaryButton, Text } from '@commercetools-frontend/ui-kit';
+import * as storage from '@commercetools-frontend/storage';
 import { ORGANIZATION_GENERAL_ERROR } from '../../constants';
 import { LoginSSO, getMessageKeyForError } from './login-sso';
 
@@ -257,13 +258,11 @@ describe('interaction', () => {
             expect.stringContaining('client_id=123')
           );
         });
-        it('should build authorize URL with redirect_uri param', () => {
-          expect(props.redirectTo).toHaveBeenCalledWith(
-            expect.stringContaining(
-              `redirect_uri=${encodeURIComponent(
-                'http://mc.ct.com/login/sso/callback?organizationId=o1'
-              )}`
-            )
+        it('should save state in nonce', () => {
+          expect(storage.put).toHaveBeenCalledWith(
+            expect.stringContaining('nonce_foo-uuid'),
+            { organizationId: 'o1' },
+            expect.objectContaining({ storage: expect.anything() })
           );
         });
         it('should build authorize URL with nonce param', () => {

--- a/packages/application-shell/src/components/login-sso/login-sso.spec.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Formik } from 'formik';
 import { PrimaryButton, Text } from '@commercetools-frontend/ui-kit';
-import * as storage from '@commercetools-frontend/storage';
 import { ORGANIZATION_GENERAL_ERROR } from '../../constants';
 import { LoginSSO, getMessageKeyForError } from './login-sso';
 
@@ -208,6 +207,7 @@ describe('interaction', () => {
     describe('when request is successful', () => {
       describe('when authProvider protocol is "oidc"', () => {
         beforeEach(() => {
+          window.sessionStorage = jest.fn();
           props = createTestProps({
             getOrganizationByName: jest.fn(() =>
               Promise.resolve({
@@ -259,10 +259,9 @@ describe('interaction', () => {
           );
         });
         it('should save state in nonce', () => {
-          expect(storage.put).toHaveBeenCalledWith(
+          expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
             expect.stringContaining('nonce_foo-uuid'),
-            { organizationId: 'o1' },
-            expect.objectContaining({ storage: expect.anything() })
+            { organizationId: 'o1' }
           );
         });
         it('should build authorize URL with nonce param', () => {

--- a/packages/storage/index.js
+++ b/packages/storage/index.js
@@ -1,8 +1,4 @@
-export const put = (key, value, { storage = window.localStorage } = {}) =>
-  storage.setItem(key, value);
-export const get = (key, { storage = window.localStorage } = {}) =>
-  storage.getItem(key);
-export const remove = (key, { storage = window.localStorage } = {}) =>
-  storage.removeItem(key);
-export const clear = ({ storage = window.localStorage } = {}) =>
-  storage.clear();
+export const put = (key, value) => window.localStorage.setItem(key, value);
+export const get = key => window.localStorage.getItem(key);
+export const remove = key => window.localStorage.removeItem(key);
+export const clear = () => window.localStorage.clear();

--- a/packages/storage/index.js
+++ b/packages/storage/index.js
@@ -1,4 +1,8 @@
-export const put = (key, value) => window.localStorage.setItem(key, value);
-export const get = key => window.localStorage.getItem(key);
-export const remove = key => window.localStorage.removeItem(key);
-export const clear = () => window.localStorage.clear();
+export const put = (key, value, { storage = window.localStorage } = {}) =>
+  storage.setItem(key, value);
+export const get = (key, { storage = window.localStorage } = {}) =>
+  storage.getItem(key);
+export const remove = (key, { storage = window.localStorage } = {}) =>
+  storage.removeItem(key);
+export const clear = ({ storage = window.localStorage } = {}) =>
+  storage.clear();


### PR DESCRIPTION
Long story short: redirecting to the IdP `/authorize` endpoint with the `redirect_url` with some query parameters does not guarantee that those params are sent back.
Since we rely on the `organizationId` to authorize the user, we need to be able to "get it" back when the IdP redirects to our `/login/sso/callback` route.

Following [the tips in here](https://auth0.com/docs/protocols/oauth2/oauth-state#how-to-use-the-parameter-to-restore-application-state) I refactored the code a bit to store the `organizationId` as a "state" object within the `nonce` in the ~~`localStorage`~~ `sessionStorage`.

This will result in the `redirect_url` to be only e.g. `https://mc.commercetools.com/login/sso/callback` and the saved nonce will contain the needed state:

```js
// sessionStorage
"nonce_123": {
  "organizationId": "org-123"
}
```

---

Unrelated thought: we should probably consider moving the login pages outside of the AppShell and into e.g. the "fallback" application. It will allow to do changes to those pages without having to touch the AppShell.