### PR TITLE
refactor(navbar): use IconSwitcher to statically render icons based on icon names

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -68,38 +68,38 @@ import messages from './messages';
 // in which case we don't have a clue on the icons used.
 // A possible solution to that would be to import the SVG using
 // a `<img src>`, given that the SVG are available from a public URL.
-export const IconSwitcher = ({ iconName, ...rest }) => {
+export const IconSwitcher = ({ iconName, ...iconProps }) => {
   switch (iconName) {
     // Application icons
     case 'TreeStructureIcon':
-      return <TreeStructureIcon {...rest} />;
+      return <TreeStructureIcon {...iconProps} />;
     case 'UserFilledIcon':
-      return <UserFilledIcon {...rest} />;
+      return <UserFilledIcon {...iconProps} />;
     case 'SpeedometerIcon':
-      return <SpeedometerIcon {...rest} />;
+      return <SpeedometerIcon {...iconProps} />;
     case 'TagMultiIcon':
-      return <TagMultiIcon {...rest} />;
+      return <TagMultiIcon {...iconProps} />;
     case 'CartIcon':
-      return <CartIcon {...rest} />;
+      return <CartIcon {...iconProps} />;
     case 'BoxIcon':
-      return <BoxIcon {...rest} />;
+      return <BoxIcon {...iconProps} />;
     case 'GearIcon':
-      return <GearIcon {...rest} />;
+      return <GearIcon {...iconProps} />;
     case 'SupportIcon':
-      return <SupportIcon {...rest} />;
+      return <SupportIcon {...iconProps} />;
     // Custom application icons set
     case 'HeartIcon':
-      return <HeartIcon {...rest} />;
+      return <HeartIcon {...iconProps} />;
     case 'PaperclipIcon':
-      return <PaperclipIcon {...rest} />;
+      return <PaperclipIcon {...iconProps} />;
     case 'PluginIcon':
-      return <PluginIcon {...rest} />;
+      return <PluginIcon {...iconProps} />;
     case 'RocketIcon':
-      return <RocketIcon {...rest} />;
+      return <RocketIcon {...iconProps} />;
     case 'StarIcon':
-      return <StarIcon {...rest} />;
+      return <StarIcon {...iconProps} />;
     case 'ConnectedSquareIcon':
-      return <ConnectedSquareIcon {...rest} />;
+      return <ConnectedSquareIcon {...iconProps} />;
     default:
       return <img src={MissingImageSvg} />;
   }

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -8,7 +8,24 @@ import { ToggleFeature, injectFeatureToggle } from '@flopflip/react-broadcast';
 import { compose, withProps } from 'recompose';
 import classnames from 'classnames';
 import { oneLineTrim } from 'common-tags';
-import { Icons } from '@commercetools-frontend/ui-kit';
+import {
+  BackIcon,
+  TreeStructureIcon,
+  UserFilledIcon,
+  SpeedometerIcon,
+  TagMultiIcon,
+  CartIcon,
+  BoxIcon,
+  GearIcon,
+  SupportIcon,
+  HeartIcon,
+  PaperclipIcon,
+  PluginIcon,
+  RocketIcon,
+  StarIcon,
+  ConnectedSquareIcon,
+} from '@commercetools-frontend/ui-kit';
+import MissingImageSvg from '@commercetools-frontend/assets/images/image__missing_image.svg';
 import * as storage from '@commercetools-frontend/storage';
 import {
   GRAPHQL_TARGETS,
@@ -40,6 +57,56 @@ import messages from './messages';
 </DataMenu>
 */
 
+// This component receives the icon name as a string
+// and statically maps it to the related icon component.
+// We need to do this to avoid importing ALL icons and pick
+// the icon dynamically.
+// https://github.com/commercetools/ui-kit/pull/270
+// TODO: find a better solution once we implement
+// https://github.com/commercetools/merchant-center-application-kit/issues/37
+// which moves the static navbar config out of the AppShell,
+// in which case we don't have a clue on the icons used.
+// A possible solution to that would be to import the SVG using
+// a `<img src>`, given that the SVG are available from a public URL.
+export const IconSwitcher = ({ iconName, ...rest }) => {
+  switch (iconName) {
+    // Application icons
+    case 'TreeStructureIcon':
+      return <TreeStructureIcon {...rest} />;
+    case 'UserFilledIcon':
+      return <UserFilledIcon {...rest} />;
+    case 'SpeedometerIcon':
+      return <SpeedometerIcon {...rest} />;
+    case 'TagMultiIcon':
+      return <TagMultiIcon {...rest} />;
+    case 'CartIcon':
+      return <CartIcon {...rest} />;
+    case 'BoxIcon':
+      return <BoxIcon {...rest} />;
+    case 'GearIcon':
+      return <GearIcon {...rest} />;
+    case 'SupportIcon':
+      return <SupportIcon {...rest} />;
+    // Custom application icons set
+    case 'HeartIcon':
+      return <HeartIcon {...rest} />;
+    case 'PaperclipIcon':
+      return <PaperclipIcon {...rest} />;
+    case 'PluginIcon':
+      return <PluginIcon {...rest} />;
+    case 'RocketIcon':
+      return <RocketIcon {...rest} />;
+    case 'StarIcon':
+      return <StarIcon {...rest} />;
+    case 'ConnectedSquareIcon':
+      return <ConnectedSquareIcon {...rest} />;
+    default:
+      return <img src={MissingImageSvg} />;
+  }
+};
+IconSwitcher.displayName = 'IconSwitcher';
+IconSwitcher.propTypes = { iconName: PropTypes.string.isRequired };
+
 export const MenuExpander = props => (
   <li
     key="expander"
@@ -52,7 +119,7 @@ export const MenuExpander = props => (
         FIXME: define hover effect.
         https://github.com/commercetools/merchant-center-frontend/issues/2216
       */}
-      <Icons.BackIcon theme="white" size="big" />
+      <BackIcon theme="white" size="big" />
     </div>
   </li>
 );
@@ -380,7 +447,6 @@ export class DataMenu extends React.PureComponent {
 
   renderMenu = (menu, menuType, index) => {
     const isActive = this.state.activeItemIndex === `${menuType}-${index}`;
-    const MenuIcon = Icons[menu.icon];
     const hasSubmenu = Boolean(menu.submenu) && menu.submenu.length > 0;
     return (
       <ToggledWithPermissions
@@ -418,7 +484,8 @@ export class DataMenu extends React.PureComponent {
             >
               <div className={styles['item-icon-text']}>
                 <div className={styles.icon}>
-                  <MenuIcon
+                  <IconSwitcher
+                    iconName={menu.icon}
                     size="scale"
                     theme={getIconTheme(
                       menu,

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -7,7 +7,6 @@ import {
 } from '@commercetools-frontend/permissions';
 import { NavLink } from 'react-router-dom';
 import * as storage from '@commercetools-frontend/storage';
-import { UserFilledIcon } from '@commercetools-frontend/ui-kit';
 import { STORAGE_KEYS, MCSupportFormURL } from '../../constants';
 import {
   NavBar,
@@ -20,6 +19,7 @@ import {
   MenuItemDivider,
   ToggledWithPermissions,
   getIconTheme,
+  IconSwitcher,
 } from './navbar';
 import { defaultNavigationItems } from './config';
 
@@ -341,8 +341,14 @@ describe('rendering', () => {
           beforeEach(() => {
             wrapper.setState({ activeItemIndex: 'scrollable-0' });
           });
+          it('should pass iconName to IconSwitcher', () => {
+            expect(wrapper.find(IconSwitcher)).toHaveProp(
+              'iconName',
+              'UserFilledIcon'
+            );
+          });
           it('should render active icon', () => {
-            expect(wrapper.find(UserFilledIcon)).toHaveProp(
+            expect(wrapper.find(IconSwitcher)).toHaveProp(
               'theme',
               'green-light'
             );
@@ -359,8 +365,14 @@ describe('rendering', () => {
             );
             wrapper.setState({ activeItemIndex: null });
           });
+          it('should pass iconName to IconSwitcher', () => {
+            expect(wrapper.find(IconSwitcher)).toHaveProp(
+              'iconName',
+              'UserFilledIcon'
+            );
+          });
           it('should render active icon', () => {
-            expect(wrapper.find(UserFilledIcon)).toHaveProp(
+            expect(wrapper.find(IconSwitcher)).toHaveProp(
               'theme',
               'green-light'
             );
@@ -378,7 +390,7 @@ describe('rendering', () => {
             wrapper.setState({ activeItemIndex: null });
           });
           it('should render default icon', () => {
-            expect(wrapper.find(UserFilledIcon)).toHaveProp('theme', 'white');
+            expect(wrapper.find(IconSwitcher)).toHaveProp('theme', 'white');
           });
         });
       });


### PR DESCRIPTION
As discussed, this removes the `import { Icons } from '@commercetools-frontend/ui-kit'` and uses a component to statically render an icon (explicitly imported) based on the icon name as string.