### PR TITLE
Refactor `Authorized` in permissions pkg to not rely on constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ before_install:
 
 script:
   - set -e
+  - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn build
   - yarn playground:build
-  - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - set +e
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ before_install:
 
 script:
   - set -e
-  - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn build
   - yarn playground:build
+  - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - set +e
 
 after_success:

--- a/packages/application-shell/src/test-utils/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils/test-utils.spec.js
@@ -169,9 +169,7 @@ describe('ApplicationContext', () => {
 
   describe('permissions', () => {
     const TestComponent = () => (
-      <RestrictedByPermissions
-        permissions={[{ mode: 'manage', resource: 'products' }]}
-      >
+      <RestrictedByPermissions permissions={['ManageProducts']}>
         {({ isAuthorized }) => (isAuthorized ? 'Authorized' : 'Not allowed')}
       </RestrictedByPermissions>
     );

--- a/packages/permissions/src/components/authorized/authorized.js
+++ b/packages/permissions/src/components/authorized/authorized.js
@@ -1,24 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { wrapDisplayName } from 'recompose';
-import { defaultMemoize } from 'reselect';
-import warning from 'warning';
-import camelCase from 'lodash.camelcase';
-import upperFirst from 'lodash.upperfirst';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   hasSomePermissions,
   hasEveryPermissions,
   getUnconfiguredPermissions,
 } from '../../utils/has-permissions';
-
-const ensurePermissionsKeyShape = defaultMemoize(demandedPermissions =>
-  demandedPermissions.map(permission =>
-    typeof permission === 'string'
-      ? permission
-      : upperFirst(camelCase(`${permission.mode} ${permission.resource}`))
-  )
-);
 
 class Authorized extends React.Component {
   static displayName = 'Authorized';
@@ -47,10 +35,7 @@ class Authorized extends React.Component {
       }
 
       // Legacy shape of permissions
-      return PropTypes.shape({
-        mode: PropTypes.string.isRequired,
-        resource: PropTypes.string.isRequired,
-      });
+      return null;
     },
     actualPermissions: PropTypes.objectOf(PropTypes.bool).isRequired,
     render: PropTypes.func,
@@ -58,28 +43,17 @@ class Authorized extends React.Component {
   static defaultProps = {
     shouldMatchSomePermissions: false,
   };
-  hasAlreadyLoggedDeprecationWarning = false;
-  componentDidUpdate() {
-    if (this.hasAlreadyLoggedDeprecationWarning) return;
-    const hasDemandedPermissionsWithDeprecatedFormat = this.props.demandedPermissions.some(
-      permission => typeof permission !== 'string'
-    );
-    const shouldSkipWarning =
-      process.env.NODE_ENV === 'production' ||
-      !hasDemandedPermissionsWithDeprecatedFormat;
-    warning(
-      shouldSkipWarning,
-      'The permission format with "{ mode, resource }" has been deprecated. Please use the constant values from the "@commercetools-frontend/permissions" package.'
-    );
-    if (!shouldSkipWarning) this.hasAlreadyLoggedDeprecationWarning = true;
-  }
   render() {
-    const demandedPermissions = ensurePermissionsKeyShape(
-      this.props.demandedPermissions
-    );
     const isAuthorized = this.props.shouldMatchSomePermissions
-      ? hasSomePermissions(demandedPermissions, this.props.actualPermissions)
-      : hasEveryPermissions(demandedPermissions, this.props.actualPermissions);
+      ? hasSomePermissions(
+          this.props.demandedPermissions,
+          this.props.actualPermissions
+        )
+      : hasEveryPermissions(
+          this.props.demandedPermissions,
+          this.props.actualPermissions
+        );
+
     return this.props.render(isAuthorized);
   }
 }

--- a/packages/permissions/src/components/authorized/authorized.js
+++ b/packages/permissions/src/components/authorized/authorized.js
@@ -9,8 +9,8 @@ import { ApplicationContext } from '@commercetools-frontend/application-shell-co
 import {
   hasSomePermissions,
   hasEveryPermissions,
+  getUnconfiguredPermissions,
 } from '../../utils/has-permissions';
-import { permissions } from '../../constants';
 
 const ensurePermissionsKeyShape = defaultMemoize(demandedPermissions =>
   demandedPermissions.map(permission =>
@@ -24,15 +24,26 @@ class Authorized extends React.Component {
   static displayName = 'Authorized';
   static propTypes = {
     shouldMatchSomePermissions: PropTypes.bool,
-    demandedPermissions: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.oneOf(Object.values(permissions)),
-        PropTypes.shape({
-          mode: PropTypes.string.isRequired,
-          resource: PropTypes.string.isRequired,
-        }),
-      ]).isRequired
-    ).isRequired,
+    demandedPermissions(props, propName, componentName) {
+      const namesOfNonConfiguredPermissions = getUnconfiguredPermissions(
+        props.demandedPermissions,
+        props.actualPermissions
+      );
+
+      if (namesOfNonConfiguredPermissions.length > 0) {
+        return new Error(
+          `Invalid prop \`${propName}\` supplied to \`${componentName}\`. The permission(s) ${namesOfNonConfiguredPermissions.join(
+            ' '
+          )} is/are not configured through \`actualPermissions\`.`
+        );
+      }
+
+      // Legacy shape of permissions
+      return PropTypes.shape({
+        mode: PropTypes.string.isRequired,
+        resource: PropTypes.string.isRequired,
+      });
+    },
     actualPermissions: PropTypes.objectOf(PropTypes.bool).isRequired,
     render: PropTypes.func,
   };

--- a/packages/permissions/src/components/authorized/authorized.js
+++ b/packages/permissions/src/components/authorized/authorized.js
@@ -5,7 +5,7 @@ import { ApplicationContext } from '@commercetools-frontend/application-shell-co
 import {
   hasSomePermissions,
   hasEveryPermissions,
-  getUnconfiguredPermissions,
+  getInvalidPermissions,
 } from '../../utils/has-permissions';
 
 class Authorized extends React.Component {
@@ -21,16 +21,14 @@ class Authorized extends React.Component {
      * added to the constants and released each time.
      */
     demandedPermissions(props, propName, componentName) {
-      const namesOfNonConfiguredPermissions = getUnconfiguredPermissions(
+      const namesOfNonConfiguredPermissions = getInvalidPermissions(
         props.demandedPermissions,
         props.actualPermissions
       );
 
       if (namesOfNonConfiguredPermissions.length > 0) {
         return new Error(
-          `Invalid prop \`${propName}\` supplied to \`${componentName}\`. The permission(s) ${namesOfNonConfiguredPermissions.join(
-            ' '
-          )} is/are not configured through \`actualPermissions\`.`
+          `Invalid prop \`${propName}\` supplied to \`${componentName}\`. The permission(s) ${namesOfNonConfiguredPermissions.toString()} is/are not configured through \`actualPermissions\`.`
         );
       }
 

--- a/packages/permissions/src/components/authorized/authorized.js
+++ b/packages/permissions/src/components/authorized/authorized.js
@@ -24,6 +24,14 @@ class Authorized extends React.Component {
   static displayName = 'Authorized';
   static propTypes = {
     shouldMatchSomePermissions: PropTypes.bool,
+    /**
+     * This custom prop-types verifies that any permission passed as
+     * `demandedPermissions` actually exists on the `actualPermissions`.
+     *
+     * This was previously achieved through a validation via the constants (`Object.keys(permissions)`).
+     * This was deemded to not be flexible enough to introduce new permissions as they have to be
+     * added to the constants and released each time.
+     */
     demandedPermissions(props, propName, componentName) {
       const namesOfNonConfiguredPermissions = getUnconfiguredPermissions(
         props.demandedPermissions,

--- a/packages/permissions/src/components/authorized/authorized.spec.js
+++ b/packages/permissions/src/components/authorized/authorized.spec.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import warning from 'warning';
 import { permissions } from '../../constants';
 import Authorized from './authorized';
-
-jest.mock('warning');
 
 const createTestProps = custom => ({
   shouldMatchSomePermissions: false,
@@ -102,75 +99,6 @@ describe('rendering', () => {
       });
       it('should pass isAuthorized as "false"', () => {
         expect(props.render).toHaveBeenCalledWith(false);
-      });
-    });
-  });
-  describe('when demandedPermissions is a list of values with the deprecated format', () => {
-    describe('if should match SOME permissions', () => {
-      describe('if can manage products', () => {
-        beforeEach(() => {
-          props = createTestProps({
-            shouldMatchSomePermissions: true,
-            demandedPermissions: [
-              { mode: 'view', resource: 'products' },
-              { mode: 'view', resource: 'orders' },
-            ],
-            actualPermissions: {
-              canManageProducts: true,
-              canViewOrders: true,
-            },
-          });
-          shallow(<Authorized {...props} />);
-        });
-        it('should pass isAuthorized as "true"', () => {
-          expect(props.render).toHaveBeenCalledWith(true);
-        });
-      });
-    });
-  });
-});
-
-describe('deprecations', () => {
-  let props;
-  let wrapper;
-  describe('permissions shape', () => {
-    describe('if demandedPermissions has the deprecated shape { mode, resource }', () => {
-      describe('when component updates', () => {
-        beforeEach(() => {
-          warning.mockClear();
-          props = createTestProps({
-            demandedPermissions: [
-              { mode: 'view', resource: 'products' },
-              { mode: 'view', resource: 'orders' },
-            ],
-          });
-          wrapper = shallow(<Authorized {...props} />);
-          wrapper.instance().componentDidUpdate();
-        });
-        it('should log warning with false condition', () => {
-          expect(warning).toHaveBeenCalledWith(
-            false,
-            'The permission format with "{ mode, resource }" has been deprecated. Please use the constant values from the "@commercetools-frontend/permissions" package.'
-          );
-        });
-      });
-    });
-    describe('if demandedPermissions does not have the deprecated shape { mode, resource }', () => {
-      describe('when component updates', () => {
-        beforeEach(() => {
-          warning.mockClear();
-          props = createTestProps({
-            demandedPermissions: [permissions.ViewProducts],
-          });
-          wrapper = shallow(<Authorized {...props} />);
-          wrapper.instance().componentDidUpdate();
-        });
-        it('should log warning with true condition', () => {
-          expect(warning).toHaveBeenCalledWith(
-            true,
-            'The permission format with "{ mode, resource }" has been deprecated. Please use the constant values from the "@commercetools-frontend/permissions" package.'
-          );
-        });
       });
     });
   });

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.js
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash.isnil';
 import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import { permissions } from '../../constants';
 import Authorized from '../authorized';
 
 const getHasChildren = children => React.Children.count(children) > 0;
@@ -11,15 +10,7 @@ export class RestrictedByPermissions extends React.Component {
   static displayName = 'RestrictedByPermissions';
   static propTypes = {
     shouldMatchSomePermissions: PropTypes.bool,
-    permissions: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.oneOf(Object.values(permissions)),
-        PropTypes.shape({
-          mode: PropTypes.string.isRequired,
-          resource: PropTypes.string.isRequired,
-        }),
-      ]).isRequired
-    ).isRequired,
+    permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
 
     unauthorizedComponent(props, propName, componentName, ...rest) {
       if (!isNil(props[propName]) && typeof props.children === 'function') {

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.js
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.js
@@ -5,10 +5,7 @@ import { RestrictedByPermissions } from './restricted-by-permissions';
 
 const createTestProps = custom => ({
   shouldMatchSomePermissions: false,
-  permissions: [
-    { mode: 'view', resource: 'products' },
-    { mode: 'view', resource: 'orders' },
-  ],
+  permissions: ['ViewProducts', 'ViewOrders'],
   applicationContext: {
     permissions: {
       canViewProducts: true,

--- a/packages/permissions/src/utils/has-permissions.js
+++ b/packages/permissions/src/utils/has-permissions.js
@@ -1,3 +1,4 @@
+import isNil from 'lodash.isnil';
 import { permissions } from '../constants';
 
 // Build the permission key from the definition to match it to the format coming
@@ -68,4 +69,18 @@ export const hasEveryPermissions = (demandedPermissions, actualPermissions) =>
 export const hasSomePermissions = (demandedPermissions, actualPermissions) =>
   demandedPermissions.some(permission =>
     hasPermission(permission, actualPermissions)
+  );
+
+// Returns an Array<String> of unconfigured (not passed as `demandedPermissions`) permissions.
+// The shapes of the arguments are:
+// - demandedPermissions:
+//     ['ViewProducts', 'ManageOrders']
+// - actualPermissions:
+//     { canViewProducts: true, canManageOrders: false }
+export const getUnconfiguredPermissions = (
+  demandedPermissions,
+  actualPermissions
+) =>
+  demandedPermissions.filter(demandedPermission =>
+    isNil(actualPermissions[toCanCase(demandedPermission)])
   );

--- a/packages/permissions/src/utils/has-permissions.js
+++ b/packages/permissions/src/utils/has-permissions.js
@@ -77,10 +77,7 @@ export const hasSomePermissions = (demandedPermissions, actualPermissions) =>
 //     ['ViewProducts', 'ManageOrders']
 // - actualPermissions:
 //     { canViewProducts: true, canManageOrders: false }
-export const getUnconfiguredPermissions = (
-  demandedPermissions,
-  actualPermissions
-) =>
+export const getInvalidPermissions = (demandedPermissions, actualPermissions) =>
   demandedPermissions.filter(demandedPermission =>
     isNil(actualPermissions[toCanCase(demandedPermission)])
   );

--- a/packages/permissions/src/utils/has-permissions.js
+++ b/packages/permissions/src/utils/has-permissions.js
@@ -77,7 +77,15 @@ export const hasSomePermissions = (demandedPermissions, actualPermissions) =>
 //     ['ViewProducts', 'ManageOrders']
 // - actualPermissions:
 //     { canViewProducts: true, canManageOrders: false }
-export const getInvalidPermissions = (demandedPermissions, actualPermissions) =>
-  demandedPermissions.filter(demandedPermission =>
+export const getInvalidPermissions = (
+  demandedPermissions,
+  actualPermissions
+) => {
+  // Given `ManageProject` is present no other permissions needs to be set and can be invalid.
+  // This is also often used in test scenarios where not all exact permissions are being passed.
+  if (hasManageProjectPermission(actualPermissions)) return [];
+  // Otherwise all demanded permissions need to be present as an actual permission.
+  return demandedPermissions.filter(demandedPermission =>
     isNil(actualPermissions[toCanCase(demandedPermission)])
   );
+};

--- a/packages/permissions/src/utils/has-permissions.spec.js
+++ b/packages/permissions/src/utils/has-permissions.spec.js
@@ -107,7 +107,7 @@ describe('hasSomePermissions', () => {
 });
 
 describe('getUnconfiguredPermissions', () => {
-  describe('given all permissions are configured (passed as `actualPermissions`', () => {
+  describe('given all permissions are configured (passed as `actualPermissions`)', () => {
     it('should return no unconfigured permissions', () => {
       expect(
         getUnconfiguredPermissions(['ManageOrders'], { canManageOrders: true })
@@ -115,7 +115,7 @@ describe('getUnconfiguredPermissions', () => {
     });
   });
 
-  describe('given some permissions are not configured (not passed as `actualPermissions`', () => {
+  describe('given some permissions are not configured (not passed as `actualPermissions`)', () => {
     it('should return unconfigured permissions', () => {
       expect(
         getUnconfiguredPermissions(['ManageOrders', 'ViewStars'], {

--- a/packages/permissions/src/utils/has-permissions.spec.js
+++ b/packages/permissions/src/utils/has-permissions.spec.js
@@ -3,7 +3,7 @@ import {
   hasPermission,
   hasEveryPermissions,
   hasSomePermissions,
-  getUnconfiguredPermissions,
+  getInvalidPermissions,
 } from './has-permissions';
 
 describe('hasPermission', () => {
@@ -106,11 +106,11 @@ describe('hasSomePermissions', () => {
   });
 });
 
-describe('getUnconfiguredPermissions', () => {
+describe('getInvalidPermissions', () => {
   describe('given all permissions are configured (passed as `actualPermissions`)', () => {
     it('should return no unconfigured permissions', () => {
       expect(
-        getUnconfiguredPermissions(['ManageOrders'], { canManageOrders: true })
+        getInvalidPermissions(['ManageOrders'], { canManageOrders: true })
       ).toHaveLength(0);
     });
   });
@@ -118,7 +118,7 @@ describe('getUnconfiguredPermissions', () => {
   describe('given some permissions are not configured (not passed as `actualPermissions`)', () => {
     it('should return unconfigured permissions', () => {
       expect(
-        getUnconfiguredPermissions(['ManageOrders', 'ViewStars'], {
+        getInvalidPermissions(['ManageOrders', 'ViewStars'], {
           canManageOrders: true,
         })
       ).toEqual(expect.arrayContaining(['ViewStars']));

--- a/packages/permissions/src/utils/has-permissions.spec.js
+++ b/packages/permissions/src/utils/has-permissions.spec.js
@@ -3,6 +3,7 @@ import {
   hasPermission,
   hasEveryPermissions,
   hasSomePermissions,
+  getUnconfiguredPermissions,
 } from './has-permissions';
 
 describe('hasPermission', () => {
@@ -102,5 +103,25 @@ describe('hasSomePermissions', () => {
         canViewOrders: true,
       })
     ).toBe(false);
+  });
+});
+
+describe('getUnconfiguredPermissions', () => {
+  describe('given all permissions are configured (passed as `actualPermissions`', () => {
+    it('should return no unconfigured permissions', () => {
+      expect(
+        getUnconfiguredPermissions(['ManageOrders'], { canManageOrders: true })
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('given some permissions are not configured (not passed as `actualPermissions`', () => {
+    it('should return unconfigured permissions', () => {
+      expect(
+        getUnconfiguredPermissions(['ManageOrders', 'ViewStars'], {
+          canManageOrders: true,
+        })
+      ).toEqual(expect.arrayContaining(['ViewStars']));
+    });
   });
 });

--- a/packages/permissions/src/utils/has-permissions.spec.js
+++ b/packages/permissions/src/utils/has-permissions.spec.js
@@ -108,7 +108,7 @@ describe('hasSomePermissions', () => {
 
 describe('getInvalidPermissions', () => {
   describe('given all permissions are configured (passed as `actualPermissions`)', () => {
-    it('should return no unconfigured permissions', () => {
+    it('should return no invalid permissions', () => {
       expect(
         getInvalidPermissions(['ManageOrders'], { canManageOrders: true })
       ).toHaveLength(0);
@@ -116,12 +116,23 @@ describe('getInvalidPermissions', () => {
   });
 
   describe('given some permissions are not configured (not passed as `actualPermissions`)', () => {
-    it('should return unconfigured permissions', () => {
-      expect(
-        getInvalidPermissions(['ManageOrders', 'ViewStars'], {
-          canManageOrders: true,
-        })
-      ).toEqual(expect.arrayContaining(['ViewStars']));
+    describe('given `ManageProject` is not configured', () => {
+      it('should return invalid permissions', () => {
+        expect(
+          getInvalidPermissions(['ManageOrders', 'ViewStars'], {
+            canManageOrders: true,
+          })
+        ).toEqual(expect.arrayContaining(['ViewStars']));
+      });
+    });
+    describe('given `ManageProject` is configured', () => {
+      it('should return no invalid permissions', () => {
+        expect(
+          getInvalidPermissions(['ManageOrders', 'ViewStars'], {
+            canManageProject: true,
+          })
+        ).toHaveLength(0);
+      });
     });
   });
 });


### PR DESCRIPTION
#### Summary

After the mc-fe now can work with `allAppliedPermissions` as a more flexible `Array<AppliedPermission>` we should also improve the behaviour of `Authorized`. 

#### Details

`Authorized` currently used the constants to determine in its prop-types if the permission is known. This is a bit inflexible:

1. Introducing new permissions requires an app-kit release
2. Tight coupling and duplication of consumer and producer

Give that we can loosen the contract a bit maybe by _validating known (actual) and required (demanded)_ permissions against one another. Given we find one which we do not know about we give a prop-type warning.

Side note: I find the naming of `demanded` and `actual` a bit misleading cause it doesn't provide an inverse: what's the opposite of actual?