### PR TITLE
chore: add setupFilesAfterEnv (for jest@24)

### DIFF
--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -25,6 +25,7 @@ module.exports = {
     resolveRelativePath('./setup-tests.js'),
     'jest-localstorage-mock',
   ],
+  setupFilesAfterEnv: [resolveRelativePath('./setup-test-framework.js')],
   setupTestFrameworkScriptFile: resolveRelativePath(
     './setup-test-framework.js'
   ),


### PR DESCRIPTION
#### Summary

This pull request adds the new `setupFilesAfterEnv` option for jest@24. Jest deprecated the old `setupTestFrameworkScriptFile` which will be removed in a future version.

#### Description

I suggest we keep the `setupTestFrameworkScriptFile` around until jest removes it (and maybe longer) and then make that part of a breaking release for app-kit to require jest@24.

Ref: https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array
