### PR TITLE
[MCD-1509] Refactor dropdown user settings menu

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -64,7 +64,7 @@
     "classnames": "^2.2.6",
     "common-tags": "1.8.0",
     "debounce-async": "0.0.2",
-    "downshift": "3.1.5",
+    "downshift": "^3.1.5",
     "fast-equals": "1.6.1",
     "formik": "^1.3.2",
     "fuse.js": "3.3.0",

--- a/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
+++ b/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
@@ -67,9 +67,10 @@ exports[`rendering should match layout structure 1`] = `
       <div
         className="spacer"
       />
-      <withRouter(UserSettingsMenu)
+      <UserSettingsMenu
         firstName="John"
         gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
+        isAccountPath={false}
         lastName="Snow"
       />
     </Inline>

--- a/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
+++ b/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
@@ -67,7 +67,7 @@ exports[`rendering should match layout structure 1`] = `
       <div
         className="spacer"
       />
-      <UserSettingsMenu
+      <withRouter(UserSettingsMenu)
         firstName="John"
         gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
         lastName="Snow"

--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -76,6 +76,7 @@ const AppBar = props => (
             firstName={props.user.firstName}
             lastName={props.user.lastName}
             gravatarHash={props.user.gravatarHash}
+            email={props.user.email}
           />
         ) : (
           <LoadingPlaceholder shape="dot" size="l" />

--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -77,6 +77,7 @@ const AppBar = props => (
             lastName={props.user.lastName}
             gravatarHash={props.user.gravatarHash}
             email={props.user.email}
+            isAccountPath={props.isAccountPath}
           />
         ) : (
           <LoadingPlaceholder shape="dot" size="l" />
@@ -97,6 +98,7 @@ AppBar.propTypes = {
     defaultProjectKey: PropTypes.string.isRequired,
   }),
   projectKeyFromUrl: PropTypes.string,
+  isAccountPath: PropTypes.bool.isRequired,
 };
 
 export default AppBar;

--- a/packages/application-shell/src/components/app-bar/app-bar.spec.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.spec.js
@@ -17,6 +17,7 @@ const createTestProps = props => ({
     lastName: 'Snow',
     gravatarHash: '20c9c1b252b46ab49d6f7a4cee9c3e68',
   },
+  isAccountPath: false,
   ...props,
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Router, Redirect, Route, Switch } from 'react-router-dom';
+import { Router, Redirect, Route, Switch, matchPath } from 'react-router-dom';
 import { ApolloProvider } from 'react-apollo';
 import { ReconfigureFlopFlip, ToggleFeature } from '@flopflip/react-broadcast';
 import { joinPaths } from '@commercetools-frontend/url-utils';
