### PR TITLE
feat: add handleApolloErrors HOC to automatically dispatch query errors

### DIFF
--- a/packages/application-shell/src/components/handle-apollo-errors/README.md
+++ b/packages/application-shell/src/components/handle-apollo-errors/README.md
@@ -1,0 +1,21 @@
+# `handleApolloErrors`
+
+Handles `ApolloError`s from GraphQL queries to dispatch notification errors.
+
+## Motivation
+
+When using the `graphql` HOC to send queries, it's a bit tricky to handle possible errors. For instance, the _connected_ component will need to check the `error` prop within the graphql query object and decide what to do. Most of the time, we simply want to dispatch a page notification to show an error message, some other times we might want to handle the error within that component.
+
+In the first case, we use this HOC to dispatch the notification errors for us.
+
+## Usage
+
+> This HOC should be composed **after** the `graphql` query components, to be able to access the query props.
+
+```js
+compose(
+  graphql(MyQuery, { name: 'user' }),
+  graphql(MyQuery, { name: 'project' }),
+  handleApolloErrors(['user', 'project'])
+);
+```

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
@@ -28,11 +28,12 @@ function handleApolloErrors(queryResultNames) {
           // If an error has not been dispatched yet, we keep track of it and we dispatch it.
           const queryResult = this.props[name];
           if (queryResult) {
-            const dispatchedError = this.dispatchedErrors.get(name);
-            if (dispatchedError && !queryResult.error) {
+            const hasPreviouslyDispatchedError = Boolean(this.dispatchedErrors.get(name));
+            const hasQueryErrored = Boolean(queryResult.error);
+            if (hasPreviouslyDispatchedError && !hasQueryErrored) {
               this.dispatchedErrors.delete(name);
             }
-            if (!dispatchedError && queryResult.error) {
+            if (!hasPreviouslyDispatchedError && hasQueryErrored) {
               this.dispatchedErrors.set(name, queryResult.error);
               this.context.store.dispatch(handleActionError(queryResult.error));
             }

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
@@ -28,7 +28,9 @@ function handleApolloErrors(queryResultNames) {
           // If an error has not been dispatched yet, we keep track of it and we dispatch it.
           const queryResult = this.props[name];
           if (queryResult) {
-            const hasPreviouslyDispatchedError = Boolean(this.dispatchedErrors.get(name));
+            const hasPreviouslyDispatchedError = Boolean(
+              this.dispatchedErrors.get(name)
+            );
             const hasQueryErrored = Boolean(queryResult.error);
             if (hasPreviouslyDispatchedError && !hasQueryErrored) {
               this.dispatchedErrors.delete(name);

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { wrapDisplayName } from 'recompose';
+import { ReactReduxContext } from 'react-redux';
+import { handleActionError } from '@commercetools-frontend/actions-global';
+
+function handleApolloErrors(queryResultNames) {
+  return Component => {
+    class WrappedComponent extends React.Component {
+      static displayName = wrapDisplayName(Component, 'handleApolloErrors');
+      static contextType = ReactReduxContext;
+      dispatchedErrors = new Map();
+      componentDidUpdate() {
+        queryResultNames.forEach(name => {
+          // To avoid infinite loops (dispatch -> store updates -> connected renders -> didUpdate -> dispatch)
+          // we keep track of the errors that have been dispatched.
+          // If an error has been dispatched already, we don't do anything else.
+          // If an error has been dispatched already but the query does not contain an error anymore,
+          // we remove the entry from the dispatchedErrors map.
+          // If an error has not been dispatched yet, we keep track of it and we dispatch it.
+          const queryResult = this.props[name];
+          if (queryResult) {
+            const dispatchedError = this.dispatchedErrors.get(name);
+            if (dispatchedError && !queryResult.error) {
+              this.dispatchedErrors.delete(name);
+            }
+            if (!dispatchedError && queryResult.error) {
+              this.dispatchedErrors.set(name, queryResult.error);
+              this.context.store.dispatch(handleActionError(queryResult.error));
+            }
+          }
+        });
+      }
+      render() {
+        return <Component {...this.props} />;
+      }
+    }
+    return WrappedComponent;
+  };
+}
+
+export default handleApolloErrors;

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { wrapDisplayName } from 'recompose';
 import { ReactReduxContext } from 'react-redux';
 import { handleActionError } from '@commercetools-frontend/actions-global';
@@ -7,6 +8,14 @@ function handleApolloErrors(queryResultNames) {
   return Component => {
     class WrappedComponent extends React.Component {
       static displayName = wrapDisplayName(Component, 'handleApolloErrors');
+      static propTypes = {
+        ...queryResultNames.reduce(
+          (names, name) => ({
+            [name]: PropTypes.shape({ error: PropTypes.object }),
+          }),
+          {}
+        ),
+      };
       static contextType = ReactReduxContext;
       dispatchedErrors = new Map();
       componentDidUpdate() {

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.spec.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.spec.js
@@ -54,13 +54,13 @@ describe('given the graphql queries for "user"', () => {
   beforeAll(() => {
     console.error = jest.fn();
   });
-  const Connected = handleApolloErrors(['user'])(Test);
+  const WithApolloErrorHandling = handleApolloErrors(['user'])(Test);
   describe('when the "user" query fails', () => {
     it('should dispatch notification error', async () => {
       const error = new Error('Oops');
       const { getByText, getByTestId } = renderWithRedux(
         <QueryController name="user" queryResult={{ data: null, error }}>
-          <Connected />
+          <WithApolloErrorHandling />
         </QueryController>
       );
       await waitForElement(() => getByText('loading'));
@@ -77,7 +77,7 @@ describe('given the graphql queries for "user"', () => {
     it('should not dispatch any notification error', async () => {
       const { getByText, getByTestId } = renderWithRedux(
         <QueryController name="user" queryResult={{ data: { ok: true } }}>
-          <Connected />
+          <WithApolloErrorHandling />
         </QueryController>
       );
       await waitForElement(() => getByText('loading'));

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.spec.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.spec.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { renderWithRedux, waitForElement, fireEvent } from '../../test-utils';
+import handleApolloErrors from './handle-apollo-errors';
+
+const createGraphqlResultProps = props => ({
+  isLoading: true,
+  data: null,
+  error: null,
+  ...props,
+});
+
+const Test = props => {
+  if (props.user.data) {
+    return <span>{`Status: ${props.user.data.ok}`}</span>;
+  }
+  return <span>{'loading'}</span>;
+};
+Test.displayName = 'Test';
+Test.propTypes = {
+  user: PropTypes.shape({ data: PropTypes.shape({ ok: PropTypes.bool }) }),
+};
+
+class QueryController extends React.Component {
+  static displayName = 'QueryController';
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    queryResult: PropTypes.object.isRequired,
+    children: PropTypes.node.isRequired,
+  };
+  state = {
+    result: createGraphqlResultProps(),
+  };
+  triggerQuery = () => {
+    this.setState({
+      result: { ...this.props.queryResult, isLoading: false },
+    });
+  };
+  render() {
+    return (
+      <React.Fragment>
+        <button data-testid={this.props.name} onClick={this.triggerQuery}>
+          {'query'}
+        </button>
+        {React.cloneElement(this.props.children, {
+          [this.props.name]: this.state.result,
+        })}
+      </React.Fragment>
+    );
+  }
+}
+
+describe('given the graphql queries for "user"', () => {
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+  const Connected = handleApolloErrors(['user'])(Test);
+  describe('when the "user" query fails', () => {
+    it('should dispatch notification error', async () => {
+      const error = new Error('Oops');
+      const { getByText, getByTestId } = renderWithRedux(
+        <QueryController name="user" queryResult={{ data: null, error }}>
+          <Connected />
+        </QueryController>
+      );
+      await waitForElement(() => getByText('loading'));
+
+      fireEvent.click(getByTestId('user'));
+
+      // See error notification
+      await waitForElement(() =>
+        getByText(/Sorry, but there seems to be something wrong./i)
+      );
+    });
+  });
+  describe('when no query fails', () => {
+    it('should not dispatch any notification error', async () => {
+      const { getByText, getByTestId } = renderWithRedux(
+        <QueryController name="user" queryResult={{ data: { ok: true } }}>
+          <Connected />
+        </QueryController>
+      );
+      await waitForElement(() => getByText('loading'));
+
+      fireEvent.click(getByTestId('user'));
+
+      await waitForElement(() => getByText(/Status: true/i));
+    });
+  });
+});

--- a/packages/application-shell/src/components/handle-apollo-errors/index.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/index.js
@@ -1,0 +1,1 @@
+export { default } from './handle-apollo-errors';

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -36,6 +36,7 @@ import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { STORAGE_KEYS, MCSupportFormURL } from '../../constants';
 import LoadingPlaceholder from '../loading-placeholder';
 import withApplicationsMenu from '../with-applications-menu';
+import handleApolloErrors from '../handle-apollo-errors';
 import FetchProjectExtensionsNavbar from './fetch-project-extensions-navbar.graphql';
 import styles from './navbar.mod.css';
 import messages from './messages';
@@ -691,7 +692,8 @@ export default compose(
       },
       fetchPolicy: 'cache-and-network',
     }),
-  })
+  }),
+  handleApolloErrors(['applicationsMenuQuery', 'projectExtensionsQuery'])
 )(NavBar);
 
 export class LoadingNavBar extends React.Component {

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -634,7 +634,6 @@ export class NavBar extends React.PureComponent {
   ref = React.createRef();
 
   render() {
-    console.log(this.props);
     const navbarMenu =
       (this.props.applicationsMenuQuery &&
         this.props.applicationsMenuQuery.applicationsMenu &&

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -634,6 +634,7 @@ export class NavBar extends React.PureComponent {
   ref = React.createRef();
 
   render() {
+    console.log(this.props);
     const navbarMenu =
       (this.props.applicationsMenuQuery &&
         this.props.applicationsMenuQuery.applicationsMenu &&

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
+import { compose } from 'recompose';
 import classnames from 'classnames';
 import Downshift from 'downshift';
 import { ToggleFeature } from '@flopflip/react-broadcast';
@@ -19,6 +20,7 @@ import {
 import Card from '../../from-core/card';
 import { MCSupportFormURL } from '../../constants';
 import withApplicationsMenu from '../with-applications-menu';
+import handleApolloErrors from '../handle-apollo-errors';
 import styles from './user-settings-menu.mod.css';
 import messages from './messages';
 
@@ -200,18 +202,21 @@ UserSettingsMenuBody.propTypes = {
   }),
 };
 
-const ConnectedUserSettingsMenuBody = withApplicationsMenu(ownProps => ({
-  queryName: 'applicationsMenuQuery',
-  queryOptions: {
-    // We can assume here that the navbar already fetched the data, since this
-    // component gets rendered only when the user opens the menu
-    fetchPolicy: 'cache-only',
-  },
-  __DEV_CONFIG__: {
-    menuLoader: ownProps.DEV_ONLY__loadAppbarMenuConfig,
-    menuKey: 'appBar',
-  },
-}))(UserSettingsMenuBody);
+const ConnectedUserSettingsMenuBody = compose(
+  withApplicationsMenu(ownProps => ({
+    queryName: 'applicationsMenuQuery',
+    queryOptions: {
+      // We can assume here that the navbar already fetched the data, since this
+      // component gets rendered only when the user opens the menu
+      fetchPolicy: 'cache-only',
+    },
+    __DEV_CONFIG__: {
+      menuLoader: ownProps.DEV_ONLY__loadAppbarMenuConfig,
+      menuKey: 'appBar',
+    },
+  })),
+  handleApolloErrors(['applicationsMenuQuery'])
+)(UserSettingsMenuBody);
 
 const UserSettingsMenu = props => (
   <div data-test="user-settings-menu">

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.js
@@ -64,7 +64,12 @@ function withApplicationsMenu(getOptions) {
                   defaultApiUrl}/api/graphql`,
               }}
             >
-              {result => <Component {...props} {...{ [queryName]: result }} />}
+              {({ data, error }) => (
+                <Component
+                  {...props}
+                  {...{ [queryName]: { ...data, error } }}
+                />
+              )}
             </Query>
           )}
         />

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 import { wrapDisplayName } from 'recompose';
-import { connect } from 'react-redux';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import * as globalActions from '@commercetools-frontend/actions-global';
 import FetchApplicationsMenu from './fetch-applications-menu.graphql';
 
 const defaultApiUrl = window.location.origin;
@@ -66,11 +63,8 @@ function withApplicationsMenu(getOptions) {
                 uri: `${environment.mcProxyApiUrl ||
                   defaultApiUrl}/api/graphql`,
               }}
-              onError={props.handleActionError}
             >
-              {({ data }) => (
-                <Component {...props} {...{ [queryName]: data }} />
-              )}
+              {result => <Component {...props} {...{ [queryName]: result }} />}
             </Query>
           )}
         />
@@ -80,13 +74,7 @@ function withApplicationsMenu(getOptions) {
       Component,
       'withApplicationsMenu'
     );
-    WrappedComponent.propTypes = {
-      handleActionError: PropTypes.func.isRequired,
-    };
-    return connect(
-      null,
-      { handleActionError: globalActions.handleActionError }
-    )(WrappedComponent);
+    return WrappedComponent;
   };
 }
 

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import upperFirst from 'lodash/upperFirst';
-import { renderWithRedux, waitForElement } from '../../test-utils';
+import { render, waitForElement } from '../../test-utils';
 import FetchApplicationsMenu from './fetch-applications-menu.graphql';
 import withApplicationsMenu from './with-applications-menu';
 
@@ -11,11 +11,15 @@ const Test = props => {
       <div key={menu.key}>{`Key: ${menu.key}`}</div>
     ));
   }
+  if (props.menuQuery && props.menuQuery.error) {
+    return <div>{`Error: ${props.menuQuery.error.message}`}</div>;
+  }
   return <div>{'loading'}</div>;
 };
 Test.displayName = 'Test';
 Test.propTypes = {
   menuQuery: PropTypes.shape({
+    error: PropTypes.shape({ message: PropTypes.string.isRequired }),
     applicationsMenu: PropTypes.shape({
       navBar: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string })),
     }),
@@ -57,7 +61,7 @@ describe('fetching the menu query', () => {
   );
   describe('when the query succeeds', () => {
     it('should render menu key', async () => {
-      const { getByText } = renderWithRedux(<Connected />, {
+      const { getByText } = render(<Connected />, {
         mocks: [
           {
             request: {
@@ -77,9 +81,9 @@ describe('fetching the menu query', () => {
     beforeEach(() => {
       console.error = jest.fn();
     });
-    it('should render menu key', async () => {
+    it('should pass error as prop', async () => {
       const error = new Error('Oops');
-      const { getByText } = renderWithRedux(<Connected />, {
+      const { getByText } = render(<Connected />, {
         mocks: [
           {
             request: {
@@ -90,10 +94,7 @@ describe('fetching the menu query', () => {
         ],
       });
       await waitForElement(() => getByText('loading'));
-      // See error notification
-      await waitForElement(() =>
-        getByText(/Sorry, but there seems to be something wrong./i)
-      );
+      await waitForElement(() => getByText(/Error: Oops/i));
     });
   });
 });

--- a/packages/application-shell/src/index.js
+++ b/packages/application-shell/src/index.js
@@ -15,6 +15,9 @@ export {
 export { selectUserId, selectProjectKeyFromUrl } from './utils';
 export { default as AsyncChunkLoader } from './components/async-chunk-loader';
 export { GtmContext } from './components/gtm-booter';
+export {
+  default as handleApolloErrors,
+} from './components/handle-apollo-errors';
 
 /**
  * NOTE:


### PR DESCRIPTION
As I was developing #289 I noticed that handling apollo query errors is not very much straightforward, especially in our case that we want to dispatch a notification error and not render an error within the component.

So I decided to experiment a bit and came up with the `handleApolloErrors` HOC. The implementation should be documented and tested well enough, so please try to read through and see if it's clear enough.