### PR TITLE
feat(app-shell): quick-access to have noresults message

### DIFF
--- a/packages/application-shell/src/components/quick-access/butler/butler.js
+++ b/packages/application-shell/src/components/quick-access/butler/butler.js
@@ -455,7 +455,10 @@ export class Butler extends React.Component {
                 </div>
               );
 
-            if (this.state.results.length === 0 && this.state.searchText !== '')
+            if (
+              this.state.results.length === 0 &&
+              this.state.searchText.trim().length > 0
+            )
               return (
                 <div className={classnames(styles.noResultsWarning)}>
                   <FormattedMessage {...messages.noResults} />

--- a/packages/application-shell/src/components/quick-access/butler/butler.js
+++ b/packages/application-shell/src/components/quick-access/butler/butler.js
@@ -455,7 +455,12 @@ export class Butler extends React.Component {
                 </div>
               );
 
-            if (!this.state.results) return null;
+            if (this.state.results.length === 0 && this.state.searchText !== '')
+              return (
+                <div className={classnames(styles.noResultsWarning)}>
+                  <FormattedMessage {...messages.noResults} />
+                </div>
+              );
 
             return this.state.results.map((command, index) => (
               <ButlerCommand

--- a/packages/application-shell/src/components/quick-access/butler/butler.mod.css
+++ b/packages/application-shell/src/components/quick-access/butler/butler.mod.css
@@ -92,3 +92,15 @@
   font-size: var(--font-size-small);
   padding: var(--spacing-4);
 }
+
+.noResultsWarning {
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: default;
+  background: var(--color-grey);
+  color: var(--color-black);
+  text-align: center;
+  text-transform: uppercase;
+  font-size: var(--font-size-small);
+  padding: var(--spacing-4);
+}

--- a/packages/application-shell/src/components/quick-access/messages.js
+++ b/packages/application-shell/src/components/quick-access/messages.js
@@ -9,6 +9,10 @@ export default defineMessages({
     id: 'QuickAccess.offline',
     defaultMessage: 'Offline',
   },
+  noResults: {
+    id: 'QuickAccess.noResults',
+    defaultMessage: 'No results found',
+  },
   // create-commands
   setResourceLanguage: {
     id: 'QuickAccess.setResourceLanguage',

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -201,11 +201,11 @@ class QuickAccess extends React.Component {
             action: {
               type: 'go',
               to: oneLineTrim`
-              /${this.props.project.key}
-              /products
-              /${productId}
-              /${variantId}
-            `,
+                /${this.props.project.key}
+                /products
+                /${productId}
+                /${variantId}
+              `,
             },
             subCommands: createProductVariantSubCommands({
               intl: this.props.intl,


### PR DESCRIPTION
#### Summary

Adds a no results message to QuickAccess to give better user feedback.

<img width="522" alt="CleanShot 2019-03-21 at 13 48 26@2x" src="https://user-images.githubusercontent.com/1877073/54755475-4c872f80-4be6-11e9-8da6-27c1c48059bb.png">

This is meant to look similar to the offline message.

<img width="463" alt="CleanShot 2019-03-21 at 13 48 49@2x" src="https://user-images.githubusercontent.com/1877073/54755500-55780100-4be6-11e9-8214-49f49b22cfd9.png">
