### PR TITLE
chore: publish to next dist-tag by default, add command to move to latest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,8 @@ You can also run the build in watch mode `yarn build:es:watch` alongside with `y
 
 ## Cutting a Release
 
+All releases go the the `next` distribution channel. This gives us a chance to test releases out before making them offical by moving the `latest` dist-tag along.
+
 #### Draft release notes in the Changelog
 
 1. Make sure that each merged PR that should be mentioned in the release changelog is labelled with one of the [labels](https://github.com/commercetools/merchant-center-application-kit/labels) named `Type: ...` to indicate what kind of change it is.
@@ -128,6 +130,16 @@ You can also run the build in watch mode `yarn build:es:watch` alongside with `y
 
 1. Make sure the `CHANGELOG.md` has been updated.
 2. Check that your npm account has access to the `@commercetools-frontend` organization and that you are logged in with the `npm` CLI.
-3. Run `yarn release`: the packages will be bundled with Rollup first, then Lerna will prompt you to select the version that you would like to release (minor, major, pre-release, etc.)
-4. Wait a bit until Lerna bumps the versions, creates a commit and a tag and finally publishes the packages to npm.
+3. Run `yarn release`: the packages will be bundled with Rollup first, then Lerna will prompt you to select the version that you would like to release (minor, major, pre-release, etc.).
+4. Wait a bit until Lerna bumps the versions, creates a commit and a tag and finally publishes the packages to npm (to the `next` distribution channel).
 5. After publishing, create a GitHub Release with the same text as the `CHANGELOG.md` entry. See previous Releases for inspiration.
+
+#### Moving the `latest` dist-tag to a release:
+
+After testing the `next` release on a production project, it's time to move to the `latest` dist-tag to make the release official.
+
+```bash
+$ yarn release-to-latest
+```
+
+The command will promote the version published on `next` to the `latest` dist-tag for each package.

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
     "format:md": "prettier --write --parser markdown '**/*.md'",
     "format:yaml": "prettier --write --parser yaml '**/*.yaml'",
     "start": "yarn playground:start",
-    "release": "npm run build; lerna publish --exact",
+    "release": "npm run build; lerna publish --exact --npm-tag next",
+    "release-to-latest": "lerna exec --no-bail --no-private --no-sort --stream -- '[ -n \"$(npm v . dist-tags.next)\" ] && npm dist-tag add ${LERNA_PACKAGE_NAME}@$(npm v . dist-tags.next) latest'",
     "test": "jest --config jest.test.config.js",
     "test:watch": "jest --config jest.test.config.js --watch",
     "playground:start": "yarn --cwd playground start",
     "playground:build": "yarn --cwd playground build",
-    "build": "NODE_ENV=production lerna run build --ignore 'playground'",
-    "build:es": "NODE_ENV=production lerna run build:es --ignore 'playground'",
-    "build:es:watch": "NODE_ENV=development lerna run --ignore 'playground' --parallel build:es:watch"
+    "build": "NODE_ENV=production lerna run build --no-private",
+    "build:es": "NODE_ENV=production lerna run build:es --no-private",
+    "build:es:watch": "NODE_ENV=development lerna run --no-private --parallel build:es:watch"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
Following the [decision](https://github.com/commercetools/ui-kit/pull/250) in the ui-kit about releasing to `next` by default.