### PR TITLE
Fix flopflip being bundled (remove rollup-plugin-peer-deps-external)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "rollup-plugin-json": "3.1.0",
     "rollup-plugin-node-builtins": "2.1.2",
     "rollup-plugin-node-resolve": "3.4.0",
-    "rollup-plugin-peer-deps-external": "2.2.0",
     "rollup-plugin-postcss": "1.6.3",
     "rollup-plugin-replace": "2.1.0",
     "shelljs": "0.8.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,12 +49,24 @@ const externalDependencies = pkgDependencies
       !dependenciesRequiringToBeBundled.includes(potentiallyExternalDependency)
   );
 
+/**
+ * Note:
+ *    This function is copied from rollup-plugin-peer-deps-external.
+ *    Reference: https://github.com/Updater/rollup-plugin-peer-deps-external/blob/master/src/get-modules-matcher.js
+ *    Without it rollup has more warnings about unresolved dependencies and unused external imports.
+ */
+const createExternalsFromDependencies = modulesNames => {
+  const moduleRegExp = module => new RegExp(`^${module}(\\/.+)*$`);
+  const regexps = modulesNames.map(moduleRegExp);
+  return id => regexps.some(regexp => regexp.test(id));
+};
+
 const config = {
   output: {
     name: pkg.name,
     sourcemap: true,
   },
-  external: externalDependencies,
+  external: createExternalsFromDependencies(externalDependencies),
   plugins: [
     babel({
       exclude: '**/node_modules/**',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13346,11 +13346,6 @@ rollup-plugin-node-resolve@3.4.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
-rollup-plugin-peer-deps-external@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.0.tgz#99ef9231aa01736f3e9605b7c3084a0d627f665b"
-  integrity sha512-BmJMHUWQcvjS2dQMwJ7dzvdbwpRChnq4AYk2sTU/4aySt9Kumk8y8W3HhTHss31wxzKb0AC/wsiX1AqDcOBIEA==
-
 rollup-plugin-postcss@1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-postcss/-/rollup-plugin-postcss-1.6.3.tgz#18256ba66f29ecd9d42a68f4ef136b92b939ddb8"


### PR DESCRIPTION
#### Summary

This pull requests fixes flopflip (and potentially other) deps to be added to an exclusion list so they're bundled.

#### Description

Given we want to achieve the above we have to remove rollup-plugin-peer-deps-external and do the work ourselves. It's not much work as one of the aims of the module seems to be to auto-add things like `lodash/flatMap` if it finds `lodash`.


