### PR TITLE
fix(browser-history): to omit the question mark

### DIFF
--- a/packages/browser-history/index.js
+++ b/packages/browser-history/index.js
@@ -2,8 +2,9 @@ import createBrowserHistory from 'history/createBrowserHistory';
 import withQuery from 'history-query-enhancer';
 import { encode, decode } from 'qss';
 
-const history = withQuery({ parse: decode, stringify: encode })(
-  createBrowserHistory()
-);
+// Note: the "?" needs to be removed.
+const parse = search => decode(search.substring(1));
+
+const history = withQuery({ parse, stringify: encode })(createBrowserHistory());
 
 export default history;


### PR DESCRIPTION
#### Summary

Caused by: https://github.com/commercetools/merchant-center-application-kit/pull/348

We need to omit the `?` otherwise parts of applications relying on it will break.