### PR TITLE
fix: template starter missing dependency

### DIFF
--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -24,7 +24,8 @@
     "react-intl": "2.7.2",
     "react-redux": "6.0.0",
     "react-router": "4.4.0-beta.6",
-    "react-router-dom": "4.4.0-beta.6"
+    "react-router-dom": "4.4.0-beta.6",
+    "redux": "4.0.1"
   },
   "devDependencies": {
     "@commercetools-frontend/jest-preset-mc-app": "5.0.2",

--- a/application-templates/starter/src/index.js
+++ b/application-templates/starter/src/index.js
@@ -1,4 +1,3 @@
-import 'react-select/dist/react-select.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import EntryPoint from './components/entry-point';

--- a/scripts/install_app_template.sh
+++ b/scripts/install_app_template.sh
@@ -11,9 +11,12 @@ fi
 
 TEMPLATE_VERSION="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 TEST_APP_NAME=test-install-app-starter
+REPO_BINARIES=$(yarn bin)
+
+pushd "$HOME"
 
 echo "Installing application for template $TEMPLATE"
-yarn run create-mc-app \
+node "$REPO_BINARIES/create-mc-app" \
   --template="$TEMPLATE" \
   --template-version="$TEMPLATE_VERSION" \
   "$TEST_APP_NAME"

--- a/scripts/install_app_template.sh
+++ b/scripts/install_app_template.sh
@@ -20,3 +20,7 @@ node "$REPO_BINARIES/create-mc-app" \
   --template="$TEMPLATE" \
   --template-version="$TEMPLATE_VERSION" \
   "$TEST_APP_NAME"
+echo "Running tests for template $TEMPLATE"
+yarn --cwd "$TEST_APP_NAME" test
+echo "Running the production build of template $TEMPLATE"
+yarn --cwd "$TEST_APP_NAME" build


### PR DESCRIPTION
I used the canary build to try the new installation approach of the template for `create-mc-app`.
The template is correctly installed but the app does not start because of the missing `redux` dependency.

So now I changed the installation script on CI to install the app outside of the app-kit repo (to avoid using hoisted dependencies) and we also run tests and build, just to make sure that everything works out of the box.