### PR TITLE
Add array wrapping to showApiErrorNotification (through .isArray)

### DIFF
--- a/packages/actions-global/global.js
+++ b/packages/actions-global/global.js
@@ -15,7 +15,9 @@ export function showApiErrorNotification({ errors, source }) {
       kind: 'api-error',
       values: {
         source,
-        errors,
+        // NOTE: Some sources or errors (e.g. GraphQL) return an array or object.
+        // The cast into an array happens here so that consumers can pass both types.
+        errors: Array.isArray(errors) ? errors : [errors],
       },
       domain: DOMAINS.PAGE,
     },

--- a/packages/actions-global/global.spec.js
+++ b/packages/actions-global/global.spec.js
@@ -8,56 +8,89 @@ import {
 } from './global';
 
 describe('dispatching notifications', () => {
-  it('dispatches the ADD_NOTIFICATION action when passing an error', () => {
-    expect(
-      showApiErrorNotification({
-        errors: [{ code: 'oops' }],
-        source: 'FOO',
-      })
-    ).toEqual(
-      toGlobal({
-        type: ADD_NOTIFICATION,
-        payload: {
-          kind: 'api-error',
-          domain: 'page',
-          values: {
+  describe('api errors', () => {
+    describe('given `errors` is not an `Array`', () => {
+      it('dispatches the ADD_NOTIFICATION action when passing the errors (as Array)', () => {
+        expect(
+          showApiErrorNotification({
+            errors: { code: 'oops' },
+            source: 'FOO',
+          })
+        ).toEqual(
+          toGlobal({
+            type: ADD_NOTIFICATION,
+            payload: {
+              kind: 'api-error',
+              domain: 'page',
+              values: {
+                errors: [{ code: 'oops' }],
+                source: 'FOO',
+                statusCode: undefined,
+              },
+            },
+            meta: {
+              dismissAfter: 0,
+            },
+          })
+        );
+      });
+    });
+
+    describe('given the `errors` is an `Array`', () => {
+      it('dispatches the ADD_NOTIFICATION action when passing the errors', () => {
+        expect(
+          showApiErrorNotification({
             errors: [{ code: 'oops' }],
             source: 'FOO',
-            statusCode: undefined,
-          },
-        },
-        meta: {
-          dismissAfter: 0,
-        },
-      })
-    );
+          })
+        ).toEqual(
+          toGlobal({
+            type: ADD_NOTIFICATION,
+            payload: {
+              kind: 'api-error',
+              domain: 'page',
+              values: {
+                errors: [{ code: 'oops' }],
+                source: 'FOO',
+                statusCode: undefined,
+              },
+            },
+            meta: {
+              dismissAfter: 0,
+            },
+          })
+        );
+      });
+    });
   });
 
-  it('dispatches ADD_NOTIFICATION when unexpected error occurs', () => {
-    expect(
-      showUnexpectedErrorNotification({
-        error: 'oops',
-        source: 'FOO',
-        errorId: 'myId',
-      })
-    ).toEqual(
-      toGlobal({
-        type: ADD_NOTIFICATION,
-        payload: {
-          kind: 'unexpected-error',
-          values: {
-            source: 'FOO',
-            errorId: 'myId',
-            body: 'oops',
-          },
-          domain: 'page',
-        },
-        meta: {
-          dismissAfter: 0,
+  describe('unexpected errors', () => {
+    it('dispatches ADD_NOTIFICATION when unexpected error occurs', () => {
+      expect(
+        showUnexpectedErrorNotification({
           error: 'oops',
-        },
-      })
-    );
+          source: 'FOO',
+          errorId: 'myId',
+        })
+      ).toEqual(
+        toGlobal({
+          type: ADD_NOTIFICATION,
+          payload: {
+            kind: 'unexpected-error',
+            values: {
+              source: 'FOO',
+              errorId: 'myId',
+              body: 'oops',
+            },
+            domain: 'page',
+          },
+          meta: {
+            dismissAfter: 0,
+            error: 'oops',
+          },
+        })
+      );
+    });
   });
 });
 


### PR DESCRIPTION
#### Summary

This adds a `isArray` check the the action creator to wrap the `errors` into an `Array` given it is not passed as such.

#### Description

In our own application we have some code which goes like

```js
.catch(({ graphQLErrors }) =>
     this.props.showApiErrorNotification({
     errors: Array.isArray(graphQLErrors) ? graphQLErrors : [graphQLErrors],
     source: 'InternationalCountriesPanel/updateProject',
  })
);
```

to avoid the boilerplate of that check we move it down into the action creator here.
