### PR TITLE
fix(app-shell): redirect to logout when catching unauthorized error

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -62,7 +62,7 @@ export const RestrictedApplication = props => (
           if (hasUnauthorizedError) {
             return (
               <Redirector
-                to="login"
+                to="logout"
                 environment={props.environment}
                 queryParams={{
                   reason: LOGOUT_REASONS.UNAUTHORIZED,


### PR DESCRIPTION
#### Summary

This pull request is also around the infinite redirect loop which is not 100% tamped according to my debugging.

#### Description

Whenever the user is deemed unauthorized (can occur by any request) with cached autorization state in local storge, then this error will be caught. Given the user does not have the `mcAccessToken` cookie _but_ the cached local storage state then the error will be caught here. However, when by redirecting to login the local storage state will never be unset leading to a another redirect loop.

I am not sure why we decided to go to /login here. Given we go to logout it will unset everything and redirect to login anyway after.
