### PR TITLE
WIP feature: mc-http-server helm chart

### DIFF
--- a/packages/mc-http-server/chart/Chart.yaml
+++ b/packages/mc-http-server/chart/Chart.yaml
@@ -1,0 +1,11 @@
+description: mc-http-server, the server for commercetools Merchant Center Plugins!
+name: mc-http-server
+version: 0.0.0
+appVersion: 7.3.0
+home: https://github.com/commercetools/merchant-center-application-kit/tree/master/packages/mc-http-server
+maintainers:
+sources:
+  - https://github.com/commercetools/merchant-center-application-kit/tree/master/packages/mc-http-server
+keywords:
+  - commercetools
+  - merchant-center-plugin

--- a/packages/mc-http-server/chart/templates/_helpers.tpl
+++ b/packages/mc-http-server/chart/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mc-http-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mc-http-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mc-http-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/packages/mc-http-server/chart/templates/configmap.yaml
+++ b/packages/mc-http-server/chart/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mc-http-server.fullname" . }}
+  labels:
+    app: {{ template "mc-http-server.name" . }}
+    chart: {{ template "mc-http-server.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data: |
+{{ .Values.mc-http-server.config | .ToJson | nindent 2 }}

--- a/packages/mc-http-server/chart/templates/deployment.yaml
+++ b/packages/mc-http-server/chart/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: {{ template "mc-http-server.fullname" . }}
+  labels:
+    app: {{ template "mc-http-server.name" . }}
+    chart: {{ template "mc-http-server.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+spec:
+  minReadySeconds: {{.Values.mc-http-server.minReadySeconds}}
+  replicas: {{.Values.mc-http-server.replicas}}
+  selector:
+    matchLabels:
+      app: {{ template "mc-http-server.name" . }}
+      chart: {{ template "mc-http-server.chart" . }}
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "mc-http-server.fullname" . }}
+      labels:
+        app: {{ template "mc-http-server.name" . }}
+        chart: {{ template "mc-http-server.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        args:
+          - --config=/etc/mc-http-server/env.json
+        image: {{ .Values.mc-http-server.image}}:{{ .Values.mc-http-server.tag}}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /version
+            port: {{.Values.mc-http-server.port}}
+          initialDelaySeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /version
+            port: {{.Values.mc-http-server.port}}
+          initialDelaySeconds: 5
+        name: mc-http-server
+        ports:
+          - name: mc-http-server
+            containerPort: {{ .Values.mc-http-server.port }}
+        volumeMounts:
+          - name: config
+            mountPath: /etc/mc-http-server/env.json
+            readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "mc-http-server.fullname" . }}-config

--- a/packages/mc-http-server/chart/values.yaml
+++ b/packages/mc-http-server/chart/values.yaml
@@ -1,0 +1,6 @@
+mc-http-server:
+  config:
+  minReadySeconds: 5
+  replicas: 3
+  image: eu.gcr.io/ct-images/mc-http-server
+  tag: v0.0.0


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This adds a helm chart for deploying the `mc-http-server` on Kubernetes. 

#### Description
Things to do before merging:

* [ ] understand the values that go into the `--config=env.json`
* [ ] Document all chart values including `env.json`
* [ ] Add `ignores` to `Docker` and `npm` for the `chart` directory.
* [ ] For users who do not want to use a CDN, add a configuration file to deploy their minified code as a config map and mount it into the correct directory inside the container. (which directory exactly?)
