### PR TITLE
refactor(application-shell): permission prop-type form navbar

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -32,10 +32,7 @@ import {
   GRAPHQL_TARGETS,
   NO_VALUE_FALLBACK,
 } from '@commercetools-frontend/constants';
-import {
-  RestrictedByPermissions,
-  permissions,
-} from '@commercetools-frontend/permissions';
+import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { STORAGE_KEYS } from '../../constants';
 import { PROJECT_EXTENSIONS } from './feature-toggles';
 import LoadingPlaceholder from '../loading-placeholder';
@@ -279,7 +276,7 @@ export const ToggledWithPermissions = props => {
 ToggledWithPermissions.displayName = 'ToggledWithPermissions';
 ToggledWithPermissions.propTypes = {
   featureToggle: PropTypes.string,
-  permissions: PropTypes.arrayOf(PropTypes.oneOf(Object.keys(permissions))),
+  permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
   children: PropTypes.element.isRequired,
 };
 ToggledWithPermissions.defaultProps = {
@@ -310,9 +307,7 @@ export class DataMenu extends React.PureComponent {
         tracking: PropTypes.object,
         icon: PropTypes.string.isRequired,
         featureToggle: PropTypes.string,
-        permissions: PropTypes.arrayOf(
-          PropTypes.oneOf(Object.keys(permissions))
-        ),
+        permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
         submenu: PropTypes.arrayOf(
           PropTypes.shape({
             key: PropTypes.string.isRequired,
@@ -325,9 +320,7 @@ export class DataMenu extends React.PureComponent {
             ),
             uriPath: PropTypes.string.isRequired,
             featureToggle: PropTypes.string,
-            permissions: PropTypes.arrayOf(
-              PropTypes.oneOf(Object.keys(permissions))
-            ),
+            permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
           })
         ),
       })


### PR DESCRIPTION
#### Summary

This removes the constant based prop-type testing from the navbar in the application shell. 

#### Description

The prop-type check should be performed by `RestrictedByPermission` (and is) based on the configured permissions. Not at any given layer of the component tree which just forwards props and pretends to have knowledge and/or a say in what permissions it should allow forwarding without even doing anything with them.
