### PR TITLE
fix(l10n): return correct localized information

### DIFF
--- a/packages/l10n/country-information.js
+++ b/packages/l10n/country-information.js
@@ -6,9 +6,9 @@ import extractLanguageFromLocale from './utils/extract-language-from-locale';
 const getImportChunk = lang => {
   switch (lang) {
     case 'de':
-      return import(/* webpackChunkName: "country-data-es" */ './data/countries/es.json');
-    case 'es':
       return import(/* webpackChunkName: "country-data-de" */ './data/countries/de.json');
+    case 'es':
+      return import(/* webpackChunkName: "country-data-es" */ './data/countries/es.json');
     default:
       return import(/* webpackChunkName: "country-data-en" */ './data/countries/en.json');
   }

--- a/packages/l10n/currency-information.js
+++ b/packages/l10n/currency-information.js
@@ -5,9 +5,9 @@ import extractLanguageFromLocale from './utils/extract-language-from-locale';
 const getImportChunk = lang => {
   switch (lang) {
     case 'de':
-      return import(/* webpackChunkName: "currency-data-es" */ './data/currencies/es.json');
-    case 'es':
       return import(/* webpackChunkName: "currency-data-de" */ './data/currencies/de.json');
+    case 'es':
+      return import(/* webpackChunkName: "currency-data-es" */ './data/currencies/es.json');
     default:
       return import(/* webpackChunkName: "currency-data-en" */ './data/currencies/en.json');
   }

--- a/packages/l10n/language-information.js
+++ b/packages/l10n/language-information.js
@@ -6,9 +6,9 @@ import extractLanguageFromLocale from './utils/extract-language-from-locale';
 const getImportChunk = lang => {
   switch (lang) {
     case 'de':
-      return import(/* webpackChunkName: "language-data-es" */ './data/languages/de.json');
+      return import(/* webpackChunkName: "language-data-de" */ './data/languages/de.json');
     case 'es':
-      return import(/* webpackChunkName: "language-data-de" */ './data/languages/es.json');
+      return import(/* webpackChunkName: "language-data-es" */ './data/languages/es.json');
     default:
       return import(/* webpackChunkName: "language-data-en" */ './data/languages/en.json');
   }

--- a/packages/l10n/time-zone-information.js
+++ b/packages/l10n/time-zone-information.js
@@ -6,9 +6,9 @@ import extractLanguageFromLocale from './utils/extract-language-from-locale';
 const getImportChunk = lang => {
   switch (lang) {
     case 'de':
-      return import(/* webpackChunkName: "timezone-data-es" */ './data/time-zones/es.json');
-    case 'es':
       return import(/* webpackChunkName: "timezone-data-de" */ './data/time-zones/de.json');
+    case 'es':
+      return import(/* webpackChunkName: "timezone-data-es" */ './data/time-zones/es.json');
     default:
       return import(/* webpackChunkName: "timezone-data-en" */ './data/time-zones/en.json');
   }


### PR DESCRIPTION
#### Summary

We had some mixed up l10n imports, as calls to german were returning spanish and vice versa.