### PR TITLE
fix(app-shell): to unset previously set cached value

### DIFF
--- a/packages/application-shell/src/components/authenticated/authenticated.js
+++ b/packages/application-shell/src/components/authenticated/authenticated.js
@@ -32,6 +32,12 @@ const Authenticated = props => {
         // is not shared anymore.
         storage.put(STORAGE_KEYS.IS_AUTHENTICATED, true);
       }}
+      onError={() => {
+        // The query fails without the `mcAccessToken`. In this case the caching
+        // needs to be unset as otherwise the application will end up in a infinte
+        // redirect loop.
+        storage.remove(STORAGE_KEYS.IS_AUTHENTICATED);
+      }}
     >
       {({ loading, data, error }) => {
         if (error) {

--- a/packages/application-shell/src/components/authenticated/authenticated.spec.js
+++ b/packages/application-shell/src/components/authenticated/authenticated.spec.js
@@ -14,6 +14,9 @@ const createTestProps = custom => ({
 });
 
 describe('rendering', () => {
+  beforeEach(() => {
+    storage.put.mockClear();
+  });
   let props;
   describe('when authenticated state was cached in local storage', () => {
     beforeEach(() => {
@@ -90,7 +93,17 @@ describe('rendering', () => {
       it('should not put `isAuthenticated` into local storage', async () => {
         await wait(
           () => {
-            expect(storage.put).not.toHaveBeenCalledWith();
+            expect(storage.put).not.toHaveBeenCalled();
+          },
+          { timeout: 1000 }
+        );
+      });
+      it('should unset any previous `isAuthenticated` in local storage', async () => {
+        await wait(
+          () => {
+            expect(storage.remove).toHaveBeenCalledWith(
+              STORAGE_KEYS.IS_AUTHENTICATED
+            );
           },
           { timeout: 1000 }
         );


### PR DESCRIPTION
#### Summary

This pull request fixes and edge case with the following repo case:

1. Log in
2. Remove the `mcAccessToken` cookie
3. Reload the page

Then you will end up in an infite redirect loop as the app assumes the user is still logged in (local storage cache) while the query `amILoggedIn` in the background fails due to the missing cookie.