### PR TITLE
fix: app crashing when project is not found

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -222,11 +222,12 @@ export const RestrictedApplication = props => (
                             <FetchProject projectKey={projectKeyFromUrl}>
                               {({ isLoading: isLoadingProject, project }) => {
                                 // Render the loading navbar as long as all the data
-                                // hasn't been loaded.
+                                // hasn't been loaded, or if the project does not exist.
                                 if (
                                   isLoadingUser ||
                                   isLoadingLocaleData ||
-                                  isLoadingProject
+                                  isLoadingProject ||
+                                  !project
                                 )
                                   return <LoadingNavBar />;
 

--- a/packages/application-shell/src/components/quick-access/create-commands.js
+++ b/packages/application-shell/src/components/quick-access/create-commands.js
@@ -316,6 +316,7 @@ export default ({
         ].filter(Boolean),
       },
     project &&
+      project.languages &&
       project.languages.length > 1 && {
         id: 'action/set-resource-language',
         text: intl.formatMessage(messages.setResourceLanguage),

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -33,16 +33,7 @@ class QuickAccess extends React.Component {
     project: PropTypes.shape({
       key: PropTypes.string.isRequired,
       languages: PropTypes.arrayOf(PropTypes.string).isRequired,
-      permissions: PropTypes.shape({
-        canViewCustomers: PropTypes.bool,
-        canViewOrders: PropTypes.bool,
-        canViewProducts: PropTypes.bool,
-        canViewProjectSettings: PropTypes.bool,
-        canManageCustomers: PropTypes.bool,
-        canManageOrders: PropTypes.bool,
-        canManageProducts: PropTypes.bool,
-        canManageProjectSettings: PropTypes.bool,
-      }),
+      permissions: PropTypes.object.isRequired,
     }),
     onClose: PropTypes.func.isRequired,
     history: PropTypes.shape({

--- a/packages/permissions/src/utils/has-permissions.js
+++ b/packages/permissions/src/utils/has-permissions.js
@@ -36,7 +36,10 @@ const hasManageProjectPermission = actualPermissions =>
 //     'ViewProducts'
 // - actualPermissions:
 //     { canViewProducts: true, canManageOrders: false }
-export const hasPermission = (demandedPermission, actualPermissions) =>
+// NOTE: in case the `actualPermissions` are not defined, fall back to an empty object.
+// This might be the case when the permissions for a user/project could not be loaded
+// (e.g. project not found).
+export const hasPermission = (demandedPermission, actualPermissions = {}) =>
   // First checking the existence of the exact permission
   hasExactPermission(demandedPermission, actualPermissions) ||
   // Then checking if a manage permission is present superposing/implying a


### PR DESCRIPTION
We found out that when the app was requesting a project that does not exist (or the user does not have access to), the app would crash.

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/1110551/48905217-38fad080-ee61-11e8-809d-5272a504e133.png">

The problem was that in some places we were assuming that the `project` was defined, which might not always be. Now, when the project is not found, we render the app correctly and show the 404 page.

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/1110551/48905122-f3d69e80-ee60-11e8-9638-ccf8e3796db9.png">
