### PR TITLE
fix(mc-scripts): use unfetch as polyfill

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -1,4 +1,3 @@
-import fetch from 'unfetch';
 import ApolloClient from 'apollo-client';
 import { ApolloLink } from 'apollo-link';
 import apolloLogger from 'apollo-link-logger';
@@ -15,11 +14,6 @@ const httpLink = createHttpLink({
   headers: {
     accept: 'application/json',
   },
-  // manual polyfill for fetch to support older browsers like IE11
-  // for some reason that I wasn't able to figure out just importing
-  // isomorphic fetch didn't make Apollo use the global fetch :(
-  // they recommend using unfetch and passing it explicitly like we are doing
-  // here. https://www.apollographql.com/docs/link/links/http.html#fetch
   fetch,
 });
 

--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -41,7 +41,8 @@
     "jest-watch-master": "1.0.0",
     "pegjs-jest": "0.0.2",
     "pkg-dir": "3.0.0",
-    "raf": "3.4.1"
+    "raf": "3.4.1",
+    "unfetch": "4.0.1"
   },
   "devDependencies": {
     "react-testing-library": "5.4.4"

--- a/packages/jest-preset-mc-app/setup-test-framework.js
+++ b/packages/jest-preset-mc-app/setup-test-framework.js
@@ -1,3 +1,4 @@
+require('unfetch/polyfill');
 require('jest-enzyme');
 require('jest-dom/extend-expect');
 require('react-testing-library/cleanup-after-each');

--- a/packages/mc-scripts/config/polyfills.js
+++ b/packages/mc-scripts/config/polyfills.js
@@ -1,5 +1,17 @@
 /* eslint-disable global-require */
 
+/**
+ * NOTE:
+ *    `unfetch` with version 4 sarted to work as a ponyfil.
+ *    Our Apollo client and http middleware need a fetch
+ *    implementation explicitely being passed. While our
+ *    mocking mechanisms (in app E2E tests) rely on being able
+ *    to stub `fetch` on the `window` (both sharing the same implemenation).
+ *    This is why `unfetch` is still used as a polyfill. Overwriting or
+ *    stubbing a ponyfill is not possible as JavaScript modules are read-only.
+ */
+import 'unfetch/polyfill';
+
 if (typeof Promise === 'undefined') {
   // Rejection tracking prevents a common issue where React gets into an
   // inconsistent state due to an error, but it gets swallowed by a Promise,

--- a/packages/sdk/src/middleware/client.js
+++ b/packages/sdk/src/middleware/client.js
@@ -1,4 +1,3 @@
-import fetch from 'unfetch';
 import { createClient as createSdkClient } from '@commercetools/sdk-client';
 import { createHttpMiddleware as createSdkHttpMiddleware } from '@commercetools/sdk-middleware-http';
 import { createUserAgentMiddleware as createSdkUserAgentMiddleware } from '@commercetools/sdk-middleware-user-agent';


### PR DESCRIPTION
#### Summary

This pull request re-adds the usage or unfetch as a polyfill. More in the code comment and in app PRs.