### PR TITLE
Replace ProjectSwitcher with a "Back to project" link in AppBar

### DIFF
--- a/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
+++ b/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
@@ -40,6 +40,27 @@ exports[`rendering should match layout structure 1`] = `
           <div
             id="locale-switcher"
           />
+          <TextDetail>
+            <Link
+              replace={false}
+              to="/test-default-project-key"
+            >
+              <Inline
+                alignItems="center"
+                scale="s"
+              >
+                <AngleLeftIcon
+                  size="small"
+                  theme="green"
+                />
+                <FormattedMessage
+                  defaultMessage="Back to project"
+                  id="AppBar.backToProjectLink"
+                  values={Object {}}
+                />
+              </Inline>
+            </Link>
+          </TextDetail>
         </Inline>
       </div>
       <div

--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Spacings } from '@commercetools-frontend/ui-kit';
+import { FormattedMessage } from 'react-intl';
+import { Link } from 'react-router-dom';
+import { Spacings, Text, AngleLeftIcon } from '@commercetools-frontend/ui-kit';
 import LogoSVG from '@commercetools-frontend/assets/images/logo.svg';
-import {
-  selectProjectKeyFromLocalStorage,
-  selectProjectKeyFromUrl,
-} from '../../utils';
+import { selectProjectKeyFromLocalStorage } from '../../utils';
 import UserSettingsMenu from '../user-settings-menu';
 import ProjectSwitcher from '../project-switcher';
 import LoadingPlaceholder from '../loading-placeholder';
 import { REQUESTS_IN_FLIGHT_LOADER_DOM_ID } from '../requests-in-flight-loader/constants';
+import messages from './messages';
 import styles from './app-bar.mod.css';
 
 const AppBar = props => (
@@ -31,31 +31,40 @@ const AppBar = props => (
           <Spacings.Inline alignItems="center">
             {/* This node is used by a react portal */}
             <div id="locale-switcher" />
-            {(() => {
+            {do {
+              const previouslyUsedProjectKey = selectProjectKeyFromLocalStorage();
               if (!props.user) {
-                return <LoadingPlaceholder shape="rect" size="s" />;
+                <LoadingPlaceholder shape="rect" size="s" />;
               }
               // The `<ProjectSwitcher>` should be rendered only if the
-              // user is fetched and the user has projects.
-              if (props.user.projects.total > 0) {
-                return (
-                  <ProjectSwitcher
-                    // In this case it's not necessary to check if the `projectKey` param
-                    // is included in the list of projects. In such case
-                    // the dropdown will still be rendered but no project will be selected.
-                    // This is fine becase the user has still the possibility to "switch"
-                    // to a project.
-                    projectKey={
-                      selectProjectKeyFromUrl() ||
-                      selectProjectKeyFromLocalStorage() ||
-                      props.user.defaultProjectKey
-                    }
-                    total={props.user.projects.total}
-                  />
-                );
-              }
-              return null;
-            })()}
+              // user is fetched and the user has projects while the app runs in an project context.
+              else if (props.user.projects.total > 0 && props.projectKeyFromUrl)
+                <ProjectSwitcher
+                  // In this case it's not necessary to check if the `projectKey` param
+                  // is included in the list of projects. In such case
+                  // the dropdown will still be rendered but no project will be selected.
+                  // This is fine becase the user has still the possibility to "switch"
+                  // to a project.
+                  projectKey={
+                    props.projectKeyFromUrl ||
+                    previouslyUsedProjectKey ||
+                    props.user.defaultProjectKey
+                  }
+                  total={props.user.projects.total}
+                />;
+              else
+                <Text.Detail>
+                  <Link
+                    to={`/${previouslyUsedProjectKey ||
+                      props.user.defaultProjectKey}`}
+                  >
+                    <Spacings.Inline alignItems="center">
+                      <AngleLeftIcon theme="green" size="small" />
+                      <FormattedMessage {...messages.backToProjectLink} />
+                    </Spacings.Inline>
+                  </Link>
+                </Text.Detail>;
+            }}
           </Spacings.Inline>
         </div>
         <div className={styles.spacer} />
@@ -83,6 +92,7 @@ AppBar.propTypes = {
     }).isRequired,
     defaultProjectKey: PropTypes.string.isRequired,
   }),
+  projectKeyFromUrl: PropTypes.string,
 };
 
 export default AppBar;

--- a/packages/application-shell/src/components/app-bar/app-bar.spec.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.spec.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
 import ProjectSwitcher from '../project-switcher';
 import UserSettingsMenu from '../user-settings-menu';
 import AppBar from './app-bar';
+
+jest.mock('../../utils');
 
 const createTestProps = props => ({
   user: {
     projects: {
       total: 0,
     },
-    defaultProjectKey: 'test-1',
+    defaultProjectKey: 'test-default-project-key',
     firstName: 'John',
     lastName: 'Snow',
     gravatarHash: '20c9c1b252b46ab49d6f7a4cee9c3e68',
@@ -71,22 +74,12 @@ describe('rendering', () => {
     });
   });
   describe('<ProjectSwitcher>', () => {
-    describe('when user is not defined', () => {
-      beforeEach(() => {
-        props = createTestProps({
-          user: null,
-        });
-        wrapper = shallow(<AppBar {...props} />);
-      });
-      it('should not render <ProjectSwitcher>', () => {
-        expect(wrapper).not.toRender(ProjectSwitcher);
-      });
-    });
-    describe('when user is defined', () => {
-      describe('when user has no projects', () => {
+    describe('with project key in url', () => {
+      describe('when user is not defined', () => {
         beforeEach(() => {
           props = createTestProps({
-            user: { ...props.user, projects: { total: 0 } },
+            user: null,
+            projectKeyFromUrl: 'test-project-key',
           });
           wrapper = shallow(<AppBar {...props} />);
         });
@@ -94,28 +87,71 @@ describe('rendering', () => {
           expect(wrapper).not.toRender(ProjectSwitcher);
         });
       });
-      describe('when user has projects', () => {
-        describe('<ProjectSwitcher>', () => {
+      describe('when user is defined', () => {
+        describe('when user has no projects', () => {
           beforeEach(() => {
             props = createTestProps({
-              user: {
-                ...props.user,
-                projects: { total: 1 },
-              },
+              user: { ...props.user, projects: { total: 0 } },
+              projectKeyFromUrl: 'test-project-key',
             });
             wrapper = shallow(<AppBar {...props} />);
           });
-          it('should render <ProjectSwitcher>', () => {
-            expect(wrapper).toRender(ProjectSwitcher);
+          it('should not render <ProjectSwitcher>', () => {
+            expect(wrapper).not.toRender(ProjectSwitcher);
           });
-          it('should pass projectKey to <ProjectSwitcher>', () => {
-            expect(wrapper.find(ProjectSwitcher)).toHaveProp(
-              'projectKey',
-              'test-1'
-            );
+        });
+        describe('when user has projects', () => {
+          describe('<ProjectSwitcher>', () => {
+            beforeEach(() => {
+              props = createTestProps({
+                user: {
+                  ...props.user,
+                  projects: { total: 1 },
+                },
+                projectKeyFromUrl: 'test-project-key',
+              });
+              wrapper = shallow(<AppBar {...props} />);
+            });
+            it('should render <ProjectSwitcher>', () => {
+              expect(wrapper).toRender(ProjectSwitcher);
+            });
+            it('should pass projectKey to <ProjectSwitcher>', () => {
+              expect(wrapper.find(ProjectSwitcher)).toHaveProp(
+                'projectKey',
+                props.projectKeyFromUrl
+              );
+            });
+            it('should pass total to <ProjectSwitcher>', () => {
+              expect(wrapper.find(ProjectSwitcher)).toHaveProp('total', 1);
+            });
           });
-          it('should pass total to <ProjectSwitcher>', () => {
-            expect(wrapper.find(ProjectSwitcher)).toHaveProp('total', 1);
+        });
+      });
+    });
+    describe('without project key in url', () => {
+      describe('when user is defined', () => {
+        describe('when user has projects', () => {
+          describe('<ProjectSwitcher>', () => {
+            beforeEach(() => {
+              props = createTestProps({
+                user: {
+                  ...props.user,
+                  projects: { total: 1 },
+                },
+              });
+              wrapper = shallow(<AppBar {...props} />);
+            });
+            it('should not render <ProjectSwitcher>', () => {
+              expect(wrapper).not.toRender(ProjectSwitcher);
+            });
+
+            it('should not render <Link> with path to previous project (default project)', () => {
+              expect(wrapper).toRender(Link);
+              expect(wrapper.find(Link)).toHaveProp(
+                'to',
+                `/${props.user.defaultProjectKey}`
+              );
+            });
           });
         });
       });

--- a/packages/application-shell/src/components/app-bar/messages.js
+++ b/packages/application-shell/src/components/app-bar/messages.js
@@ -1,0 +1,8 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  backToProjectLink: {
+    id: 'AppBar.backToProjectLink',
+    defaultMessage: 'Back to project',
+  },
+});

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -95,6 +95,8 @@ export const RestrictedApplication = props => (
         );
       }
 
+      const projectKeyFromUrl = selectProjectKeyFromUrl();
+
       return (
         <ApplicationContextProvider user={user} environment={props.environment}>
           {/*
@@ -139,8 +141,7 @@ export const RestrictedApplication = props => (
                       <ToggleFeature flag={QUICK_ACCESS}>
                         <Route
                           render={routeProps => {
-                            const projectKey = selectProjectKeyFromUrl();
-                            if (!projectKey)
+                            if (!projectKeyFromUrl)
                               return (
                                 <QuickAccess
                                   history={routeProps.history}
@@ -148,7 +149,7 @@ export const RestrictedApplication = props => (
                                 />
                               );
                             return (
-                              <FetchProject projectKey={projectKey}>
+                              <FetchProject projectKey={projectKeyFromUrl}>
                                 {({ isLoading: isProjectLoading, project }) => {
                                   if (isProjectLoading) return null;
 
@@ -200,7 +201,10 @@ export const RestrictedApplication = props => (
                       </ToggleFeature>
 
                       <header>
-                        <AppBar user={user} />
+                        <AppBar
+                          user={user}
+                          projectKeyFromUrl={projectKeyFromUrl}
+                        />
                       </header>
 
                       <aside>
@@ -215,7 +219,6 @@ export const RestrictedApplication = props => (
                           // redirect to `/:projectKey`). Therefore, we should not
                           // rely on the value in localStorage to determine which
                           // `projectKey` is currently used.
-                          const projectKeyFromUrl = selectProjectKeyFromUrl();
                           if (!projectKeyFromUrl) return null;
                           return (
                             <FetchProject projectKey={projectKeyFromUrl}>

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -25,6 +25,7 @@
   "ApiError.SyntaxError": "Syntax error: the given Predicate is not valid. Please read the documentation to define a correct predicate.",
   "ApiError.TaxCategoryDuplicateCountry": "Duplicate tax rates submitted. Please remove the duplicates.",
   "ApiError.Unauthorized": "Sorry, but you are not authorized to access this feature.",
+  "AppBar.backToProjectLink": "Back to project",
   "ErrorApologizer.notifiedTeam": "Our team has been notified about this issue.",
   "ErrorApologizer.title": "Sorry! An unexpected error occured.",
   "FailedAuthentication.paragraph1": "Please try again and contact your system administrator if you have any further questions.",


### PR DESCRIPTION
#### Summary

This pull request replaces the ProjectSwitcher with a "Back to project" link in any application not running within a project context.

#### Description

![cleanshot 2018-11-21 at 13 18 52](https://user-images.githubusercontent.com/1877073/48840899-35e3df80-ed90-11e8-8c65-b99f65325ee2.gif)

