### PR TITLE
chore: update omit-empty-es to v1.0.3

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -78,7 +78,7 @@
     "lodash-es": "4.17.11",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.23",
-    "omit-empty-es": "1.0.2",
+    "omit-empty-es": "1.0.3",
     "perfume.js": "1.1.4",
     "prop-types": "15.7.2",
     "qss": "2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13040,10 +13040,10 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-omit-empty-es@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/omit-empty-es/-/omit-empty-es-1.0.2.tgz#e0a7877f9a882c4a637995024503d4c0a93849d0"
-  integrity sha512-7g3l5Is3DbS0SLcPj83NJ+g5V+eyCqPVm4hCCCs/7eYe0F4mzZdGdxeOljeEsAeH+AF8crebzp9hAO67JC6rGQ==
+omit-empty-es@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/omit-empty-es/-/omit-empty-es-1.0.3.tgz#b6577b40756ff7d8da6e2d0ed4b4c79c883793e1"
+  integrity sha512-SobkOViA9e2sNtw7ebBDEfgy76zKbXx+quKqgCZ17a4Y7FZ6JduHwOlABsjs0Rdz6d/YAf9/bRS0Q+V6idWxOQ==
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
The bundle is now built with rollup, before it was built with parcel and apparently I either did something wrong or it didn't work as expected.