@@ -202,6 +202,7 @@ export const RestrictedApplication = props => (
                         <AppBar
                           user={user}
                           projectKeyFromUrl={projectKeyFromUrl}
+                          isAccountPath={props.isAccountPath}
                         />
                       </header>
 
@@ -344,6 +345,7 @@ export const RestrictedApplication = props => (
 
 RestrictedApplication.displayName = 'RestrictedApplication';
 RestrictedApplication.propTypes = {
+  isAccountPath: PropTypes.bool.isRequired,
   environment: PropTypes.object.isRequired,
   defaultFeatureFlags: PropTypes.object,
   render: PropTypes.func.isRequired,
@@ -453,7 +455,7 @@ export default class ApplicationShell extends React.Component {
                    */}
                   <Route path="/logout" component={Logout} />
                   <Route
-                    render={() => (
+                    render={routerProps => (
                       <Authenticated>
                         {({ isAuthenticated }) => {
                           if (isAuthenticated)
@@ -463,6 +465,11 @@ export default class ApplicationShell extends React.Component {
                                 defaultFeatureFlags={
                                   this.props.defaultFeatureFlags
                                 }
+                                isAccountPath={Boolean(
+                                  matchPath(routerProps.location.pathname, {
+                                    path: '/account',
+                                  })
+                                )}
                                 render={this.props.render}
                                 applicationMessages={
                                   this.props.applicationMessages

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -50,6 +50,7 @@ const createTestProps = props => ({
   showUnexpectedErrorNotification: jest.fn(),
   onRegisterErrorListeners: jest.fn(),
   INTERNAL__isApplicationFallback: false,
+  isAccountPath: false,
   ...props,
 });
 
@@ -108,7 +109,9 @@ describe('rendering', () => {
           {wrapper
             .find('Switch > Route')
             .last()
-            .prop('render')()}
+            .prop('render')({
+            location: { pathname: '/account' },
+          })}
         </div>
       );
     });

--- a/packages/application-shell/src/components/user-settings-menu/__snapshots__/user-settings-menu.spec.js.snap
+++ b/packages/application-shell/src/components/user-settings-menu/__snapshots__/user-settings-menu.spec.js.snap
@@ -23,7 +23,7 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
       className=""
     >
       <Inset
-        scale="s"
+        scale="xs"
       >
         <Inline
           alignItems="center"
@@ -36,9 +36,8 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
             lastName="Doe"
             size="s"
           />
-          <Stack
-            alignItems="stretch"
-            scale="xs"
+          <div
+            className=""
           >
             <TextBody
               isBold={true}
@@ -50,7 +49,7 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
             >
               john@doe.com
             </TextBody>
-          </Stack>
+          </div>
         </Inline>
       </Inset>
     </div>

--- a/packages/application-shell/src/components/user-settings-menu/__snapshots__/user-settings-menu.spec.js.snap
+++ b/packages/application-shell/src/components/user-settings-menu/__snapshots__/user-settings-menu.spec.js.snap
@@ -1,85 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering menu when menu is open should render matching tree 1`] = `
-<div
-  onBlur={[MockFunction]}
->
-  <div
+<div>
+  <button
     className="settings-container"
-    onClick={[MockFunction]}
   >
     <WithMouseOverState(UserAvatar)
       firstName="John Test"
       gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
       lastName="Doe"
     />
-  </div>
+  </button>
   <Card
     className="menu"
     theme="light"
     type="raised"
   >
-    <div
-      className=""
-    >
-      <Inset
-        scale="xs"
-      >
-        <Inline
-          alignItems="center"
-          scale="xs"
-        >
-          <Avatar
-            firstName="John Test"
-            gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
-            isHighlighted={false}
-            lastName="Doe"
-            size="s"
-          />
-          <div
-            className=""
-          >
-            <TextBody
-              isBold={true}
-            >
-              John Test Doe
-            </TextBody>
-            <TextBody
-              truncate={true}
-            >
-              john@doe.com
-            </TextBody>
-          </div>
-        </Inline>
-      </Inset>
-    </div>
-    <Link
-      onClick={[MockFunction]}
-      replace={false}
-      to="/account/profile"
-    >
+    <div>
       <div
-        className="item"
+        className=""
       >
         <Inset
-          scale="s"
+          scale="xs"
         >
-          <FormattedMessage
-            defaultMessage="My Profile"
-            description="The label for user profile option"
-            id="UserSettingsMenu.userProfile"
-            values={Object {}}
-          />
+          <Inline
+            alignItems="center"
+            scale="xs"
+          >
+            <Avatar
+              firstName="John Test"
+              gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
+              isHighlighted={false}
+              lastName="Doe"
+              size="s"
+            />
+            <div
+              className=""
+            >
+              <TextBody
+                isBold={true}
+              >
+                John Test Doe
+              </TextBody>
+              <TextBody
+                truncate={true}
+              >
+                john@doe.com
+              </TextBody>
+            </div>
+          </Inline>
         </Inset>
       </div>
-    </Link>
-    <ToggleFeature
-      flag="organizationsList"
-    >
       <Link
         onClick={[MockFunction]}
         replace={false}
-        to="/account/organizations"
+        to="/account/profile"
       >
         <div
           className="item"
@@ -88,22 +63,90 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
             scale="s"
           >
             <FormattedMessage
-              defaultMessage="Manage Organizations"
-              description="The label for manage organizations option"
-              id="UserSettingsMenu.manageOrganizations"
+              defaultMessage="My Profile"
+              description="The label for user profile option"
+              id="UserSettingsMenu.userProfile"
               values={Object {}}
             />
           </Inset>
         </div>
       </Link>
-    </ToggleFeature>
-    <ToggleFeature
-      flag="projectsList"
-    >
-      <Link
+      <ToggleFeature
+        flag="organizationsList"
+      >
+        <Link
+          onClick={[MockFunction]}
+          replace={false}
+          to="/account/organizations"
+        >
+          <div
+            className="item"
+          >
+            <Inset
+              scale="s"
+            >
+              <FormattedMessage
+                defaultMessage="Manage Organizations"
+                description="The label for manage organizations option"
+                id="UserSettingsMenu.manageOrganizations"
+                values={Object {}}
+              />
+            </Inset>
+          </div>
+        </Link>
+      </ToggleFeature>
+      <ToggleFeature
+        flag="projectsList"
+      >
+        <Link
+          onClick={[MockFunction]}
+          replace={false}
+          to="/account/projects"
+        >
+          <div
+            className="item item-divider-account-section"
+          >
+            <Inset
+              scale="s"
+            >
+              <FormattedMessage
+                defaultMessage="Manage Projects"
+                description="The label for manage projects option"
+                id="UserSettingsMenu.manageProjects"
+                values={Object {}}
+              />
+            </Inset>
+          </div>
+        </Link>
+      </ToggleFeature>
+      <a
+        href="https://commercetools.com/privacy"
         onClick={[MockFunction]}
-        replace={false}
-        to="/account/projects"
+        target="_blank"
+      >
+        <div
+          className="item"
+        >
+          <Inset
+            scale="s"
+          >
+            <FormattedMessage
+              defaultMessage="Privacy Policy"
+              description="The label for privacy policy option"
+              id="UserSettingsMenu.privacyPolicy"
+              values={Object {}}
+            />
+          </Inset>
+        </div>
+      </a>
+      <a
+        data-track-component="Navigation-Support-links"
+        data-track-event="click"
+        data-track-label="support_textlink"
+        href="https://jira.commercetools.com/servicedesk/customer/portal/1/create/167"
+        onClick={[MockFunction]}
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <div
           className="item item-divider-account-section"
@@ -112,77 +155,35 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
             scale="s"
           >
             <FormattedMessage
-              defaultMessage="Manage Projects"
-              description="The label for manage projects option"
-              id="UserSettingsMenu.manageProjects"
+              defaultMessage="Support"
+              description="The label for Support"
+              id="UserSettingsMenu.support"
               values={Object {}}
             />
           </Inset>
         </div>
-      </Link>
-    </ToggleFeature>
-    <a
-      href="https://commercetools.com/privacy"
-      target="_blank"
-    >
-      <div
-        className="item"
+      </a>
+      <a
+        data-test="logout-button"
+        href="/logout?reason=user"
       >
-        <Inset
-          scale="s"
+        <div
+          className="item"
+          tabIndex="0"
         >
-          <FormattedMessage
-            defaultMessage="Privacy Policy"
-            description="The label for privacy policy option"
-            id="UserSettingsMenu.privacyPolicy"
-            values={Object {}}
-          />
-        </Inset>
-      </div>
-    </a>
-    <a
-      data-track-component="Navigation-Support-links"
-      data-track-event="click"
-      data-track-label="support_textlink"
-      href="https://jira.commercetools.com/servicedesk/customer/portal/1/create/167"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <div
-        className="item item-divider-account-section"
-      >
-        <Inset
-          scale="s"
-        >
-          <FormattedMessage
-            defaultMessage="Support"
-            description="The label for Support"
-            id="UserSettingsMenu.support"
-            values={Object {}}
-          />
-        </Inset>
-      </div>
-    </a>
-    <a
-      data-test="logout-button"
-      href="/logout?reason=user"
-    >
-      <div
-        className="item"
-        tabIndex="0"
-      >
-        <Inset
-          scale="s"
-        >
-          <FormattedMessage
-            defaultMessage="Logout"
-            description="The label for logout option"
-            id="UserSettingsMenu.logout"
-            values={Object {}}
-          />
-        </Inset>
-      </div>
-    </a>
+          <Inset
+            scale="s"
+          >
+            <FormattedMessage
+              defaultMessage="Logout"
+              description="The label for logout option"
+              id="UserSettingsMenu.logout"
+              values={Object {}}
+            />
+          </Inset>
+        </div>
+      </a>
+    </div>
   </Card>
 </div>
 `;

--- a/packages/application-shell/src/components/user-settings-menu/__snapshots__/user-settings-menu.spec.js.snap
+++ b/packages/application-shell/src/components/user-settings-menu/__snapshots__/user-settings-menu.spec.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering menu when menu is open should render matching tree 1`] = `
-<div>
+<div
+  onBlur={[MockFunction]}
+>
   <div
     className="settings-container"
     onClick={[MockFunction]}
@@ -17,15 +19,41 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
     theme="light"
     type="raised"
   >
-    <Inset
-      scale="s"
+    <div
+      className=""
     >
-      <TextDetail
-        tone="secondary"
+      <Inset
+        scale="s"
       >
-        John Test Doe
-      </TextDetail>
-    </Inset>
+        <Inline
+          alignItems="center"
+          scale="xs"
+        >
+          <Avatar
+            firstName="John Test"
+            gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
+            isHighlighted={false}
+            lastName="Doe"
+            size="s"
+          />
+          <Stack
+            alignItems="stretch"
+            scale="xs"
+          >
+            <TextBody
+              isBold={true}
+            >
+              John Test Doe
+            </TextBody>
+            <TextBody
+              truncate={true}
+            >
+              john@doe.com
+            </TextBody>
+          </Stack>
+        </Inline>
+      </Inset>
+    </div>
     <Link
       onClick={[MockFunction]}
       replace={false}
@@ -122,7 +150,7 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
       target="_blank"
     >
       <div
-        className="item"
+        className="item item-divider-account-section"
       >
         <Inset
           scale="s"
@@ -142,6 +170,7 @@ exports[`rendering menu when menu is open should render matching tree 1`] = `
     >
       <div
         className="item"
+        tabIndex="0"
       >
         <Inset
           scale="s"

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -91,21 +91,25 @@ export class UserSettingsMenu extends React.PureComponent {
                       [styles['item-divider-account-section']]: isAccountPath,
                     })}
                   >
-                    <Spacings.Inset scale="s">
+                    <Spacings.Inset scale="xs">
                       <Spacings.Inline scale="xs" alignItems="center">
                         <Avatar
                           firstName={this.props.firstName}
                           lastName={this.props.lastName}
                           gravatarHash={this.props.gravatarHash}
                         />
-                        <Spacings.Stack scale="xs">
+                        <div
+                          className={classnames({
+                            [styles['email-divider']]: isAccountPath,
+                          })}
+                        >
                           <Text.Body isBold>
                             {[this.props.firstName, this.props.lastName]
                               .join(' ')
                               .trim()}
                           </Text.Body>
                           <Text.Body truncate>{this.props.email}</Text.Body>
-                        </Spacings.Stack>
+                        </div>
                       </Spacings.Inline>
                     </Spacings.Inset>
                   </div>

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -162,10 +162,6 @@ export class UserSettingsMenu extends React.PureComponent {
                         </ToggleFeature>
                       </React.Fragment>
                     )}
-                    {
-                      // FIXME: added as urgent request for GDPR changes
-                      // Should be properly added on the CTP-1209 task
-                    }
                     <a
                       href={`https://commercetools.com/privacy`}
                       target="_blank"

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link, withRouter, matchPath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import classnames from 'classnames';
 import Downshift from 'downshift';
@@ -48,6 +48,20 @@ UserAvatar.propTypes = {
 };
 const UserAvatarWithHoverState = withMouseOverState(UserAvatar);
 
+function stateReducer(state, changes) {
+  switch (changes.type) {
+    // So in case the user wants to navigate with the tab button
+    // we need to make sure that the menu does not close
+    case Downshift.stateChangeTypes.blurButton:
+      return {
+        ...changes,
+        isOpen: true,
+      };
+    default:
+      return changes;
+  }
+}
+
 export class UserSettingsMenu extends React.PureComponent {
   static displayName = 'UserSettingsMenu';
 
@@ -56,141 +70,146 @@ export class UserSettingsMenu extends React.PureComponent {
     lastName: PropTypes.string,
     email: PropTypes.string,
     gravatarHash: PropTypes.string.isRequired,
-
-    // withRouter
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-    }).isRequired,
+    isAccountPath: PropTypes.bool.isRequired,
   };
 
   render() {
-    const isAccountPath = Boolean(
-      matchPath(this.props.location.pathname, {
-        path: '/account',
-      })
-    );
     return (
-      <div className={styles.container} data-test="user-settings-menu">
-        <Downshift>
-          {({ isOpen, toggleMenu }) => (
-            <div onBlur={toggleMenu}>
-              <div
+      <div data-test="user-settings-menu">
+        <Downshift stateReducer={stateReducer}>
+          {({ isOpen, toggleMenu, getToggleButtonProps, getMenuProps }) => (
+            <div>
+              <button
                 className={styles['settings-container']}
-                onClick={toggleMenu}
+                {...getToggleButtonProps()}
               >
                 <UserAvatarWithHoverState
                   firstName={this.props.firstName}
                   lastName={this.props.lastName}
                   gravatarHash={this.props.gravatarHash}
                 />
-              </div>
+              </button>
               {isOpen && (
                 <Card className={styles.menu}>
-                  <div
-                    className={classnames({
-                      [styles['item-divider-account-section']]: isAccountPath,
-                    })}
-                  >
-                    <Spacings.Inset scale="xs">
-                      <Spacings.Inline scale="xs" alignItems="center">
-                        <Avatar
-                          firstName={this.props.firstName}
-                          lastName={this.props.lastName}
-                          gravatarHash={this.props.gravatarHash}
-                        />
-                        <div
-                          className={classnames({
-                            [styles['email-divider']]: isAccountPath,
-                          })}
-                        >
-                          <Text.Body isBold>
-                            {[this.props.firstName, this.props.lastName]
-                              .join(' ')
-                              .trim()}
-                          </Text.Body>
-                          <Text.Body truncate>{this.props.email}</Text.Body>
-                        </div>
-                      </Spacings.Inline>
-                    </Spacings.Inset>
-                  </div>
-                  {!isAccountPath && (
-                    <React.Fragment>
-                      <Link to="/account/profile" onClick={toggleMenu}>
-                        <div className={styles.item}>
-                          <Spacings.Inset scale="s">
-                            <FormattedMessage {...messages.userProfile} />
-                          </Spacings.Inset>
-                        </div>
-                      </Link>
-                      <ToggleFeature flag={ORGANIZATIONS_LIST}>
-                        <Link to="/account/organizations" onClick={toggleMenu}>
+                  <div {...getMenuProps()}>
+                    <div
+                      className={classnames({
+                        [styles['item-divider-account-section']]: this.props
+                          .isAccountPath,
+                      })}
+                    >
+                      <Spacings.Inset scale="xs">
+                        <Spacings.Inline scale="xs" alignItems="center">
+                          <Avatar
+                            firstName={this.props.firstName}
+                            lastName={this.props.lastName}
+                            gravatarHash={this.props.gravatarHash}
+                          />
+                          <div
+                            className={classnames({
+                              [styles['email-divider']]: this.props
+                                .isAccountPath,
+                            })}
+                          >
+                            <Text.Body isBold>
+                              {[this.props.firstName, this.props.lastName]
+                                .join(' ')
+                                .trim()}
+                            </Text.Body>
+                            <Text.Body truncate>{this.props.email}</Text.Body>
+                          </div>
+                        </Spacings.Inline>
+                      </Spacings.Inset>
+                    </div>
+                    {!this.props.isAccountPath && (
+                      <React.Fragment>
+                        <Link to="/account/profile" onClick={toggleMenu}>
                           <div className={styles.item}>
                             <Spacings.Inset scale="s">
-                              <FormattedMessage
-                                {...messages.manageOrganizations}
-                              />
+                              <FormattedMessage {...messages.userProfile} />
                             </Spacings.Inset>
                           </div>
                         </Link>
-                      </ToggleFeature>
-                      <ToggleFeature flag={PROJECTS_LIST}>
-                        <Link to="/account/projects" onClick={toggleMenu}>
-                          <div
-                            className={classnames(
-                              styles.item,
-                              styles['item-divider-account-section']
-                            )}
+                        <ToggleFeature flag={ORGANIZATIONS_LIST}>
+                          <Link
+                            to="/account/organizations"
+                            onClick={toggleMenu}
                           >
-                            <Spacings.Inset scale="s">
-                              <FormattedMessage {...messages.manageProjects} />
-                            </Spacings.Inset>
-                          </div>
-                        </Link>
-                      </ToggleFeature>
-                    </React.Fragment>
-                  )}
-                  {
-                    // FIXME: added as urgent request for GDPR changes
-                    // Should be properly added on the CTP-1209 task
-                  }
-                  <a href={`https://commercetools.com/privacy`} target="_blank">
-                    <div className={styles.item}>
-                      <Spacings.Inset scale="s">
-                        <FormattedMessage {...messages.privacyPolicy} />
-                      </Spacings.Inset>
-                    </div>
-                  </a>
-                  <a
-                    href={MCSupportFormURL}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    data-track-component="Navigation-Support-links"
-                    data-track-event="click"
-                    data-track-label="support_textlink"
-                  >
-                    <div
-                      className={classnames(
-                        styles.item,
-                        styles['item-divider-account-section']
-                      )}
+                            <div className={styles.item}>
+                              <Spacings.Inset scale="s">
+                                <FormattedMessage
+                                  {...messages.manageOrganizations}
+                                />
+                              </Spacings.Inset>
+                            </div>
+                          </Link>
+                        </ToggleFeature>
+                        <ToggleFeature flag={PROJECTS_LIST}>
+                          <Link to="/account/projects" onClick={toggleMenu}>
+                            <div
+                              className={classnames(
+                                styles.item,
+                                styles['item-divider-account-section']
+                              )}
+                            >
+                              <Spacings.Inset scale="s">
+                                <FormattedMessage
+                                  {...messages.manageProjects}
+                                />
+                              </Spacings.Inset>
+                            </div>
+                          </Link>
+                        </ToggleFeature>
+                      </React.Fragment>
+                    )}
+                    {
+                      // FIXME: added as urgent request for GDPR changes
+                      // Should be properly added on the CTP-1209 task
+                    }
+                    <a
+                      href={`https://commercetools.com/privacy`}
+                      target="_blank"
+                      onClick={toggleMenu}
                     >
-                      <Spacings.Inset scale="s">
-                        <FormattedMessage {...messages.support} />
-                      </Spacings.Inset>
-                    </div>
-                  </a>
-                  <a
-                    // NOTE: we want to redirect to a new page so that the
-                    // server can remove things like cookie for access token.
-                    href={`/logout?reason=${LOGOUT_REASONS.USER}`}
-                    data-test="logout-button"
-                  >
-                    <div className={styles.item} tabIndex="0">
-                      <Spacings.Inset scale="s">
-                        <FormattedMessage {...messages.logout} />
-                      </Spacings.Inset>
-                    </div>
-                  </a>
+                      <div className={styles.item}>
+                        <Spacings.Inset scale="s">
+                          <FormattedMessage {...messages.privacyPolicy} />
+                        </Spacings.Inset>
+                      </div>
+                    </a>
+                    <a
+                      href={MCSupportFormURL}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                      data-track-component="Navigation-Support-links"
+                      data-track-event="click"
+                      data-track-label="support_textlink"
+                      onClick={toggleMenu}
+                    >
+                      <div
+                        className={classnames(
+                          styles.item,
+                          styles['item-divider-account-section']
+                        )}
+                      >
+                        <Spacings.Inset scale="s">
+                          <FormattedMessage {...messages.support} />
+                        </Spacings.Inset>
+                      </div>
+                    </a>
+                    <a
+                      // NOTE: we want to redirect to a new page so that the
+                      // server can remove things like cookie for access token.
+                      href={`/logout?reason=${LOGOUT_REASONS.USER}`}
+                      data-test="logout-button"
+                    >
+                      <div className={styles.item} tabIndex="0">
+                        <Spacings.Inset scale="s">
+                          <FormattedMessage {...messages.logout} />
+                        </Spacings.Inset>
+                      </div>
+                    </a>
+                  </div>
                 </Card>
               )}
             </div>
@@ -201,4 +220,4 @@ export class UserSettingsMenu extends React.PureComponent {
   }
 }
 
-export default withRouter(UserSettingsMenu);
+export default UserSettingsMenu;

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
@@ -1,18 +1,27 @@
-.container {
-  position: relative;
+:root {
+  --menu-width: 315px;
+  --menu-position-top: 40px;
+  --menu-position-right: 14px;
+}
+
+.container > div {
+  display: flex;
 }
 
 .settings-container {
   cursor: pointer;
+  border: none;
+  padding: 0;
+  display: flex;
 }
 
 .menu {
   position: absolute;
   border: 1px var(--color-green-40) solid;
   box-shadow: var(--shadow-7-first), var(--shadow-7-second);
-  width: 315px;
-  right: 0;
-  top: 34px;
+  width: var(--menu-width);
+  right: var(--menu-position-right);
+  top: var(--menu-position-top);
   padding: var(--spacing-4);
   overflow: hidden;
 }
@@ -31,9 +40,9 @@
   content: '';
   position: absolute;
   right: 28px;
-  top: -8px;
+  top: calc(var(--spacing-8) * -1);
   border-style: solid;
-  border-width: 0 8px 8px;
+  border-width: 0 var(--spacing-8) var(--spacing-8);
   z-index: 0;
 }
 

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
@@ -10,6 +10,7 @@
   border: none;
   padding: 0;
   display: flex;
+  background: transparent;
 }
 
 .menu {

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
@@ -2,10 +2,7 @@
   --menu-width: 315px;
   --menu-position-top: 40px;
   --menu-position-right: 14px;
-}
-
-.container > div {
-  display: flex;
+  --menu-offset-right: 28px;
 }
 
 .settings-container {
@@ -39,7 +36,7 @@
 .menu::after {
   content: '';
   position: absolute;
-  right: 28px;
+  right: var(--menu-offset-right);
   top: calc(var(--spacing-8) * -1);
   border-style: solid;
   border-width: 0 var(--spacing-8) var(--spacing-8);

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
@@ -50,3 +50,7 @@
 .item-divider-account-section {
   border-bottom: 1px solid var(--color-gray);
 }
+
+.email-divider {
+  margin-bottom: var(--spacing-4);
+}

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.mod.css
@@ -8,12 +8,12 @@
 
 .menu {
   position: absolute;
-  border: 1px var(--color-gray-60) solid;
+  border: 1px var(--color-green-40) solid;
   box-shadow: var(--shadow-7-first), var(--shadow-7-second);
-  width: 200px;
+  width: 315px;
   right: 0;
   top: 34px;
-  padding: 0;
+  padding: var(--spacing-4);
   overflow: hidden;
 }
 
@@ -24,7 +24,6 @@
   top: -6px;
   border-style: solid;
   border-width: 0 6px 6px;
-  border-color: transparent transparent var(--color-white) transparent;
   z-index: 1;
 }
 
@@ -35,7 +34,6 @@
   top: -8px;
   border-style: solid;
   border-width: 0 8px 8px;
-  border-color: transparent transparent var(--color-gray-60) transparent;
   z-index: 0;
 }
 

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -9,16 +9,16 @@ const createTestProps = props => ({
   firstName: 'John Test',
   lastName: 'Doe',
   email: 'john@doe.com',
-  location: {
-    pathname: '/test-1/products',
-  },
   gravatarHash: '20c9c1b252b46ab49d6f7a4cee9c3e68',
+  isAccountPath: false,
   ...props,
 });
 
 const createDownshiftProps = props => ({
   isOpen: false,
   toggleMenu: jest.fn(),
+  getToggleButtonProps: jest.fn(),
+  getMenuProps: jest.fn(),
   ...props,
 });
 
@@ -43,10 +43,8 @@ describe('rendering', () => {
         wrapper.find(Downshift).prop('children')(downshiftProps)
       );
     });
-    it('should render div with click handler', () => {
-      expect(
-        menuStateContainerRenderWrapper.find('.settings-container')
-      ).toHaveProp('onClick', downshiftProps.toggleMenu);
+    it('should render button', () => {
+      expect(menuStateContainerRenderWrapper).toRender('button');
     });
     it('should render WithMouseOverState(UserAvatar)', () => {
       expect(menuStateContainerRenderWrapper).toRender(
@@ -80,9 +78,7 @@ describe('rendering', () => {
       });
       describe('when is in the account section', () => {
         beforeEach(() => {
-          props = createTestProps({
-            location: { pathname: '/account/organizations' },
-          });
+          props = createTestProps({ isAccountPath: true });
           wrapper = shallow(<UserSettingsMenu {...props} />);
           downshiftProps = createDownshiftProps({ isOpen: true });
           menuStateContainerRenderWrapper = shallow(

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { CaretDownIcon } from '@commercetools-frontend/ui-kit';
+import { CaretDownIcon, Avatar } from '@commercetools-frontend/ui-kit';
 import Downshift from 'downshift';
 import { MCSupportFormURL } from '../../constants';
 import { UserSettingsMenu, UserAvatar } from './user-settings-menu';
@@ -137,15 +137,15 @@ describe('rendering', () => {
     });
 
     it('should pass prop firstName to `Avatar` component', () => {
-      expect(wrapper.find('Avatar')).toHaveProp('firstName', 'John Test');
+      expect(wrapper.find(Avatar)).toHaveProp('firstName', 'John Test');
     });
 
     it('should pass prop lastName to `Avatar` component', () => {
-      expect(wrapper.find('Avatar')).toHaveProp('lastName', 'Doe');
+      expect(wrapper.find(Avatar)).toHaveProp('lastName', 'Doe');
     });
 
     it('should pass prop `gravatarHash` to `Avatar` component', () => {
-      expect(wrapper.find('Avatar')).toHaveProp(
+      expect(wrapper.find(Avatar)).toHaveProp(
         'gravatarHash',
         '20c9c1b252b46ab49d6f7a4cee9c3e68'
       );

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -1,14 +1,24 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Avatar, CaretDownIcon } from '@commercetools-frontend/ui-kit';
-import MenuStateContainer from '../menu-state-container';
+import { CaretDownIcon } from '@commercetools-frontend/ui-kit';
+import Downshift from 'downshift';
 import { MCSupportFormURL } from '../../constants';
-import UserSettingsMenu, { UserAvatar } from './user-settings-menu';
+import { UserSettingsMenu, UserAvatar } from './user-settings-menu';
 
 const createTestProps = props => ({
   firstName: 'John Test',
   lastName: 'Doe',
+  email: 'john@doe.com',
+  location: {
+    pathname: '/test-1/products',
+  },
   gravatarHash: '20c9c1b252b46ab49d6f7a4cee9c3e68',
+  ...props,
+});
+
+const createDownshiftProps = props => ({
+  isOpen: false,
+  toggleMenu: jest.fn(),
   ...props,
 });
 
@@ -20,25 +30,23 @@ describe('rendering', () => {
     wrapper = shallow(<UserSettingsMenu {...props} />);
   });
 
-  it('should render <MenuStateContainer> wrapper', () => {
-    expect(wrapper).toRender(MenuStateContainer);
+  it('should render <Downshift> wrapper', () => {
+    expect(wrapper).toRender(Downshift);
   });
 
   describe('menu', () => {
-    let menuStateContainerProps;
+    let downshiftProps;
     let menuStateContainerRenderWrapper;
     beforeEach(() => {
-      menuStateContainerProps = { isOpen: false, toggleMenu: jest.fn() };
+      downshiftProps = createDownshiftProps();
       menuStateContainerRenderWrapper = shallow(
-        wrapper.find(MenuStateContainer).prop('children')(
-          menuStateContainerProps
-        )
+        wrapper.find(Downshift).prop('children')(downshiftProps)
       );
     });
     it('should render div with click handler', () => {
       expect(
         menuStateContainerRenderWrapper.find('.settings-container')
-      ).toHaveProp('onClick', menuStateContainerProps.toggleMenu);
+      ).toHaveProp('onClick', downshiftProps.toggleMenu);
     });
     it('should render WithMouseOverState(UserAvatar)', () => {
       expect(menuStateContainerRenderWrapper).toRender(
@@ -47,11 +55,9 @@ describe('rendering', () => {
     });
     describe('when menu is open', () => {
       beforeEach(() => {
-        menuStateContainerProps = { isOpen: true, toggleMenu: jest.fn() };
+        downshiftProps = createDownshiftProps({ isOpen: true });
         menuStateContainerRenderWrapper = shallow(
-          wrapper.find(MenuStateContainer).prop('children')(
-            menuStateContainerProps
-          )
+          wrapper.find(Downshift).prop('children')(downshiftProps)
         );
       });
       it('should render matching tree', () => {
@@ -72,14 +78,39 @@ describe('rendering', () => {
           href: MCSupportFormURL,
         });
       });
+      describe('when is in the account section', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            location: { pathname: '/account/organizations' },
+          });
+          wrapper = shallow(<UserSettingsMenu {...props} />);
+          downshiftProps = createDownshiftProps({ isOpen: true });
+          menuStateContainerRenderWrapper = shallow(
+            wrapper.find(Downshift).prop('children')(downshiftProps)
+          );
+        });
+        it('should not render link to "/account/profile"', () => {
+          expect(menuStateContainerRenderWrapper).not.toRender({
+            to: '/account/profile',
+          });
+        });
+        it('should not render link to "/account/organizations"', () => {
+          expect(menuStateContainerRenderWrapper).not.toRender({
+            to: '/account/organizations',
+          });
+        });
+        it('should not render link to "/account/projects"', () => {
+          expect(menuStateContainerRenderWrapper).not.toRender({
+            to: '/account/projects',
+          });
+        });
+      });
     });
     describe('when menu is closed', () => {
       beforeEach(() => {
-        menuStateContainerProps = { isOpen: false, toggleMenu: jest.fn() };
+        downshiftProps = createDownshiftProps();
         menuStateContainerRenderWrapper = shallow(
-          wrapper.find(MenuStateContainer).prop('children')(
-            menuStateContainerProps
-          )
+          wrapper.find(Downshift).prop('children')(downshiftProps)
         );
       });
       it('should not render <Card>', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5092,7 +5092,7 @@ dotenv@6.1.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.1.0.tgz#9853b6ca98292acb7dec67a95018fa40bccff42c"
   integrity sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==
 
-downshift@3.1.5:
+downshift@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.1.5.tgz#2f8a54bd5026942ca06affdb0a5b19c14d949e9c"
   integrity sha512-2PpR4+A0WiF0R+Q6sq79sSG+sAy4KBlH5FwnU8FtD5zkeZH/UQZm/QS7kq/CglSH8vl1qpPoaap4Z2Oe9Swcrg==


### PR DESCRIPTION
#### Summary

Ticket: https://jira.commercetools.com/browse/MCD-1509
Design: https://projects.invisionapp.com/d/main#/projects/prototypes/16095086

#### Description

This PR contains the changes to refactor the user settings menu to the new designs including:

* add downshift for the outer click functionality
* Address minor design issues (border, inside padding, separators, user information)
* Hide projects, organizations and profile options if we are in account section.
* Pass email from `app-bar` so we can use it

| When in the MC | When in account section  |  
|:-:|---|
| ![image](https://user-images.githubusercontent.com/11442895/49215421-0dc83200-f3c9-11e8-8a95-226e7dc588f7.png) | ![image](https://user-images.githubusercontent.com/11442895/49215435-14ef4000-f3c9-11e8-904d-bc7bb45ca6ac.png) |  
