### PR TITLE
chore: drop unnecessary deep-freeze dependency

### DIFF
--- a/packages/notifications/middleware/middleware.spec.js
+++ b/packages/notifications/middleware/middleware.spec.js
@@ -1,4 +1,3 @@
-import deepFreeze from 'deep-freeze';
 import oneLine from 'common-tags/lib/oneLine';
 import middleware from '.';
 import { addNotification, removeNotification } from '../action-creators';
@@ -14,7 +13,7 @@ describe('dispatching add/remove notification actions', () => {
       });
     };
     const next = (/* action */) => {};
-    const notification = deepFreeze({ foo: 'bar' });
+    const notification = { foo: 'bar' };
     const action = addNotification(notification);
     const handle = middleware({ dispatch })(next)(action);
     expect(handle.id).toBe(NOTIFICATION_ID);
@@ -23,7 +22,7 @@ describe('dispatching add/remove notification actions', () => {
 
   it('should dispatch the add notification action', () => {
     const NOTIFICATION_ID = 2;
-    const notification = deepFreeze({ foo: 'bar' });
+    const notification = { foo: 'bar' };
     const dispatch = (/* action */) => {};
     const next = action => {
       expect(action).toEqual({
@@ -49,7 +48,7 @@ describe('dispatching add/remove notification actions', () => {
       });
       middleware({ dispatch: noop })(next)(removeAction);
     };
-    const notification = deepFreeze({ foo: 'bar' });
+    const notification = { foo: 'bar' };
     const action = addNotification(notification, {
       onDismiss(notificationId) {
         expect(notificationId).toBe(NOTIFICATION_ID);
@@ -75,7 +74,7 @@ describe('dispatching add/remove notification actions', () => {
         });
         middleware({ dispatch: noop })(next)(removeAction);
       };
-      const notification = deepFreeze({ foo: 'bar' });
+      const notification = { foo: 'bar' };
       const action = addNotification(notification, {
         dismissAfter: 300,
         onDismiss(notificationId) {
@@ -91,7 +90,7 @@ describe('dispatching add/remove notification actions', () => {
     const NOTIFICATION_ID = 5;
     const next = (/* action */) => {};
     const dispatch = (/* action */) => {};
-    const notification = deepFreeze({ foo: 'bar' });
+    const notification = { foo: 'bar' };
     const action = addNotification(notification, {
       onDismiss(notificationId) {
         expect(notificationId).toBe(NOTIFICATION_ID);

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -34,7 +34,6 @@
     "build:es:watch": "npm run build:es -- -w"
   },
   "dependencies": {
-    "common-tags": "1.8.0",
-    "deep-freeze": "0.0.1"
+    "common-tags": "1.8.0"
   }
 }

--- a/packages/notifications/reducer/reducer.spec.js
+++ b/packages/notifications/reducer/reducer.spec.js
@@ -1,11 +1,10 @@
-import deepFreeze from 'deep-freeze';
 import { addNotification, removeNotification } from '../action-creators';
 import reducer from './reducer';
 
 describe('reducing add/remove notification actions', () => {
   it('should reduce the add notification action', () => {
     const notification = { id: 1, foo: 'bar' };
-    const state = deepFreeze([{ id: 0, foo: 'baz' }]);
+    const state = [{ id: 0, foo: 'baz' }];
     expect(reducer(state, addNotification(notification))).toEqual([
       { id: 1, foo: 'bar' },
       { id: 0, foo: 'baz' },
@@ -13,7 +12,7 @@ describe('reducing add/remove notification actions', () => {
   });
 
   it('should reduce the remove notification action', () => {
-    const state = deepFreeze([{ id: 0, foo: 'bar' }, { id: 1, foo: 'baz' }]);
+    const state = [{ id: 0, foo: 'bar' }, { id: 1, foo: 'baz' }];
     expect(reducer(state, removeNotification(1))).toEqual([
       { id: 0, foo: 'bar' },
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,11 +4899,6 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-freeze@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
-  integrity sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
This is part of the OSS licenses review process.

The `deep-freeze` dependency has an unknown/outdated licence. Moreover, the package is basically useless and very much outdated.