### PR TITLE
build(travis): skip canary release if build is triggered by a pull request

### DIFF
--- a/scripts/release_canary.sh
+++ b/scripts/release_canary.sh
@@ -4,8 +4,11 @@ set -e
 
 : "${NPM_TOKEN?Required env variable NPM_TOKEN}"
 
-# Always skip it if it's not master branch or the commit message contains `[skip publish]`
-if [ "$TRAVIS_BRANCH" = "master" ] && [[ ! "$TRAVIS_COMMIT_MESSAGE" =~ \[skip\ publish\] ]]; then
+# Only trigger the canary release when:
+# - the branch is `master`
+# - the build has not been triggered by a pull request
+# - the commit message does not contain `[skip publish]`
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ ! "$TRAVIS_COMMIT_MESSAGE" =~ \[skip\ publish\] ]]; then
   echo "Configuring npm for automation bot"
   cat > ~/.npmrc << EOF
 email=npmjs@commercetools.com


### PR DESCRIPTION
So apparently the `TRAVIS_BRANCH` env variable is set to the target branch (e.g. `master`) for builds triggered by `pr`.

<img width="694" alt="image" src="https://user-images.githubusercontent.com/1110551/50727302-4cb07c80-1119-11e9-9f49-e4aa45475158.png">

Therefore, we can check extra that the build is not triggered by a PR.