### PR TITLE
fix(mc-scripts/extract-intl): do not overwrite existing core messages by default

### DIFF
--- a/packages/mc-scripts/extract-intl.js
+++ b/packages/mc-scripts/extract-intl.js
@@ -33,7 +33,7 @@ if (commands.length === 0 || (flags.help && commands.length === 0)) {
   --output-path         The location where to put the extracted messages
   --locale=<locale>     (optional) The default locale to use [default "en"]
   --build-translations  (optional) In case you want to manually build the locale files with the translations [default "false"]
-  --force-core          (optional) By default, if a core.json file exists, existing keys won't be overwritten. This is to ensure that messages in core.json can be updated from external sources. In case you want to avoid this check, you can force writing the extracted messages to core.json [default "false"]
+  --overwrite-core      (optional) By default, if a core.json file exists, existing keys won't be overwritten. This is to ensure that messages in core.json can be updated from external sources. In case you want to avoid this check, you can force writing the extracted messages to core.json [default "false"]
   `);
   process.exit(0);
 }
@@ -52,7 +52,7 @@ const locales = ['en', 'de', 'es'];
 const defaultLocale = flags.locale;
 const outputPath = flags['output-path'];
 const shouldBuildTranslations = flags['build-translations'];
-const shouldForceWritingToCore = flags['force-core'];
+const shouldOverwriteWritingToCore = flags['overwrite-core'];
 const globFilesToParse = commands[0];
 
 const newLine = () => process.stdout.write('\n');
@@ -66,16 +66,6 @@ const task = message => {
     }
     return newLine();
   };
-};
-
-const fileExists = fileName => {
-  // Make sure that the `index.html` is available.
-  try {
-    fs.accessSync(fileName, fs.F_OK);
-    return true;
-  } catch (error) {
-    return false;
-  }
 };
 
 // Wrap async functions below into a promise
@@ -186,7 +176,10 @@ const extractFromFile = async fileName => {
     // If a message already exists in the core.json file, we do not overwrite it.
     // This is to ensure that core.json messages can be updated from external sources.
     let safelyMergedMessages;
-    if (!shouldForceWritingToCore && fileExists(coreTranslationFileName)) {
+    if (
+      !shouldOverwriteWritingToCore &&
+      fs.existsSync(coreTranslationFileName)
+    ) {
       const existingCoreMessages = JSON.parse(
         fs.readFileSync(coreTranslationFileName, { encoding: 'utf8' })
       );


### PR DESCRIPTION
Fixes #146 

#### Default behaviour (no overwrite)

![2018-11-28 22 00 05](https://user-images.githubusercontent.com/1110551/49182299-382ed680-f35a-11e8-89ae-ee749b84f909.gif)

#### With `force-core` option (will overwrite)

![2018-11-28 22 01 09](https://user-images.githubusercontent.com/1110551/49182315-3f55e480-f35a-11e8-9335-f81b4373b07e.gif)

#### Deleted messages will be removed (as before)

![2018-11-28 22 04 20](https://user-images.githubusercontent.com/1110551/49182326-47ae1f80-f35a-11e8-9da0-a5008bab9587.gif)

