### PR TITLE
chore(playground): remove ui-kit materials transpilation

### DIFF
--- a/playground/webpack.config.dev.js
+++ b/playground/webpack.config.dev.js
@@ -3,24 +3,7 @@ const createWebpackConfigForDevelopment = require('@commercetools-frontend/mc-sc
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [
-  path.resolve(__dirname, 'src'),
-  // NOTE: we still need to include the materials folder in order for `postcss`
-  // to compile the css module files.
-  path.resolve(
-    require.resolve('@commercetools-frontend/ui-kit'),
-    '../../materials'
-  ),
-  // Fall back to main node_modules. This might be needed in case the playground
-  // uses a different version of the ui-kit compared to the app-kit packages.
-  // Consequently, yarn workspaces will now hoist the ui-kit package with the
-  // different version. However, ui-kit imports from the app-kit packages should
-  // still resolve to the main hoisted ui-kit package.
-  path.resolve(
-    __dirname,
-    '../node_modules/@commercetools-frontend/ui-kit/materials'
-  ),
-];
+const sourceFolders = [path.resolve(__dirname, 'src')];
 
 module.exports = createWebpackConfigForDevelopment({
   distPath,

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -3,24 +3,7 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [
-  path.resolve(__dirname, 'src'),
-  // NOTE: we still need to include the materials folder in order for `postcss`
-  // to compile the css module files.
-  path.resolve(
-    require.resolve('@commercetools-frontend/ui-kit'),
-    '../../materials'
-  ),
-  // Fall back to main node_modules. This might be needed in case the playground
-  // uses a different version of the ui-kit compared to the app-kit packages.
-  // Consequently, yarn workspaces will now hoist the ui-kit package with the
-  // different version. However, ui-kit imports from the app-kit packages should
-  // still resolve to the main hoisted ui-kit package.
-  path.resolve(
-    __dirname,
-    '../node_modules/@commercetools-frontend/ui-kit/materials'
-  ),
-];
+const sourceFolders = [path.resolve(__dirname, 'src')];
 
 module.exports = createWebpackConfigForProduction({
   distPath,


### PR DESCRIPTION
#### Summary

Since `ui-kit` v4.0.0, we no longer access material variables by @importing them in our css files. So we no longer need to pass this folder to our webpack configs.

#### Approach

Stop passing `ui-kit` materials folder to webpack configs in playground.