### PR TITLE
feat(babel-preset-mc-app): disable console on production

### DIFF
--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -124,6 +124,7 @@ module.exports = function getBabePresetConfigForMcApp() {
       isEnvTest &&
         // Transform dynamic import to require
         require('babel-plugin-transform-dynamic-import').default,
+      isEnvProduction && require('babel-plugin-transform-remove-console'),
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -124,7 +124,9 @@ module.exports = function getBabePresetConfigForMcApp() {
       isEnvTest &&
         // Transform dynamic import to require
         require('babel-plugin-transform-dynamic-import').default,
-      isEnvProduction && require('babel-plugin-transform-remove-console'),
+      isEnvProduction &&
+        !isRollup &&
+        require('babel-plugin-transform-remove-console'),
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-react": "7.0.0",
     "babel-plugin-macros": "2.4.5",
     "babel-plugin-transform-dynamic-import": "2.1.0",
-    "babel-plugin-transform-react-remove-prop-types": "0.4.21"
+    "babel-plugin-transform-react-remove-prop-types": "0.4.21",
+    "babel-plugin-transform-remove-console": "6.9.4"
   }
 }

--- a/packages/mc-scripts/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-development.js
@@ -111,35 +111,26 @@ module.exports = ({
         NODE_ENV: JSON.stringify('development'),
       },
     }),
-  ]
-    .concat(
-      toggleFlags.generateIndexHtml
-        ? [
-            new HtmlWebpackPlugin({
-              inject: false,
-              filename: path.join(distPath, 'assets/index.html'),
-              template: require.resolve(
-                '@commercetools-frontend/mc-html-template'
-              ),
-            }),
-            (() => {
-              // eslint-disable-next-line global-require
-              const LocalHtmlWebpackPlugin = require('../webpack-plugins/local-html-webpack-plugin');
-              return new LocalHtmlWebpackPlugin();
-            })(),
-          ]
-        : []
-    )
-    .concat([
-      // Add module names to factory functions so they appear in browser profiler.
-      // https://webpack.js.org/guides/caching/
-      new webpack.NamedModulesPlugin(),
-      // Strip all locales except `en`, `de`
-      // (`en` is built into Moment and can't be removed).
-      new MomentLocalesPlugin({ localesToKeep: ['de', 'es'] }),
-      // This is necessary to emit hot updates (currently CSS only).
-      new webpack.HotModuleReplacementPlugin(),
-    ]),
+    toggleFlags.generateIndexHtml &&
+      new HtmlWebpackPlugin({
+        inject: false,
+        filename: path.join(distPath, 'assets/index.html'),
+        template: require.resolve('@commercetools-frontend/mc-html-template'),
+      }),
+    (() => {
+      // eslint-disable-next-line global-require
+      const LocalHtmlWebpackPlugin = require('../webpack-plugins/local-html-webpack-plugin');
+      return new LocalHtmlWebpackPlugin();
+    })(),
+    // Add module names to factory functions so they appear in browser profiler.
+    // https://webpack.js.org/guides/caching/
+    new webpack.NamedModulesPlugin(),
+    // Strip all locales except `en`, `de`
+    // (`en` is built into Moment and can't be removed).
+    new MomentLocalesPlugin({ localesToKeep: ['de', 'es'] }),
+    // This is necessary to emit hot updates (currently CSS only).
+    new webpack.HotModuleReplacementPlugin(),
+  ].filter(Boolean),
 
   module: {
     // Makes missing exports an error instead of warning.

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -401,7 +401,7 @@ module.exports = ({
           },
         ],
       },
