### PR TITLE
Make locale data work with CJS bundle

### DIFF
--- a/packages/l10n/country-information.js
+++ b/packages/l10n/country-information.js
@@ -27,7 +27,7 @@ const getCountriesForLocale = (locale, cb) => {
   // The files are named like "country-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(countries => cb(null, countries.default))
+    .then(countries => cb(null, countries))
     .catch(error => cb(error));
 };
 

--- a/packages/l10n/currency-information.js
+++ b/packages/l10n/currency-information.js
@@ -24,7 +24,7 @@ const getCurrenciesForLocale = (locale, cb) => {
   // The files are named like "currency-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(currencies => cb(null, currencies.default))
+    .then(currencies => cb(null, currencies))
     .catch(error => cb(error));
 };
 

--- a/packages/l10n/language-information.js
+++ b/packages/l10n/language-information.js
@@ -32,7 +32,7 @@ const getLanguagesForLocale = (locale, cb) => {
   // The files are named like "language-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(languages => cb(null, languages.default))
+    .then(languages => cb(null, languages))
     .catch(error => cb(error));
 };
 export const withLanguages = createL10NInjector({

--- a/packages/l10n/time-zone-information.js
+++ b/packages/l10n/time-zone-information.js
@@ -33,7 +33,7 @@ const getTimeZonesForLocale = (locale, cb) => {
   // The files are named like "time-zone-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(timeZones => cb(null, timeZones.default))
+    .then(timeZones => cb(null, timeZones))
     .catch(error => cb(error));
 };
 


### PR DESCRIPTION
#### Summary

Currently locale data imports don't work when using the CJS bundle, as default export isn't available with the CJS build.

#### Approach

Remove the `.default` from the import.

With ES bundle

![screen shot 2018-11-29 at 4 59 19 pm](https://user-images.githubusercontent.com/2425013/49236716-ff940900-f3fc-11e8-90c7-682e0b5811e8.png)

With CJS

![screen shot 2018-11-29 at 5 03 19 pm](https://user-images.githubusercontent.com/2425013/49236724-06228080-f3fd-11e8-9b0b-72fba583d7cc.png)

I also tested both bundles with the MC-FE.