### PR TITLE
fix(apps-menu): to trigger remote query based on servedByProxy value

### DIFF
--- a/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
+++ b/packages/application-shell/src/components/app-bar/__snapshots__/app-bar.spec.js.snap
@@ -78,6 +78,11 @@ exports[`rendering should match layout structure 1`] = `
       />
       <UserSettingsMenu
         email="john.snow@winter.com"
+        environment={
+          Object {
+            "servedByProxy": false,
+          }
+        }
         firstName="John"
         gravatarHash="20c9c1b252b46ab49d6f7a4cee9c3e68"
         lastName="Snow"

--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -119,7 +119,7 @@ AppBar.propTypes = {
   }),
   projectKeyFromUrl: PropTypes.string,
   environment: PropTypes.shape({
-    servedByProxy: PropTypes.oneOf([true, false, 'true', 'false']).isRequired,
+    servedByProxy: PropTypes.bool.isRequired,
   }).isRequired,
   DEV_ONLY__loadAppbarMenuConfig: PropTypes.func,
 };

--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -91,6 +91,7 @@ const AppBar = props => {
               lastName={props.user.lastName}
               gravatarHash={props.user.gravatarHash}
               email={props.user.email}
+              environment={props.environment}
               DEV_ONLY__loadAppbarMenuConfig={
                 props.DEV_ONLY__loadAppbarMenuConfig
               }
@@ -117,6 +118,9 @@ AppBar.propTypes = {
     defaultProjectKey: PropTypes.string.isRequired,
   }),
   projectKeyFromUrl: PropTypes.string,
+  environment: PropTypes.shape({
+    servedByProxy: PropTypes.oneOf([true, false, 'true', 'false']).isRequired,
+  }).isRequired,
   DEV_ONLY__loadAppbarMenuConfig: PropTypes.func,
 };
 

--- a/packages/application-shell/src/components/app-bar/app-bar.spec.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.spec.js
@@ -19,6 +19,9 @@ const createTestProps = props => ({
     email: 'john.snow@winter.com',
     gravatarHash: '20c9c1b252b46ab49d6f7a4cee9c3e68',
   },
+  environment: {
+    servedByProxy: false,
+  },
   ...props,
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -335,6 +335,16 @@ RestrictedApplication.propTypes = {
   DEV_ONLY__loadNavbarMenuConfig: PropTypes.func,
 };
 
+const shallowlyCoerceBooleanValues = obj =>
+  Object.keys(obj).reduce((updatedObj, key) => {
+    const value = obj[key];
+    const isBoolean = value === 'true' || value === 'false';
+    return {
+      ...updatedObj,
+      [key]: isBoolean ? value === 'true' : value,
+    };
+  }, {});
+
 export default class ApplicationShell extends React.Component {
   static displayName = 'ApplicationShell';
   static propTypes = {
@@ -363,9 +373,12 @@ export default class ApplicationShell extends React.Component {
     });
   }
   render() {
+    const environmentValues = shallowlyCoerceBooleanValues(
+      this.props.environment
+    );
     return (
       <ApplicationShellProvider
-        environment={this.props.environment}
+        environment={environmentValues}
         trackingEventWhitelist={this.props.trackingEventWhitelist}
         applicationMessages={this.props.applicationMessages}
       >
@@ -373,7 +386,7 @@ export default class ApplicationShell extends React.Component {
           if (isAuthenticated)
             return (
               <RestrictedApplication
-                environment={this.props.environment}
+                environment={environmentValues}
                 defaultFeatureFlags={this.props.defaultFeatureFlags}
                 render={this.props.render}
                 applicationMessages={this.props.applicationMessages}

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -153,9 +153,7 @@ export const RestrictedApplication = props => (
                                     <QuickAccess
                                       history={routeProps.history}
                                       user={user}
-                                      useFullRedirectsForLinks={
-                                        props.INTERNAL__isApplicationFallback
-                                      }
+                                      environment={props.environment}
                                     />
                                   );
                                 return (
@@ -177,9 +175,7 @@ export const RestrictedApplication = props => (
                                           }
                                           history={routeProps.history}
                                           user={user}
-                                          useFullRedirectsForLinks={
-                                            props.INTERNAL__isApplicationFallback
-                                          }
+                                          environment={props.environment}
                                         />
                                       </ApplicationContextProvider>
                                     )}
@@ -195,6 +191,7 @@ export const RestrictedApplication = props => (
                         <AppBar
                           user={user}
                           projectKeyFromUrl={projectKeyFromUrl}
+                          environment={props.environment}
                           DEV_ONLY__loadAppbarMenuConfig={
                             props.DEV_ONLY__loadAppbarMenuConfig
                           }
@@ -239,9 +236,7 @@ export const RestrictedApplication = props => (
                                       menuVisibilities={
                                         project.menuVisibilities
                                       }
-                                      useFullRedirectsForLinks={
-                                        props.INTERNAL__isApplicationFallback
-                                      }
+                                      environment={props.environment}
                                       DEV_ONLY__loadNavbarMenuConfig={
                                         props.DEV_ONLY__loadNavbarMenuConfig
                                       }
@@ -336,7 +331,6 @@ RestrictedApplication.propTypes = {
   render: PropTypes.func.isRequired,
   applicationMessages: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
     .isRequired,
-  INTERNAL__isApplicationFallback: PropTypes.bool.isRequired,
   DEV_ONLY__loadAppbarMenuConfig: PropTypes.func,
   DEV_ONLY__loadNavbarMenuConfig: PropTypes.func,
 };
@@ -359,12 +353,9 @@ export default class ApplicationShell extends React.Component {
     // Only available in development mode
     DEV_ONLY__loadAppbarMenuConfig: PropTypes.func,
     DEV_ONLY__loadNavbarMenuConfig: PropTypes.func,
-    // Internal usage only, does not need to be documented
-    INTERNAL__isApplicationFallback: PropTypes.bool,
   };
   static defaultProps = {
     trackingEventWhitelist: {},
-    INTERNAL__isApplicationFallback: false,
   };
   componentDidMount() {
     this.props.onRegisterErrorListeners({
@@ -386,9 +377,6 @@ export default class ApplicationShell extends React.Component {
                 defaultFeatureFlags={this.props.defaultFeatureFlags}
                 render={this.props.render}
                 applicationMessages={this.props.applicationMessages}
-                INTERNAL__isApplicationFallback={
-                  this.props.INTERNAL__isApplicationFallback
-                }
                 DEV_ONLY__loadAppbarMenuConfig={
                   this.props.DEV_ONLY__loadAppbarMenuConfig
                 }

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -48,7 +48,6 @@ const createTestProps = props => ({
   showApiErrorNotification: jest.fn(),
   showUnexpectedErrorNotification: jest.fn(),
   onRegisterErrorListeners: jest.fn(),
-  INTERNAL__isApplicationFallback: false,
   ...props,
 });
 
@@ -319,10 +318,10 @@ describe('<RestrictedApplication>', () => {
             'en'
           );
         });
-        it('should pass "useFullRedirectsForLinks"', () => {
+        it('should pass "environment"', () => {
           expect(wrapperAside.find(NavBar)).toHaveProp(
-            'useFullRedirectsForLinks',
-            props.INTERNAL__isApplicationFallback
+            'environment',
+            props.environment
           );
         });
         describe('when user, locale and project are loading', () => {

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -610,9 +610,8 @@ export class NavBar extends React.PureComponent {
     applicationLanguage: PropTypes.string.isRequired,
     projectKey: PropTypes.string.isRequired,
     environment: PropTypes.shape({
-      servedByProxy: PropTypes.oneOf([true, false, 'true', 'false']).isRequired,
-      useFullRedirectsForLinks: PropTypes.oneOf([true, false, 'true', 'false'])
-        .isRequired,
+      servedByProxy: PropTypes.bool.isRequired,
+      useFullRedirectsForLinks: PropTypes.bool.isRequired,
     }).isRequired,
     menuVisibilities: PropTypes.objectOf(PropTypes.bool).isRequired,
     // Injected
@@ -662,9 +661,9 @@ export class NavBar extends React.PureComponent {
           menuVisibilities={this.props.menuVisibilities}
           applicationLanguage={this.props.applicationLanguage}
           projectKey={this.props.projectKey}
-          useFullRedirectsForLinks={[true, 'true'].includes(
+          useFullRedirectsForLinks={
             this.props.environment.useFullRedirectsForLinks
-          )}
+          }
         />
       </NavBarLayout>
     );
@@ -699,8 +698,7 @@ export default flowRight(
   injectMenuToggleState,
   withApplicationsMenu({
     queryName: 'applicationsMenuQuery',
-    skipRemoteQuery: ownProps =>
-      [false, 'false'].includes(ownProps.environment.servedByProxy),
+    skipRemoteQuery: ownProps => !ownProps.environment.servedByProxy,
     options: ownProps => ({
       __DEV_CONFIG__: {
         menuLoader: ownProps.DEV_ONLY__loadNavbarMenuConfig,
@@ -711,7 +709,7 @@ export default flowRight(
   graphql(FetchProjectExtensionsNavbar, {
     name: 'projectExtensionsQuery',
     skip: ownProps =>
-      [false, 'false'].includes(ownProps.environment.servedByProxy) ||
+      !ownProps.environment.servedByProxy ||
       !ownProps.areProjectExtensionsEnabled,
     options: () => ({
       variables: {

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -46,7 +46,10 @@ const createTestProps = props => ({
   // From parent
   applicationLanguage: 'en',
   projectKey: 'test-1',
-  useFullRedirectsForLinks: false,
+  environment: {
+    servedByProxy: false,
+    useFullRedirectsForLinks: false,
+  },
   menuVisibilities: { hideOrdersList: true },
   // Injected
   areProjectExtensionsEnabled: true,
@@ -79,6 +82,7 @@ const createDataMenuTestProps = props => {
   } = navbarProps;
   return {
     ...passThroughProps,
+    useFullRedirectsForLinks: false,
     data: [
       createTestMenuConfig('orders'),
       createTestMenuConfig('products'),

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -79,7 +79,10 @@ class QuickAccess extends React.Component {
     onChangeProjectDataLocale: PropTypes.func,
     pimSearchProductIds: PropTypes.func.isRequired,
     getPimSearchStatus: PropTypes.func.isRequired,
-    useFullRedirectsForLinks: PropTypes.bool,
+    environment: PropTypes.shape({
+      useFullRedirectsForLinks: PropTypes.oneOf([true, false, 'true', 'false'])
+        .isRequired,
+    }).isRequired,
   };
 
   state = {
@@ -321,7 +324,11 @@ class QuickAccess extends React.Component {
         // and always open other pages in a new window
         if (meta.openInNewTab || !command.action.to.startsWith('/')) {
           open(command.action.to, '_blank');
-        } else if (this.props.useFullRedirectsForLinks) {
+        } else if (
+          [true, 'true'].includes(
+            this.props.environment.useFullRedirectsForLinks
+          )
+        ) {
           window.location.replace(command.action.to);
         } else {
           this.props.history.push(command.action.to);

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -80,8 +80,7 @@ class QuickAccess extends React.Component {
     pimSearchProductIds: PropTypes.func.isRequired,
     getPimSearchStatus: PropTypes.func.isRequired,
     environment: PropTypes.shape({
-      useFullRedirectsForLinks: PropTypes.oneOf([true, false, 'true', 'false'])
-        .isRequired,
+      useFullRedirectsForLinks: PropTypes.bool,
     }).isRequired,
   };
 
@@ -324,11 +323,7 @@ class QuickAccess extends React.Component {
         // and always open other pages in a new window
         if (meta.openInNewTab || !command.action.to.startsWith('/')) {
           open(command.action.to, '_blank');
-        } else if (
-          [true, 'true'].includes(
-            this.props.environment.useFullRedirectsForLinks
-          )
-        ) {
+        } else if (this.props.environment.useFullRedirectsForLinks) {
           window.location.replace(command.action.to);
         } else {
           this.props.history.push(command.action.to);

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -68,6 +68,7 @@ const createTestProps = custom => ({
       ],
     },
   },
+  environment: { useFullRedirectsForLinks: false },
   ...custom,
 });
 
@@ -360,7 +361,7 @@ describe('QuickAccess', () => {
   it('should open (reload to) dashboard when chosing the "Open Dashboard" command when using full redirects for links', async () => {
     const mocks = [createMatchlessSearchMock('Open dshbrd')];
     const props = createTestProps({
-      useFullRedirectsForLinks: true,
+      environment: { useFullRedirectsForLinks: true },
     });
     const { getByTestId, queryByTestId, getByText } = renderWithRedux(
       <QuickAccess {...props} />,

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.js
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.js
@@ -21,10 +21,7 @@ export class ForcePageReload extends React.PureComponent {
 export class RouteCatchAll extends React.PureComponent {
   static displayName = 'RouteCatchAll';
   static propTypes = {
-    servedByProxy: PropTypes.oneOfType([
-      PropTypes.bool.isRequired,
-      PropTypes.oneOf(['true', 'false']).isRequired,
-    ]),
+    servedByProxy: PropTypes.bool,
   };
   // NOTE: it's important that the return value is a `Route` component!
   render() {
@@ -40,11 +37,7 @@ export class RouteCatchAll extends React.PureComponent {
     // the request to the discounts app.
     // If no route matches, the application fallback will handle the request
     // instead, showing e.g. a 404 page.
-    if (
-      this.props.servedByProxy === true ||
-      this.props.servedByProxy === 'true'
-    )
-      return <Route component={ForcePageReload} />;
+    if (this.props.servedByProxy) return <Route component={ForcePageReload} />;
 
     // In case we are developing the app locally, we simply render a 404
     // page because we most likely don't have other "apps" running at the same

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
@@ -26,18 +26,7 @@ describe('rendering', () => {
     });
   });
   describe('<RouteCatchAll>', () => {
-    describe('when "servedByProxy" is "true" (string)', () => {
-      beforeEach(() => {
-        props = createTestProps({
-          servedByProxy: 'true',
-        });
-        wrapper = shallow(<RouteCatchAll {...props} />);
-      });
-      it('should render Route with <ForcePageReload>', () => {
-        expect(wrapper.find('Route')).toHaveProp('component', ForcePageReload);
-      });
-    });
-    describe('when "servedByProxy" is "true" (boolean)', () => {
+    describe('when "servedByProxy" is "true"', () => {
       beforeEach(() => {
         props = createTestProps({
           servedByProxy: true,

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -202,18 +202,22 @@ UserSettingsMenuBody.propTypes = {
 };
 
 const ConnectedUserSettingsMenuBody = flowRight(
-  withApplicationsMenu(ownProps => ({
+  withApplicationsMenu({
     queryName: 'applicationsMenuQuery',
     queryOptions: {
       // We can assume here that the navbar already fetched the data, since this
       // component gets rendered only when the user opens the menu
       fetchPolicy: 'cache-only',
     },
-    __DEV_CONFIG__: {
-      menuLoader: ownProps.DEV_ONLY__loadAppbarMenuConfig,
-      menuKey: 'appBar',
-    },
-  })),
+    skipRemoteQuery: ownProps =>
+      [false, 'false'].includes(ownProps.environment.servedByProxy),
+    options: ownProps => ({
+      __DEV_CONFIG__: {
+        menuLoader: ownProps.DEV_ONLY__loadAppbarMenuConfig,
+        menuKey: 'appBar',
+      },
+    }),
+  }),
   handleApolloErrors(['applicationsMenuQuery'])
 )(UserSettingsMenuBody);
 

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -209,8 +209,7 @@ const ConnectedUserSettingsMenuBody = flowRight(
       // component gets rendered only when the user opens the menu
       fetchPolicy: 'cache-only',
     },
-    skipRemoteQuery: ownProps =>
-      [false, 'false'].includes(ownProps.environment.servedByProxy),
+    skipRemoteQuery: ownProps => !ownProps.environment.servedByProxy,
     options: ownProps => ({
       __DEV_CONFIG__: {
         menuLoader: ownProps.DEV_ONLY__loadAppbarMenuConfig,

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
@@ -56,9 +56,7 @@ const createGraphqlResponse = custom => ({
 });
 
 describe('fetching the menu query', () => {
-  const Connected = withApplicationsMenu(() => ({ queryName: 'menuQuery' }))(
-    Test
-  );
+  const Connected = withApplicationsMenu({ queryName: 'menuQuery' })(Test);
   describe('when the query succeeds', () => {
     it('should render menu key', async () => {
       const { getByText } = render(<Connected />, {


### PR DESCRIPTION
Fixes #407

Previously we were basing the logic to load the apps menu config from the local file or remotely based on the `NODE_ENV` variable. However, when testing the production bundle locally in production mode, the app would break because the graphql endpoint does not exist.

Now we base the logic on the `servedByProxy` flag.

Additionally, I also removed the prop `INTERNAL__isApplicationFallback` and assume that the `useFullRedirectsForLinks` comes from the `env.json`. We only use it internally in our fallback app, so I don't consider it a breaking change.