### PR TITLE
chore: configure npm to release canary builds with automation bot account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ script:
   - set +e
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" = "master" ] && [[ ! "$TRAVIS_COMMIT_MESSAGE" =~ \[skip\ publish\] ]]; then yarn release-canary; fi
+  - ./scripts/release_canary.sh
   - ./scripts/push_translations.sh

--- a/scripts/release_canary.sh
+++ b/scripts/release_canary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+: "${NPM_TOKEN?Required env variable NPM_TOKEN}"
+
+# Always skip it if it's not master branch or the commit message contains `[skip publish]`
+if [ "$TRAVIS_BRANCH" = "master" ] && [[ ! "$TRAVIS_COMMIT_MESSAGE" =~ \[skip\ publish\] ]]; then
+  echo "Configuring npm for automation bot"
+  cat > ~/.npmrc << EOF
+email=npmjs@commercetools.com
+//registry.npmjs.org/:_authToken=$NPM_TOKEN
+EOF
+
+  echo "Releasing canary version"
+  yarn release-canary
+
+else
+  echo "Not on master branch, skipping release"
+fi


### PR DESCRIPTION
Follow up of #243 

I forgot to configure npm to publish with our automation bot account.


Btw: this would have been the version to be published last time out.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/1110551/50694716-ece3a400-103a-11e9-8ed0-1d84890d3fd6.png">