### PR TITLE
Remove visibility overwrites from permissions

### DIFF
--- a/packages/application-shell/src/components/fetch-project/fetch-project.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.graphql
@@ -27,35 +27,6 @@ query ProjectQuery($projectKey: String!) {
       canManageTypes
       canViewPayments
       canManagePayments
-      canAddCategories
-      canAddCustomers
-      canAddCustomerGroups
-      canAddDiscountCodes
-      canAddOrders
-      canAddPrices
-      canAddProducts
-      canDeletePrices
-      canDeleteProducts
-      canEditPrices
-      canPublishProducts
-      canUnpublishProducts
-      canViewCartDiscounts
-      canViewCategories
-      canViewCategoriesSearch
-      canViewCustomApplications
-      canViewCustomerGroups
-      canViewDashboard
-      canViewDeveloperSettings
-      canViewDirectAccess
-      canViewDiscountCodes
-      canViewDiscounts
-      canViewModifiedProducts
-      canViewPimSearch
-      canViewProductDiscounts
-      canViewProductTypes
-      canViewProjectSettingsMisc
-      canViewSettings
-      canViewShippingLists
     }
     owner {
       id


### PR DESCRIPTION
#### Summary

This pull request removes the recently added but not yet used permissions and visibility overwrites from the project's query permissions field.

#### Description

After various rounds of meetings with API, POs and UX we decided on the following conceptually:

1. OAuth scopes can be derived from action restrictions
   - Given I have no restrictions (e.g. removePrice) then I need manage_products
   - Given I have everything restricted then I get only view_products (in this case)
2. Permissions and Visibility Hiding (name may change) are split
   - Conceptually I can say `addCategories` as a permission and then hide it in the menu but have it visible in other apps
   - This may sound a bit strange but we had multiple hours of meetings and concrete examples agreeing that this is the only feasible path forward

Moreover, @qmateub and I discussed that we'd like to not use the `permissions` field much as it's far too "static". Every addition of a permission needs an app-kit release. As a result we would like to proceed with something like:


```graphql
project {
   allAppliedPermissions {
      name
      value
   }
   allAppliedVisibilityOverwrites {
      name
      value
   }
}
```

We will then map the shape of `[ { name: string, value: boolean } ]` back into the `[string]: boolean` shape for the permission system in the app.

When rendering the menu we will check both: permission (e.g. `addCategory` and the visibility overwrite (name TDB).

Hope this makes sense. /cc @emmenko for awareness.
