### PR TITLE
fix(app-shell): css height for app container

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.mod.css
+++ b/packages/application-shell/src/components/application-shell/application-shell.mod.css
@@ -3,6 +3,10 @@
   --menuWidth: 200px;
 }
 
+:global(#app) {
+  height: 100%;
+}
+
 .app-layout {
   height: 100vh;
   display: grid;


### PR DESCRIPTION
Fixes #505 

**Before**

<img width="869" alt="image" src="https://user-images.githubusercontent.com/1110551/55383654-048ed380-5529-11e9-85ce-b44220194bbc.png">


**After**

<img width="871" alt="image" src="https://user-images.githubusercontent.com/1110551/55383646-022c7980-5529-11e9-88c0-ccdcd01f5038.png">
