### PR TITLE
fix: rearrange postcss plugins

### DIFF
--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -322,7 +322,6 @@ module.exports = ({
                   browsers: browserslist.production,
                   autoprefixer: { grid: true },
                 }),
-                postcssColorModFunction(),
                 postcssCustomProperties({
                   preserve: false,
                   importFrom: require.resolve(
@@ -334,6 +333,7 @@ module.exports = ({
                     '@commercetools-frontend/ui-kit/materials/media-queries.mod.css'
                   ),
                 }),
+                postcssColorModFunction(),
                 postcssReporter(),
               ],
             },


### PR DESCRIPTION
Build is falling when you encounter something like this.

```
  background-color: color-mod(var(--color-green) alpha(20%)) !important;
```

fix is re-arrange the plugins. They were already in this order for development.