### PR TITLE
refactor(test-utils): to avoid conflicting named exports with rtl render function

### DIFF
--- a/application-templates/starter/src/components/main-view/main-view.spec.js
+++ b/application-templates/starter/src/components/main-view/main-view.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  render,
+  renderApp,
   waitForElement,
   fireEvent,
 } from '@commercetools-frontend/application-shell/test-utils';
@@ -9,7 +9,7 @@ import { ApplicationStarter } from '../entry-point';
 describe('main view', () => {
   it('the user can click on the link to "one" and the page should show a text with "View one"', async () => {
     const initialRoute = '/my-project/examples-starter';
-    const { getByText, history } = render(<ApplicationStarter />, {
+    const { getByText, history } = renderApp(<ApplicationStarter />, {
       route: initialRoute,
     });
     await waitForElement(() => getByText(/Hello, world/i));

--- a/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { render, waitForElement } from '../../test-utils';
+import { renderApp, waitForElement } from '../../test-utils';
 import ProjectQuery from './fetch-project.graphql';
 import FetchProject, { mapAllAppliedToObjectShape } from './fetch-project';
 
 const renderProject = options =>
-  render(
+  renderApp(
     <FetchProject projectKey="test-1">
       {({ isLoading, error, project }) => {
         if (isLoading) return <div>{'loading...'}</div>;

--- a/packages/application-shell/src/components/fetch-user/fetch-user.spec.js
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { render, waitForElement } from '../../test-utils';
+import { renderApp, waitForElement } from '../../test-utils';
 import LoggedInUserQuery from './fetch-user.graphql';
 import FetchUser from './fetch-user';
 
 const renderUser = options =>
-  render(
+  renderApp(
     <FetchUser>
       {({ isLoading, error, user }) => {
         if (isLoading) return <div>{'loading...'}</div>;

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.spec.js
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.spec.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { renderWithRedux, waitForElement, fireEvent } from '../../test-utils';
+import {
+  renderAppWithRedux,
+  waitForElement,
+  fireEvent,
+} from '../../test-utils';
 import handleApolloErrors from './handle-apollo-errors';
 
 const createGraphqlResultProps = props => ({
@@ -58,7 +62,7 @@ describe('given the graphql queries for "user"', () => {
   describe('when the "user" query fails', () => {
     it('should dispatch notification error', async () => {
       const error = new Error('Oops');
-      const { getByText, getByTestId } = renderWithRedux(
+      const { getByText, getByTestId } = renderAppWithRedux(
         <QueryController name="user" queryResult={{ data: null, error }}>
           <WithApolloErrorHandling />
         </QueryController>
@@ -75,7 +79,7 @@ describe('given the graphql queries for "user"', () => {
   });
   describe('when no query fails', () => {
     it('should not dispatch any notification error', async () => {
-      const { getByText, getByTestId } = renderWithRedux(
+      const { getByText, getByTestId } = renderAppWithRedux(
         <QueryController name="user" queryResult={{ data: { ok: true } }}>
           <WithApolloErrorHandling />
         </QueryController>

--- a/packages/application-shell/src/components/inject-reducers/inject-reducers.spec.js
+++ b/packages/application-shell/src/components/inject-reducers/inject-reducers.spec.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { renderWithRedux, waitForElement, fireEvent } from '../../test-utils';
+import {
+  renderAppWithRedux,
+  waitForElement,
+  fireEvent,
+} from '../../test-utils';
 import InjectReducers from './inject-reducers';
 
 const Counter = props => (
@@ -37,7 +41,7 @@ const reducers = { counter: counterReducer };
 
 describe('injecting reducers', () => {
   it('should inject reducers and render count from connected store', async () => {
-    const { getByText, getByTestId } = renderWithRedux(
+    const { getByText, getByTestId } = renderAppWithRedux(
       <InjectReducers id="test" reducers={reducers}>
         <ConnectedCounter />
       </InjectReducers>

--- a/packages/application-shell/src/components/login-locked/login-locked.spec.js
+++ b/packages/application-shell/src/components/login-locked/login-locked.spec.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, waitForElement } from '../../test-utils';
+import { renderApp, waitForElement } from '../../test-utils';
 import LockedAccount from './async';
 
 it('renders maintenance page for locked account', async () => {
-  const { getByText, queryByText } = render(<LockedAccount />);
+  const { getByText, queryByText } = renderApp(<LockedAccount />);
   await waitForElement(() => getByText(/Account Locked/i));
   expect(queryByText(/reset your password/i)).toBeDefined();
   expect(queryByText(/Help Desk/i)).toBeDefined();

--- a/packages/application-shell/src/components/login/login.spec.js
+++ b/packages/application-shell/src/components/login/login.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 // import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import {
-  renderWithRedux,
+  renderAppWithRedux,
   wait,
   waitForElement,
   fireEvent,
@@ -26,7 +26,7 @@ describe('reset password flow', () => {
   });
   it('should open a dialog and redirect to the AC', async () => {
     const props = createTestProps();
-    const { getByText } = renderWithRedux(<Login {...props} />, {
+    const { getByText } = renderAppWithRedux(<Login {...props} />, {
       environment: { adminCenterUrl: 'http://ac.com' },
     });
 

--- a/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route } from 'react-router';
-import { render, waitForElement } from '../../test-utils';
+import { renderApp, waitForElement } from '../../test-utils';
 import ProjectSuspended from './project-suspended';
 
 describe('rendering', () => {
   it('when suspension is temporary it should print correct message', async () => {
-    const { getByText } = render(
+    const { getByText } = renderApp(
       <Route
         path="/:projectKey"
         render={() => <ProjectSuspended isTemporary={true} />}

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { renderWithRedux, fireEvent, waitForElement } from '../../test-utils';
+import {
+  renderAppWithRedux,
+  fireEvent,
+  waitForElement,
+} from '../../test-utils';
 import QuickAccessQuery from './quick-access.graphql';
 import * as gtm from '../../utils/gtm';
 import QuickAccess from './index';
@@ -134,7 +138,7 @@ describe('QuickAccess', () => {
   });
 
   it('should open when pressing "f" on document body', async () => {
-    const { getByTestId } = renderWithRedux(
+    const { getByTestId } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       { sdkMocks: [createPimAvailabilityCheckSdkMock()] }
     );
@@ -151,7 +155,7 @@ describe('QuickAccess', () => {
   });
 
   it('should open when pressing "f" on an element with tabIndex="-1" (like a modal)', async () => {
-    const { getByTestId } = renderWithRedux(
+    const { getByTestId } = renderAppWithRedux(
       <div>
         <QuickAccess {...createTestProps()} />
         <div tabIndex="-1" data-testid="modal">
@@ -173,7 +177,7 @@ describe('QuickAccess', () => {
   });
 
   it('should not close when the search input is clicked', async () => {
-    const { getByTestId } = renderWithRedux(
+    const { getByTestId } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       { sdkMocks: [createPimAvailabilityCheckSdkMock()] }
     );
@@ -189,7 +193,7 @@ describe('QuickAccess', () => {
   });
 
   it('should not open when pressing "f" not directly on other focusable elements', async () => {
-    const { queryByTestId } = renderWithRedux(
+    const { queryByTestId } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       { sdkMocks: [createPimAvailabilityCheckSdkMock()] }
     );
@@ -200,7 +204,7 @@ describe('QuickAccess', () => {
   });
 
   it('should track when QuickAccess is opened', async () => {
-    const { getByTestId } = renderWithRedux(
+    const { getByTestId } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       { sdkMocks: [createPimAvailabilityCheckSdkMock()] }
     );
@@ -218,7 +222,7 @@ describe('QuickAccess', () => {
   });
 
   it('should close when pressing Escape', async () => {
-    const { getByTestId, queryByTestId } = renderWithRedux(
+    const { getByTestId, queryByTestId } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       { sdkMocks: [createPimAvailabilityCheckSdkMock()] }
     );
@@ -238,7 +242,7 @@ describe('QuickAccess', () => {
 
   it('should show results when searching for Dashboard', async () => {
     const mocks = [createMatchlessSearchMock('Open dshbrd')];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       {
         mocks,
@@ -284,7 +288,7 @@ describe('QuickAccess', () => {
           },
         },
       ];
-      const { getByTestId, getByText, queryByText } = renderWithRedux(
+      const { getByTestId, getByText, queryByText } = renderAppWithRedux(
         <QuickAccess {...createTestProps()} />,
         // Note that this test setup isn't perfect as the sdk request
         // currently succeeds while the Apollo request fails
@@ -339,7 +343,7 @@ describe('QuickAccess', () => {
           error: new Error('aw shucks'),
         },
       ];
-      const { getByTestId, getByText, queryByText } = renderWithRedux(
+      const { getByTestId, getByText, queryByText } = renderAppWithRedux(
         <QuickAccess {...createTestProps()} />,
         // Note that this test setup isn't perfect as the sdk request
         // currently succeeds while the Apollo request fails
@@ -377,7 +381,7 @@ describe('QuickAccess', () => {
   it('should open (route to) dashboard when chosing the "Open Dashboard" command', async () => {
     const mocks = [createMatchlessSearchMock('Open dshbrd')];
     const props = createTestProps();
-    const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+    const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...props} />,
       {
         mocks,
@@ -410,7 +414,7 @@ describe('QuickAccess', () => {
     const props = createTestProps({
       environment: { useFullRedirectsForLinks: true },
     });
-    const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+    const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...props} />,
       {
         mocks,
@@ -449,7 +453,7 @@ describe('QuickAccess', () => {
     it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+enter', async () => {
       const mocks = [createMatchlessSearchMock('Open dshbrd')];
       const props = createTestProps();
-      const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+      const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -483,7 +487,7 @@ describe('QuickAccess', () => {
     it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+click', async () => {
       const mocks = [createMatchlessSearchMock('Open dshbrd')];
       const props = createTestProps();
-      const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+      const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -526,7 +530,7 @@ describe('QuickAccess', () => {
     it('should open dashboard in new tab when chosing the "Open Dashboard" command by ctrl+enter', async () => {
       const mocks = [createMatchlessSearchMock('Open dshbrd')];
       const props = createTestProps();
-      const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+      const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -560,7 +564,7 @@ describe('QuickAccess', () => {
     it('should open dashboard in new tab when chosing the "Open Dashboard" command by ctrl+click', async () => {
       const mocks = [createMatchlessSearchMock('Open dshbrd')];
       const props = createTestProps();
-      const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+      const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -596,7 +600,7 @@ describe('QuickAccess', () => {
   it('should open dashboard in new tab when chosing the "Open Dashboard" command by click', async () => {
     const mocks = [createMatchlessSearchMock('Open dshbrd')];
     const props = createTestProps();
-    const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+    const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...props} />,
       {
         mocks,
@@ -631,7 +635,7 @@ describe('QuickAccess', () => {
       createMatchlessSearchMock('Open prdcts'),
     ];
     const props = createTestProps();
-    const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+    const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...props} />,
       {
         mocks,
@@ -765,7 +769,7 @@ describe('QuickAccess', () => {
         },
       },
     ];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       {
         mocks,
@@ -828,7 +832,7 @@ describe('QuickAccess', () => {
         },
       },
     ];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       {
         mocks,
@@ -891,7 +895,7 @@ describe('QuickAccess', () => {
         },
       },
     ];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       {
         mocks,
@@ -955,7 +959,7 @@ describe('QuickAccess', () => {
         },
       },
     ];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps({ projectDataLocale: 'de' })} />,
       {
         mocks,
@@ -984,7 +988,7 @@ describe('QuickAccess', () => {
   it('should find sub commands', async () => {
     const searchTerm = 'Open producttypesettings';
     const mocks = [createMatchlessSearchMock(searchTerm)];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       {
         mocks,
@@ -1009,7 +1013,7 @@ describe('QuickAccess', () => {
   it('should be possible to navigate to sub commands and back out', async () => {
     const searchTerm = 'Open dshbrd';
     const mocks = [createMatchlessSearchMock(searchTerm)];
-    const { getByTestId, getByText } = renderWithRedux(
+    const { getByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...createTestProps()} />,
       {
         mocks,
@@ -1065,7 +1069,7 @@ describe('QuickAccess', () => {
     const searchTerm = 'Open dshbrd';
     const mocks = [createMatchlessSearchMock(searchTerm)];
     const props = createTestProps();
-    const { getByTestId, queryByTestId, getByText } = renderWithRedux(
+    const { getByTestId, queryByTestId, getByText } = renderAppWithRedux(
       <QuickAccess {...props} />,
       {
         mocks,
@@ -1107,7 +1111,7 @@ describe('QuickAccess', () => {
     const searchTerm = 'Open Dashboard';
     const mocks = [createMatchlessSearchMock(searchTerm)];
     const props = createTestProps({ project: undefined });
-    const { getByTestId, queryByText, getByText } = renderWithRedux(
+    const { getByTestId, queryByText, getByText } = renderAppWithRedux(
       <QuickAccess {...props} />,
       { mocks }
     );
@@ -1138,7 +1142,7 @@ describe('QuickAccess', () => {
         canViewProducts: true,
       };
 
-      const { getByTestId, queryByText, getByText } = renderWithRedux(
+      const { getByTestId, queryByText, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -1173,7 +1177,7 @@ describe('QuickAccess', () => {
         canViewProducts: true,
       };
 
-      const { getByTestId, getByText } = renderWithRedux(
+      const { getByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -1226,7 +1230,7 @@ describe('QuickAccess', () => {
               },
             },
           });
-          const { getByTestId, queryByText, getByText } = renderWithRedux(
+          const { getByTestId, queryByText, getByText } = renderAppWithRedux(
             <QuickAccess {...props} />,
             {
               mocks,
@@ -1270,7 +1274,7 @@ describe('QuickAccess', () => {
             },
           },
         });
-        const { getByTestId, queryByText, getByText } = renderWithRedux(
+        const { getByTestId, queryByText, getByText } = renderAppWithRedux(
           <QuickAccess {...props} />
         );
 
@@ -1299,7 +1303,7 @@ describe('QuickAccess', () => {
         queryByText,
         getByText,
         queryByTestId,
-      } = renderWithRedux(<QuickAccess {...props} />, {
+      } = renderAppWithRedux(<QuickAccess {...props} />, {
         mocks,
         sdkMocks: [
           createPimAvailabilityCheckSdkMock(),
@@ -1325,7 +1329,7 @@ describe('QuickAccess', () => {
       const props = createTestProps();
       const searchTerm = 'Opn PIM Srch';
       const mocks = [createMatchlessSearchMock(searchTerm)];
-      const { getByTestId, getByText } = renderWithRedux(
+      const { getByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...props} />,
         {
           mocks,
@@ -1388,7 +1392,7 @@ describe('QuickAccess', () => {
           },
         },
       ];
-      const { getByTestId, getByText } = renderWithRedux(
+      const { getByTestId, getByText } = renderAppWithRedux(
         <QuickAccess {...createTestProps()} />,
         {
           mocks,

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import upperFirst from 'lodash/upperFirst';
-import { render, waitForElement } from '../../test-utils';
+import { renderApp, waitForElement } from '../../test-utils';
 import FetchApplicationsMenu from './fetch-applications-menu.graphql';
 import withApplicationsMenu from './with-applications-menu';
 
@@ -59,7 +59,7 @@ describe('fetching the menu query', () => {
   const Connected = withApplicationsMenu({ queryName: 'menuQuery' })(Test);
   describe('when the query succeeds', () => {
     it('should render menu key', async () => {
-      const { getByText } = render(<Connected />, {
+      const { getByText } = renderApp(<Connected />, {
         mocks: [
           {
             request: {
@@ -81,7 +81,7 @@ describe('fetching the menu query', () => {
     });
     it('should pass error as prop', async () => {
       const error = new Error('Oops');
-      const { getByText } = render(<Connected />, {
+      const { getByText } = renderApp(<Connected />, {
         mocks: [
           {
             request: {

--- a/packages/application-shell/src/test-utils/README.md
+++ b/packages/application-shell/src/test-utils/README.md
@@ -18,9 +18,8 @@ The `ApplicationShell` provides the following context:
 - [test-utils](#test-utils-1)
   - [Basics](#basics)
   - [API](#api)
-    - [render(ui: ReactElement, options: Object)](#renderui-reactelement-options-object)
-    - [renderWithRedux(ui: ReactElement, options: Object)](#renderwithreduxui-reactelement-options-object)
-    - [rtlRender(ui: ReactElement, options: Object)](#rtlrenderui-reactelement-options-object)
+    - [renderApp(ui: ReactElement, options: Object)](#renderappui-reactelement-options-object)
+    - [renderAppWithRedux(ui: ReactElement, options: Object)](#renderappwithreduxui-reactelement-options-object)
   - [Examples](#examples)
     - [`locale` (`react-intl`)](#locale-react-intl)
     - [`dataLocale` (Localisation)](#datalocale-localisation)
@@ -35,7 +34,9 @@ The `ApplicationShell` provides the following context:
 
 [`react-testing-library`](https://github.com/kentcdodds/react-testing-library) allows you to interact with the component using the DOM. It is a great testing library due to its philosophy of testing from a user-perspective, instead of testing the implementation. The assertions are written against the produced DOM, and the component-under-test is interacted with using DOM events.
 
-The `render` method exposed by `react-testing-library` is used to render your component and returns a bunch of getters to query the DOM produced by the component-under-test. `ApplicationShell`s `test-utils` export an enhanced `render` method which adds more context to the component-under-test, so that it can be rendered as-if it was rendered by `ApplicationShell` itself.
+The `render` method exposed by `react-testing-library` is used to render your component and returns a bunch of getters to query the DOM produced by the component-under-test. `ApplicationShell`s `test-utils` export an enhanced `renderApp` method which adds more context to the component-under-test, so that it can be rendered as-if it was rendered by `ApplicationShell` itself.
+
+> All exports of `react-testing-library` are re-exported from `test-utils`.
 
 ## `test-utils`
 
@@ -59,11 +60,11 @@ This component uses [`ApplicationContext`](https://github.com/commercetools/merc
 A test which verifies the authenticated user's first name being rendered by this component can look like this:
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 
 describe('FirstName', () => {
   it('should render the authenticated users first name', () => {
-    const { container, user } = render(<FirstName />);
+    const { container, user } = renderApp(<FirstName />);
     expect(container).toHaveTextContent('Sheldon');
   });
 });
@@ -74,11 +75,11 @@ This test renders the `FirstName` component and then verifies that the name _"Sh
 We can make the test more robust by explicitly declaring the authenticated users first name. This ensures the test keeps working even when the defaults change, and makes it easier to follow.
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 
 describe('FirstName', () => {
   it('should render the authenticated users first name', () => {
-    const { container, user } = render(<FirstName />, {
+    const { container, user } = renderApp(<FirstName />, {
       user: {
         firstName: 'Leonard',
       },
@@ -93,11 +94,11 @@ Here we overwrite the authenticated user's `firstName` for our test. The data we
 We can also test the case in which no user is authenticated by passing `{ user: null }`:
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 
 describe('FirstName', () => {
   it('should render the authenticated users first name', () => {
-    const { container, user } = render(<FirstName />, { user: null });
+    const { container, user } = renderApp(<FirstName />, { user: null });
     expect(container).toHaveTextContent('Anonymous');
   });
 });
@@ -109,9 +110,9 @@ When passing `null` for `user` the default `user` will not be added to the conte
 
 This section describes the methods exported by `@commercetools-frontend/application-shell/test-utils`.
 
-`test-utils` is builds on top of `react-testing-library`, so all [`react-testing-library`](https://github.com/kentcdodds/react-testing-library) exports are available. It should not be necessary for you to import `react-testing-library` into your tests. The following section describes the additional exports added on top of `react-testing-library` and the overwritten `render` of `react-testing-library` itself.
+`test-utils` is builds on top of `react-testing-library`, so all [`react-testing-library`](https://github.com/kentcdodds/react-testing-library) exports are available. The following section describes the additional exports added on top of `react-testing-library`.
 
-#### `render(ui: ReactElement, options: Object)`
+#### `renderApp(ui: ReactElement, options: Object)`
 
 | Argument              | Type          | Concern                                                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                        |
 | --------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -132,23 +133,23 @@ This section describes the methods exported by `@commercetools-frontend/applicat
 
 **Additional return values**
 
-Calling `render` returns an object which contains all keys `react-testing-library`'s `render` method contains, but also contains these additional entries:
+Calling `renderApp` returns an object which contains all keys `react-testing-library`'s original `render` method contains, but also contains these additional entries:
 
 | Entry         | Type     | Description                                                                                                                                                                                                                                                                                                       |
 | ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `history`     | `Object` | The history created by `render` which is passed to the rotuer. It can be used to simulate location changes and so on.                                                                                                                                                                                             |
+| `history`     | `Object` | The history created by `renderApp` which is passed to the rotuer. It can be used to simulate location changes and so on.                                                                                                                                                                                          |
 | `user`        | `Object` | The `user` object used to configure `ApplicationContextProvider`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`).                                  |
 | `project`     | `Object` | The `project` object used to configure `ApplicationContextProvider`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`).                         |
 | `environment` | `Object` | The `environment` object used to configure `ApplicationContextProvider`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`). |
 
-#### `renderWithRedux(ui: ReactElement, options: Object)`
+#### `renderAppWithRedux(ui: ReactElement, options: Object)`
 
 > This function might change in the future. Use with caution.
 
-This render function simply wraps the `render` with some components related to Redux.
+This render function simply wraps the `renderApp` with some components related to Redux.
 It's recommended to use this render function if some of your component-under-test uses Redux `connect`.
 
-The function accepts all options from `render` plus the following:
+The function accepts all options from `renderApp` plus the following:
 
 | Argument                             | Type       | Concern | Description                                                                                                                                                                                                                                                    |
 | ------------------------------------ | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -157,15 +158,11 @@ The function accepts all options from `render` plus the following:
 | `options.sdkMocks`                   | `Array`    | Redux   | Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/master/packages/sdk/src/test-utils/README.md). |
 | `options.mapNotificationToComponent` | `Function` | Redux   | Pass a function to map a notification to a custom component.                                                                                                                                                                                                   |
 
-#### `rtlRender(ui: ReactElement, options: Object)`
-
-This is the renamed original bare-bones `render` method of `react-testing-library`. `rtl` is short for `react-testing-library`. See the the original [`render` documentation](https://github.com/kentcdodds/react-testing-library#render).
-
 ### Examples
 
 #### `locale` (`react-intl`)
 
-The component-under- rendered with `render` will get rendered in `react-intl`s `IntlProvider`. During tests, the core-messages will be used. It's still possible to use a different locale though.
+The component-under-test will get rendered in `react-intl`s `IntlProvider`. During tests, the core-messages will be used. It's still possible to use a different locale though.
 
 ```jsx
 const Flag = props => {
@@ -179,16 +176,16 @@ export default injectIntl(Flag);
 ```
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 import Flag from './flag';
 
 describe('Flag', () => {
   it('should render the british flag when the locale is english', () => {
-    const { container } = render(<Flag />);
+    const { container } = renderApp(<Flag />);
     expect(container).toHaveTextContent('🇬🇧');
   });
   it('should render the german flag when the locale is german', () => {
-    const { container } = render(<Flag />, { locale: 'de' });
+    const { container } = renderApp(<Flag />, { locale: 'de' });
     expect(container).toHaveTextContent('🇩🇪');
   });
 });
@@ -207,7 +204,7 @@ export const ProductName = props => (
 ```
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 import { ProductName } from './product-name';
 
 describe('ProductName', () => {
@@ -215,13 +212,13 @@ describe('ProductName', () => {
     name: { en: 'Party Parrot', de: 'Party Papagei' },
   };
   it('should render the product name in the given data locale', async () => {
-    const { container } = render(<ProductName product={partyParrot} />, {
+    const { container } = renderApp(<ProductName product={partyParrot} />, {
       dataLocale: 'en',
     });
     expect(container).toHaveTextContent('Party Parrot');
   });
   it('should render the product name in the given data locale', async () => {
-    const { container } = render(<ProductName product={partyParrot} />, {
+    const { container } = renderApp(<ProductName product={partyParrot} />, {
       dataLocale: 'de',
     });
     expect(container).toHaveTextContent('Party Papagei');
@@ -253,7 +250,7 @@ export const BankAccountBalance = props => (
 ```
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 import {
   BankAccountBalance,
   BankAccountBalanceQuery,
@@ -261,7 +258,7 @@ import {
 
 describe('BankAccountBalance', () => {
   it('should render the balance', async () => {
-    const { container } = render(<BankAccountBalance token="foo-bar" />, {
+    const { container } = renderApp(<BankAccountBalance token="foo-bar" />, {
       mocks: [
         {
           request: {
@@ -338,12 +335,12 @@ export default ConnectedBankAccount;
 ```
 
 ```jsx
-import { renderWithRedux } from '@commercetools-frontend/application-shell/test-utils';
+import { renderAppWithRedux } from '@commercetools-frontend/application-shell/test-utils';
 import BankAccountBalance from './bank-account-balance';
 
 describe('BankAccountBalance', () => {
   it('should render the balance', async () => {
-    const { container } = renderWithRedux(
+    const { container } = renderAppWithRedux(
       <BankAccountBalance token="foo-bar" />,
       {
         sdkMocks: [
@@ -389,14 +386,14 @@ export default injectFeatureToggle('experimentalAgeOnProfileFlag', 'showAge')(
 ```
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 import Profile from './profile';
 
 describe('Profile', () => {
   const baseProps = { name: 'Penny', age: 32 };
 
   it('should show no age when feature is toggled off', () => {
-    const { container } = render(<Profile {...baseProps} />, {
+    const { container } = renderApp(<Profile {...baseProps} />, {
       flags: { experimentalAgeOnProfileFlag: false },
     });
     expect(container).toHaveTextContent('Penny');
@@ -404,7 +401,7 @@ describe('Profile', () => {
   });
 
   it('should show age when feature toggle is on', () => {
-    const { container } = render(<Profile {...baseProps} />, {
+    const { container } = renderApp(<Profile {...baseProps} />, {
       flags: { experimentalAgeOnProfileFlag: true },
     });
     expect(container).toHaveTextContent('Penny (32)');
@@ -433,18 +430,18 @@ const DeleteProductButton = () => (
 ```
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 import DeleteProductButton from './delete-product-button';
 
 describe('DeleteProductButton', () => {
   it('should be disabled when the user does not have permission to manage products', () => {
-    const { getByText } = render(<DeleteProductButton />, {
+    const { getByText } = renderApp(<DeleteProductButton />, {
       permissions: { canManageProducts: false },
     });
     expect(getByText('Delete Product')).toBeDisabled();
   });
   it('should be enabled when the user has permission to manage products', () => {
-    const { getByText } = render(<DeleteProductButton />, {
+    const { getByText } = renderApp(<DeleteProductButton />, {
       permissions: { canManageProducts: true },
     });
     expect(getByText('Delete Product')).not.toBeDisabled();
@@ -468,24 +465,24 @@ export const ProductTabs = () => (
 ```
 
 ```jsx
-import { render } from '@commercetools-frontend/application-shell/test-utils';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
 import ProductTabs from './product-tabs';
 
 describe('router', () => {
   it('should redirect to "general" when no tab is given', () => {
-    const { container } = render(<ProductTabs />, {
+    const { container } = renderApp(<ProductTabs />, {
       route: '/products/party-parrot',
     });
     expect(container).toHaveTextContent('General');
   });
   it('should render "general" when on general tab', () => {
-    const { container } = render(<ProductTabs />, {
+    const { container } = renderApp(<ProductTabs />, {
       route: '/products/party-parrot/general',
     });
     expect(container).toHaveTextContent('General');
   });
   it('should render "pricing" when on pricing tab', () => {
-    const { container } = render(<ProductTabs />, {
+    const { container } = renderApp(<ProductTabs />, {
       route: '/products/party-parrot/pricing',
     });
     expect(container).toHaveTextContent('Pricing');

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Router } from 'react-router-dom';
 import invariant from 'tiny-invariant';
 import { ApolloProvider } from 'react-apollo';
-import { render as rtlRender } from 'react-testing-library';
+import * as rtl from 'react-testing-library';
 import { createMemoryHistory } from 'history';
 import { IntlProvider } from 'react-intl';
 import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
@@ -98,7 +98,7 @@ const defaultGtmTracking = {
 
 // Inspired by
 // https://github.com/kentcdodds/react-testing-library-course/blob/2a5b1560656790bb1d9c055fba3845780b2c2c97/src/__tests__/react-router-03.js
-const render = (
+const renderApp = (
   ui,
   {
     // react-intl
@@ -132,7 +132,7 @@ const render = (
   const mergedEnvironment = mergeOptional(defaultEnvironment, environment);
   const mergedGtmTracking = mergeOptional(defaultGtmTracking, gtmTracking);
   return {
-    ...rtlRender(
+    ...rtl.render(
       <IntlProvider locale={locale}>
         <ApolloProviderComponent mocks={mocks} addTypename={addTypename}>
           <ConfigureFlopFlip adapter={adpater} defaultFlags={flags}>
@@ -179,7 +179,7 @@ const render = (
 // Test setup for rendering with Redux
 // We expose a sophisticated function because we plan to get rid of Redux
 // Use this function only when your test actually needs Redux
-const renderWithRedux = (
+const renderAppWithRedux = (
   ui,
   {
     // The store option is kept around to keep the API open as not all use-cases
@@ -188,10 +188,10 @@ const renderWithRedux = (
     store = undefined,
     // Pass an initial state to Redux store.
     storeState = undefined,
-    // renderWithRedux supports mocking requests made through the sdk
+    // renderAppWithRedux supports mocking requests made through the sdk
     // middleware. The approach is inspired by ApolloMockProvider.
     // You can pass responses for specific actions like
-    //   renderWithRedux(ui, {
+    //   renderAppWithRedux(ui, {
     //     sdkMocks: [
     //       {
     //         action: { type: 'SDK', payload: {}},
@@ -200,7 +200,7 @@ const renderWithRedux = (
     //     ]
     //   })
     // You can also fake a failing request using
-    //   renderWithRedux(ui, {
+    //   renderAppWithRedux(ui, {
     //     sdkMocks: [
     //       {
     //         action: { type: 'SDK', payload: {}},
@@ -246,7 +246,7 @@ const renderWithRedux = (
   })();
 
   return {
-    ...render(
+    ...renderApp(
       <NotificationProviderForCustomComponent
         mapNotificationToComponent={mapNotificationToComponent}
       >
@@ -269,7 +269,7 @@ const renderWithRedux = (
 };
 
 // Renders UI without mocking ApolloProvider
-const experimentalRender = (ui, renderOptions) => {
+const experimentalRenderAppWithRedux = (ui, renderOptions) => {
   const client = createApolloClient();
   const RealApolloProvider = ({ children }) => (
     <ApolloProvider client={client}>{children}</ApolloProvider>
@@ -279,7 +279,7 @@ const experimentalRender = (ui, renderOptions) => {
     children: PropTypes.node.isRequired,
   };
 
-  return renderWithRedux(ui, {
+  return renderAppWithRedux(ui, {
     ...renderOptions,
     ApolloProviderComponent: RealApolloProvider,
   });
@@ -288,11 +288,4 @@ const experimentalRender = (ui, renderOptions) => {
 // re-export everything
 export * from 'react-testing-library';
 
-export {
-  // override render method of react-testing-library
-  render,
-  renderWithRedux,
-  experimentalRender,
-  // the original "render" method of react-testing-library
-  rtlRender,
-};
+export { renderApp, renderAppWithRedux, experimentalRenderAppWithRedux };

--- a/packages/application-shell/src/test-utils/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils/test-utils.spec.js
@@ -12,16 +12,16 @@ import { injectFeatureToggle } from '@flopflip/react-broadcast';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { Switch, Route } from 'react-router';
-import { render, wait } from './test-utils';
+import { renderApp, wait } from './test-utils';
 
 describe('Intl', () => {
   const TestComponent = injectIntl(props => props.intl.locale);
   it('should have intl', () => {
-    const { container } = render(<TestComponent />);
+    const { container } = renderApp(<TestComponent />);
     expect(container).toHaveTextContent('en');
   });
   it('should be possible to overwrite', () => {
-    const { container } = render(<TestComponent />, {
+    const { container } = renderApp(<TestComponent />, {
       locale: 'de',
     });
     expect(container).toHaveTextContent('de');
@@ -45,7 +45,7 @@ describe('ApolloMockProvider', () => {
     </Query>
   );
   it('should be possible to fake GraphQL requests', async () => {
-    const { container } = render(<TestComponent />, {
+    const { container } = renderApp(<TestComponent />, {
       mocks: [
         {
           request: {
@@ -69,11 +69,11 @@ describe('FlopFlip', () => {
     props => (props.isFooBarEnabled ? 'enabled' : 'disabled')
   );
   it('should not have feature toggles by default', () => {
-    const { container } = render(<TestComponent />);
+    const { container } = renderApp(<TestComponent />);
     expect(container).toHaveTextContent('disabled');
   });
   it('should be possible to provide feature toggles', () => {
-    const { container } = render(<TestComponent />, {
+    const { container } = renderApp(<TestComponent />, {
       flags: { [FEATURE_NAME]: true },
     });
     expect(container).toHaveTextContent('enabled');
@@ -89,7 +89,7 @@ describe('ApplicationContext', () => {
     );
 
     it('should render with defaults', () => {
-      const { container, user } = render(<TestComponent />);
+      const { container, user } = renderApp(<TestComponent />);
       expect(container).toHaveTextContent('Sheldon Cooper');
       // the user should be returned from "render"
       expect(user).toEqual({
@@ -103,7 +103,7 @@ describe('ApplicationContext', () => {
     });
 
     it('should respect user overwrites', () => {
-      const { container, user } = render(<TestComponent />, {
+      const { container, user } = renderApp(<TestComponent />, {
         user: { firstName: 'Leonard' },
       });
       // shows that data gets merged and overwrites have priority
@@ -128,7 +128,7 @@ describe('ApplicationContext', () => {
     );
 
     it('should render with defaults', () => {
-      const { container, project } = render(<TestComponent />);
+      const { container, project } = renderApp(<TestComponent />);
       expect(container).toHaveTextContent(
         'test-with-big-data Test with big data'
       );
@@ -147,7 +147,7 @@ describe('ApplicationContext', () => {
     });
 
     it('should respect project overwrites', () => {
-      const { container, project } = render(<TestComponent />, {
+      const { container, project } = renderApp(<TestComponent />, {
         project: { name: 'Geek' },
       });
       // shows that data gets merged and overwrites have priority
@@ -174,11 +174,11 @@ describe('ApplicationContext', () => {
       </RestrictedByPermissions>
     );
     it('should have all permissions by default', () => {
-      const { container } = render(<TestComponent />);
+      const { container } = renderApp(<TestComponent />);
       expect(container).toHaveTextContent('Authorized');
     });
     it('should allow overwriting permissions', () => {
-      const { container } = render(<TestComponent />, {
+      const { container } = renderApp(<TestComponent />, {
         permissions: { canManageProducts: false },
       });
       expect(container).toHaveTextContent('Not allowed');
@@ -190,7 +190,7 @@ describe('ApplicationContext', () => {
       <ApplicationContext render={({ dataLocale }) => dataLocale} />
     );
     it('should add the locale to the project', () => {
-      const { container } = render(<TestComponent />, { dataLocale: 'de' });
+      const { container } = renderApp(<TestComponent />, { dataLocale: 'de' });
       expect(container).toHaveTextContent('de');
     });
   });
@@ -205,7 +205,7 @@ describe('ApplicationContext', () => {
     );
 
     it('should render with defaults', () => {
-      const { container, environment } = render(<TestComponent />);
+      const { container, environment } = renderApp(<TestComponent />);
       // shows that data gets merged and overwrites have priority
       expect(container).toHaveTextContent('eu production');
       // the project should be returned from "render"
@@ -220,7 +220,7 @@ describe('ApplicationContext', () => {
     });
 
     it('should respect user overwrites', () => {
-      const { container, environment } = render(<TestComponent />, {
+      const { container, environment } = renderApp(<TestComponent />, {
         environment: { location: 'us' },
       });
       // shows that data gets merged and overwrites have priority
@@ -247,17 +247,17 @@ describe('router', () => {
     </Switch>
   );
   it('should render fallback when no route is provided', () => {
-    const { container } = render(<TestComponent />);
+    const { container } = renderApp(<TestComponent />);
     expect(container).not.toHaveTextContent('Foo');
     expect(container).toHaveTextContent('None');
   });
   it('should render the route when a route is provided', () => {
-    const { container } = render(<TestComponent />, { route: '/foo' });
+    const { container } = renderApp(<TestComponent />, { route: '/foo' });
     expect(container).toHaveTextContent('Foo');
     expect(container).not.toHaveTextContent('None');
   });
   it('should return a history object', () => {
-    const { history } = render(<TestComponent />, { route: '/foo' });
+    const { history } = renderApp(<TestComponent />, { route: '/foo' });
     expect(history.location.pathname).toBe('/foo');
   });
 });

--- a/playground/src/components/state-machines-list/state-machines-list.spec.js
+++ b/playground/src/components/state-machines-list/state-machines-list.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  renderWithRedux,
+  renderAppWithRedux,
   waitForElement,
 } from '@commercetools-frontend/application-shell/test-utils';
 import { ApplicationStateMachines } from '../entry-point';
@@ -33,7 +33,7 @@ describe('list view', () => {
   console.warn = jest.fn();
   it('the user can see a list of state machines', async () => {
     const initialRoute = '/my-project/state-machines';
-    const { getByText } = renderWithRedux(<ApplicationStateMachines />, {
+    const { getByText } = renderAppWithRedux(<ApplicationStateMachines />, {
       route: initialRoute,
       sdkMocks: [createStateMachinesSdkMock()],
     });


### PR DESCRIPTION
Using the latest babel version, we get this error when testing the apps that consume the `test-utils` bundle.

<img width="663" alt="image" src="https://user-images.githubusercontent.com/1110551/54997527-30abd100-4fcc-11e9-94af-7fd0070672a8.png">

The problem seems to be the way we export our custom `render` function, which clashes with the re-exported `render` function of RTL.

Solution: we should export our custom render function under different names.

| Before | After |
| --- | --- |
| `render` | `renderApp` |
| `renderWithRedux` | `renderAppWithRedux` |
| `experimentalRender` | `experimentalRenderAppWithRedux` |

More info:
- https://github.com/kentcdodds/react-testing-library/issues/169
- https://github.com/kentcdodds/react-testing-library/pull/179