-      // Process JS with Babel.
+      // Process application JavaScript with Babel.
       {
         test: /\.js$/,
         use: [
@@ -425,6 +425,37 @@ module.exports = ({
           },
         ],
         include: sourceFolders,
+      },
+      /**
+       * NOTE:
+       *    Some dependencies may use `console.*` to log (e.g. Apollo). These log statements
+       *    should be removed for production builds. This could also be achieved using `UglifyJS`.
+       *    However, the fact that also `prop-types` (from dependencies in `node_modules`)
+       *    should be stripped from production builds requires a separate configuration
+       *    for the `babel-loader` including files from `node_modules` while removing
+       *    the mentioned `prop-types` and console statements.
+       */
+      {
+        test: /\.js$/,
+        use: [
+          require.resolve('thread-loader'),
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              babelrc: false,
+              plugins: [
+                require.resolve('babel-plugin-transform-remove-console'),
+                [
+                  require.resolve(
+                    'babel-plugin-transform-react-remove-prop-types'
+                  ),
+                  { removeImport: true },
+                ],
+              ],
+            },
+          },
+        ],
+        include: /node_modules/,
       },
       // Allow to import `*.graphql` SDL files.
       {

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -96,19 +96,8 @@ const defaultToggleFlags = {
  * The function requires the file path to the related application
  * "entry point".
  */
-module.exports = ({
-  distPath,
-  entryPoint,
-  sourceFolders,
-  toggleFlags = defaultToggleFlags,
-}) => {
-  // NOTE: Without properly defauling passing one flag (e.g. `enabledVendorOptimizations`)
-  // would disable other flags defaulted to `true` (e.g. `enableExtractCss`).
-  const defaultedToggleFlags = {
-    ...defaultToggleFlags,
-    ...toggleFlags,
-  };
-
+module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
+  const mergedToggleFlags = { ...defaultToggleFlags, ...toggleFlags };
   return {
     // Don't attempt to continue if there are any errors.
     bail: true,
@@ -126,7 +115,7 @@ module.exports = ({
     optimization: {
       minimizer: [
         new UglifyJsPlugin(uglifyConfig),
-        defaultedToggleFlags.enableExtractCss &&
+        mergedToggleFlags.enableExtractCss &&
           new OptimizeCSSAssetsPlugin(optimizeCSSConfig),
       ].filter(Boolean),
       // Automatically split vendor and commons
@@ -134,7 +123,7 @@ module.exports = ({
       splitChunks: {
         chunks: 'all',
         // NOTE: if you enable `cacheGroups` for CSS, remember to toggle it with
-        // the `defaultedToggleFlags.enableExtractCss`
+        // the `mergedToggleFlags.enableExtractCss`
       },
       // Keep the runtime chunk seperated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985
@@ -202,13 +191,13 @@ module.exports = ({
         outputPath: distPath,
         includeFields: ['entrypoints', 'assets', 'publicPath', 'time'],
       }),
-      defaultedToggleFlags.generateIndexHtml &&
+      mergedToggleFlags.generateIndexHtml &&
         new HtmlWebpackPlugin({
           inject: false,
           filename: 'index.html.template',
           template: require.resolve('@commercetools-frontend/mc-html-template'),
         }),
-      defaultedToggleFlags.enableExtractCss && // Extracts CSS into one CSS file to mimic CSS order in dev
+      mergedToggleFlags.enableExtractCss && // Extracts CSS into one CSS file to mimic CSS order in dev
         new MiniCssExtractPlugin({
           filename: '[name].[chunkhash].css',
           chunkFilename: '[id].[name].[chunkhash].css',
@@ -295,7 +284,7 @@ module.exports = ({
           test: /\.mod\.css$/,
           include: sourceFolders,
           use: [
-            defaultedToggleFlags.enableExtractCss
+            mergedToggleFlags.enableExtractCss
               ? MiniCssExtractPlugin.loader
               : require.resolve('style-loader'),
             {
@@ -350,7 +339,7 @@ module.exports = ({
               // Use "postcss" for all the included source folders.
               include: sourceFolders,
               use: [
-                defaultedToggleFlags.enableExtractCss
+                mergedToggleFlags.enableExtractCss
                   ? MiniCssExtractPlugin.loader
                   : require.resolve('style-loader'),
                 require.resolve('css-loader'),
@@ -387,7 +376,7 @@ module.exports = ({
               // But still use MiniCssExtractPlugin :)
               include: /node_modules/,
               loaders: [
-                defaultedToggleFlags.enableExtractCss
+                mergedToggleFlags.enableExtractCss
                   ? MiniCssExtractPlugin.loader
                   : require.resolve('style-loader'),
                 require.resolve('css-loader'),
@@ -431,7 +420,7 @@ module.exports = ({
          *    for the `babel-loader` including files from `node_modules` while removing
          *    the mentioned `prop-types` and console statements.
          */
-        defaultedToggleFlags.enabledVendorOptimizations && {
+        mergedToggleFlags.enabledVendorOptimizations && {
           test: /\.js$/,
           include: /node_modules/,
           exclude: sourceFolders,

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -437,6 +437,8 @@ module.exports = ({
        */
       {
         test: /\.js$/,
+        include: /node_modules/,
+        exclude: sourceFolders,
         use: [
           require.resolve('thread-loader'),
           {
@@ -455,7 +457,6 @@ module.exports = ({
             },
           },
         ],
-        include: /node_modules/,
       },
       // Allow to import `*.graphql` SDL files.
       {

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -101,371 +101,384 @@ module.exports = ({
   entryPoint,
   sourceFolders,
   toggleFlags = defaultToggleFlags,
-}) => ({
-  // Don't attempt to continue if there are any errors.
-  bail: true,
+}) => {
+  // NOTE: Without properly defauling passing one flag (e.g. `enabledVendorOptimizations`)
+  // would disable other flags defaulted to `true` (e.g. `enableExtractCss`).
+  const defaultedToggleFlags = {
+    ...defaultToggleFlags,
+    ...toggleFlags,
+  };
 
-  // https://webpack.js.org/concepts/#mode
-  mode: 'production',
+  return {
+    // Don't attempt to continue if there are any errors.
+    bail: true,
 
-  // We generate sourcemaps in production. This is slow but gives good results.
-  // Sourcemaps are pushed to Google Storage and Sentry.
-  // https://webpack.js.org/configuration/devtool/#devtool
-  devtool: 'source-map',
+    // https://webpack.js.org/concepts/#mode
+    mode: 'production',
 
-  // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-  // https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a
-  optimization: {
-    minimizer: [
-      new UglifyJsPlugin(uglifyConfig),
-      toggleFlags.enableExtractCss &&
-        new OptimizeCSSAssetsPlugin(optimizeCSSConfig),
-    ].filter(Boolean),
-    // Automatically split vendor and commons
-    // https://twitter.com/wSokra/status/969633336732905474
-    splitChunks: {
-      chunks: 'all',
-      // NOTE: if you enable `cacheGroups` for CSS, remember to toggle it with
-      // the `toggleFlags.enableExtractCss`
+    // We generate sourcemaps in production. This is slow but gives good results.
+    // Sourcemaps are pushed to Google Storage and Sentry.
+    // https://webpack.js.org/configuration/devtool/#devtool
+    devtool: 'source-map',
+
+    // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+    // https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a
+    optimization: {
+      minimizer: [
+        new UglifyJsPlugin(uglifyConfig),
+        defaultedToggleFlags.enableExtractCss &&
+          new OptimizeCSSAssetsPlugin(optimizeCSSConfig),
+      ].filter(Boolean),
+      // Automatically split vendor and commons
+      // https://twitter.com/wSokra/status/969633336732905474
+      splitChunks: {
+        chunks: 'all',
+        // NOTE: if you enable `cacheGroups` for CSS, remember to toggle it with
+        // the `defaultedToggleFlags.enableExtractCss`
+      },
+      // Keep the runtime chunk seperated to enable long term caching
+      // https://twitter.com/wSokra/status/969679223278505985
+      runtimeChunk: true,
     },
-    // Keep the runtime chunk seperated to enable long term caching
-    // https://twitter.com/wSokra/status/969679223278505985
-    runtimeChunk: true,
-  },
 
-  // In production, we only want to load the polyfills and the app code.
-  entry: {
-    app: [
-      require.resolve('./polyfills'),
-      require.resolve('babel-polyfill'),
-      entryPoint,
-    ],
-  },
+    // In production, we only want to load the polyfills and the app code.
+    entry: {
+      app: [
+        require.resolve('./polyfills'),
+        require.resolve('babel-polyfill'),
+        entryPoint,
+      ],
+    },
 
-  output: {
-    // Generated JS file names (with nested folders).
-    // There will be one main bundle, and one file per asynchronous chunk.
-    filename: '[name].[chunkhash].js',
-    chunkFilename: '[id].[name].[chunkhash].js',
-    // The build folder.
-    path: path.join(distPath, 'assets'),
-    pathinfo: false,
-    // Will be injected on runtime. See `packages/application-shell/src/public-path.js`
-    publicPath: '',
-  },
+    output: {
+      // Generated JS file names (with nested folders).
+      // There will be one main bundle, and one file per asynchronous chunk.
+      filename: '[name].[chunkhash].js',
+      chunkFilename: '[id].[name].[chunkhash].js',
+      // The build folder.
+      path: path.join(distPath, 'assets'),
+      pathinfo: false,
+      // Will be injected on runtime. See `packages/application-shell/src/public-path.js`
+      publicPath: '',
+    },
 
-  plugins: [
-    new CleanWebpackPlugin([distPath], { allowExternal: true }),
-    // Allows to "assign" custom options to the `webpack` object.
-    // At the moment, this is used to share some props with `postcss.config`.
-    new webpack.LoaderOptionsPlugin({
-      options: {
-        sourceFolders,
-        context: __dirname,
-      },
-    }),
-    // Makes some environment variables available to the JS code, for example:
-    // if (process.env.NODE_ENV === 'production') { ... }.
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
-    // Add module names to factory functions so they appear in browser profiler.
-    // NOTE: instead of using `HashedModuleIdsPlugin`, we use `NamedModulesPlugin`
-    // for production as well, despite the `HashedModuleIdsPlugin` being the
-    // recommended choice for production.
-    // It appears that using `HashedModuleIdsPlugin` the gzipped bundles are
-    // bigger in size compared to the bundles produces by `NamedModulesPlugin`.
-    // Therefore we go for the choice of having smaller bundles.
-    // Refs:
-    // - https://gitlab.com/gitlab-org/gitlab-ce/issues/32835
-    // - https://medium.com/@schnibl/hashes-are-had-to-zip-pathnames-not-therefore-your-end-result-with-named-modules-is-unintuitively-94baa1a507e
-    new webpack.NamedModulesPlugin(),
-    // Strip all locales except `en`, `de`
-    // (`en` is built into Moment and can't be removed)
-    new MomentLocalesPlugin({ localesToKeep: ['de', 'es'] }),
-
-    // Generate a `stats.json` file containing information and paths to
-    // the assets that webpack created.
-    // This is necessary to programmatically refer to the correct bundle path
-    // in the `index.html`.
-    new FinalStatsWriterPlugin({
-      outputPath: distPath,
-      includeFields: ['entrypoints', 'assets', 'publicPath', 'time'],
-    }),
-    toggleFlags.generateIndexHtml &&
-      new HtmlWebpackPlugin({
-        inject: false,
-        filename: 'index.html.template',
-        template: require.resolve('@commercetools-frontend/mc-html-template'),
+    plugins: [
+      new CleanWebpackPlugin([distPath], { allowExternal: true }),
+      // Allows to "assign" custom options to the `webpack` object.
+      // At the moment, this is used to share some props with `postcss.config`.
+      new webpack.LoaderOptionsPlugin({
+        options: {
+          sourceFolders,
+          context: __dirname,
+        },
       }),
-    toggleFlags.enableExtractCss && // Extracts CSS into one CSS file to mimic CSS order in dev
-      new MiniCssExtractPlugin({
-        filename: '[name].[chunkhash].css',
-        chunkFilename: '[id].[name].[chunkhash].css',
+      // Makes some environment variables available to the JS code, for example:
+      // if (process.env.NODE_ENV === 'production') { ... }.
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify('production'),
+        },
       }),
-    process.env.ANALYZE_BUNDLE === 'true' &&
-      new BundleAnalyzerPlugin({
-        defaultSizes: 'gzip',
+      // Add module names to factory functions so they appear in browser profiler.
+      // NOTE: instead of using `HashedModuleIdsPlugin`, we use `NamedModulesPlugin`
+      // for production as well, despite the `HashedModuleIdsPlugin` being the
+      // recommended choice for production.
+      // It appears that using `HashedModuleIdsPlugin` the gzipped bundles are
+      // bigger in size compared to the bundles produces by `NamedModulesPlugin`.
+      // Therefore we go for the choice of having smaller bundles.
+      // Refs:
+      // - https://gitlab.com/gitlab-org/gitlab-ce/issues/32835
+      // - https://medium.com/@schnibl/hashes-are-had-to-zip-pathnames-not-therefore-your-end-result-with-named-modules-is-unintuitively-94baa1a507e
+      new webpack.NamedModulesPlugin(),
+      // Strip all locales except `en`, `de`
+      // (`en` is built into Moment and can't be removed)
+      new MomentLocalesPlugin({ localesToKeep: ['de', 'es'] }),
+
+      // Generate a `stats.json` file containing information and paths to
+      // the assets that webpack created.
+      // This is necessary to programmatically refer to the correct bundle path
+      // in the `index.html`.
+      new FinalStatsWriterPlugin({
+        outputPath: distPath,
+        includeFields: ['entrypoints', 'assets', 'publicPath', 'time'],
       }),
-  ].filter(Boolean),
+      defaultedToggleFlags.generateIndexHtml &&
+        new HtmlWebpackPlugin({
+          inject: false,
+          filename: 'index.html.template',
+          template: require.resolve('@commercetools-frontend/mc-html-template'),
+        }),
+      defaultedToggleFlags.enableExtractCss && // Extracts CSS into one CSS file to mimic CSS order in dev
+        new MiniCssExtractPlugin({
+          filename: '[name].[chunkhash].css',
+          chunkFilename: '[id].[name].[chunkhash].css',
+        }),
+      process.env.ANALYZE_BUNDLE === 'true' &&
+        new BundleAnalyzerPlugin({
+          defaultSizes: 'gzip',
+        }),
+    ].filter(Boolean),
 
-  module: {
-    // Makes missing exports an error instead of warning.
-    strictExportPresence: true,
+    module: {
+      // Makes missing exports an error instead of warning.
+      strictExportPresence: true,
 
-    rules: [
-      // Disable require.ensure as it's not a standard language feature.
-      { parser: { requireEnsure: false } },
-      // For svg icons, we want to get them transformed into React components
-      // when we import them.
-      {
-        test: /\.react\.svg$/,
-        use: [
-          {
-            loader: require.resolve('babel-loader'),
-            options: {
-              babelrc: false,
-              presets: [
-                require.resolve('@commercetools-frontend/babel-preset-mc-app'),
-              ],
-              // This is a feature of `babel-loader` for webpack (not Babel itself).
-              // It enables caching results in ./node_modules/.cache/babel-loader/
-              // directory for faster rebuilds.
-              cacheDirectory: true,
-              highlightCode: true,
-            },
-          },
-          {
-            loader: require.resolve('@svgr/webpack'),
-            options: {
-              // NOTE: disable this and manually add `removeViewBox: false` in the SVGO plugins list
-              // See related PR: https://github.com/smooth-code/svgr/pull/137
-              icon: false,
-              svgoConfig: {
-                plugins: [
-                  { removeViewBox: false },
-                  // Keeps ID's of svgs so they can be targeted with CSS
-                  { cleanupIDs: false },
+      rules: [
+        // Disable require.ensure as it's not a standard language feature.
+        { parser: { requireEnsure: false } },
+        // For svg icons, we want to get them transformed into React components
+        // when we import them.
+        {
+          test: /\.react\.svg$/,
+          use: [
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                babelrc: false,
+                presets: [
+                  require.resolve(
+                    '@commercetools-frontend/babel-preset-mc-app'
+                  ),
                 ],
+                // This is a feature of `babel-loader` for webpack (not Babel itself).
+                // It enables caching results in ./node_modules/.cache/babel-loader/
+                // directory for faster rebuilds.
+                cacheDirectory: true,
+                highlightCode: true,
               },
             },
-          },
-        ],
-      },
-      // For normal svg files (not icons) we should load the file normally
-      // and simply use it as a `<img src/>`.
-      {
-        test: function testForNormalSvgFiles(fileName) {
-          return (
-            // Use this only for plain SVG.
-            // For SVG as React components, see loader above.
-            fileName.endsWith('.svg') && !fileName.endsWith('.react.svg')
-          );
-        },
-        use: [
-          {
-            loader: require.resolve('svg-url-loader'),
-            options: { noquotes: true },
-          },
-        ],
-      },
-      // "url" loader works like "file" loader except that it embeds assets
-      // smaller than specified limit in bytes as data URLs to avoid requests.
-      // A missing `test` is equivalent to a match.
-      {
-        test: /\.png$/,
-        use: [require.resolve('url-loader')],
-      },
-      // "postcss" loader applies autoprefixer to our CSS
-      // "css" loader resolves paths in CSS and adds assets as dependencies.
-      // "style" loader turns CSS into JS modules that inject <style> tags.
-      {
-        test: /\.mod\.css$/,
-        include: sourceFolders,
-        use: [
-          toggleFlags.enableExtractCss
-            ? MiniCssExtractPlugin.loader
-            : require.resolve('style-loader'),
-          {
-            loader: require.resolve('css-loader'),
-            options: {
-              modules: true,
-              importLoaders: 1,
-              localIdentName: '[name]__[local]___[hash:base64:5]',
-            },
-          },
-          {
-            loader: require.resolve('postcss-loader'),
-            options: {
-              ident: 'postcss',
-              plugins: () => [
-                postcssImport({ path: sourceFolders }),
-                postcssPresetEnv({
-                  browsers: browserslist.production,
-                  autoprefixer: { grid: true },
-                }),
-                postcssCustomProperties({
-                  preserve: false,
-                  importFrom: require.resolve(
-                    '@commercetools-frontend/ui-kit/materials/custom-properties.css'
-                  ),
-                }),
-                postcssCustomMediaQueries({
-                  importFrom: require.resolve(
-                    '@commercetools-frontend/ui-kit/materials/media-queries.mod.css'
-                  ),
-                }),
-                postcssColorModFunction(),
-                postcssReporter(),
-              ],
-            },
-          },
-        ],
-      },
-      {
-        test: function testForNormalCssFiles(fileName) {
-          return (
-            // Use this only for plain CSS.
-            // For css-modules, see loader above.
-            fileName.endsWith('.css') && !fileName.endsWith('.mod.css')
-          );
-        },
-        // "postcss" loader applies autoprefixer to our CSS.
-        // "css" loader resolves paths in CSS and adds assets as dependencies.
-        // "MiniCssExtractPlugin" or "style" loader extracts css to one file per css file.
-        oneOf: [
-          {
-            // Use "postcss" for all the included source folders.
-            include: sourceFolders,
-            use: [
-              toggleFlags.enableExtractCss
-                ? MiniCssExtractPlugin.loader
-                : require.resolve('style-loader'),
-              require.resolve('css-loader'),
-              {
-                loader: require.resolve('postcss-loader'),
-                options: {
-                  ident: 'postcss',
-                  plugins: () => [
-                    postcssImport(),
-                    postcssPresetEnv({
-                      browsers: browserslist.production,
-                      autoprefixer: { grid: true },
-                    }),
-                    postcssCustomMediaQueries({
-                      importFrom: require.resolve(
-                        '@commercetools-frontend/ui-kit/materials/media-queries.mod.css'
-                      ),
-                    }),
-                    postcssCustomProperties({
-                      preserve: false,
-                      importFrom: require.resolve(
-                        '@commercetools-frontend/ui-kit/materials/custom-properties.css'
-                      ),
-                    }),
-                    postcssColorModFunction(),
-                    postcssReporter(),
+            {
+              loader: require.resolve('@svgr/webpack'),
+              options: {
+                // NOTE: disable this and manually add `removeViewBox: false` in the SVGO plugins list
+                // See related PR: https://github.com/smooth-code/svgr/pull/137
+                icon: false,
+                svgoConfig: {
+                  plugins: [
+                    { removeViewBox: false },
+                    // Keeps ID's of svgs so they can be targeted with CSS
+                    { cleanupIDs: false },
                   ],
                 },
               },
-            ],
-          },
-          {
-            // For all other vendor CSS, do not use "postcss" loader.
-            // But still use MiniCssExtractPlugin :)
-            include: /node_modules/,
-            loaders: [
-              toggleFlags.enableExtractCss
-                ? MiniCssExtractPlugin.loader
-                : require.resolve('style-loader'),
-              require.resolve('css-loader'),
-            ],
-          },
-        ],
-      },
-      // Process application JavaScript with Babel.
-      {
-        test: /\.js$/,
-        use: [
-          // This loader parallelizes code compilation, it is optional but
-          // improves compile time on larger projects
-          require.resolve('thread-loader'),
-          {
-            loader: require.resolve('babel-loader'),
-            options: {
-              babelrc: false,
-              compact: false,
-              presets: [
-                require.resolve('@commercetools-frontend/babel-preset-mc-app'),
-              ],
-              // This is a feature of `babel-loader` for webpack (not Babel itself).
-              // It enables caching results in ./node_modules/.cache/babel-loader/
-              // directory for faster rebuilds.
-              cacheDirectory: true,
-              highlightCode: true,
             },
+          ],
+        },
+        // For normal svg files (not icons) we should load the file normally
+        // and simply use it as a `<img src/>`.
+        {
+          test: function testForNormalSvgFiles(fileName) {
+            return (
+              // Use this only for plain SVG.
+              // For SVG as React components, see loader above.
+              fileName.endsWith('.svg') && !fileName.endsWith('.react.svg')
+            );
           },
-        ],
-        include: sourceFolders,
-      },
-      /**
-       * NOTE:
-       *    Some dependencies may use `console.*` to log (e.g. Apollo). These log statements
-       *    should be removed for production builds. This could also be achieved using `UglifyJS`.
-       *    However, the fact that also `prop-types` (from dependencies in `node_modules`)
-       *    should be stripped from production builds requires a separate configuration
-       *    for the `babel-loader` including files from `node_modules` while removing
-       *    the mentioned `prop-types` and console statements.
-       */
-      toggleFlags.enabledVendorOptimizations && {
-        test: /\.js$/,
-        include: /node_modules/,
-        exclude: sourceFolders,
-        use: [
-          require.resolve('thread-loader'),
-          {
-            loader: require.resolve('babel-loader'),
-            options: {
-              babelrc: false,
-              plugins: [
-                require.resolve('babel-plugin-transform-remove-console'),
-                [
-                  require.resolve(
-                    'babel-plugin-transform-react-remove-prop-types'
-                  ),
-                  { removeImport: true },
+          use: [
+            {
+              loader: require.resolve('svg-url-loader'),
+              options: { noquotes: true },
+            },
+          ],
+        },
+        // "url" loader works like "file" loader except that it embeds assets
+        // smaller than specified limit in bytes as data URLs to avoid requests.
+        // A missing `test` is equivalent to a match.
+        {
+          test: /\.png$/,
+          use: [require.resolve('url-loader')],
+        },
+        // "postcss" loader applies autoprefixer to our CSS
+        // "css" loader resolves paths in CSS and adds assets as dependencies.
+        // "style" loader turns CSS into JS modules that inject <style> tags.
+        {
+          test: /\.mod\.css$/,
+          include: sourceFolders,
+          use: [
+            defaultedToggleFlags.enableExtractCss
+              ? MiniCssExtractPlugin.loader
+              : require.resolve('style-loader'),
+            {
+              loader: require.resolve('css-loader'),
+              options: {
+                modules: true,
+                importLoaders: 1,
+                localIdentName: '[name]__[local]___[hash:base64:5]',
+              },
+            },
+            {
+              loader: require.resolve('postcss-loader'),
+              options: {
+                ident: 'postcss',
+                plugins: () => [
+                  postcssImport({ path: sourceFolders }),
+                  postcssPresetEnv({
+                    browsers: browserslist.production,
+                    autoprefixer: { grid: true },
+                  }),
+                  postcssCustomProperties({
+                    preserve: false,
+                    importFrom: require.resolve(
+                      '@commercetools-frontend/ui-kit/materials/custom-properties.css'
+                    ),
+                  }),
+                  postcssCustomMediaQueries({
+                    importFrom: require.resolve(
+                      '@commercetools-frontend/ui-kit/materials/media-queries.mod.css'
+                    ),
+                  }),
+                  postcssColorModFunction(),
+                  postcssReporter(),
                 ],
+              },
+            },
+          ],
+        },
+        {
+          test: function testForNormalCssFiles(fileName) {
+            return (
+              // Use this only for plain CSS.
+              // For css-modules, see loader above.
+              fileName.endsWith('.css') && !fileName.endsWith('.mod.css')
+            );
+          },
+          // "postcss" loader applies autoprefixer to our CSS.
+          // "css" loader resolves paths in CSS and adds assets as dependencies.
+          // "MiniCssExtractPlugin" or "style" loader extracts css to one file per css file.
+          oneOf: [
+            {
+              // Use "postcss" for all the included source folders.
+              include: sourceFolders,
+              use: [
+                defaultedToggleFlags.enableExtractCss
+                  ? MiniCssExtractPlugin.loader
+                  : require.resolve('style-loader'),
+                require.resolve('css-loader'),
+                {
+                  loader: require.resolve('postcss-loader'),
+                  options: {
+                    ident: 'postcss',
+                    plugins: () => [
+                      postcssImport(),
+                      postcssPresetEnv({
+                        browsers: browserslist.production,
+                        autoprefixer: { grid: true },
+                      }),
+                      postcssCustomMediaQueries({
+                        importFrom: require.resolve(
+                          '@commercetools-frontend/ui-kit/materials/media-queries.mod.css'
+                        ),
+                      }),
+                      postcssCustomProperties({
+                        preserve: false,
+                        importFrom: require.resolve(
+                          '@commercetools-frontend/ui-kit/materials/custom-properties.css'
+                        ),
+                      }),
+                      postcssColorModFunction(),
+                      postcssReporter(),
+                    ],
+                  },
+                },
               ],
             },
-          },
-        ],
-      },
-      // Allow to import `*.graphql` SDL files.
-      {
-        test: /\.graphql$/,
-        include: sourceFolders,
-        use: [require.resolve('graphql-tag/loader')],
-      },
-      {
-        test: /\.pegjs$/,
-        use: [require.resolve('pegjs-loader')],
-      },
-    ].filter(Boolean),
-  },
-  // Some libraries import Node modules but don't use them in the browser.
-  // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    dgram: 'empty',
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-    child_process: 'empty',
-  },
-  // Turn off performance hints in production because we utilize
-  // our own hints via the FileSizeReporter (toolbox/build.js).
-  performance: {
-    hints: false,
-  },
-});
+            {
+              // For all other vendor CSS, do not use "postcss" loader.
+              // But still use MiniCssExtractPlugin :)
+              include: /node_modules/,
+              loaders: [
+                defaultedToggleFlags.enableExtractCss
+                  ? MiniCssExtractPlugin.loader
+                  : require.resolve('style-loader'),
+                require.resolve('css-loader'),
+              ],
+            },
+          ],
+        },
+        // Process application JavaScript with Babel.
+        {
+          test: /\.js$/,
+          use: [
+            // This loader parallelizes code compilation, it is optional but
+            // improves compile time on larger projects
+            require.resolve('thread-loader'),
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                babelrc: false,
+                compact: false,
+                presets: [
+                  require.resolve(
+                    '@commercetools-frontend/babel-preset-mc-app'
+                  ),
+                ],
+                // This is a feature of `babel-loader` for webpack (not Babel itself).
+                // It enables caching results in ./node_modules/.cache/babel-loader/
+                // directory for faster rebuilds.
+                cacheDirectory: true,
+                highlightCode: true,
+              },
+            },
+          ],
+          include: sourceFolders,
+        },
+        /**
+         * NOTE:
+         *    Some dependencies may use `console.*` to log (e.g. Apollo). These log statements
+         *    should be removed for production builds. This could also be achieved using `UglifyJS`.
+         *    However, the fact that also `prop-types` (from dependencies in `node_modules`)
+         *    should be stripped from production builds requires a separate configuration
+         *    for the `babel-loader` including files from `node_modules` while removing
+         *    the mentioned `prop-types` and console statements.
+         */
+        defaultedToggleFlags.enabledVendorOptimizations && {
+          test: /\.js$/,
+          include: /node_modules/,
+          exclude: sourceFolders,
+          use: [
+            require.resolve('thread-loader'),
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                babelrc: false,
+                plugins: [
+                  require.resolve('babel-plugin-transform-remove-console'),
+                  [
+                    require.resolve(
+                      'babel-plugin-transform-react-remove-prop-types'
+                    ),
+                    { removeImport: true },
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+        // Allow to import `*.graphql` SDL files.
+        {
+          test: /\.graphql$/,
+          include: sourceFolders,
+          use: [require.resolve('graphql-tag/loader')],
+        },
+        {
+          test: /\.pegjs$/,
+          use: [require.resolve('pegjs-loader')],
+        },
+      ].filter(Boolean),
+    },
+    // Some libraries import Node modules but don't use them in the browser.
+    // Tell Webpack to provide empty mocks for them so importing them works.
+    node: {
+      dgram: 'empty',
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty',
+      child_process: 'empty',
+    },
+    // Turn off performance hints in production because we utilize
+    // our own hints via the FileSizeReporter (toolbox/build.js).
+    performance: {
+      hints: false,
+    },
+  };
+};

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -87,6 +87,7 @@ const defaultToggleFlags = {
   enableExtractCss: true,
   // Allow to disable index.html generation in case it's not necessary (e.g. for Storybook)
   generateIndexHtml: true,
+  enabledVendorOptimizations: false,
 };
 
 /**
@@ -435,7 +436,7 @@ module.exports = ({
        *    for the `babel-loader` including files from `node_modules` while removing
        *    the mentioned `prop-types` and console statements.
        */
-      {
+      toggleFlags.enabledVendorOptimizations && {
         test: /\.js$/,
         include: /node_modules/,
         exclude: sourceFolders,
@@ -468,7 +469,7 @@ module.exports = ({
         test: /\.pegjs$/,
         use: [require.resolve('pegjs-loader')],
       },
-    ],
+    ].filter(Boolean),
   },
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -9,4 +9,7 @@ module.exports = createWebpackConfigForProduction({
   distPath,
   entryPoint,
   sourceFolders,
+  toggleFlags: {
+    enabledVendorOptimizations: true,
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,6 +2871,11 @@ babel-plugin-transform-react-remove-prop-types@0.4.21:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.21.tgz#0087938f4348cb751b3e5055a6b38f3c61b5231b"
   integrity sha512-+gQBtcnEhYFbMPFGr8YL7SHD4BpHifFDGEc+ES0+1iDwC9psist2+eumcLoHjBMumL7N/HI/G64XR5aQC8Nr5Q==
 
+babel-plugin-transform-remove-console@6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
 babel-plugin-transform-rename-import@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"


### PR DESCRIPTION
#### Summary

This pull request adds a babel plugin to remove console.* statements on production.

#### Description

Given we are building for production we can remove console log statements. It's not strictly needed but also can not hurt much.

There are other alternatives to do this:

1. During uglification
    - Decided against it as it create a lock-in to a minifier
2. Overwriting `console.log = () => {}`
    - It's not really a good practice to overwrite built-ins
    - It also affects code which is not "ours"

Given that I went with a simple babel plugin applied only when building for prod. Moreover the babel plugin allows only overwriting specific loggers (so if needed later we can keep `error` again etc).
