### PR TITLE
fix(apollo-cache): to use __typename + key for whitelisted types only if the id is not present

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -72,7 +72,10 @@ export const createApolloClient = () =>
     cache: new InMemoryCache({
       fragmentMatcher,
       dataIdFromObject: result => {
-        if (typeNamesWithoutIdAsIdentifier.includes(result.__typename))
+        if (
+          !result.id &&
+          typeNamesWithoutIdAsIdentifier.includes(result.__typename)
+        )
           return `${result.__typename}:${result.key}`;
         // Generally all id's are unique accross the platform, so we don't need to
         // include the type name in the cache key.


### PR DESCRIPTION
Fixes a small regression from #310 

TL;DR: the custom apps menu config and the apps menu config use (unfortunately) the same type name `NavbarMenu`, which causes the cache to override the menu items of custom apps within the custom apps list view.

Since custom apps menu query returns ids, we can simply check that the `result` contains an id before returning a `__typename` + `key` cache id.

As follow ups, we might consider to do different things:
- rename the app menu types (not for custom apps)
- make the `dataIdFromObject` more robust
- allow to pass a custom mapping function to the `dataIdFromObject`