### PR TITLE
refactor: improve `experimentalRender` testing experience

### DIFF
--- a/packages/application-shell/src/components/local-store-provider/local-store-provider.js
+++ b/packages/application-shell/src/components/local-store-provider/local-store-provider.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 import { compose } from 'recompose';
 import has from 'lodash.has';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import * as storage from '@commercetools-frontend/storage';
 import { __LOCAL } from '../../middleware/add-plugin-to-notification/constants';
 import { STORAGE_KEYS } from '../../constants';
-import { withUser } from '../fetch-user';
-import { withProject } from '../fetch-project';
 
 export class LocalStoreProvider extends React.Component {
   static displayName = 'LocalStoreProvider';
@@ -19,6 +17,7 @@ export class LocalStoreProvider extends React.Component {
 
     // Injected
     hasStateForActivePlugin: PropTypes.bool.isRequired,
+    permissions: PropTypes.object.isRequired,
     user: PropTypes.shape({
       id: PropTypes.string.isRequired,
       firstName: PropTypes.string.isRequired,
@@ -26,7 +25,6 @@ export class LocalStoreProvider extends React.Component {
       language: PropTypes.string.isRequired,
     }).isRequired,
     project: PropTypes.shape({
-      permissions: PropTypes.object.isRequired,
       countries: PropTypes.array.isRequired,
       languages: PropTypes.array.isRequired,
       currencies: PropTypes.array.isRequired,
@@ -103,13 +101,12 @@ export class LocalStoreProvider extends React.Component {
     },
 
     // Project info
-    permissions: this.props.project.permissions,
+    permissions: this.props.permissions,
     countries: this.props.project.countries,
     languages: this.props.project.languages,
     currencies: this.props.project.currencies,
     projectKey: this.props.project.key,
     projectSettings: this.props.project.settings,
-    projectExpired: this.props.project.expiry.isActive,
   });
 
   render() {
@@ -123,8 +120,10 @@ export const mapStateToProps = (state, ownProps) => ({
 });
 
 export default compose(
-  withRouter, // Used by `withProject`
-  withProject(ownProps => ownProps.match.params.projectKey),
-  withUser(),
+  withApplicationContext(applicationContext => ({
+    user: applicationContext.user,
+    project: applicationContext.project,
+    permissions: applicationContext.permissions,
+  })),
   connect(mapStateToProps)
 )(LocalStoreProvider);

--- a/packages/application-shell/src/components/local-store-provider/local-store-provider.spec.js
+++ b/packages/application-shell/src/components/local-store-provider/local-store-provider.spec.js
@@ -221,7 +221,6 @@ describe('lifecycle', () => {
               currencies: props.project.currencies,
               projectKey: props.project.key,
               projectSettings: props.project.settings,
-              projectExpired: props.project.expiry.isActive,
             },
           })
         );

--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -28,11 +28,10 @@ const httpLink = createHttpLink({
 // in the response/phase they are executed bottom to top
 // `tokenRetryLink` needs to stay after `errorLink` in order to be executed before `errorLink` for responses
 const link = ApolloLink.from([
-  headerLink,
-  errorLink,
-  apolloLogger,
-  tokenRetryLink,
-  httpLink,
+  ...[headerLink, errorLink],
+  // We don't want to log Apollo Stuff in testing environment
+  ...(process.env.NODE_ENV !== 'test' ? [apolloLogger] : []),
+  ...[tokenRetryLink, httpLink],
 ]);
 
 /**

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -5,6 +5,7 @@
 // and then use it together with react-testing-library.
 import React from 'react';
 import PropTypes from 'prop-types';
+import merge from 'lodash.merge';
 import { Router } from 'react-router-dom';
 import { ApolloProvider } from 'react-apollo';
 import { render as rtlRender } from 'react-testing-library';
@@ -62,7 +63,7 @@ const defaultPermissions = { canManageProject: true };
 // Allow consumers of `render` to extend the defaults by passing an object
 // or to completely omit the value by passing `null`
 const mergeOptional = (defaultValue, value) =>
-  value === null ? undefined : { ...defaultValue, ...value };
+  value === null ? undefined : merge(defaultValue, value);
 
 const LoadingFallback = () => 'Loading...';
 LoadingFallback.displayName = 'LoadingFallback';


### PR DESCRIPTION
#### Summary

`experimentalRender` uses actual Apollo and in my test in MC I try to use actual Redux setup as well. To do so, I need to:

* Get rid off logging in the test environment
* Perform <InjectReducer /> in my tests in MC (which will move to `experimentalRender` at some point).
