### PR TITLE
Fix fetching custom application menu only when feature is enabled

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -611,7 +611,7 @@ export class NavBar extends React.PureComponent {
     useFullRedirectsForLinks: PropTypes.bool.isRequired,
     menuVisibilities: PropTypes.objectOf(PropTypes.bool).isRequired,
     // Injected
-    areCustomApplicationsEnabled: PropTypes.bool.isRequired,
+    areProjectExtensionsEnabled: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
     isForcedMenuOpen: PropTypes.bool,
     applicationsMenuQuery: PropTypes.shape({
@@ -666,7 +666,7 @@ export class NavBar extends React.PureComponent {
 
 export default compose(
   withRouter, // Connect again, to access the `location` object
-  injectFeatureToggle('customApplications', 'areCustomApplicationsEnabled'),
+  injectFeatureToggle('projectExtensions', 'areProjectExtensionsEnabled'),
   withProps(() => {
     const cachedIsForcedMenuOpen = storage.get(
       STORAGE_KEYS.IS_FORCED_MENU_OPEN
@@ -688,7 +688,7 @@ export default compose(
   graphql(FetchProjectExtensionsNavbar, {
     name: 'projectExtensionsQuery',
     skip: ownProps =>
-      !ownProps.areCustomApplicationsEnabled ||
+      !ownProps.areProjectExtensionsEnabled ||
       process.env.NODE_ENV === 'development',
     options: () => ({
       variables: {

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -4,7 +4,7 @@ import isNil from 'lodash/isNil';
 import { FormattedMessage } from 'react-intl';
 import { NavLink, matchPath, withRouter } from 'react-router-dom';
 import { graphql } from 'react-apollo';
-import { ToggleFeature } from '@flopflip/react-broadcast';
+import { ToggleFeature, injectFeatureToggle } from '@flopflip/react-broadcast';
 import { compose, withProps } from 'recompose';
 import classnames from 'classnames';
 import { oneLineTrim } from 'common-tags';
@@ -611,6 +611,7 @@ export class NavBar extends React.PureComponent {
     useFullRedirectsForLinks: PropTypes.bool.isRequired,
     menuVisibilities: PropTypes.objectOf(PropTypes.bool).isRequired,
     // Injected
+    areCustomApplicationsEnabled: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
     isForcedMenuOpen: PropTypes.bool,
     applicationsMenuQuery: PropTypes.shape({
@@ -665,6 +666,7 @@ export class NavBar extends React.PureComponent {
 
 export default compose(
   withRouter, // Connect again, to access the `location` object
+  injectFeatureToggle('customApplications', 'areCustomApplicationsEnabled'),
   withProps(() => {
     const cachedIsForcedMenuOpen = storage.get(
       STORAGE_KEYS.IS_FORCED_MENU_OPEN
@@ -685,7 +687,9 @@ export default compose(
   })),
   graphql(FetchProjectExtensionsNavbar, {
     name: 'projectExtensionsQuery',
-    skip: () => process.env.NODE_ENV === 'development',
+    skip: ownProps =>
+      !ownProps.areCustomApplicationsEnabled ||
+      process.env.NODE_ENV === 'development',
     options: () => ({
       variables: {
         target: GRAPHQL_TARGETS.SETTINGS_SERVICE,

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -49,6 +49,7 @@ const createTestProps = props => ({
   useFullRedirectsForLinks: false,
   menuVisibilities: { hideOrdersList: true },
   // Injected
+  areCustomApplicationsEnabled: true,
   location: { pathname: '' },
   isForcedMenuOpen: false,
   applicationsMenuQuery: {

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -49,7 +49,7 @@ const createTestProps = props => ({
   useFullRedirectsForLinks: false,
   menuVisibilities: { hideOrdersList: true },
   // Injected
-  areCustomApplicationsEnabled: true,
+  areProjectExtensionsEnabled: true,
   location: { pathname: '' },
   isForcedMenuOpen: false,
   applicationsMenuQuery: {


### PR DESCRIPTION
#### Summary

This pull request "fixes" the GraphQL query to load custom application menus to only run when the feature is enabled.

#### Description

Custom applications is not enabled for all users yet. Furthermore, it's not available on AWS deployments yet. Given the query runs in such an env the server will respond with `{ __status__: 'not-configured' }` which Apollo seems to fail to parse and throw an error for. In addition to responding with an empty `data: {}` I'd suggest to not run the query at all. We can then setup a targeting rule using the `tenant` being `aws`.
