### PR TITLE
fix(l10n): prefer loading default, fall back to normal import (esm vs cjs)

### DIFF
--- a/packages/i18n/load-i18n.js
+++ b/packages/i18n/load-i18n.js
@@ -46,7 +46,12 @@ export default function loadI18n(lang) {
   const localeDataPromises = [reactIntlChunkImport, momentChunkImport];
 
   return Promise.all(localeDataPromises).then(response => {
-    addLocaleData([...response[0].default]);
-    return getLocalizedStringsChunkImport(lang).then(result => result.default);
+    // Prefer loading `default` (for ESM bundles) and
+    // fall back to normal import (for CJS bundles).
+    const loadedData = response[0].default || response[0];
+    addLocaleData([...loadedData]);
+    return getLocalizedStringsChunkImport(lang).then(
+      result => result.default || result
+    );
   });
 }

--- a/packages/l10n/country-information.js
+++ b/packages/l10n/country-information.js
@@ -27,7 +27,9 @@ const getCountriesForLocale = (locale, cb) => {
   // The files are named like "country-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(countries => cb(null, countries))
+    // Prefer loading `default` (for ESM bundles) and
+    // fall back to normal import (for CJS bundles).
+    .then(countries => cb(null, countries.default || countries))
     .catch(error => cb(error));
 };
 

--- a/packages/l10n/currency-information.js
+++ b/packages/l10n/currency-information.js
@@ -24,7 +24,9 @@ const getCurrenciesForLocale = (locale, cb) => {
   // The files are named like "currency-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(currencies => cb(null, currencies))
+    // Prefer loading `default` (for ESM bundles) and
+    // fall back to normal import (for CJS bundles).
+    .then(currencies => cb(null, currencies.default || currencies))
     .catch(error => cb(error));
 };
 

--- a/packages/l10n/language-information.js
+++ b/packages/l10n/language-information.js
@@ -32,7 +32,9 @@ const getLanguagesForLocale = (locale, cb) => {
   // The files are named like "language-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(languages => cb(null, languages))
+    // Prefer loading `default` (for ESM bundles) and
+    // fall back to normal import (for CJS bundles).
+    .then(languages => cb(null, languages.default || languages))
     .catch(error => cb(error));
 };
 export const withLanguages = createL10NInjector({

--- a/packages/l10n/time-zone-information.js
+++ b/packages/l10n/time-zone-information.js
@@ -33,7 +33,9 @@ const getTimeZonesForLocale = (locale, cb) => {
   // The files are named like "time-zone-data-en-json.chunk.js" after compilation
   // https://webpack.js.org/api/module-methods/#import-
   getImportChunk(supportedLocale)
-    .then(timeZones => cb(null, timeZones))
+    // Prefer loading `default` (for ESM bundles) and
+    // fall back to normal import (for CJS bundles).
+    .then(timeZones => cb(null, timeZones.default || timeZones))
     .catch(error => cb(error));
 };
 


### PR DESCRIPTION
Caused by #154 

## Problem

This is what l10n loads

<img width="668" alt="image" src="https://user-images.githubusercontent.com/1110551/49305058-6fbe8f80-f4ce-11e8-9329-2b44e977835a.png">

To explain it a bit further: the bundled JSONs look like this

<img width="710" alt="image" src="https://user-images.githubusercontent.com/1110551/49305896-e65c8c80-f4d0-11e8-912e-6fd704689a8a.png">

The `default` export includes all the locales (languages + country)

<img width="424" alt="image" src="https://user-images.githubusercontent.com/1110551/49305948-0d1ac300-f4d1-11e8-906f-3c5a95df2a82.png">

But the named exports are only for "top-level" locales (language tag).

The CJS includes all locales in one object

<img width="425" alt="image" src="https://user-images.githubusercontent.com/1110551/49306045-579c3f80-f4d1-11e8-9d98-29b9ee892600.png">

## Solution

We check first if the loaded module has a `default` property, in which case we pick that (ESM bundle). If not, we simply load the module as-is (CJS bundle).