### PR TITLE
Add `sentry.io` as connect-src to CSP headers

### DIFF
--- a/packages/mc-html-template/load-headers.js
+++ b/packages/mc-html-template/load-headers.js
@@ -87,6 +87,7 @@ module.exports = (env, options) => {
         'clientstream.launchdarkly.com',
         'events.launchdarkly.com',
         'app.getsentry.com',
+        'sentry.io',
         'www.google-analytics.com',
       ].concat(
         isMcDevEnv ? ['ws:', 'localhost:8080', 'webpack-internal:'] : []


### PR DESCRIPTION
#### Summary

This pull request suggests adding `sentry.io` as a CSP header. 