### PR TITLE
feat(l10n): rename Macedonia -> North Macedonia 🇲🇰 🇲🇰 🇲🇰 🇲🇰 🇲🇰 🇲🇰 🇲🇰 

### DIFF
--- a/packages/l10n/data/countries/de.json
+++ b/packages/l10n/data/countries/de.json
@@ -149,7 +149,7 @@
   "mf": "St. Martin",
   "mg": "Madagaskar",
   "mh": "Marshallinseln",
-  "mk": "Mazedonien",
+  "mk": "Nordmazedonien",
   "ml": "Mali",
   "mm": "Myanmar",
   "mn": "Mongolei",

--- a/packages/l10n/data/countries/en.json
+++ b/packages/l10n/data/countries/en.json
@@ -149,7 +149,7 @@
   "mf": "St. Martin",
   "mg": "Madagascar",
   "mh": "Marshall Islands",
-  "mk": "Macedonia",
+  "mk": "North Macedonia",
   "ml": "Mali",
   "mm": "Myanmar (Burma)",
   "mn": "Mongolia",

--- a/packages/l10n/data/countries/es.json
+++ b/packages/l10n/data/countries/es.json
@@ -149,7 +149,7 @@
   "mf": "San Martín",
   "mg": "Madagascar",
   "mh": "Islas Marshall",
-  "mk": "Macedonia",
+  "mk": "Macedonia del Norte",
   "ml": "Mali",
   "mm": "Myanmar (Birmania)",
   "mn": "Mongolia",

--- a/packages/l10n/data/languages/de.json
+++ b/packages/l10n/data/languages/de.json
@@ -1272,11 +1272,12 @@
     "country": "Neuseeland"
   },
   "mk": {
-    "language": "Mazedonisch"
+    "language": "Mazedonisch",
+    "country": "Nordmazedonien"
   },
   "mk-MK": {
     "language": "Mazedonisch",
-    "country": "Mazedonien"
+    "country": "Nordmazedonien"
   },
   "ml": {
     "language": "Malayalam"

--- a/packages/l10n/data/languages/en.json
+++ b/packages/l10n/data/languages/en.json
@@ -1272,11 +1272,12 @@
     "country": "New Zealand"
   },
   "mk": {
-    "language": "Macedonian"
+    "language": "Macedonian",
+    "country": "North Macedonia"
   },
   "mk-MK": {
     "language": "Macedonian",
-    "country": "Macedonia"
+    "country": "North Macedonia"
   },
   "ml": {
     "language": "Malayalam"

--- a/packages/l10n/data/languages/es.json
+++ b/packages/l10n/data/languages/es.json
@@ -1272,11 +1272,12 @@
     "country": "Nueva Zelanda"
   },
   "mk": {
-    "language": "macedonio"
+    "language": "macedonio",
+    "country": "Macedonia del Norte"
   },
   "mk-MK": {
     "language": "macedonio",
-    "country": "Macedonia"
+    "country": "Macedonia del Norte"
   },
   "ml": {
     "language": "malayalam"


### PR DESCRIPTION
As of February 12th, Macedonia is now known as Northern Macedonia. 🇲🇰 

I got the german name from [here](https://de.wikipedia.org/wiki/Streit_um_den_Namen_Mazedonien)
And the spanish name from [here](https://es.wikipedia.org/wiki/Disputa_sobre_el_nombre_de_Macedonia)
and english from [here](https://www.theguardian.com/world/2019/feb/12/nato-flag-raised-ahead-of-north-macedonias-prospective-accession)