### PR TITLE
feat(app-shell): export withApplicationsMenu from app-shell

### DIFF
--- a/packages/application-shell/src/index.js
+++ b/packages/application-shell/src/index.js
@@ -18,6 +18,9 @@ export { GtmContext } from './components/gtm-booter';
 export {
   default as handleApolloErrors,
 } from './components/handle-apollo-errors';
+export {
+  default as withApplicationsMenu,
+} from './components/with-applications-menu';
 
 /**
  * NOTE:


### PR DESCRIPTION
#### Summary

This PR re-exports the `withApplicationsMenu` from the application-shell.

#### Description

Given we want to use the `withApplicationsMenu` in the new welcome screen we need it exported from app-kit. As it wasn't before this PR intends to do so.

Just a side note: personally I am not yet 100% sold if this being of high value or being really a good idea given the use case:

1. Always having permissions in sync is super ✅ 
2. Assuming that the menu names ever change and can get out of sync maybe a bit far fetched 
    - I am not even sure design wants the same name all the time
3. Logic to deduct the icon (maybe even with another field on the query feels a bit over done
    - The welcome page can be in 100% control of the icons nothing can get out of sync

Maybe I am missing something. Maybe it could be improved by augmenting the schema by e.g. new fields like `isVisibleInWelcomeScreen` or `welcomeScreen: { icon, title }` which allow us to more generically target things. I just wanted to raise my thoughts here.
