### PR TITLE
Add `allAppliedPermissions` and remove `permissions`

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.js
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.js
@@ -44,13 +44,7 @@ const mapProjectToApplicationContextProject = project => {
 const mapProjectToApplicationContextPermissions = project => {
   if (!project) return null;
 
-  return project.allAppliedPermissions.reduce(
-    (appliedPermissions, appliedPermission) => ({
-      ...appliedPermissions,
-      [appliedPermission.name]: appliedPermission.value,
-    }),
-    {}
-  );
+  return project.permissions;
 };
 
 const createApplicationContext = defaultMemoize(
@@ -110,12 +104,7 @@ ApplicationContextProvider.propTypes = {
     owner: PropTypes.shape({
       id: PropTypes.string.isRequired,
     }).isRequired,
-    allAppliedPermissions: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        value: PropTypes.bool.isRequired,
-      })
-    ).isRequired,
+    permissions: PropTypes.object.isRequired,
     // ...plus other fields that we don't want to expose
   }),
   projectDataLocale: PropTypes.string,

--- a/packages/application-shell-connectors/src/components/application-context/application-context.js
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { wrapDisplayName } from 'recompose';
 import { defaultMemoize } from 'reselect';
 import moment from 'moment-timezone';
-import omit from 'lodash.omit';
 
 const Context = React.createContext({});
 
