### PR TITLE
Update uglify plugin / stop shipping es6 code to ie

### DIFF
--- a/application-templates/starter/webpack.config.prod.js
+++ b/application-templates/starter/webpack.config.prod.js
@@ -3,7 +3,7 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const vendorJsFolders = [/node_modules\/omit-empty/];
+const vendorsToTranspile = [/node_modules\/omit-empty/];
 
 const sourceFolders = [path.resolve(__dirname, 'src')];
 
@@ -11,5 +11,5 @@ module.exports = createWebpackConfigForProduction({
   distPath,
   entryPoint,
   sourceFolders,
-  vendorJsFolders,
+  vendorsToTranspile,
 });

--- a/application-templates/starter/webpack.config.prod.js
+++ b/application-templates/starter/webpack.config.prod.js
@@ -3,7 +3,9 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [path.resolve(__dirname, 'src')];
+const sourceFolders = [path.resolve(__dirname, 'src')].concat([
+  'node_modules/omit-empty',
+]);
 
 module.exports = createWebpackConfigForProduction({
   distPath,

--- a/application-templates/starter/webpack.config.prod.js
+++ b/application-templates/starter/webpack.config.prod.js
@@ -3,9 +3,10 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [path.resolve(__dirname, 'src')].concat([
-  'node_modules/omit-empty',
-]);
+const sourceFolders = [
+  path.resolve(__dirname, 'src'),
+  /node_modules\/omit-empty/,
+];
 
 module.exports = createWebpackConfigForProduction({
   distPath,

--- a/application-templates/starter/webpack.config.prod.js
+++ b/application-templates/starter/webpack.config.prod.js
@@ -3,13 +3,13 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [
-  path.resolve(__dirname, 'src'),
-  /node_modules\/omit-empty/,
-];
+const vendorJsFolders = [/node_modules\/omit-empty/];
+
+const sourceFolders = [path.resolve(__dirname, 'src')];
 
 module.exports = createWebpackConfigForProduction({
   distPath,
   entryPoint,
   sourceFolders,
+  vendorJsFolders,
 });

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -50,7 +50,13 @@ const defaultToggleFlags = {
  * The function requires the file path to the related application
  * "entry point".
  */
-module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
+module.exports = ({
+  distPath,
+  entryPoint,
+  sourceFolders,
+  toggleFlags,
+  vendorJsFolders = [],
+}) => {
   const mergedToggleFlags = { ...defaultToggleFlags, ...toggleFlags };
 
   return {
@@ -364,7 +370,7 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
               },
             },
           ],
-          include: sourceFolders,
+          include: sourceFolders.concat(vendorJsFolders),
         },
         // Allow to import `*.graphql` SDL files.
         {

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -55,7 +55,10 @@ module.exports = ({
   entryPoint,
   sourceFolders,
   toggleFlags,
-  vendorJsFolders = [],
+  // some vendors ship es6 code that has not been transpiled to es5.
+  // in order to keep compatibility with browsers, and to save build time
+  // we don't run babel on node_modules, just on the required modules
+  vendorsToTranspile = [],
 }) => {
   const mergedToggleFlags = { ...defaultToggleFlags, ...toggleFlags };
 
@@ -370,7 +373,7 @@ module.exports = ({
               },
             },
           ],
-          include: sourceFolders.concat(vendorJsFolders),
+          include: sourceFolders.concat(vendorsToTranspile),
         },
         // Allow to import `*.graphql` SDL files.
         {

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -37,51 +37,6 @@ const optimizeCSSConfig = {
   },
 };
 
-const uglifyConfig = {
-  // This configuration is from the slack team:
-  // https://slack.engineering/keep-webpack-fast-a-field-guide-for-better-build-performance-f56a5995e8f1
-  uglifyOptions: {
-    compress: {
-      arrows: false,
-      booleans: false,
-      collapse_vars: false,
-      comparisons: false,
-      computed_props: false,
-      hoist_funs: false,
-      hoist_props: false,
-      hoist_vars: false,
-      if_return: false,
-      inline: false,
-      join_vars: false,
-      keep_infinity: true,
-      loops: false,
-      negate_iife: false,
-      properties: false,
-      reduce_funcs: false,
-      reduce_vars: false,
-      sequences: false,
-      side_effects: false,
-      switches: false,
-      top_retain: false,
-      toplevel: false,
-      typeofs: false,
-      unused: false,
-
-      // Switch off all types of compression except those needed to convince
-      // react-devtools that we're using a production build
-      // (here are the checks react devtools makes
-      // https://github.com/facebook/react-devtools/blob/7443291103bc619e7e9b8ab009fb6da1281ba302/backend/installGlobalHook.js#L52-L118)
-      conditionals: true,
-      dead_code: true,
-      evaluate: true,
-    },
-    mangle: true,
-  },
-  warningsFilter: () => true,
-  sourceMap: true,
-  parallel: true,
-};
-
 const defaultToggleFlags = {
   // Allow to disable CSS extraction in case it's not necessary (e.g. for Storybook)
   enableExtractCss: true,
@@ -114,7 +69,7 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
     // https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a
     optimization: {
       minimizer: [
-        new UglifyJsPlugin(uglifyConfig),
+        new UglifyJsPlugin(),
         mergedToggleFlags.enableExtractCss &&
           new OptimizeCSSAssetsPlugin(optimizeCSSConfig),
       ].filter(Boolean),

--- a/packages/mc-scripts/config/polyfills.js
+++ b/packages/mc-scripts/config/polyfills.js
@@ -10,7 +10,7 @@
  *    This is why `unfetch` is still used as a polyfill. Overwriting or
  *    stubbing a ponyfill is not possible as JavaScript modules are read-only.
  */
-import 'unfetch/polyfill';
+import 'unfetch/polyfill/index';
 
 if (typeof Promise === 'undefined') {
   // Rejection tracking prevents a common issue where React gets into an

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -61,7 +61,7 @@
     "style-loader": "0.23.1",
     "svg-url-loader": "2.3.2",
     "thread-loader": "2.1.2",
-    "uglifyjs-webpack-plugin": "1.2.7",
+    "uglifyjs-webpack-plugin": "2.1.1",
     "url-loader": "1.1.2",
     "webpack": "4.29.5",
     "webpack-bundle-analyzer": "3.0.4",

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -3,7 +3,9 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [path.resolve(__dirname, 'src')];
+const sourceFolders = [path.resolve(__dirname, 'src')].concat[
+  'node_modules/omit-empty'
+];
 
 module.exports = createWebpackConfigForProduction({
   distPath,

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -3,7 +3,7 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const vendorJsFolders = [/node_modules\/omit-empty/];
+const vendorsToTranspile = [/node_modules\/omit-empty/];
 
 const sourceFolders = [path.resolve(__dirname, 'src')];
 
@@ -11,5 +11,5 @@ module.exports = createWebpackConfigForProduction({
   distPath,
   entryPoint,
   sourceFolders,
-  vendorJsFolders,
+  vendorsToTranspile,
 });

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -3,8 +3,9 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [path.resolve(__dirname, 'src')].concat[
-  'node_modules/omit-empty'
+const sourceFolders = [
+  path.resolve(__dirname, 'src'),
+  /node_modules\/omit-empty/,
 ];
 
 module.exports = createWebpackConfigForProduction({

--- a/playground/webpack.config.prod.js
+++ b/playground/webpack.config.prod.js
@@ -3,13 +3,13 @@ const createWebpackConfigForProduction = require('@commercetools-frontend/mc-scr
 
 const distPath = path.resolve(__dirname, 'dist');
 const entryPoint = path.resolve(__dirname, 'src/index.js');
-const sourceFolders = [
-  path.resolve(__dirname, 'src'),
-  /node_modules\/omit-empty/,
-];
+const vendorJsFolders = [/node_modules\/omit-empty/];
+
+const sourceFolders = [path.resolve(__dirname, 'src')];
 
 module.exports = createWebpackConfigForProduction({
   distPath,
   entryPoint,
   sourceFolders,
+  vendorJsFolders,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4405,26 +4405,7 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-cacache@^10.0.4:
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
-  integrity sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==
-  dependencies:
-    bluebird "^3.5.1"
-    chownr "^1.0.1"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    lru-cache "^4.1.1"
-    mississippi "^2.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.2"
-    ssri "^5.2.4"
-    unique-filename "^1.1.0"
-    y18n "^4.0.0"
-
-cacache@^11.0.1, cacache@^11.0.2, cacache@^11.3.2:
+cacache@^11.0.1, cacache@^11.0.2, cacache@^11.2.0, cacache@^11.3.2:
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
   integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
@@ -4697,7 +4678,7 @@ chokidar@^2.0.0, chokidar@^2.0.2:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chownr@^1.0.1, chownr@^1.1.1:
+chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
@@ -10869,7 +10850,7 @@ lru-cache@2.5.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.5.0.tgz#d82388ae9c960becbea0c73bb9eb79b6c6ce9aeb"
   integrity sha1-2COIrpyWC+y+oMc7uet5tsbOmus=
 
-lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -11338,22 +11319,6 @@ minizlib@^1.1.1:
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
-
-mississippi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
-  integrity sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==
-  dependencies:
-    concat-stream "^1.5.0"
-    duplexify "^3.4.2"
-    end-of-stream "^1.1.0"
-    flush-write-stream "^1.0.0"
-    from2 "^2.1.0"
-    parallel-transform "^1.1.0"
-    pump "^2.0.1"
-    pumpify "^1.3.3"
-    stream-each "^1.1.0"
-    through2 "^2.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -13813,7 +13778,7 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-pump@^2.0.0, pump@^2.0.1:
+pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
   integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
@@ -15862,13 +15827,6 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^5.2.4:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
-  integrity sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==
-  dependencies:
-    safe-buffer "^5.1.1"
-
 ssri@^6.0.0, ssri@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
@@ -16852,7 +16810,7 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
   integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
-uglify-es@3.3.9, uglify-es@^3.3.4:
+uglify-es@3.3.9:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
   integrity sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==
@@ -16860,7 +16818,7 @@ uglify-es@3.3.9, uglify-es@^3.3.4:
     commander "~2.13.0"
     source-map "~0.6.1"
 
-uglify-js@3.4.x, uglify-js@^3.1.4:
+uglify-js@3.4.x, uglify-js@^3.0.0, uglify-js@^3.1.4:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
   integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
@@ -16873,17 +16831,17 @@ uglifycss@0.0.29:
   resolved "https://registry.yarnpkg.com/uglifycss/-/uglifycss-0.0.29.tgz#abe49531155d146e75dd2fdf933d371bc1180054"
   integrity sha512-J2SQ2QLjiknNGbNdScaNZsXgmMGI0kYNrXaDlr4obnPW9ni1jljb1NeEVWAiTgZ8z+EBWP2ozfT9vpy03rjlMQ==
 
-uglifyjs-webpack-plugin@1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz#57638dd99c853a1ebfe9d97b42160a8a507f9d00"
-  integrity sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==
+uglifyjs-webpack-plugin@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.1.tgz#6937d7513a37280d4792f1fb536bef35e08e420a"
+  integrity sha512-TQEcyMNkObX/H+FfcKjiDgs5RcXX8vW2UUUrDTOfQgg3lrafztfeM5WAwXo+AzqozJK6NP9w98xNpG/dutzSsg==
   dependencies:
-    cacache "^10.0.4"
-    find-cache-dir "^1.0.0"
-    schema-utils "^0.4.5"
+    cacache "^11.2.0"
+    find-cache-dir "^2.0.0"
+    schema-utils "^1.0.0"
     serialize-javascript "^1.4.0"
     source-map "^0.6.1"
-    uglify-es "^3.3.4"
+    uglify-js "^3.0.0"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
@@ -16984,7 +16942,7 @@ uniqs@^2.0.0:
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
   integrity sha1-/+3ks2slKQaW5uFl1KWe25mOawI=
 
-unique-filename@^1.1.0, unique-filename@^1.1.1:
+unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
   integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==


### PR DESCRIPTION
#### The problem

Currently, our production bundles have code like this in it.

```js
const n=r("../node_modules/omit-empty/node_modules/kind-of/index.js");
```

```js
const a=(e,t)=>{let r=!!t&&t.omitZero```
```

This is bad because arrow functions are **NOT** supported by IE 11.

### The solution

Passing a new parameter to createWebpackConfigForProduction and compiling those deps.

Explicitly compiling dependencies that are shipping ES6 code with babel.

Here's a screenshot of trying to use the MC with IE11. Notice how it crashes and doesn't load the login page.

![screen shot 2019-02-25 at 1 17 41 pm](https://user-images.githubusercontent.com/2425013/53336866-ec131400-38ff-11e9-8e03-12caae2882c3.png)
