### PR TITLE
chore: build template app within monorepo, to use linked dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn build
   - yarn playground:build
-  - ./scripts/install_app_template.sh starter
+  - yarn --cwd application-templates/starter build
   - set +e
 
 after_success:

--- a/jest.test.config.js
+++ b/jest.test.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   preset: './packages/jest-preset-mc-app',
-  moduleDirectories: ['packages', 'playground', 'node_modules'],
+  moduleDirectories: [
+    'application-templates',
+    'packages',
+    'playground',
+    'node_modules',
+  ],
   modulePathIgnorePatterns: ['examples'],
   transformIgnorePatterns: [
     // This option tells Jest to ignore specific folders from being transpiled


### PR DESCRIPTION
I tried [different things](https://github.com/commercetools/merchant-center-application-kit/commits/nm-fix-ci-install-app-template) but I couldn't get the symlinking to work outside of the monorepo directory.

So to unblock CI, I think we can just keep building the apps within the monorepo, to ensure the deps are properly symlinked.

However, we need to be aware that we might bump into the issue of having missing dependencies again (see #270). I guess it's a tradeoff.