### PR TITLE
feat(i18n): fix code splitting for mc-app-kit messages

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,9 +1,10 @@
 # @commercetools-frontend/i18n
 
-MC messages and locale data (moment and react-intl).
-Supported languages:
+This package contains JSON data about the i18n messages from the different application-kit packages (e.g. `application-shell`, etc). Additionally, it also loads locale data for `moment` and `react-intl`, which is necessary for runtime usage.
 
-- `en`
+Supported languages are:
+
+- `en` (_default_)
 - `de`
 - `es`
 
@@ -15,20 +16,22 @@ $ npm install --save @commercetools-frontend/i18n
 
 ### Usage
 
+> This package should not be used directly, the `application-shell` does that internally.
+
 ```js
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import { ConfigureIntlProvider } from '@commercetools-frontend/application-shell';
 
-const applicationMessages = {
+const myApplicationMessages = {
   en: {
     Title: 'Application Title',
   },
 };
 
-const Application = props => (
+const MyApplication = props => (
   <AsyncLocaleData
-    locale={props.user.language}
-    applicationMessages={applicationMessages}
+    locale={props.user.locale}
+    applicationMessages={myApplicationMessages}
   >
     {({ isLoading, language, messages }) => {
       if (isLoading) return null;
@@ -43,7 +46,7 @@ const Application = props => (
 );
 ```
 
-### Async Usage
+### Usage with code splitting
 
 ```js
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
@@ -63,7 +66,7 @@ const loadApplicationMessagesForLanguage = lang =>
 
 const Application = props => (
   <AsyncLocaleData
-    locale={props.user.language}
+    locale={props.user.locale}
     applicationMessages={loadApplicationMessagesForLanguage}
   >
     {({ isLoading, language, messages }) => {

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,6 +1,6 @@
 # @commercetools-frontend/i18n
 
-MC i18n messages.
+MC messages and locale data (moment and react-intl).
 Supported languages:
 
 - `en`
@@ -16,10 +16,67 @@ $ npm install --save @commercetools-frontend/i18n
 ### Usage
 
 ```js
-import * as i18n from '@commercetools-frontend/i18n';
+import { AsyncLocaleData } from '@commercetools-frontend/i18n';
+import { ConfigureIntlProvider } from '@commercetools-frontend/application-shell';
 
-// i18n.en
-// i18n.de
+const applicationMessages = {
+  en: {
+    Title: 'Application Title',
+  },
+};
+
+const Application = props => (
+  <AsyncLocaleData
+    locale={props.user.language}
+    applicationMessages={applicationMessages}
+  >
+    {({ isLoading, language, messages }) => {
+      if (isLoading) return null;
+
+      return (
+        <ConfigureIntlProvider language={language} messages={messages}>
+          ...
+        </ConfigureIntlProvider>
+      );
+    }}
+  </AsyncLocaleData>
+);
+```
+
+### Async Usage
+
+```js
+import { AsyncLocaleData } from '@commercetools-frontend/i18n';
+import { ConfigureIntlProvider } from '@commercetools-frontend/application-shell';
+
+const loadApplicationMessagesForLanguage = lang =>
+  new Promise((resolve, reject) =>
+    import(`../../i18n/data/${lang}.json` /* webpackChunkName: "application-messages-[request]" */).then(
+      response => {
+        resolve(response.default);
+      },
+      error => {
+        reject(error);
+      }
+    )
+  );
+
+const Application = props => (
+  <AsyncLocaleData
+    locale={props.user.language}
+    applicationMessages={loadApplicationMessagesForLanguage}
+  >
+    {({ isLoading, language, messages }) => {
+      if (isLoading) return null;
+
+      return (
+        <ConfigureIntlProvider language={language} messages={messages}>
+          ...
+        </ConfigureIntlProvider>
+      );
+    }}
+  </AsyncLocaleData>
+);
 ```
 
 ### Generating translation files

--- a/packages/i18n/index.js
+++ b/packages/i18n/index.js
@@ -1,6 +1,2 @@
-import en from './data/en.json';
-import de from './data/de.json';
-import es from './data/es.json';
-
-export { en, de, es };
+// eslint-disable-next-line import/prefer-default-export
 export { default as AsyncLocaleData } from './async-locale-data';

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -18,8 +18,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/i18n.cjs.js",
-  "module": "dist/i18n.es.js",
+  "main": "dist/i18n-index.cjs.js",
+  "module": "dist/i18n-index.es.js",
   "files": [
     "dist",
     "package.json",
@@ -29,8 +29,8 @@
   "scripts": {
     "prebuild": "rimraf dist/**",
     "build": "npm run build:es && npm run build:cjs",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs index.js -o dist/i18n.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es index.js -o dist/i18n.es.js",
+    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs index.js --dir ./dist --chunkFileNames i18n-[name]-[hash].cjs.js --entryFileNames i18n-[name].cjs.js --experimentalCodeSplitting",
+    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es index.js --dir ./dist --chunkFileNames i18n-[name]-[hash].es.js --entryFileNames i18n-[name].es.js --experimentalCodeSplitting",
     "build:es:watch": "npm run build:es -- -w"
   },
   "dependencies": {


### PR DESCRIPTION
#### Summary

Even though we were using `import()`  for the react-intl-localized-strings used by the app-kit, it wasn't resulting in any code splitting because
* we weren't using `experimentalCodeSplitting` in the rollup config for this package
* we were exporting the json directly from index.js

This PR resolves both of those and updates the README for the i18n package.

I'm not sure I would consider this a breaking change, because the app-kit messages are only really supposed to be used inside of the app-kit 🤔.

If we want to keep the direct exports of the i18n files, we should look into using multiple entry points here... But I don't think it's necessary. WDYT?