### PR TITLE
feat(i18n): add backwards compatible async messages

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -75,8 +75,12 @@ export const RestrictedApplication = props => (
         // user's browser to attempt to match the language for the correct translations.
         const userLocale = getBrowserLanguage(window);
         return (
-          <AsyncLocaleData locale={userLocale}>
-            {({ language, messages }) => {
+          <AsyncLocaleData
+            locale={userLocale}
+            fetchApplicationMessages={props.fetchApplicationMessages}
+            applicationMessages={props.applicationMessages}
+          >
+            {({ language, messages, applicationMessages }) => {
               reportErrorToSentry(error, {});
               return (
                 <ConfigureIntlProvider
@@ -84,7 +88,7 @@ export const RestrictedApplication = props => (
                   messages={mergeMessages(
                     messages,
                     i18n[language],
-                    props.applicationMessages[language]
+                    applicationMessages
                   )}
                 >
                   <ErrorApologizer />
@@ -104,8 +108,17 @@ export const RestrictedApplication = props => (
             Therefore, as long as there is no locale, the children should consider using the
             `isLoading` prop to decide what to render.
           */}
-          <AsyncLocaleData locale={user && user.language}>
-            {({ isLoading: isLoadingLocaleData, language, messages }) => (
+          <AsyncLocaleData
+            locale={user && user.language}
+            applicationMessages={props.applicationMessages}
+            fetchApplicationMessages={props.fetchApplicationMessages}
+          >
+            {({
+              isLoading: isLoadingLocaleData,
+              language,
+              messages,
+              applicationMessages,
+            }) => (
               <ConfigureIntlProvider
                 // We do not want to pass the language as long as the locale data
                 // is not loaded.
@@ -116,7 +129,7 @@ export const RestrictedApplication = props => (
                       messages: mergeMessages(
                         messages,
                         i18n[language],
-                        props.applicationMessages[language]
+                        applicationMessages
                       ),
                     })}
               >
@@ -345,7 +358,8 @@ RestrictedApplication.propTypes = {
   environment: PropTypes.object.isRequired,
   defaultFeatureFlags: PropTypes.object,
   render: PropTypes.func.isRequired,
-  applicationMessages: PropTypes.object.isRequired,
+  applicationMessages: PropTypes.object,
+  fetchApplicationMessages: PropTypes.func,
   INTERNAL__isApplicationFallback: PropTypes.bool.isRequired,
 };
 
@@ -403,7 +417,8 @@ export default class ApplicationShell extends React.Component {
     ),
     render: PropTypes.func.isRequired,
     onRegisterErrorListeners: PropTypes.func.isRequired,
-    applicationMessages: PropTypes.object.isRequired,
+    applicationMessages: PropTypes.object,
+    fetchApplicationMessages: PropTypes.func,
     // Internal usage only, does not need to be documented
     INTERNAL__isApplicationFallback: PropTypes.bool,
   };
@@ -448,6 +463,9 @@ export default class ApplicationShell extends React.Component {
                                 applicationMessages={
                                   this.props.applicationMessages
                                 }
+                                fetchApplicationMessages={
+                                  this.props.fetchApplicationMessages
+                                }
                                 INTERNAL__isApplicationFallback={
                                   this.props.INTERNAL__isApplicationFallback
                                 }
@@ -456,14 +474,26 @@ export default class ApplicationShell extends React.Component {
                           const browserLanguage = getBrowserLanguage(window);
 
                           return (
-                            <AsyncLocaleData locale={browserLanguage}>
-                              {({ language, messages }) => (
+                            <AsyncLocaleData
+                              locale={browserLanguage}
+                              applicationMessages={
+                                this.props.applicationMessages
+                              }
+                              fetchApplicationMessages={
+                                this.props.fetchApplicationMessages
+                              }
+                            >
+                              {({
+                                language,
+                                messages,
+                                applicationMessages,
+                              }) => (
                                 <ConfigureIntlProvider
                                   language={language}
                                   messages={mergeMessages(
                                     messages,
                                     i18n[language],
-                                    this.props.applicationMessages[language]
+                                    applicationMessages
                                   )}
                                 >
                                   <UnrestrictedApplication />

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -57,6 +57,9 @@ const testLocaleData = {
   isLoading: false,
   language: 'en',
   messages: { 'AppKit.title': 'Title en' },
+  applicationMessages: {
+    'CustomApp.title': 'Title en',
+  },
 };
 
 const renderForAsyncData = ({ props, userData, localeData = testLocaleData }) =>
@@ -136,6 +139,7 @@ describe('rendering', () => {
           .renderProp('children', {
             language: 'en',
             messages: testLocaleData.messages,
+            applicationMessages: props.applicationMessages.en,
           });
       });
       it('should pass "language" to <ConfigureIntlProvider>', () => {

--- a/packages/i18n/async-locale-data/async-locale-data.spec.js
+++ b/packages/i18n/async-locale-data/async-locale-data.spec.js
@@ -13,6 +13,9 @@ const ChildComponent = () => <div>Child</div>;
 const createTestProps = props => ({
   children: jest.fn(() => <ChildComponent />),
   locale: 'en-US',
+  applicationMessages: {
+    en: { 'CustomApp.title': 'Title en' },
+  },
   ...props,
 });
 
@@ -61,6 +64,7 @@ describe('rendering', () => {
           isLoading: false,
           language: 'en',
           messages: { title: 'Title en' },
+          applicationMessages: props.applicationMessages.en,
         });
       });
     });
@@ -98,6 +102,45 @@ describe('rendering', () => {
     });
   });
 
+  describe('when fetchApplicationMessages is used', () => {
+    beforeEach(() => {
+      loadI18n.mockClear();
+      loadI18n.mockClear();
+      loadI18n.mockImplementation(
+        jest.fn(() => Promise.resolve({ title: 'Title en' }))
+      );
+      props = createTestProps({
+        locale: 'en-CA',
+        applicationMessages: null,
+        fetchApplicationMessages: jest
+          .fn(() => Promise.resolve({ 'CustomApp.title': 'New title en' }))
+          .mockName('fetchApplicationMessages'),
+      });
+      wrapper = shallow(<AsyncLocaleData {...props} />);
+    });
+
+    describe('when component is mounted', () => {
+      beforeEach(() => {
+        wrapper.instance().componentDidMount();
+      });
+
+      it('should call `fetchApplicationMessages`', () => {
+        expect(props.fetchApplicationMessages).toHaveBeenCalled();
+      });
+
+      it('should call `children` with state', () => {
+        expect(props.children).toHaveBeenCalledWith({
+          isLoading: false,
+          language: 'en',
+          messages: { title: 'Title en' },
+          applicationMessages: {
+            'CustomApp.title': 'New title en',
+          },
+        });
+      });
+    });
+  });
+
   describe('when locale is not defined', () => {
     beforeEach(() => {
       loadI18n.mockClear();
@@ -112,6 +155,7 @@ describe('rendering', () => {
         isLoading: true,
         language: null,
         messages: null,
+        applicationMessages: null,
       });
     });
   });

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@commercetools-frontend/sentry": "2.1.1",
+    "lodash.isfunction": "3.0.9",
     "moment": "2.22.2",
     "prop-types": "15.6.2"
   },

--- a/playground/src/components/entry-point/entry-point.js
+++ b/playground/src/components/entry-point/entry-point.js
@@ -11,6 +11,19 @@ import {
 import { Sdk } from '@commercetools-frontend/sdk';
 import * as globalActions from '@commercetools-frontend/actions-global';
 import { Redirect, Route, Switch } from 'react-router-dom';
+// import applicationMessages from '../../i18n';
+
+const fetchApplicationMessages = lang =>
+  new Promise((resolve, reject) =>
+    import(`../../i18n/data/${lang}.json` /* webpackChunkName: "application-messages-[request]" */).then(
+      response => {
+        resolve(response.default);
+      },
+      error => {
+        reject(error);
+      }
+    )
+  );
 
 // Here we split up the main (app) bundle with the actual application business logic.
 // Splitting by route is usually recommended and you can potentially have a splitting
@@ -19,9 +32,6 @@ const AsyncChannels = Loadable({
   loader: () => import('../../routes' /* webpackChunkName: "channels" */),
   loading: AsyncChunkLoader,
 });
-
-// TODO: define intl messages
-const messages = { en: {} };
 
 // Ensure to setup the global error listener before any React component renders
 // in order to catch possible errors on rendering/mounting.
@@ -40,7 +50,7 @@ class EntryPoint extends React.Component {
                 reduxStore.dispatch
               );
           }}
-          applicationMessages={messages}
+          fetchApplicationMessages={fetchApplicationMessages}
           render={() => (
             <Switch>
               {/* For development, it's useful to redirect to the actual

--- a/playground/src/i18n/data/de.json
+++ b/playground/src/i18n/data/de.json
@@ -1,0 +1,6 @@
+{
+  "Channels.ListView.column.channelKey": "Kanalschlüssel",
+  "Channels.ListView.column.channelName": "Kanalname",
+  "Channels.ListView.noResults": "Es gibt keine Ergebnisse, die Ihren Suchkriterien entsprechen.",
+  "Channels.ListView.title": "Kanäle"
+}

--- a/playground/src/i18n/data/en.json
+++ b/playground/src/i18n/data/en.json
@@ -1,0 +1,6 @@
+{
+  "Channels.ListView.column.channelKey": "Channel key",
+  "Channels.ListView.column.channelName": "Channel name",
+  "Channels.ListView.noResults": "There are no results matching your search criteria.",
+  "Channels.ListView.title": "Channels"
+}

--- a/playground/src/i18n/index.js
+++ b/playground/src/i18n/index.js
@@ -1,0 +1,4 @@
+import en from './data/en.json';
+import de from './data/de.json';
+
+export default { en, de };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9180,6 +9180,11 @@ lodash.isequal@^3.0:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
 lodash.isnil@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"


### PR DESCRIPTION
#### Adds backwards compatible option for async loading of applicationMessages.

#### Summary

When <AsyncLocaleData> is given the prop `fetchApplicationMessages`, of type function, and that function is invoked with a language, which results in a promise, then `AsyncLocaleData` will resolve that promise and invoke `children` with its result. Else, it will just invoke children with the property `applicationMessages`, which is passed into it from app-shell.