@@ -45,7 +44,13 @@ const mapProjectToApplicationContextProject = project => {
 const mapProjectToApplicationContextPermissions = project => {
   if (!project) return null;
 
-  return omit(project.permissions, ['__typename']);
+  return project.allAppliedPermissions.reduce(
+    (appliedPermissions, appliedPermission) => ({
+      ...appliedPermissions,
+      [appliedPermission.name]: appliedPermission.value,
+    }),
+    {}
+  );
 };
 
 const createApplicationContext = defaultMemoize(
@@ -105,7 +110,12 @@ ApplicationContextProvider.propTypes = {
     owner: PropTypes.shape({
       id: PropTypes.string.isRequired,
     }).isRequired,
-    permissions: PropTypes.object.isRequired,
+    allAppliedPermissions: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.bool.isRequired,
+      })
+    ).isRequired,
     // ...plus other fields that we don't want to expose
   }),
   projectDataLocale: PropTypes.string,

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.js
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.js
@@ -28,7 +28,7 @@ describe('rendering', () => {
             countries: ['us'],
             currencies: ['USD'],
             languages: ['en'],
-            permissions: { canManageProject: true },
+            allAppliedPermissions: [{ name: 'canManageProject', value: true }],
             // Fields that should not be exposed
             expiry: { isActive: false },
             suspension: { isActive: false },
@@ -83,7 +83,9 @@ describe('rendering', () => {
       expect(wrapper).toHaveProp(
         'value',
         expect.objectContaining({
-          permissions: expect.any(Object),
+          permissions: {
+            canManageProject: true,
+          },
         })
       );
     });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.js
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.js
@@ -28,7 +28,7 @@ describe('rendering', () => {
             countries: ['us'],
             currencies: ['USD'],
             languages: ['en'],
-            allAppliedPermissions: [{ name: 'canManageProject', value: true }],
+            permissions: { canManageProject: true },
             // Fields that should not be exposed
             expiry: { isActive: false },
             suspension: { isActive: false },

--- a/packages/application-shell/src/components/fetch-project/fetch-project.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.graphql
@@ -13,21 +13,6 @@ query ProjectQuery($projectKey: String!) {
     suspension {
       isActive
     }
-    permissions {
-      canManageOrganization
-      canManageProject
-      canViewProjectSettings
-      canViewProducts
-      canManageProducts
-      canViewOrders
-      canManageOrders
-      canViewCustomers
-      canManageCustomers
-      canViewTypes
-      canManageTypes
-      canViewPayments
-      canManagePayments
-    }
     allAppliedPermissions {
       name
       value

--- a/packages/application-shell/src/components/fetch-project/fetch-project.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.graphql
@@ -28,6 +28,10 @@ query ProjectQuery($projectKey: String!) {
       canViewPayments
       canManagePayments
     }
+    allAppliedPermissions {
+      name
+      value
+    }
     owner {
       id
       name

--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -12,6 +12,26 @@ import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import deprecateComponent from '../../from-core/deprecate-component';
 import ProjectQuery from './fetch-project.graphql';
 
+/**
+ * NOTE:
+ *
+ * Permissions are being fetched though the `allAppliedPermissions` which
+ * is an array of `{ name: string, value: boolean }`. This gives more
+ * flexibility to introduce new permissions to apps without having to release
+ * the merchant-center-app-kit.
+ *
+ * The application below however expects permissions to be of the shape
+ * `[name: string]: boolean` which is what the shape above is mapped into here.
+ */
+export const mapAppliedPermissionsToPermissions = appliedPermissions =>
+  appliedPermissions.reduce(
+    (transfromedPermissions, appliedPermission) => ({
+      ...transfromedPermissions,
+      [appliedPermission.name]: appliedPermission.value,
+    }),
+    {}
+  );
+
 const graphqlOptions = {
   alias: 'withProject',
   name: 'projectData',
@@ -27,7 +47,12 @@ const graphqlOptions = {
     projectData: {
       isLoading: projectData.loading,
       error: projectData.error,
-      project: projectData.project,
+      project: projectData.project && {
+        ...projectData.project,
+        permissions: mapAppliedPermissionsToPermissions(
+          projectData.project.appliedPermissions
+        ),
+      },
     },
   }),
 };

--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -28,8 +28,8 @@ import ProjectQuery from './fetch-project.graphql';
  * the fetching logic. Given this mapping needs to be used elsewere feel free
  * to move this over to `permissions` and export it there.
  */
-export const mapAppliedPermissionsToPermissions = appliedPermissions =>
-  appliedPermissions.reduce(
+export const mapAppliedPermissionsToPermissions = allAppliedPermissions =>
+  allAppliedPermissions.reduce(
     (transfromedPermissions, appliedPermission) => ({
       ...transfromedPermissions,
       [appliedPermission.name]: appliedPermission.value,
@@ -55,7 +55,7 @@ const graphqlOptions = {
       project: projectData.project && {
         ...projectData.project,
         permissions: mapAppliedPermissionsToPermissions(
-          projectData.project.appliedPermissions
+          projectData.project.allAppliedPermissions
         ),
       },
     },

--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -22,6 +22,11 @@ import ProjectQuery from './fetch-project.graphql';
  *
  * The application below however expects permissions to be of the shape
  * `[name: string]: boolean` which is what the shape above is mapped into here.
+ *
+ * This function by concern belongs into the `permissions` package. However,
+ * for now it doesn't have to be shared and as a result can be co-located with
+ * the fetching logic. Given this mapping needs to be used elsewere feel free
+ * to move this over to `permissions` and export it there.
  */
 export const mapAppliedPermissionsToPermissions = appliedPermissions =>
   appliedPermissions.reduce(

--- a/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { FetchProject, withProject } from './fetch-project';
+import {
+  FetchProject,
+  withProject,
+  mapAppliedPermissionsToPermissions,
+} from './fetch-project';
 
 describe('rendering', () => {
   let props;
@@ -71,6 +75,26 @@ describe('rendering', () => {
       it('should render FetchProject internally', () => {
         expect(wrapper).toRender('FetchProject');
       });
+    });
+  });
+});
+
+describe('helpers', () => {
+  describe('mapAppliedPermissionsToPermissions', () => {
+    const allAppliedPermissions = [
+      {
+        name: 'manageProject',
+        value: true,
+      },
+    ];
+
+    it('should transform all permissions', () => {
+      const firstAppliedPermission = allAppliedPermissions[0];
+      expect(mapAppliedPermissionsToPermissions(allAppliedPermissions)).toEqual(
+        expect.objectContaining({
+          [firstAppliedPermission.name]: firstAppliedPermission.value,
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
#### Summary

This pull request adds the not yet implemented (@qmateub is on it) `allAppliedPermissions` field.

#### Description

For the underlying system nothing should change. We map back the `allAppliedPermissions` of shape `[ { name: string, value: boolean } ]` into `{ [name: string]: boolean }`. 

This all in all should decouple app-kit from any app in the future in regards to permissions as anything the mc-be decides to flush through will be available. The only left-over dependency is constants.
