### PR TITLE
Add pim search to quick access

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -96,6 +96,7 @@
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
     "reselect": "^4.0.0",
+    "tiny-invariant": "1.0.3",
     "unfetch": "3.1.1",
     "uuid": "3.3.2",
     "warning": "4.0.2"

--- a/packages/application-shell/src/components/quick-access/index.js
+++ b/packages/application-shell/src/components/quick-access/index.js
@@ -61,8 +61,16 @@ export class QuickAccessTrigger extends React.Component {
   state = {
     isVisible: false,
     hasError: false,
+    // We store the information of whether a project is indexed by pim-indexer,
+    // to avoid having to refetch that information every time Quick Access is
+    // opened. We can't move the information to the quick-access.js component
+    // as that component unmounts and would lose its state.
+    //
+    // We need to know whether a project is indexed by pim-indexer to know
+    // whether we should query pim-search or whether we can skip that request.
+    //
     // We don't need to update this information when the project key changes,
-    // as changing a project always results in a full reload anyways.
+    // as changing a project always results in a full page reload anyways.
     //
     // undefined: we did not check yet
     // true: the project is indexed by pim-indexer

--- a/packages/application-shell/src/components/quick-access/index.js
+++ b/packages/application-shell/src/components/quick-access/index.js
@@ -4,6 +4,7 @@ import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import * as gtm from '../../utils/gtm';
 import trackingEvents from './tracking-events';
 import ButlerContainer from './butler-container';
+import pimIndexerStates from './pim-indexer-states';
 
 const QuickAccess = React.lazy(() =>
   import('./quick-access' /* webpackChunkName: "quick-access" */)
@@ -71,11 +72,7 @@ export class QuickAccessTrigger extends React.Component {
     //
     // We don't need to update this information when the project key changes,
     // as changing a project always results in a full page reload anyways.
-    //
-    // undefined: we did not check yet
-    // true: the project is indexed by pim-indexer
-    // false: the project is not indexed by pim-indexer
-    isProjectPimIndexed: undefined,
+    pimIndexerState: pimIndexerStates.UNCHECKED,
   };
 
   handler = event => {
@@ -142,9 +139,9 @@ export class QuickAccessTrigger extends React.Component {
         <QuickAccess
           {...this.props}
           onClose={this.close}
-          isProjectPimIndexed={this.state.isProjectPimIndexed}
-          onProjectPimIndexedChange={isProjectPimIndexed =>
-            this.setState({ isProjectPimIndexed })
+          pimIndexerState={this.state.pimIndexerState}
+          onPimIndexerStateChange={pimIndexerState =>
+            this.setState({ pimIndexerState })
           }
         />
       </QuickAccessContainer>

--- a/packages/application-shell/src/components/quick-access/pim-indexer-states.js
+++ b/packages/application-shell/src/components/quick-access/pim-indexer-states.js
@@ -1,0 +1,8 @@
+export default {
+  // we did not check yet
+  UNCHECKED: 'UNCHECKED',
+  // the project is indexed by pim-indexer
+  INDEXED: 'INDEXED',
+  // the project is not indexed by pim-indexer
+  NOT_INDEXED: 'NOT_INDEXED',
+};

--- a/packages/application-shell/src/components/quick-access/quick-access.graphql
+++ b/packages/application-shell/src/components/quick-access/quick-access.graphql
@@ -1,6 +1,6 @@
-query QuickAccess($searchText: String!, $canViewProducts: Boolean!, $productsWhereClause: String!) {
+query QuickAccess($searchText: String!, $canViewProducts: Boolean!, $productsWhereClause: String, $includeProductsByIds: Boolean!) {
 
-  productsById: products(where: $productsWhereClause) @include(if: $canViewProducts) {
+  productsByIds: products(where: $productsWhereClause) @include(if: $includeProductsByIds) {
     results {
       id,
       masterData {

--- a/packages/application-shell/src/components/quick-access/quick-access.graphql
+++ b/packages/application-shell/src/components/quick-access/quick-access.graphql
@@ -1,7 +1,6 @@
 query QuickAccess($searchText: String!, $canViewProducts: Boolean!, $productsWhereClause: String!) {
 
   productsById: products(where: $productsWhereClause) @include(if: $canViewProducts) {
-    total
     results {
       id,
       masterData {

--- a/packages/application-shell/src/components/quick-access/quick-access.graphql
+++ b/packages/application-shell/src/components/quick-access/quick-access.graphql
@@ -1,4 +1,19 @@
-query QuickAccess($searchText: String!, $canViewProducts: Boolean!) {
+query QuickAccess($searchText: String!, $canViewProducts: Boolean!, $productsWhereClause: String!) {
+
+  productsById: products(where: $productsWhereClause) @include(if: $canViewProducts) {
+    total
+    results {
+      id,
+      masterData {
+        staged {
+          nameAllLocales {
+            locale
+            value
+          }
+        }
+      }
+    }
+  }
 
   productById: product(id: $searchText) @include(if: $canViewProducts) {
     key

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -204,7 +204,7 @@ class QuickAccess extends React.Component {
         if (containsMatchesByProducstIds(data)) {
           data.productsByIds.results.forEach(product => {
             commands.push({
-              id: `go/product-by-id/product(${product.id})`,
+              id: `go/product-by-search-text/product(${product.id})`,
               text: this.props.intl.formatMessage(messages.showProduct, {
                 productName: translate(
                   product.masterData.staged.nameAllLocales,

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -125,9 +125,6 @@ const createPimSearchSdkMock = (
   response: {},
 });
 
-const openDshbrdMock = createPimSearchSdkMock('Open dshbrd');
-const openPrdctsMock = createPimSearchSdkMock('Open prdcts');
-
 describe('QuickAccess', () => {
   beforeEach(() => {
     gtm.track.mockReset();
@@ -244,7 +241,10 @@ describe('QuickAccess', () => {
       {
         mocks,
         flags,
-        sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+        sdkMocks: [
+          createPimAvailabilityCheckSdkMock(),
+          createPimSearchSdkMock('Open dshbrd'),
+        ],
       }
     );
 
@@ -333,7 +333,10 @@ describe('QuickAccess', () => {
       {
         mocks,
         flags,
-        sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+        sdkMocks: [
+          createPimAvailabilityCheckSdkMock(),
+          createPimSearchSdkMock('Open dshbrd'),
+        ],
       }
     );
 
@@ -369,7 +372,10 @@ describe('QuickAccess', () => {
         {
           mocks,
           flags,
-          sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+          sdkMocks: [
+            createPimAvailabilityCheckSdkMock(),
+            createPimSearchSdkMock('Open dshbrd'),
+          ],
         }
       );
 
@@ -400,7 +406,10 @@ describe('QuickAccess', () => {
         {
           mocks,
           flags,
-          sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+          sdkMocks: [
+            createPimAvailabilityCheckSdkMock(),
+            createPimSearchSdkMock('Open dshbrd'),
+          ],
         }
       );
 
@@ -440,7 +449,10 @@ describe('QuickAccess', () => {
         {
           mocks,
           flags,
-          sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+          sdkMocks: [
+            createPimAvailabilityCheckSdkMock(),
+            createPimSearchSdkMock('Open dshbrd'),
+          ],
         }
       );
 
@@ -471,7 +483,10 @@ describe('QuickAccess', () => {
         {
           mocks,
           flags,
-          sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+          sdkMocks: [
+            createPimAvailabilityCheckSdkMock(),
+            createPimSearchSdkMock('Open dshbrd'),
+          ],
         }
       );
 
@@ -504,7 +519,10 @@ describe('QuickAccess', () => {
       {
         mocks,
         flags,
-        sdkMocks: [createPimAvailabilityCheckSdkMock(), openDshbrdMock],
+        sdkMocks: [
+          createPimAvailabilityCheckSdkMock(),
+          createPimSearchSdkMock('Open dshbrd'),
+        ],
       }
     );
 
@@ -538,8 +556,8 @@ describe('QuickAccess', () => {
         flags,
         sdkMocks: [
           createPimAvailabilityCheckSdkMock(),
-          openDshbrdMock,
-          openPrdctsMock,
+          createPimSearchSdkMock('Open dshbrd'),
+          createPimSearchSdkMock('Open prdcts'),
         ],
       }
     );

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -1351,7 +1351,7 @@ describe('QuickAccess', () => {
 
       expect(
         getByTestId(
-          `quick-access-result(go/product-by-id/product(${partyParrotId}))`
+          `quick-access-result(go/product-by-search-text/product(${partyParrotId}))`
         )
       ).toHaveClass('result activeResult');
     });

--- a/packages/application-shell/src/configure-store.js
+++ b/packages/application-shell/src/configure-store.js
@@ -36,7 +36,9 @@ const patchedGetCorrelationId = () =>
 // We use a factory as it's more practicable for tests
 // The application can import the configured store (the default export)
 export const createReduxStore = (
-  preloadedState = { requestsInFlight: null }
+  preloadedState = { requestsInFlight: null },
+  // additional middleware, used for testing
+  middleware = []
 ) => {
   const sdkMiddleware = createSdkMiddleware({
     getCorrelationId: patchedGetCorrelationId,
@@ -55,6 +57,7 @@ export const createReduxStore = (
     preloadedState,
     compose(
       applyMiddleware(
+        ...middleware,
         // Should be defined before `createExtractGlobalActions`
         addPluginToNotificationMiddleware,
         createExtractGlobalActions([

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -181,6 +181,15 @@ const renderWithRedux = (
     //       }
     //     ]
     //   })
+    // You can also fake a failing request using
+    //   renderWithRedux(ui, {
+    //     sdkMocks: [
+    //       {
+    //         action: { type: 'SDK', payload: {}},
+    //         error: new Error('foo'),
+    //       }
+    //     ]
+    //   })
     // Note that each response will only be used once. When multiple responses
     // are provided for identical actions, then they are used in the order
     // they are provided in.
@@ -233,13 +242,12 @@ const renderWithRedux = (
             )}`
           );
 
-        const { response } = clonedSdkMocks[index];
+        const { response, error } = clonedSdkMocks[index];
 
         // remove result as each result is only mocked once
         sdkMocks.splice(index, 1);
 
-        // It is not possible yet to fake a failing request.
-        return Promise.resolve(response);
+        return error ? Promise.reject(error) : Promise.resolve(response);
       }
 
       return next(action);


### PR DESCRIPTION
![pim-search](https://user-images.githubusercontent.com/1765075/50102630-d5787e80-0225-11e9-9d23-6121cd62226c.gif)

This PR
- adds support for pim-search to Quick Access.
- also adds support of mocking `sdk` requests made through the sdk middleware to `test-utils` - similar to how `ApolloMockProvider` lets us mock GraphQL requests.

I might eventually split the PR up into the two separate parts, but I left it in one PR while gathering feedback for now.