### PR TITLE
fix(app-shell): quick-access to support full reloads

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -166,6 +166,9 @@ export const RestrictedApplication = props => (
                                     <QuickAccess
                                       history={routeProps.history}
                                       user={user}
+                                      useFullRedirectsForLinks={
+                                        props.INTERNAL__isApplicationFallback
+                                      }
                                     />
                                   );
                                 return (
@@ -187,6 +190,9 @@ export const RestrictedApplication = props => (
                                           }
                                           history={routeProps.history}
                                           user={user}
+                                          useFullRedirectsForLinks={
+                                            props.INTERNAL__isApplicationFallback
+                                          }
                                         />
                                       </ApplicationContextProvider>
                                     )}

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -79,6 +79,7 @@ class QuickAccess extends React.Component {
     onChangeProjectDataLocale: PropTypes.func,
     pimSearchProductIds: PropTypes.func.isRequired,
     getPimSearchStatus: PropTypes.func.isRequired,
+    useFullRedirectsForLinks: PropTypes.bool,
   };
 
   state = {
@@ -320,6 +321,8 @@ class QuickAccess extends React.Component {
         // and always open other pages in a new window
         if (meta.openInNewTab || !command.action.to.startsWith('/')) {
           open(command.action.to, '_blank');
+        } else if (this.props.useFullRedirectsForLinks) {
+          open(command.action.to);
         } else {
           this.props.history.push(command.action.to);
         }

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -325,7 +325,7 @@ describe('QuickAccess', () => {
     });
   });
 
-  it('should open dashboard when chosing the "Open Dashboard" command', async () => {
+  it('should open (route to) dashboard when chosing the "Open Dashboard" command', async () => {
     const mocks = [createMatchlessSearchMock('Open dshbrd')];
     const props = createTestProps();
     const { getByTestId, queryByTestId, getByText } = renderWithRedux(
@@ -349,6 +349,39 @@ describe('QuickAccess', () => {
     await waitForElement(() => getByText('Open Dashboard'));
     fireEvent.keyUp(searchInput, { key: 'Enter' });
     expect(props.history.push).toHaveBeenCalledWith(
+      '/test-with-big-data-44/dashboard'
+    );
+
+    // should close quick access
+    expect(queryByTestId('quick-access')).not.toBeInTheDocument();
+  });
+
+  it('should open (reload to) dashboard when chosing the "Open Dashboard" command when using full redirects for links', async () => {
+    const mocks = [createMatchlessSearchMock('Open dshbrd')];
+    const props = createTestProps({
+      useFullRedirectsForLinks: true,
+    });
+    const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+      <QuickAccess {...props} />,
+      {
+        mocks,
+        flags,
+        sdkMocks: [
+          createPimAvailabilityCheckSdkMock(),
+          createPimSearchSdkMock('Open dshbrd'),
+        ],
+      }
+    );
+
+    // open quick-access
+    fireEvent.keyDown(document.body, { key: 'f' });
+    await waitForElement(() => getByTestId('quick-access-search-input'));
+
+    const searchInput = getByTestId('quick-access-search-input');
+    fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
+    await waitForElement(() => getByText('Open Dashboard'));
+    fireEvent.keyUp(searchInput, { key: 'Enter' });
+    expect(global.open).toHaveBeenCalledWith(
       '/test-with-big-data-44/dashboard'
     );
 


### PR DESCRIPTION
#### Summary

This pull request adds the feature (needed as a fix) for QuickAccess to support redirects with full page reloads. 

When QuickAccess is rendered in the application-fallback we can not render a `RouteCatchAll` as a result never triggering a full page reload from there to any other app. As a result we see the 404 page served by the application-fallback app itself.

We have the notion of `INTERNAL__isApplicationFallback` the NavBar already uses for these cases. We use the same concept, passing it the same as `useFullRedirectsForLinks` to `open` instead of `push` to history.