### PR TITLE
fix: update react-router to v5

### DIFF
--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -24,8 +24,8 @@
     "react-dom": "16.8.4",
     "react-intl": "2.8.0",
     "react-redux": "6.0.1",
-    "react-router": "4.4.0",
-    "react-router-dom": "4.4.0",
+    "react-router": "5.0.0",
+    "react-router-dom": "5.0.0",
     "redux": "4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "stylelint-order": "0.8.1"
   },
   "resolutions": {
-    "react-router": "4.4.0",
-    "react-router-dom": "4.4.0"
+    "react-router": "5.0.0",
+    "react-router-dom": "5.0.0"
   },
   "engines": {
     "node": ">=8.9",

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -101,8 +101,8 @@
     "react-dom": "16.8.4",
     "react-intl": "2.8.0",
     "react-redux": "6.0.1",
-    "react-router": "4.4.0",
-    "react-router-dom": "4.4.0",
+    "react-router": "5.0.0",
+    "react-router-dom": "5.0.0",
     "react-testing-library": "6.0.0",
     "redux": "4.0.1",
     "wait-for-observables": "1.0.3"

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -52,8 +52,8 @@
     "react-dom": "16.8.4",
     "react-intl": "2.8.0",
     "react-redux": "6.0.1",
-    "react-router": "4.4.0",
-    "react-router-dom": "4.4.0"
+    "react-router": "5.0.0",
+    "react-router-dom": "5.0.0"
   },
   "peerDependencies": {
     "@commercetools-frontend/ui-kit": "9.x",

--- a/playground/package.json
+++ b/playground/package.json
@@ -33,8 +33,8 @@
     "react-dom": "16.8.4",
     "react-intl": "2.8.0",
     "react-redux": "6.0.1",
-    "react-router": "4.4.0",
-    "react-router-dom": "4.4.0",
+    "react-router": "5.0.0",
+    "react-router-dom": "5.0.0",
     "react-select": "1.2.1",
     "redux": "4.0.1"
   },

--- a/visual-testing-app/package.json
+++ b/visual-testing-app/package.json
@@ -13,8 +13,8 @@
     "formik": "1.5.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
-    "react-router": "4.4.0",
-    "react-router-dom": "4.4.0"
+    "react-router": "5.0.0",
+    "react-router-dom": "5.0.0"
   },
   "devDependencies": {
     "serve": "10.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9095,18 +9095,6 @@ history@4.9.0, history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^0.4.0"
 
-history@^4.8.0-beta.0:
-  version "4.8.0-beta.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.8.0-beta.0.tgz#8b48c1354ac290341c0d73dd33c763bd140531f4"
-  integrity sha512-LDjPtGgAFDO3lZ+bumN67k0R3GWvUBLLgRJpFU2mnJ1w+D5rEbiZC1c37yPla7tx/dUzVfznt5Rmttnz0MvGdA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^2.2.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^0.4.0"
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -15363,23 +15351,23 @@ react-required-if@1.0.3:
   resolved "https://registry.yarnpkg.com/react-required-if/-/react-required-if-1.0.3.tgz#6a40a761b1d54815c1d4e6610910cbf92b5aa987"
   integrity sha1-akCnYbHVSBXB1OZhCRDL+StaqYc=
 
-react-router-dom@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.4.0.tgz#fad67b46375f7081a76d1c92a83a92d28b5abc35"
-  integrity sha512-r4knbi8lanTGrwoUXFaWALrJZOAl3h9bdFUz4woHgEm7/bYcpBGfnYhPU82xjXrPeJyWF6OmIxpwXjxos30gOQ==
+react-router-dom@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"
+  integrity sha512-wSpja5g9kh5dIteZT3tUoggjnsa+TPFHSMrpHXMpFsaHhQkm/JNVGh2jiF9Dkh4+duj4MKCkwO6H08u6inZYgQ==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    history "^4.8.0-beta.0"
+    history "^4.9.0"
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
-    react-router "^4.4.0"
+    react-router "5.0.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@4.4.0, react-router@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.4.0.tgz#e8b8b88329f564d4c48b7ee631b10310188c6888"
-  integrity sha512-qTGsOSF2b02zOsUfcnHjw7muI0Ejx+yA2e4P9qqzB2O+N3Icpca4epViXRgkBIvBjagXBtroxXqH0RJhYDMUbg==
+react-router@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.0.tgz#349863f769ffc2fa10ee7331a4296e86bc12879d"
+  integrity sha512-6EQDakGdLG/it2x9EaCt9ZpEEPxnd0OCLBHQ1AcITAAx7nCnyvnzf76jKWG1s2/oJ7SSviUgfWHofdYljFexsA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     create-react-context "^0.2.2"


### PR DESCRIPTION
#### Summary

This pull request updates to react-router v5 which doens't have any breaking changes for us.

#### Description

We recently (maybe even overly eager) update to 4.4 which is now unpublished and makes app-kit kind of be in lala-land.

Release notes here: https://reacttraining.com/blog/react-router-v5/

> There are no breaking changes in this release. If you are already using version 4.x, you can use version 5 immediately with zero code changes. 🎉 Version 5 will pick up where the 4.x roadmap (now the 5.x roadmap) left off.
