### PR TITLE
fix(app-shell): to be specific about cache key generation

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -64,13 +64,16 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData,
 });
 
+const typeNamesWithoutIdAsIdentifier = ['Project', 'BaseMenu', 'NavbarMenu'];
+
 export const createApolloClient = () =>
   new ApolloClient({
     link,
     cache: new InMemoryCache({
       fragmentMatcher,
       dataIdFromObject: result => {
-        if (result.__typename === 'Project') return result.key;
+        if (typeNamesWithoutIdAsIdentifier.includes(result.__typename))
+          return result.key;
         // Generally all id's are unique accross the platform, so we don't need to
         // include the type name in the cache key.
         // However, a reference has the shape { typeId, id } where the id is the
@@ -78,9 +81,7 @@ export const createApolloClient = () =>
         // they would clash with the referenced resource.
         if (result.__typename === 'Reference')
           return `${result.__typename}:${result.id}`;
-        if (result.__typename && result.key !== undefined) {
-          return `${result.__typename}:${result.key}`;
-        }
+
         return result.id;
       },
     }),


### PR DESCRIPTION
#### Summary

This fixes Apollo to normalize the cache in a too specific manner by generaeting different cache keys for the same entity.

#### Description

I’ll try my best to illustrate the problem. So we changed the generation of Apollo’s cache keys. If there is a `__typename` and `key` we put it under a concatenation of both. However, nobody forces us to request the `key` with any entity having one. So if one request does

```
{
   key
   id
   name
}
```

and the next

```
{
   id
   description
}
```

those two items end up in different locations of the cache. Question being a. why should we care and b. why is this a problem.

a. cause we want clean normalisation of data
b. combing from a. if the first component fetching `name` wants the `description` it will not get it (cause it strictly speaking didn’t request it but depends on a prior fetch

So how can we fix it. Just to give my two cents

1. Add `key` and `id` to any query to have “consistent” cache keys/addresses and properly normalized data
2. Add a `&& !result.id` to the new condition in `dataFromId`
3. Be specific for what type we want to use the `key` to normalise

1. may sound logical but I think leads to silent bugs. It’s total “hidden” to anybody entities with different (`key` and `id`) identifiers need for fetch with both to yield a consistent cache normalisation.
2. seems cool but is strange as it describes something very specific in “abstract form” (like the first condition for the project to normalise by key)
3. Seems to most specific and least impactful/restrictive to anybody using apollo to load data

That’s why I vote for 3.
