### PR TITLE
feat(app-shell): Add prop do defer adapter config on flop flip provider setup

### DIFF
--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.js
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.js
@@ -26,6 +26,7 @@ export class SetupFlopFlipProvider extends React.PureComponent {
     defaultFlags: PropTypes.object,
     appEnv: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
+    shouldDeferAdapterConfiguration: PropTypes.bool,
   };
 
   createLaunchdarklyAdapterArgs = defaultMemoize(
@@ -68,7 +69,11 @@ export class SetupFlopFlipProvider extends React.PureComponent {
           this.props.user && this.props.user.launchdarklyTrackingTenant
         )}
         defaultFlags={this.props.defaultFlags}
-        shouldDeferAdapterConfiguration={!this.props.user}
+        shouldDeferAdapterConfiguration={
+          typeof this.props.shouldDeferAdapterConfiguration === 'boolean'
+            ? this.props.shouldDeferAdapterConfiguration
+            : !this.props.user
+        }
       >
         {this.props.children}
       </ConfigureFlopFlip>

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.spec.js
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.spec.js
@@ -111,24 +111,52 @@ describe('rendering', () => {
       })
     );
   });
-  describe('when user is not defined', () => {
-    beforeEach(() => {
-      props = createTestProps({ user: null });
-      wrapper = shallow(<SetupFlopFlipProvider {...props} />);
+  describe('when shouldDeferAdapterConfiguration is defined', () => {
+    describe('when its true', () => {
+      beforeEach(() => {
+        props = createTestProps({ shouldDeferAdapterConfiguration: true });
+        wrapper = shallow(<SetupFlopFlipProvider {...props} />);
+      });
+      it('should set "shouldDeferAdapterConfiguration" to true', () => {
+        expect(wrapper.find(ConfigureFlopFlip)).toHaveProp(
+          'shouldDeferAdapterConfiguration',
+          true
+        );
+      });
     });
-    it('should set "shouldDeferAdapterConfiguration" to true', () => {
-      expect(wrapper.find(ConfigureFlopFlip)).toHaveProp(
-        'shouldDeferAdapterConfiguration',
-        true
-      );
+    describe('when its false', () => {
+      beforeEach(() => {
+        props = createTestProps({ shouldDeferAdapterConfiguration: false });
+        wrapper = shallow(<SetupFlopFlipProvider {...props} />);
+      });
+      it('should set "shouldDeferAdapterConfiguration" to false', () => {
+        expect(wrapper.find(ConfigureFlopFlip)).toHaveProp(
+          'shouldDeferAdapterConfiguration',
+          false
+        );
+      });
     });
   });
-  describe('when user is defined', () => {
-    it('should set "shouldDeferAdapterConfiguration" to false', () => {
-      expect(wrapper.find(ConfigureFlopFlip)).toHaveProp(
-        'shouldDeferAdapterConfiguration',
-        false
-      );
+  describe('when shouldDeferAdapterConfiguration is not defined', () => {
+    describe('when user is not defined', () => {
+      beforeEach(() => {
+        props = createTestProps({ user: null });
+        wrapper = shallow(<SetupFlopFlipProvider {...props} />);
+      });
+      it('should set "shouldDeferAdapterConfiguration" to true', () => {
+        expect(wrapper.find(ConfigureFlopFlip)).toHaveProp(
+          'shouldDeferAdapterConfiguration',
+          true
+        );
+      });
+    });
+    describe('when user is defined', () => {
+      it('should set "shouldDeferAdapterConfiguration" to false', () => {
+        expect(wrapper.find(ConfigureFlopFlip)).toHaveProp(
+          'shouldDeferAdapterConfiguration',
+          false
+        );
+      });
     });
   });
   describe('when env is production', () => {

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.spec.js
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.spec.js
@@ -112,7 +112,7 @@ describe('rendering', () => {
     );
   });
   describe('when shouldDeferAdapterConfiguration is defined', () => {
-    describe('when its true', () => {
+    describe('when is true', () => {
       beforeEach(() => {
         props = createTestProps({ shouldDeferAdapterConfiguration: true });
         wrapper = shallow(<SetupFlopFlipProvider {...props} />);
@@ -124,7 +124,7 @@ describe('rendering', () => {
         );
       });
     });
-    describe('when its false', () => {
+    describe('when is false', () => {
       beforeEach(() => {
         props = createTestProps({ shouldDeferAdapterConfiguration: false });
         wrapper = shallow(<SetupFlopFlipProvider {...props} />);


### PR DESCRIPTION
#### Summary

This PR adds a new prop to the  `SetupFlopFlipProvider` to manually set the `shouldDeferAdapterConfiguration` flag of `ConfigureFlopFlip`. 

When `shouldDeferAdapterConfiguration` is defined, it is used.
When it's not defined, it defaults to the same as before: by negating the existence of the user prop.