### PR TITLE
refactor(login-sso): use new /tokens/sso endpoint

### DIFF
--- a/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
+++ b/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
@@ -69,7 +69,7 @@ describe('lifecylcle', () => {
       });
       it('should call requestAccessToken with organization id', () => {
         expect(props.requestAccessToken).toHaveBeenCalledWith(
-          expect.objectContaining({ organization: 'o1' })
+          expect.objectContaining({ organizationId: 'o1' })
         );
       });
       describe('when request is successful', () => {

--- a/packages/application-shell/src/components/login-sso/login-sso.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.js
@@ -75,30 +75,27 @@ export class LoginSSO extends React.PureComponent {
     this.props.getOrganizationByName(values.organizationName).then(
       authProvider => {
         actions.setSubmitting(false);
-        // TODO: handle cases with another protocol?
-        if (authProvider.protocol === 'oidc') {
-          // Quick note: we assume that the authorization endpoint is /authorize
-          // This endpoint name is not mandatory. However, it is used as a common
-          // practice throughout the OIDC specification.
-          // We might have to let customers set a custom endpoint in the future.
-          const params = querystring.stringify({
-            scope: 'openid email profile',
-            response_type: 'id_token',
-            client_id: authProvider.clientId,
-            redirect_uri: trimLeadingAndTrailingSlashes(
-              // Avoid providing query parameters as some IdP (e.g. Azure) apparently
-              // will consider the full URL to match as part of the callback whitelist.
-              // Instead, we store additional information within the `nonce` value
-              // which is stored in sessionStorage. See `generateAndCacheNonceWithState`.
-              joinPaths(this.props.originUrl, this.props.match.url, `callback`)
-            ),
-            nonce: generateAndCacheNonceWithState({
-              organizationId: authProvider.organizationId,
-            }),
-          });
-          const authUrl = authProvider.url.replace(/\/$/, ''); // trim trailing slash
-          this.props.redirectTo(`${authUrl}/authorize?${params}`);
-        }
+
+        // Quick note: we assume that the authorization endpoint is /authorize
+        // This endpoint name is not mandatory. However, it is used as a common
+        // practice throughout the OIDC specification.
+        // We might have to let customers set a custom endpoint in the future.
+        const params = querystring.stringify({
+          scope: 'openid email profile',
+          response_type: 'id_token',
+          client_id: authProvider.clientId,
+          redirect_uri: trimLeadingAndTrailingSlashes(
+            // Avoid providing query parameters as some IdP (e.g. Azure) apparently
+            // will consider the full URL to match as part of the callback whitelist.
+            // Instead, we store additional information within the `nonce` value
+            // which is stored in sessionStorage. See `generateAndCacheNonceWithState`.
+            joinPaths(this.props.originUrl, this.props.match.url, `callback`)
+          ),
+          nonce: generateAndCacheNonceWithState({
+            organizationId: authProvider.organizationId,
+          }),
+        });
+        this.props.redirectTo(`${authProvider.authorizeUrl}?${params}`);
       },
       error => {
         actions.setSubmitting(false);

--- a/packages/application-shell/src/components/login-sso/login-sso.spec.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.spec.js
@@ -211,10 +211,9 @@ describe('interaction', () => {
           props = createTestProps({
             getOrganizationByName: jest.fn(() =>
               Promise.resolve({
-                protocol: 'oidc',
+                authorizeUrl: 'https://auth0.ct.com/authorize',
                 organizationId: 'o1',
                 clientId: '123',
-                url: 'https://auth0.ct.com',
               })
             ),
           });
@@ -231,14 +230,9 @@ describe('interaction', () => {
             'commercetools'
           );
         });
-        it('should build authorize URL with mc domain', () => {
+        it('should build authorize URL', () => {
           expect(props.redirectTo).toHaveBeenCalledWith(
-            expect.stringContaining('https://auth0.ct.com')
-          );
-        });
-        it('should build authorize URL with /authorize endpoint', () => {
-          expect(props.redirectTo).toHaveBeenCalledWith(
-            expect.stringContaining('/authorize')
+            expect.stringContaining('https://auth0.ct.com/authorize')
           );
         });
         it('should build authorize URL with scope param', () => {
@@ -268,29 +262,6 @@ describe('interaction', () => {
           expect(props.redirectTo).toHaveBeenCalledWith(
             expect.stringContaining('nonce=foo-uuid')
           );
-        });
-      });
-      describe('when authProvider protocol is not "oidc"', () => {
-        beforeEach(() => {
-          props = createTestProps({
-            getOrganizationByName: jest.fn(() =>
-              Promise.resolve({
-                body: {
-                  protocol: 'something-else',
-                  organizationId: 'o1',
-                  clientId: '123',
-                  url: 'https://auth0.ct.com',
-                },
-              })
-            ),
-          });
-          wrapper = shallow(<LoginSSO {...props} />);
-          wrapper
-            .instance()
-            .handleSubmit({ organizationName: 'commercetools' }, formActions);
-        });
-        it('should not call redirectTo', () => {
-          expect(props.redirectTo).not.toHaveBeenCalled();
         });
       });
     });

--- a/packages/application-shell/src/components/login/login.js
+++ b/packages/application-shell/src/components/login/login.js
@@ -86,7 +86,7 @@ export class Login extends React.PureComponent {
         storage.put(STORAGE_KEYS.IS_AUTHENTICATED, true);
         // Ensure to remove the IdP Url value from local storage, as in this
         // case login is not done through SSO.
-        storage.remove(STORAGE_KEYS.IDENTITY_PROVIDER_URL);
+        storage.remove(STORAGE_KEYS.LOGIN_STRATEGY);
         // Redirect to a `redirectTo` url, if present, otherwise to defaul route
         const nextTargetUrl = this.props.location.query.redirectTo;
         // We force a browser redirect, to let the proxy server handle

--- a/packages/application-shell/src/components/logout/logout.js
+++ b/packages/application-shell/src/components/logout/logout.js
@@ -11,8 +11,10 @@ import {
 import GtmUserLogoutTracker from '../gtm-user-logout-tracker';
 
 export const getLoginStrategy = () => {
-  const idpUrl = storage.get(STORAGE_KEYS.IDENTITY_PROVIDER_URL);
-  return idpUrl ? LOGIN_STRATEGY_SSO : LOGIN_STRATEGY_DEFAULT;
+  const loginStrategy = storage.get(STORAGE_KEYS.LOGIN_STRATEGY);
+  return loginStrategy === LOGIN_STRATEGY_SSO
+    ? LOGIN_STRATEGY_SSO
+    : LOGIN_STRATEGY_DEFAULT;
 };
 
 export class Logout extends React.PureComponent {
@@ -45,7 +47,7 @@ export class Logout extends React.PureComponent {
 
     // The user is no longer authenticated.
     storage.remove(STORAGE_KEYS.IS_AUTHENTICATED);
-    storage.remove(STORAGE_KEYS.IDENTITY_PROVIDER_URL);
+    storage.remove(STORAGE_KEYS.LOGIN_STRATEGY);
     // NOTE: we need to ensure the cached projectKey is removed, because
     // the user can log in with another account and most likely he won't
     // access to the cached project.

--- a/packages/application-shell/src/components/logout/logout.spec.js
+++ b/packages/application-shell/src/components/logout/logout.spec.js
@@ -42,10 +42,8 @@ describe('componentDidMount', () => {
   it('should remove isAuthenticated from storage', () => {
     expect(storage.remove).toHaveBeenCalledWith(STORAGE_KEYS.IS_AUTHENTICATED);
   });
-  it('should remove identityProviderUrl from storage', () => {
-    expect(storage.remove).toHaveBeenCalledWith(
-      STORAGE_KEYS.IDENTITY_PROVIDER_URL
-    );
+  it('should remove loginStrategy from storage', () => {
+    expect(storage.remove).toHaveBeenCalledWith(STORAGE_KEYS.LOGIN_STRATEGY);
   });
   it('should remove projectKey from storage', () => {
     expect(storage.remove).toHaveBeenCalledWith(
@@ -93,7 +91,7 @@ describe('componentDidMount', () => {
 describe('getLoginStrategy', () => {
   describe('when IdP URL is defined', () => {
     beforeEach(() => {
-      storage.get.mockReturnValue('xxx');
+      storage.get.mockReturnValue('sso');
     });
     it('should return SSO as the login strategy', () => {
       expect(getLoginStrategy()).toBe(LOGIN_STRATEGY_SSO);

--- a/packages/application-shell/src/constants.js
+++ b/packages/application-shell/src/constants.js
@@ -11,7 +11,7 @@ export const STORAGE_KEYS = {
   ACTIVE_PROJECT_KEY: 'activeProjectKey',
   SELECTED_DATA_LOCALE: 'selectedDataLocale',
   IS_FORCED_MENU_OPEN: 'isForcedMenuOpen',
-  IDENTITY_PROVIDER_URL: 'identityProviderUrl',
+  LOGIN_STRATEGY: 'loginStrategy',
 };
 export const SUSPENSION_REASONS = {
   TEMPORARY_MAINTENANCE: 'TemporaryMaintenance',


### PR DESCRIPTION
This is mostly an internal refactor/clean up of the SSO login flow. There will be a new specific endpoint `/tokens/sso` in the MC BE to perform the login, this PR is in preparation for that.

NOTE: those changes do not affect any application directly, as the login routes are usually served by the fallback application.