### PR TITLE
fix(app-shell): show <ProjectExpired> also when daysLeft are less than 0

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -155,12 +155,15 @@ export const RestrictedApplication = props => (
                                   if (isProjectLoading) return null;
 
                                   // when used outside of a project context,
-                                  // or when the project is expired or supsended
+                                  // or when the project is expired or suspended
                                   const useProjectContext =
                                     project &&
                                     !(
-                                      project.suspension?.isActive ||
-                                      project.expiry?.isActive
+                                      (project.suspension &&
+                                        project.suspension.isActive) ||
+                                      (project.expiry &&
+                                        (project.expiry.isActive ||
+                                          project.expiry.daysLeft < 0))
                                     );
 
                                   if (!useProjectContext)

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -132,7 +132,10 @@ export class ProjectContainer extends React.Component {
                   }
                 />
               );
-            if (project.expiry && project.expiry.isActive)
+            if (
+              project.expiry &&
+              (project.expiry.isActive || project.expiry.daysLeft < 0)
+            )
               return <ProjectExpired />;
 
             return (

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -253,6 +253,20 @@ describe('rendering', () => {
         expect(wrapper).toRender(ProjectExpired);
       });
     });
+    describe('when days left of trials are less than 0', () => {
+      beforeEach(() => {
+        wrapper = wrapper.find(FetchProject).renderProp('children', {
+          isLoading: false,
+          project: createTestProjectProps({
+            suspension: { isActive: false },
+            expiry: { isActive: false, daysLeft: -1 },
+          }),
+        });
+      });
+      it('should render <ProjectExpired>', () => {
+        expect(wrapper).toRender(ProjectExpired);
+      });
+    });
     describe('when project is in a valid state', () => {
       describe('<ProjectDataLocale>', () => {
         let wrapperDataLocale;

--- a/packages/application-shell/src/components/project-switcher/project-switcher-fragments.graphql
+++ b/packages/application-shell/src/components/project-switcher/project-switcher-fragments.graphql
@@ -6,5 +6,6 @@ fragment projectFragment on Project {
   }
   expiry {
     isActive
+    daysLeft
   }
 }

--- a/packages/application-shell/src/components/project-switcher/project-switcher.js
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.js
@@ -135,12 +135,14 @@ export class ProjectSwitcher extends React.PureComponent {
         className={classnames(styles['item-text-main'], {
           [styles['item-text-disabled']]:
             (project.suspension && project.suspension.isActive) ||
-            (project.expiry && project.expiry.isActive),
+            (project.expiry &&
+              (project.expiry.isActive || project.expiry.daysLeft < 0)),
         })}
       >
         {project.name}
         {((project.suspension && project.suspension.isActive) ||
-          (project.expiry && project.expiry.isActive)) && (
+          (project.expiry &&
+            (project.expiry.isActive || project.expiry.daysLeft < 0))) && (
           <span className={styles['disabled-icon-container']}>
             <ErrorIcon size="medium" />
           </span>
@@ -150,7 +152,8 @@ export class ProjectSwitcher extends React.PureComponent {
         className={classnames(styles['item-text-small'], {
           [styles['item-text-disabled']]:
             (project.suspension && project.suspension.isActive) ||
-            (project.expiry && project.expiry.isActive),
+            (project.expiry &&
+              (project.expiry.isActive || project.expiry.daysLeft < 0)),
         })}
       >
         {project.key}
@@ -160,11 +163,12 @@ export class ProjectSwitcher extends React.PureComponent {
           <FormattedMessage {...messages.suspended} />
         </div>
       )}
-      {project.expiry && project.expiry.isActive && (
-        <div className={classnames(styles.red, styles['item-text-small'])}>
-          <FormattedMessage {...messages.expired} />
-        </div>
-      )}
+      {project.expiry &&
+        (project.expiry.isActive || project.expiry.daysLeft < 0) && (
+          <div className={classnames(styles.red, styles['item-text-small'])}>
+            <FormattedMessage {...messages.expired} />
+          </div>
+        )}
     </div>
   );
 


### PR DESCRIPTION
I noticed that projects with a trial expired based on `daysLeft` should be shown the `<ProjectExpired>` page