### PR TITLE
Enable session storage along with local storage

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -7,7 +7,7 @@ import {
   joinPaths,
   trimLeadingAndTrailingSlashes,
 } from '@commercetools-frontend/url-utils';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { DOMAINS, LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import history from '@commercetools-frontend/browser-history';
 import {
@@ -35,7 +35,6 @@ import AsyncLoginSSOCallback from '../login-sso-callback/async';
 import AsyncLoginLocked from '../login-locked/async';
 import Logout from '../logout';
 import SetupFlopFlipProvider from '../setup-flop-flip-provider';
-// import VersionCheckSubscriber from '../version-check-subscriber';
 import RequestsInFlightLoader from '../requests-in-flight-loader';
 import GtmUserTracker from '../gtm-user-tracker';
 import GtmBooter from '../gtm-booter';
@@ -437,7 +436,7 @@ export default class ApplicationShell extends React.Component {
     });
     // NOTE: this is a temporary thingy, to ensure we clear the `token`
     // from localStorage.
-    storage.remove('token');
+    localStorage.remove('token');
   }
   componentDidCatch(error, errorInfo) {
     this.setState({ hasError: true });

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -18,7 +18,6 @@ import ApplicationShell, {
   mergeMessages,
 } from './application-shell';
 
-jest.mock('@commercetools-frontend/storage');
 jest.mock('@commercetools-frontend/sentry');
 jest.mock('../../utils');
 

--- a/packages/application-shell/src/components/authenticated/authenticated.js
+++ b/packages/application-shell/src/components/authenticated/authenticated.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 
 const getIsAuthenticated = () =>
-  storage.get(STORAGE_KEYS.IS_AUTHENTICATED) === 'true';
+  localStorage.get(STORAGE_KEYS.IS_AUTHENTICATED) === 'true';
 
 const Authenticated = props => {
   const isAuthenticated = getIsAuthenticated();

--- a/packages/application-shell/src/components/authenticated/authenticated.spec.js
+++ b/packages/application-shell/src/components/authenticated/authenticated.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import Authenticated from './authenticated';
 
 jest.mock('@commercetools-frontend/storage');
@@ -15,7 +15,7 @@ describe('rendering', () => {
   let props;
   describe('when user is authenticated', () => {
     beforeEach(() => {
-      storage.get.mockReturnValue('true');
+      localStorage.get.mockReturnValue('true');
       props = createTestProps();
       createWrapper(props);
     });
@@ -26,7 +26,7 @@ describe('rendering', () => {
   });
   describe('when the user is not logged in', () => {
     beforeEach(() => {
-      storage.get.mockReturnValue('false');
+      localStorage.get.mockReturnValue('false');
       props = createTestProps();
       createWrapper(props);
     });

--- a/packages/application-shell/src/components/login-sso-callback/login-sso-callback.js
+++ b/packages/application-shell/src/components/login-sso-callback/login-sso-callback.js
@@ -4,14 +4,14 @@ import { compose, withProps } from 'recompose';
 import qs from 'query-string';
 import jwtDecode from 'jwt-decode';
 import { connect } from 'react-redux';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage, sessionStorage } from '@commercetools-frontend/storage';
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
 import { STORAGE_KEYS } from '../../constants';
 import ApplicationLoader from '../application-loader';
 import FailedAuthentication from '../failed-authentication';
 
 const loadSessionState = key => {
-  const sessionState = window.sessionStorage.getItem(key);
+  const sessionState = sessionStorage.get(key);
   if (sessionState) {
     try {
       return JSON.parse(sessionState);
@@ -50,7 +50,7 @@ export class LoginSSOCallback extends React.PureComponent {
     const nonceKey = `${STORAGE_KEYS.NONCE}_${decodedIdToken.nonce}`;
     const sessionState = loadSessionState(nonceKey);
     // Clear the nonce, we don't need it anymore
-    window.sessionStorage.removeItem(nonceKey);
+    sessionStorage.remove(nonceKey);
 
     if (!sessionState) {
       this.setAuthenticationFailed(true);
@@ -62,9 +62,9 @@ export class LoginSSOCallback extends React.PureComponent {
         })
         .then(payload => {
           // Set a flag to indicate that the user has been authenticated
-          storage.put(STORAGE_KEYS.IS_AUTHENTICATED, true);
+          localStorage.put(STORAGE_KEYS.IS_AUTHENTICATED, true);
           // Store the IdP Url, useful for redirecting logic on logout.
-          storage.put(STORAGE_KEYS.LOGIN_STRATEGY, payload.loginStrategy);
+          localStorage.put(STORAGE_KEYS.LOGIN_STRATEGY, payload.loginStrategy);
 
           this.props.redirectTo('/');
         })

--- a/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
+++ b/packages/application-shell/src/components/login-sso-callback/login-sso-callback.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { sessionStorage } from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 import FailedAuthentication from '../failed-authentication';
 import { LoginSSOCallback } from './login-sso-callback';
@@ -57,7 +58,7 @@ describe('lifecylcle', () => {
 
     describe('when nonce is correct', () => {
       beforeEach(() => {
-        window.sessionStorage.getItem.mockReturnValue(
+        sessionStorage.get.mockReturnValue(
           JSON.stringify({ organizationId: 'o1' })
         );
         wrapper.instance().componentDidMount();
@@ -80,7 +81,7 @@ describe('lifecylcle', () => {
             ),
           });
           wrapper = shallow(<LoginSSOCallback {...props} />);
-          window.sessionStorage.setItem(
+          sessionStorage.get(
             `${STORAGE_KEYS.NONCE}_EY`,
             JSON.stringify({
               organizationId: 'o1',
@@ -98,7 +99,7 @@ describe('lifecylcle', () => {
             requestAccessToken: jest.fn(() => Promise.reject(new Error())),
           });
           wrapper = shallow(<LoginSSOCallback {...props} />);
-          window.sessionStorage.getItem.mockReturnValue(
+          sessionStorage.get.mockReturnValue(
             JSON.stringify({
               organizationId: 'o1',
             })
@@ -116,7 +117,7 @@ describe('lifecylcle', () => {
 
     describe('when nonce is wrong', () => {
       beforeEach(() => {
-        window.sessionStorage.getItem.mockReturnValue(null);
+        sessionStorage.get.mockReturnValue(null);
         wrapper.instance().componentDidMount();
       });
       it('should set hasAuthenticationFailed to true', () => {

--- a/packages/application-shell/src/components/login-sso/login-sso.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.js
@@ -16,6 +16,7 @@ import {
   joinPaths,
   trimLeadingAndTrailingSlashes,
 } from '@commercetools-frontend/url-utils';
+import { sessionStorage } from '@commercetools-frontend/storage';
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
 import { connect } from 'react-redux';
 import { ORGANIZATION_GENERAL_ERROR, STORAGE_KEYS } from '../../constants';
@@ -41,10 +42,7 @@ function generateAndCacheNonceWithState(state) {
   // the id_token and, once validated, we can retrieve and use
   // the state object.
   // https://auth0.com/docs/protocols/oauth2/oauth-state#how-to-use-the-parameter-to-restore-application-state
-  window.sessionStorage.setItem(
-    `${STORAGE_KEYS.NONCE}_${nonce}`,
-    JSON.stringify(state)
-  );
+  sessionStorage.put(`${STORAGE_KEYS.NONCE}_${nonce}`, JSON.stringify(state));
   return nonce;
 }
 

--- a/packages/application-shell/src/components/login-sso/login-sso.spec.js
+++ b/packages/application-shell/src/components/login-sso/login-sso.spec.js
@@ -6,6 +6,7 @@ import {
   PrimaryButton,
   Text,
 } from '@commercetools-frontend/ui-kit';
+import { sessionStorage } from '@commercetools-frontend/storage';
 import { ORGANIZATION_GENERAL_ERROR } from '../../constants';
 import { LoginSSO, getMessageKeyForError } from './login-sso';
 
@@ -175,7 +176,6 @@ describe('interaction', () => {
     describe('when request is successful', () => {
       describe('when authProvider protocol is "oidc"', () => {
         beforeEach(() => {
-          window.sessionStorage = jest.fn();
           props = createTestProps({
             getOrganizationByName: jest.fn(() =>
               Promise.resolve({
@@ -221,7 +221,7 @@ describe('interaction', () => {
           );
         });
         it('should save state in nonce', () => {
-          expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+          expect(sessionStorage.put).toHaveBeenCalledWith(
             expect.stringContaining('nonce_foo-uuid'),
             JSON.stringify({ organizationId: 'o1' })
           );

--- a/packages/application-shell/src/components/logout/logout.js
+++ b/packages/application-shell/src/components/logout/logout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withProps } from 'recompose';
 import { SentryUserLogoutTracker } from '@commercetools-frontend/sentry';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import {
   LOGIN_STRATEGY_DEFAULT,
   LOGIN_STRATEGY_SSO,
@@ -11,7 +11,7 @@ import {
 import GtmUserLogoutTracker from '../gtm-user-logout-tracker';
 
 export const getLoginStrategy = () => {
-  const loginStrategy = storage.get(STORAGE_KEYS.LOGIN_STRATEGY);
+  const loginStrategy = localStorage.get(STORAGE_KEYS.LOGIN_STRATEGY);
   return loginStrategy === LOGIN_STRATEGY_SSO
     ? LOGIN_STRATEGY_SSO
     : LOGIN_STRATEGY_DEFAULT;
@@ -46,12 +46,12 @@ export class Logout extends React.PureComponent {
     }
 
     // The user is no longer authenticated.
-    storage.remove(STORAGE_KEYS.IS_AUTHENTICATED);
-    storage.remove(STORAGE_KEYS.LOGIN_STRATEGY);
+    localStorage.remove(STORAGE_KEYS.IS_AUTHENTICATED);
+    localStorage.remove(STORAGE_KEYS.LOGIN_STRATEGY);
     // NOTE: we need to ensure the cached projectKey is removed, because
     // the user can log in with another account and most likely he won't
     // access to the cached project.
-    storage.remove(STORAGE_KEYS.ACTIVE_PROJECT_KEY);
+    localStorage.remove(STORAGE_KEYS.ACTIVE_PROJECT_KEY);
     // We simply redirect to a "new" browser page, instead of using the
     // history router. This will simplify a lot of things and avoid possible
     // problems like e.g. resetting the store/state.

--- a/packages/application-shell/src/components/logout/logout.spec.js
+++ b/packages/application-shell/src/components/logout/logout.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import {
   LOGIN_STRATEGY_SSO,
   LOGIN_STRATEGY_DEFAULT,
@@ -34,19 +34,23 @@ describe('componentDidMount', () => {
   let props;
   beforeEach(() => {
     props = createTestProps();
-    storage.get.mockReturnValue('foo-1');
+    localStorage.get.mockReturnValue('foo-1');
 
     const wrapper = shallow(<Logout {...props} />);
     wrapper.instance().componentDidMount();
   });
   it('should remove isAuthenticated from storage', () => {
-    expect(storage.remove).toHaveBeenCalledWith(STORAGE_KEYS.IS_AUTHENTICATED);
+    expect(localStorage.remove).toHaveBeenCalledWith(
+      STORAGE_KEYS.IS_AUTHENTICATED
+    );
   });
   it('should remove loginStrategy from storage', () => {
-    expect(storage.remove).toHaveBeenCalledWith(STORAGE_KEYS.LOGIN_STRATEGY);
+    expect(localStorage.remove).toHaveBeenCalledWith(
+      STORAGE_KEYS.LOGIN_STRATEGY
+    );
   });
   it('should remove projectKey from storage', () => {
-    expect(storage.remove).toHaveBeenCalledWith(
+    expect(localStorage.remove).toHaveBeenCalledWith(
       STORAGE_KEYS.ACTIVE_PROJECT_KEY
     );
   });
@@ -91,7 +95,7 @@ describe('componentDidMount', () => {
 describe('getLoginStrategy', () => {
   describe('when IdP URL is defined', () => {
     beforeEach(() => {
-      storage.get.mockReturnValue('sso');
+      localStorage.get.mockReturnValue('sso');
     });
     it('should return SSO as the login strategy', () => {
       expect(getLoginStrategy()).toBe(LOGIN_STRATEGY_SSO);
@@ -99,7 +103,7 @@ describe('getLoginStrategy', () => {
   });
   describe('when IdP URL is not defined', () => {
     beforeEach(() => {
-      storage.get.mockReturnValue(null);
+      localStorage.get.mockReturnValue(null);
     });
     it('should return default as the login strategy', () => {
       expect(getLoginStrategy()).toBe(LOGIN_STRATEGY_DEFAULT);

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -27,7 +27,7 @@ import {
   ConnectedSquareIcon,
 } from '@commercetools-frontend/ui-kit';
 import MissingImageSvg from '@commercetools-frontend/assets/images/image__missing_image.svg';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import {
   GRAPHQL_TARGETS,
   NO_VALUE_FALLBACK,
@@ -424,7 +424,7 @@ export class DataMenu extends React.PureComponent {
 
     this.setState(prevState => {
       const nextIsMenuOpen = !prevState.isMenuOpen;
-      storage.put(STORAGE_KEYS.IS_FORCED_MENU_OPEN, nextIsMenuOpen);
+      localStorage.put(STORAGE_KEYS.IS_FORCED_MENU_OPEN, nextIsMenuOpen);
       return { isMenuOpen: nextIsMenuOpen };
     });
   };
@@ -666,7 +666,7 @@ export class NavBar extends React.PureComponent {
 export default compose(
   withRouter, // Connect again, to access the `location` object
   withProps(() => {
-    const cachedIsForcedMenuOpen = storage.get(
+    const cachedIsForcedMenuOpen = localStorage.get(
       STORAGE_KEYS.IS_FORCED_MENU_OPEN
     );
     return {

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -7,7 +7,7 @@ import {
   RestrictedByPermissions,
   permissions,
 } from '@commercetools-frontend/permissions';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 import {
   NavBar,
@@ -1098,7 +1098,7 @@ describe('instance methods', () => {
           wrapper.instance().handleToggleMenu();
         });
         it('should update isForcedMenuOpen to false', () => {
-          expect(storage.put).toHaveBeenCalledWith(
+          expect(localStorage.put).toHaveBeenCalledWith(
             STORAGE_KEYS.IS_FORCED_MENU_OPEN,
             false
           );
@@ -1110,7 +1110,7 @@ describe('instance methods', () => {
           wrapper.instance().handleToggleMenu();
         });
         it('should update isForcedMenuOpen to true', () => {
-          expect(storage.put).toHaveBeenCalledWith(
+          expect(localStorage.put).toHaveBeenCalledWith(
             STORAGE_KEYS.IS_FORCED_MENU_OPEN,
             true
           );

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -5,7 +5,7 @@ import { Redirect } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import isNil from 'lodash/isNil';
 import { DOMAINS } from '@commercetools-frontend/constants';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { Notifier } from '@commercetools-frontend/react-notifications';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
@@ -88,7 +88,7 @@ export class ProjectContainer extends React.Component {
 
     // Ensure to sync the `projectKey` from the URL with localStorage.
     const projectKey = this.props.match.params.projectKey;
-    storage.put(STORAGE_KEYS.ACTIVE_PROJECT_KEY, projectKey);
+    localStorage.put(STORAGE_KEYS.ACTIVE_PROJECT_KEY, projectKey);
   }
   componentDidCatch(error, errorInfo) {
     this.setState({ hasError: true });

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import { Redirect } from 'react-router-dom';
 import { shallow } from 'enzyme';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { Notifier } from '@commercetools-frontend/react-notifications';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import ProjectExpired from '../project-expired';
@@ -450,12 +450,12 @@ describe('lifecycle', () => {
   describe('componentDidUpdate', () => {
     beforeEach(() => {
       props = createTestProps({ match: { params: { projectKey: 'p1' } } });
-      storage.get.mockReturnValueOnce('p1');
+      localStorage.get.mockReturnValueOnce('p1');
       wrapper = shallow(<ProjectContainer {...props} />);
       wrapper.instance().componentDidUpdate(props);
     });
     it('should store the project key in localStorage', () => {
-      expect(storage.put).toHaveBeenCalledWith(
+      expect(localStorage.put).toHaveBeenCalledWith(
         STORAGE_KEYS.ACTIVE_PROJECT_KEY,
         'p1'
       );

--- a/packages/application-shell/src/components/project-data-locale/project-data-locale.js
+++ b/packages/application-shell/src/components/project-data-locale/project-data-locale.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { deepEqual } from 'fast-equals';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 
 const defaultLocale = 'en';
@@ -12,7 +12,7 @@ const getSelectedDataLocaleForProject = projectLocales => {
   // value is. When the user access a proper project, this value will
   // be correctly picked.
   if (!projectLocales) return defaultLocale;
-  const cachedDataLocale = storage.get(STORAGE_KEYS.SELECTED_DATA_LOCALE);
+  const cachedDataLocale = localStorage.get(STORAGE_KEYS.SELECTED_DATA_LOCALE);
   // Make sure the cached locale is listed in the selected project
   const isCachedDataLocaleIncludedInProjectLanguages = projectLocales.includes(
     cachedDataLocale
@@ -21,7 +21,10 @@ const getSelectedDataLocaleForProject = projectLocales => {
   // Pick the first locale from the list
   const defaultDataLocaleForProject = projectLocales[0];
   // Cache it
-  storage.put(STORAGE_KEYS.SELECTED_DATA_LOCALE, defaultDataLocaleForProject);
+  localStorage.put(
+    STORAGE_KEYS.SELECTED_DATA_LOCALE,
+    defaultDataLocaleForProject
+  );
   return defaultDataLocaleForProject;
 };
 
@@ -49,7 +52,7 @@ export default class ProjectDataLocale extends React.PureComponent {
   handleSetProjectDataLocale = locale => {
     this.setState({ locale });
     // Cache it
-    storage.put(STORAGE_KEYS.SELECTED_DATA_LOCALE, locale);
+    localStorage.put(STORAGE_KEYS.SELECTED_DATA_LOCALE, locale);
   };
 
   render() {

--- a/packages/application-shell/src/components/project-data-locale/project-data-locale.spec.js
+++ b/packages/application-shell/src/components/project-data-locale/project-data-locale.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 import ProjectDataLocale from './project-data-locale';
 
@@ -62,7 +62,7 @@ describe('lifecycle', () => {
       });
       describe('when locale has been already cached', () => {
         beforeEach(() => {
-          storage.get.mockReturnValue('de');
+          localStorage.get.mockReturnValue('de');
           nextProps = { locales: ['it', 'de'] };
           derivedState = ProjectDataLocale.getDerivedStateFromProps(
             nextProps,
@@ -82,7 +82,7 @@ describe('lifecycle', () => {
       });
       describe('when cached locale is not listed in the project locales', () => {
         beforeEach(() => {
-          storage.put(STORAGE_KEYS.SELECTED_DATA_LOCALE, 'de');
+          localStorage.put(STORAGE_KEYS.SELECTED_DATA_LOCALE, 'de');
           nextProps = { locales: ['it', 'de'] };
           derivedState = ProjectDataLocale.getDerivedStateFromProps(
             nextProps,

--- a/packages/application-shell/src/components/quick-access/history.js
+++ b/packages/application-shell/src/components/quick-access/history.js
@@ -1,8 +1,10 @@
+import { sessionStorage } from '@commercetools-frontend/storage';
+
 const STORAGE_KEY = 'quickAccessHistory';
 
 export const saveHistory = value => {
   try {
-    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    sessionStorage.put(STORAGE_KEY, JSON.stringify(value));
     return true;
   } catch (error) {
     return false;
@@ -11,7 +13,7 @@ export const saveHistory = value => {
 
 export const loadHistory = () => {
   try {
-    const value = sessionStorage.getItem(STORAGE_KEY);
+    const value = sessionStorage.get(STORAGE_KEY);
     return value ? JSON.parse(value) : [];
   } catch (error) {
     return [];

--- a/packages/application-shell/src/utils/select-project-key-from-local-storage/select-project-key-from-local-storage.js
+++ b/packages/application-shell/src/utils/select-project-key-from-local-storage/select-project-key-from-local-storage.js
@@ -1,7 +1,7 @@
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import { STORAGE_KEYS } from '../../constants';
 
 // Attempt to load the `projectKey` from localStorage
 export default function selectProjectKeyFromLocalStorage() {
-  return storage.get(STORAGE_KEYS.ACTIVE_PROJECT_KEY);
+  return localStorage.get(STORAGE_KEYS.ACTIVE_PROJECT_KEY);
 }

--- a/packages/application-shell/src/utils/select-project-key-from-local-storage/select-project-key-from-local-storage.spec.js
+++ b/packages/application-shell/src/utils/select-project-key-from-local-storage/select-project-key-from-local-storage.spec.js
@@ -1,11 +1,11 @@
-import * as storage from '@commercetools-frontend/storage';
+import { localStorage } from '@commercetools-frontend/storage';
 import selectProjectKeyFromLocalStorage from './select-project-key-from-local-storage';
 
 jest.mock('@commercetools-frontend/storage');
 
 describe('when project key is cached in localStorage', () => {
   beforeEach(() => {
-    storage.get.mockReturnValue('foo-1');
+    localStorage.get.mockReturnValue('foo-1');
   });
   it('should return cached key', () => {
     expect(selectProjectKeyFromLocalStorage()).toBe('foo-1');
@@ -14,7 +14,7 @@ describe('when project key is cached in localStorage', () => {
 
 describe('when project key is not cached in localStorage', () => {
   beforeEach(() => {
-    storage.get.mockReturnValue(null);
+    localStorage.get.mockReturnValue(null);
   });
   it('should return default key', () => {
     expect(selectProjectKeyFromLocalStorage()).toBe(null);

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -4,7 +4,7 @@
   <a href="https://www.npmjs.com/package/@commercetools-frontend/storage"><img src="https://img.shields.io/npm/v/@commercetools-frontend/storage.svg"></a>
 </p>
 
-Getters and setters for `window.localStorage`.
+Getters and setters for `window.localStorage` and `window.sessionStorage`.
 
 ## Install
 

--- a/packages/storage/index.js
+++ b/packages/storage/index.js
@@ -1,4 +1,2 @@
-export const put = (key, value) => window.localStorage.setItem(key, value);
-export const get = key => window.localStorage.getItem(key);
-export const remove = key => window.localStorage.removeItem(key);
-export const clear = () => window.localStorage.clear();
+export { default as localStorage } from './localStorage';
+export { default as sessionStorage } from './sessionStorage';

--- a/packages/storage/localStorage.js
+++ b/packages/storage/localStorage.js
@@ -1,0 +1,6 @@
+const put = (key, value) => window.localStorage.setItem(key, value);
+const get = key => window.localStorage.getItem(key);
+const remove = key => window.localStorage.removeItem(key);
+const clear = () => window.localStorage.clear();
+
+export default { put, get, remove, clear };

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commercetools-frontend/storage",
   "version": "7.0.0",
-  "description": "Getters and setters for window.localStorage",
+  "description": "Getters and setters for window.localStorage and window.sessionStorage",
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",

--- a/packages/storage/sessionStorage.js
+++ b/packages/storage/sessionStorage.js
@@ -1,0 +1,6 @@
+const put = (key, value) => window.sessionStorage.setItem(key, value);
+const get = key => window.sessionStorage.getItem(key);
+const remove = key => window.sessionStorage.removeItem(key);
+const clear = () => window.sessionStorage.clear();
+
+export default { put, get, remove, clear };


### PR DESCRIPTION
### Summary

- add session storage to the storage module
- adapt `storage` usage and update failing tests

#### Description

this aims to unify the use of storage inside the merchant center app kit and also next in the merchant center frontend. 

since I needed to work with `sessionStorage` on mc-frontend, and after seeing it's been used previously directly from `window.sessionStorage`, I thought it is better to add it to the `storage` module to have a better and more unified developer experience.