### PR TITLE
feat(test-utils): run tests agains actual ApolloProvider

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -68,22 +68,24 @@ const introspectionQueryResultData = {
 const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData,
 });
-const client = new ApolloClient({
-  link,
-  cache: new InMemoryCache({
-    fragmentMatcher,
-    dataIdFromObject: result => {
-      if (result.__typename === 'Project') return result.key;
-      // Generally all id's are unique accross the platform, so we don't need to
-      // include the type name in the cache key.
-      // However, a reference has the shape { typeId, id } where the id is the
-      // id of the referenced entity. If we didn't prefix ids of References
-      // they would clash with the referenced resource.
-      if (result.__typename === 'Reference')
-        return `${result.__typename}:${result.id}`;
-      return result.id;
-    },
-  }),
-});
 
-export default client;
+export const createApolloClient = () =>
+  new ApolloClient({
+    link,
+    cache: new InMemoryCache({
+      fragmentMatcher,
+      dataIdFromObject: result => {
+        if (result.__typename === 'Project') return result.key;
+        // Generally all id's are unique accross the platform, so we don't need to
+        // include the type name in the cache key.
+        // However, a reference has the shape { typeId, id } where the id is the
+        // id of the referenced entity. If we didn't prefix ids of References
+        // they would clash with the referenced resource.
+        if (result.__typename === 'Reference')
+          return `${result.__typename}:${result.id}`;
+        return result.id;
+      },
+    }),
+  });
+
+export default createApolloClient();


### PR DESCRIPTION
#### Summary

I am about to try new way of mocking Graphql: one which will mock http requests, and not relay on `<MockProvider />`. To do this, I need:

1.  a way to render Component under test with production Apollo setup
2. force `render` method from `test-utils` to re-create Apollo Client before each test, so that tests will not share the same Apollo Cache.

#### Description

Our current approach of mocking Graphql is utilising `<MockProvider/>` helper from `react-apollo`, but that has a bunch of drawbacks:

1. Tests are too tightly coupled to the implementation of a Component being tested, because
 * test have to import Graphql queries used by those Components
 * appropriate responses are matched based on query variables values, which is implementation detail of a Component under test.
2. `<MockProvider/>` does not do a good job in letting us know, when it wasn't able to find appropriate response for a given request. That makes keeping fixtures up to date with query variable values hard and frustrating. 
3. Tests do not give enough confidence, as they always return same response no matter what was the shape of a query fired by a Component. This way it's quite easy to end up with false-positive results.  
4. Our setup of ApolloClient is not being exercised in a test harness.

#### Solution

I will combine our actual Graphql schema, `factory-girl`-like approach and http-mocking to solve all that drawbacks. For now I gonna experiment with that in MC repo, and once I will be happy with the result I will spin off a PR in this repo.

But to start experimenting I need to changes in app-kit introduced in this PR. 