### PR TITLE
chore(mc-scripts): add webpack filter plugin to suppress css order warnings

### DIFF
--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -9,6 +9,7 @@ const safeParser = require('postcss-safe-parser');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 // as "aliasing v1.0.0 as webpack.optimize.UglifyJsPlugin is scheduled for
 // webpack v4.0.0" (https://webpack.js.org/plugins/uglifyjs-webpack-plugin/)
 // we need to explicitly use the library to be using the newest version
@@ -153,6 +154,14 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
 
     plugins: [
       new CleanWebpackPlugin([distPath], { allowExternal: true }),
+      // Silence mini-css-extract-plugin generating lots of warnings for CSS ordering.
+      // We use CSS modules that should not care for the order of CSS imports, so we
+      // should be safe to ignore these.
+      //
+      // See: https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
+      new FilterWarningsPlugin({
+        exclude: /mini-css-extract-plugin[^]*Conflicting order between:/,
+      }),
       // Allows to "assign" custom options to the `webpack` object.
       // At the moment, this is used to share some props with `postcss.config`.
       new webpack.LoaderOptionsPlugin({

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -66,6 +66,7 @@
     "webpack": "4.29.3",
     "webpack-bundle-analyzer": "3.0.3",
     "webpack-dev-server": "3.1.14",
+    "webpack-filter-warnings-plugin": "1.2.1",
     "webpackbar": "3.1.5"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15592,6 +15592,11 @@ webpack-dev-server@3.1.14:
     webpack-log "^2.0.0"
     yargs "12.0.2"
 
+webpack-filter-warnings-plugin@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz#dc61521cf4f9b4a336fbc89108a75ae1da951cdb"
+  integrity sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==
+
 webpack-log@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f"


### PR DESCRIPTION
#### Summary

[This issue](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250) describes the issue well. 

Right now, we are pinning the dependency `mini-css-extract-plugin` to an older version just so we don't get these warnings. However, the output CSS remains the same as the new version, the only difference is that the older version didn't output the warnings. So why not just suppress the warnings?