### PR TITLE
refactor(login): validate same origin for redirect target url after login

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { Router, Redirect, Route, Switch, matchPath } from 'react-router-dom';
 import { ApolloProvider } from 'react-apollo';
 import { ReconfigureFlopFlip, ToggleFeature } from '@flopflip/react-broadcast';
-import { joinPaths } from '@commercetools-frontend/url-utils';
+import {
+  joinPaths,
+  trimLeadingAndTrailingSlashes,
+} from '@commercetools-frontend/url-utils';
 import * as storage from '@commercetools-frontend/storage';
 import { DOMAINS, LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import history from '@commercetools-frontend/browser-history';
@@ -378,7 +381,11 @@ export const UnrestrictedApplication = () => (
           // to redirect to this location.
           ...(location.pathname === '/'
             ? {}
-            : { redirectTo: location.pathname }),
+            : {
+                redirectTo: trimLeadingAndTrailingSlashes(
+                  joinPaths(window.location.origin, location.pathname)
+                ),
+              }),
         };
         return (
           <Redirect

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -618,7 +618,7 @@ describe('<UnrestrictedApplication>', () => {
             'to',
             expect.objectContaining({
               query: expect.objectContaining({
-                redirectTo: '/foo-1/products',
+                redirectTo: `${window.location.origin}/foo-1/products`,
               }),
             })
           );


### PR DESCRIPTION
To prevent possible unwanted redirects to 3rd party "malicious" websites after the user logs in, we should check that the `redirectTo` query parameter matches the current `Origin`.
So if you're in `https://mc.commercetools.com/login`, the `redirectTo` is valid if it contains the same origin `https://mc.commercetools.com` (e.g. `https://mc.commercetools.com/my-project/orders`).

To make the validation possible, the `redirectTo` now contains the `origin`, where previously it only contained the uri path.