### PR TITLE
fix(i18n): exports to not include default key

### DIFF
--- a/packages/i18n/index.js
+++ b/packages/i18n/index.js
@@ -1,5 +1,6 @@
-export { default as en } from './data/en.json';
-export { default as de } from './data/de.json';
-export { default as es } from './data/es.json';
+import en from './data/en.json';
+import de from './data/de.json';
+import es from './data/es.json';
 
+export { en, de, es };
 export { default as AsyncLocaleData } from './async-locale-data';

--- a/packages/i18n/load-i18n.js
+++ b/packages/i18n/load-i18n.js
@@ -47,6 +47,6 @@ export default function loadI18n(lang) {
 
   return Promise.all(localeDataPromises).then(response => {
     addLocaleData([...response[0].default]);
-    return getLocalizedStringsChunkImport(lang);
+    return getLocalizedStringsChunkImport(lang).then(result => result.default);
   });
 }


### PR DESCRIPTION
Same problem we had with the ui-kit when we switched to rollup. 

The messages were exposed in an object `{ default: { /* messages */ } }`.

With this change, the messages returned is correct

<img width="756" alt="screen shot 2018-11-15 at 16 49 05" src="https://user-images.githubusercontent.com/1110551/48565945-f9306800-e8f9-11e8-9ab0-f467940865df.png">

