### PR TITLE
Add placeholder to quick-access input

### DIFF
--- a/packages/application-shell/src/components/quick-access/butler/butler.js
+++ b/packages/application-shell/src/components/quick-access/butler/butler.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Fuse from 'fuse.js';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import last from 'lodash/last';
 import classnames from 'classnames';
 import { SearchIcon } from '@commercetools-frontend/ui-kit';
@@ -44,7 +44,7 @@ const hasNewWindowModifier = event => {
   }
 };
 
-export default class Butler extends React.Component {
+export class Butler extends React.Component {
   static displayName = 'Butler';
 
   static propTypes = {
@@ -63,6 +63,10 @@ export default class Butler extends React.Component {
     getNextCommands: PropTypes.func.isRequired,
     executeCommand: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
+    // injectIntl
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   state = {
@@ -430,6 +434,9 @@ export default class Butler extends React.Component {
             <input
               id="quick-access-search-input"
               ref={this.searchInputRef}
+              placeholder={this.props.intl.formatMessage(
+                messages.inputPlacehoder
+              )}
               type="text"
               className={styles.searchText}
               value={this.state.searchText}
@@ -484,3 +491,5 @@ export default class Butler extends React.Component {
     );
   }
 }
+
+export default injectIntl(Butler);

--- a/packages/application-shell/src/components/quick-access/butler/butler.mod.css
+++ b/packages/application-shell/src/components/quick-access/butler/butler.mod.css
@@ -77,6 +77,10 @@
   padding: var(--spacing-16) var(--spacing-16) var(--spacing-8) var(--spacing-8);
 }
 
+.searchText::placeholder {
+  color: var(--color-gray-60);
+}
+
 .offlineWarning {
   overflow: hidden;
   white-space: nowrap;

--- a/packages/application-shell/src/components/quick-access/messages.js
+++ b/packages/application-shell/src/components/quick-access/messages.js
@@ -1,6 +1,10 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
+  inputPlacehoder: {
+    id: 'QuickAccess.inputPlaceholder',
+    defaultMessage: 'Go to...',
+  },
   offline: {
     id: 'QuickAccess.offline',
     defaultMessage: 'Offline',

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -73,6 +73,7 @@
   "ProjectSwitcher.projects": "Projects",
   "ProjectSwitcher.searchPlaceholder": "Search for a project",
   "ProjectSwitcher.suspended": "Suspended",
+  "QuickAccess.inputPlaceholder": "Go to...",
   "QuickAccess.logout": "Logout",
   "QuickAccess.offline": "Offline",
   "QuickAccess.openAddCartDiscount": "Open Add Cart Discount",


### PR DESCRIPTION
#### Summary

This pull request adds a placeholder text to the input of quick access.

<img width="1338" alt="cleanshot 2019-02-04 at 14 48 49 2x" src="https://user-images.githubusercontent.com/1877073/52212241-564e1100-288c-11e9-9dcc-d283ac2555e2.png">
