### PR TITLE
Fail fast on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,11 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 script:
+  - set -e
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn build
   - yarn playground:build
+  - set +e
 
 after_success:
   - ./scripts/push_translations.sh


### PR DESCRIPTION
Closes #156 

#### Summary

If the tests fail on CI, the apps still build. See [here](https://travis-ci.org/commercetools/merchant-center-application-kit/builds/461379125?utm_source=github_status&utm_medium=notification) for an example.

#### Approach

Add `set -e` to the beginning of our scripts (instructs bash to quit if there is an error), and add `set +e` to unset the flag at the end of our scripts, as travis can sometimes have internal scripts that exit with a non zero code that we wouldn't result in our build failing.

#### Example

Check [here](https://travis-ci.org/commercetools/merchant-center-application-kit/builds/463221055?utm_source=github_status&utm_medium=notification) for an example of this PR resulting in a fail fast.

#### Help / docs

[https://github.com/travis-ci/travis-ci/issues/1066](https://github.com/travis-ci/travis-ci/issues/1066)
