### PR TITLE
refactor: disable loggers based on runtime configuration

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -7,6 +7,7 @@ import {
   IntrospectionFragmentMatcher,
 } from 'apollo-cache-inmemory';
 import { errorLink, headerLink, tokenRetryLink } from './apollo-links';
+import { isLoggerEnabled } from './utils/logger';
 
 const httpLink = createHttpLink({
   uri: `${window.app.mcApiUrl}/graphql`,
@@ -25,7 +26,7 @@ const link = ApolloLink.from([
   headerLink,
   errorLink,
   // Avoid logging queries in test environment
-  ...(process.env.NODE_ENV !== 'test' ? [apolloLogger] : []),
+  ...(isLoggerEnabled() ? [apolloLogger] : []),
   tokenRetryLink,
   httpLink,
 ]);

--- a/packages/application-shell/src/middleware/logger.js
+++ b/packages/application-shell/src/middleware/logger.js
@@ -3,8 +3,10 @@ import {
   ADD_NOTIFICATION,
   REMOVE_NOTIFICATION,
 } from '@commercetools-frontend/notifications';
+import logger from '../utils/logger';
 
 const loggerMiddleware = createLogger({
+  logger,
   collapsed: true,
   colors: {
     title: () => '#000000',
@@ -17,8 +19,6 @@ const loggerMiddleware = createLogger({
   // Only enable if you want detailed debugging.
   diff: false,
   predicate: (getState, action) => {
-    if (process.env.NODE_ENV === 'test') return false;
-
     if (!action) return false;
 
     const { type, payload } = action;

--- a/packages/application-shell/src/utils/logger.js
+++ b/packages/application-shell/src/utils/logger.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+
+export const isLoggerEnabled = () => {
+  if (process.env.DEBUG === 'true') return true;
+  if (process.env.NODE_ENV === 'development') return true;
+
+  const queryParams = new URL(window.location.href);
+  if (
+    process.env.NODE_ENV === 'production' &&
+    queryParams.searchParams.get('debug') === 'true'
+  )
+    return true;
+
+  return false;
+};
+
+export default {
+  groupCollapsed: (...args) =>
+    isLoggerEnabled() && console.groupCollapsed(...args),
+  groupEnd: (...args) => isLoggerEnabled() && console.groupEnd(...args),
+  info: (...args) => isLoggerEnabled() && console.info(...args),
+  log: (...args) => isLoggerEnabled() && console.log(...args),
+  error: (...args) => isLoggerEnabled() && console.error(...args),
+  warn: (...args) => isLoggerEnabled() && console.warn(...args),
+};

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -124,9 +124,6 @@ module.exports = function getBabePresetConfigForMcApp() {
       isEnvTest &&
         // Transform dynamic import to require
         require('babel-plugin-transform-dynamic-import').default,
-      isEnvProduction &&
-        !isRollup &&
-        require('babel-plugin-transform-remove-console'),
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -40,7 +40,6 @@
     "@babel/preset-react": "7.0.0",
     "babel-plugin-macros": "2.4.5",
     "babel-plugin-transform-dynamic-import": "2.1.0",
-    "babel-plugin-transform-react-remove-prop-types": "0.4.21",
-    "babel-plugin-transform-remove-console": "6.9.4"
+    "babel-plugin-transform-react-remove-prop-types": "0.4.21"
   }
 }

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -433,7 +433,6 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
                 babelrc: false,
                 plugins: [
                   require.resolve('@babel/plugin-syntax-dynamic-import'),
-                  require.resolve('babel-plugin-transform-remove-console'),
                   [
                     require.resolve(
                       'babel-plugin-transform-react-remove-prop-types'

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -87,7 +87,6 @@ const defaultToggleFlags = {
   enableExtractCss: true,
   // Allow to disable index.html generation in case it's not necessary (e.g. for Storybook)
   generateIndexHtml: true,
-  enabledVendorOptimizations: false,
 };
 
 /**
@@ -411,38 +410,6 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
             },
           ],
           include: sourceFolders,
-        },
-        /**
-         * NOTE:
-         *    Some dependencies may use `console.*` to log (e.g. Apollo). These log statements
-         *    should be removed for production builds. This could also be achieved using `UglifyJS`.
-         *    However, the fact that also `prop-types` (from dependencies in `node_modules`)
-         *    should be stripped from production builds requires a separate configuration
-         *    for the `babel-loader` including files from `node_modules` while removing
-         *    the mentioned `prop-types` and console statements.
-         */
-        mergedToggleFlags.enabledVendorOptimizations && {
-          test: /\.js$/,
-          include: /node_modules/,
-          exclude: sourceFolders,
-          use: [
-            require.resolve('thread-loader'),
-            {
-              loader: require.resolve('babel-loader'),
-              options: {
-                babelrc: false,
-                plugins: [
-                  require.resolve('@babel/plugin-syntax-dynamic-import'),
-                  [
-                    require.resolve(
-                      'babel-plugin-transform-react-remove-prop-types'
-                    ),
-                    { removeImport: true },
-                  ],
-                ],
-              },
-            },
-          ],
         },
         // Allow to import `*.graphql` SDL files.
         {

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@babel/core": "7.2.2",
-    "@babel/plugin-syntax-dynamic-import": "7.2.0",
     "@babel/runtime": "7.2.0",
     "@commercetools-frontend/babel-preset-mc-app": "5.1.0",
     "@commercetools-frontend/mc-html-template": "5.1.0",
@@ -31,7 +30,6 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.5",
     "babel-plugin-react-intl": "3.0.1",
-    "babel-plugin-transform-react-remove-prop-types": "0.4.21",
     "babel-polyfill": "6.26.0",
     "browserslist": "4.3.7",
     "chalk": "2.4.2",

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@babel/core": "7.2.2",
+    "@babel/plugin-syntax-dynamic-import": "7.2.0",
     "@babel/runtime": "7.2.0",
     "@commercetools-frontend/babel-preset-mc-app": "5.1.0",
     "@commercetools-frontend/mc-html-template": "5.1.0",
@@ -30,7 +31,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.5",
     "babel-plugin-react-intl": "3.0.1",
-    "babel-plugin-transform-dynamic-import": "2.1.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.21",
     "babel-polyfill": "6.26.0",
     "browserslist": "4.3.7",
     "chalk": "2.4.2",

--- a/packages/sdk/src/utils/logger.js
+++ b/packages/sdk/src/utils/logger.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+
+const isLoggerEnabled = () => {
+  if (process.env.DEBUG === 'true') return true;
+  if (process.env.NODE_ENV === 'development') return true;
+
+  const queryParams = new URL(window.location.href);
+  if (
+    process.env.NODE_ENV === 'production' &&
+    queryParams.searchParams.get('debug') === 'true'
+  )
+    return true;
+
+  return false;
+};
+
+export default {
+  groupCollapsed: (...args) =>
+    isLoggerEnabled() && console.groupCollapsed(...args),
+  groupEnd: (...args) => isLoggerEnabled() && console.groupEnd(...args),
+  info: (...args) => isLoggerEnabled() && console.info(...args),
+  log: (...args) => isLoggerEnabled() && console.log(...args),
+  error: (...args) => isLoggerEnabled() && console.error(...args),
+  warn: (...args) => isLoggerEnabled() && console.warn(...args),
+};

--- a/packages/sdk/src/utils/utils.js
+++ b/packages/sdk/src/utils/utils.js
@@ -1,4 +1,5 @@
 import qs from 'query-string';
+import logger from './logger';
 
 export const parseUri = uri => {
   const parser = document.createElement('a');
@@ -12,23 +13,21 @@ export const parseUri = uri => {
 
 export const logRequest = ({ method, request, response, error, action }) => {
   const uriParts = parseUri(request.uri);
-  /* eslint-disable no-console */
   const groupName = `%c${method} %c${uriParts.pathname}`;
-  console.groupCollapsed(
+  logger.groupCollapsed(
     groupName,
     `color: ${error ? 'red' : 'black'}; font-weight: bold;`,
     'color: gray; font-weight: lighter;'
   );
-  console.log('%caction', 'color: cadetblue; font-weight: bold;', action);
-  console.log('%crequest', `color: cornflowerblue; font-weight: bold;`, {
+  logger.log('%caction', 'color: cadetblue; font-weight: bold;', action);
+  logger.log('%crequest', `color: cornflowerblue; font-weight: bold;`, {
     headers: request.headers,
     uri: request.uri,
     params: uriParts.search,
     ...(method === 'POST' ? { body: action.payload.payload } : {}),
   });
   if (response)
-    console.log('%cresponse', `color: green; font-weight: bold;`, response);
-  if (error) console.log('%cerror', `color: red; font-weight: bold;`, error);
-  console.groupEnd(groupName);
-  /* eslint-enable no-console */
+    logger.log('%cresponse', `color: green; font-weight: bold;`, response);
+  if (error) logger.log('%cerror', `color: red; font-weight: bold;`, error);
+  logger.groupEnd(groupName);
 };

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "mc-scripts build",
     "start": "mc-scripts start",
+    "start:prod:local": "NODE_ENV=production mc-http-server --csp=$(pwd)/csp.json --config=$(pwd)/env.json --use-local-assets",
     "i18n:build": "mc-scripts extract-intl --output-path=$(pwd)/src/i18n/data 'src/**/!(*.spec).js' --build-translations",
     "deploy": "npm run build; rm dist/assets/*.js.map; npm run deploy:eu; npm run deploy:us",
     "deploy:eu": "now --local-config=now.eu.json --docker; now alias --local-config=now.eu.json",

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -9,7 +9,4 @@ module.exports = createWebpackConfigForProduction({
   distPath,
   entryPoint,
   sourceFolders,
-  toggleFlags: {
-    enabledVendorOptimizations: true,
-  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,11 +2871,6 @@ babel-plugin-transform-react-remove-prop-types@0.4.21:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.21.tgz#0087938f4348cb751b3e5055a6b38f3c61b5231b"
   integrity sha512-+gQBtcnEhYFbMPFGr8YL7SHD4BpHifFDGEc+ES0+1iDwC9psist2+eumcLoHjBMumL7N/HI/G64XR5aQC8Nr5Q==
 
-babel-plugin-transform-remove-console@6.9.4:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
-  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
-
 babel-plugin-transform-rename-import@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"


### PR DESCRIPTION
Follow up of #272 

I've been giving it some more thoughts and I think we can solve this problem a bit differently, which is why I'm proposing this new approach.

In general, if we think about it, libraries usually don't log anything. So there is no need to run the babel transform in every node module.
On the other hand, the AppShell is like a mix of library and application code, which is why it logs some stuff (apollo, redux).

At the end, we want to disable logging on production BUT **when we need it, we should be able to see those logs**.

Therefore, we can these applications logs are enabled based on some runtime configuration:
- `process.env.DEBUG === 'true'`
- app is built for development (not test, not production)
- if the app is built for production and there is a `debug=true` query parameter in the URL

I like the fact that we can also enable this on runtime via a query parameter. This is useful for example when working on support tickets with the customer, to temporary enable debug logs.

Let me know what you think.