### PR TITLE
refactor(configure-apollo): add special mapping for DeliveryItem type

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -66,6 +66,8 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
 
 const typeNamesWithoutIdAsIdentifier = ['Project', 'BaseMenu', 'NavbarMenu'];
 
+const typeNameWithReferencedEntity = ['Reference', 'DeliveryItem'];
+
 export const createApolloClient = () =>
   new ApolloClient({
     link,
@@ -82,7 +84,10 @@ export const createApolloClient = () =>
         // However, a reference has the shape { typeId, id } where the id is the
         // id of the referenced entity. If we didn't prefix ids of References
         // they would clash with the referenced resource.
-        if (result.__typename === 'Reference')
+        // The same use case happens for DeliveryItem type in which the `id`
+        // is really the lineItem id referenced in the delivery
+        // https://docs.commercetools.com/http-api-projects-orders.html#deliveryitem
+        if (typeNameWithReferencedEntity.includes(result.__typename))
           return `${result.__typename}:${result.id}`;
 
         return result.id;


### PR DESCRIPTION
#### Summary

Adds a special mapping for `DeliveryItem` type of graphql. Basically it contains two attributes, `id` and `quantity`. But the `id` is really the line item id referenced in the delivery item, so once it gets in the apollo cache we get the wrong data. See screenshots:



|Response  | After apollo caches it |
|---|---|
|![image](https://user-images.githubusercontent.com/11442895/53508374-e8c38800-3ab9-11e9-8035-d6afccb39c15.png)  | ![image](https://user-images.githubusercontent.com/11442895/53508444-0abd0a80-3aba-11e9-906e-036174dbe3b0.png) |

See how the `typeName` is wrong for the delivery item.

The documentation is also clear about this:

![image](https://user-images.githubusercontent.com/11442895/53508484-22948e80-3aba-11e9-88ec-f1c5ff03a4ef.png)

