### PR TITLE
refactor(i18n): to load the i18n messages async

### DIFF
--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -17,7 +17,7 @@
     "@commercetools-frontend/i18n": "13.1.0",
     "@commercetools-frontend/mc-http-server": "13.0.0",
     "@commercetools-frontend/permissions": "13.1.0",
-    "@commercetools-frontend/ui-kit": "9.1.2",
+    "@commercetools-frontend/ui-kit": "9.2.0",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-apollo": "2.5.4",

--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -44,7 +44,7 @@
     "warning": "4.0.3"
   },
   "devDependencies": {
-    "@commercetools-frontend/ui-kit": "9.1.2",
+    "@commercetools-frontend/ui-kit": "9.2.0",
     "@storybook/addon-actions": "5.0.6",
     "@storybook/addon-info": "5.0.6",
     "@storybook/addon-knobs": "5.0.6",

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -94,7 +94,7 @@
     "warning": "4.0.3"
   },
   "devDependencies": {
-    "@commercetools-frontend/ui-kit": "9.1.2",
+    "@commercetools-frontend/ui-kit": "9.2.0",
     "react": "16.8.6",
     "react-apollo": "2.5.4",
     "react-dom": "16.8.6",

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.js
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.js
@@ -1,3 +1,4 @@
+import './global-style-imports';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Router } from 'react-router-dom';
@@ -7,7 +8,6 @@ import history from '@commercetools-frontend/browser-history';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
-import { i18n as uikitMessages } from '@commercetools-frontend/ui-kit';
 import internalReduxStore from '../../configure-store';
 import apolloClient from '../../configure-apollo';
 import ConfigureIntlProvider from '../configure-intl-provider';
@@ -15,8 +15,7 @@ import Authenticated from '../authenticated';
 import GtmBooter from '../gtm-booter';
 import ApplicationLoader from '../application-loader';
 import ErrorApologizer from '../error-apologizer';
-import './global-style-imports';
-import { getBrowserLocale, mergeMessages } from './utils';
+import { getBrowserLocale } from './utils';
 
 export default class ApplicationShellProvider extends React.Component {
   static displayName = 'ApplicationShellProvider';
@@ -74,12 +73,7 @@ export default class ApplicationShellProvider extends React.Component {
                           {({ locale, messages }) => (
                             <ConfigureIntlProvider
                               locale={locale}
-                              messages={mergeMessages(
-                                messages,
-                                AsyncLocaleData.getMessagesForLocale(
-                                  uikitMessages
-                                )
-                              )}
+                              messages={messages}
                             >
                               {this.props.children({ isAuthenticated })}
                             </ConfigureIntlProvider>

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
@@ -6,7 +6,7 @@ import { ApplicationContext } from '@commercetools-frontend/application-shell-co
 import { GtmContext } from '../gtm-booter';
 // eslint-disable-next-line import/named
 import { setIsAuthenticated } from '../authenticated';
-import { getBrowserLocale, mergeMessages } from './utils';
+import { getBrowserLocale } from './utils';
 import ApplicationShellProvider from './application-shell-provider';
 
 jest.mock('@commercetools-frontend/sentry');
@@ -114,9 +114,6 @@ describe('rendering', () => {
   it('when not authenticated, it should setup intl provider', async () => {
     setIsAuthenticated('false');
     getBrowserLocale.mockReturnValue('de');
-    mergeMessages.mockImplementation((...messages) =>
-      Object.assign({}, ...messages)
-    );
     const { getByText } = render(
       <ApplicationShellProvider {...createTestProps()}>
         {({ isAuthenticated }) =>

--- a/packages/application-shell/src/components/application-shell-provider/utils.js
+++ b/packages/application-shell/src/components/application-shell-provider/utils.js
@@ -1,8 +1,7 @@
 import { getSupportedLocale } from '@commercetools-frontend/l10n';
 
+// eslint-disable-next-line import/prefer-default-export
 export const getBrowserLocale = window => {
   const browserLocale = window && window.navigator && window.navigator.language;
   return getSupportedLocale(browserLocale);
 };
-
-export const mergeMessages = (...messages) => Object.assign({}, ...messages);

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -14,15 +14,11 @@ import {
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
-import { i18n } from '@commercetools-frontend/ui-kit';
 import internalReduxStore from '../../configure-store';
 import ProjectDataLocale from '../project-data-locale';
 import PortalsContainer from '../portals-container';
 import ApplicationShellProvider from '../application-shell-provider';
-import {
-  getBrowserLocale,
-  mergeMessages,
-} from '../application-shell-provider/utils';
+import { getBrowserLocale } from '../application-shell-provider/utils';
 import FetchUser from '../fetch-user';
 import FetchProject from '../fetch-project';
 import ConfigureIntlProvider from '../configure-intl-provider';
@@ -82,13 +78,7 @@ export const RestrictedApplication = props => (
             {({ locale, messages }) => {
               reportErrorToSentry(error, {});
               return (
-                <ConfigureIntlProvider
-                  locale={locale}
-                  messages={mergeMessages(
-                    messages,
-                    AsyncLocaleData.getMessagesForLocale(i18n, locale)
-                  )}
-                >
+                <ConfigureIntlProvider locale={locale} messages={messages}>
                   <ErrorApologizer />
                 </ConfigureIntlProvider>
               );
@@ -116,15 +106,7 @@ export const RestrictedApplication = props => (
               <ConfigureIntlProvider
                 // We do not want to pass the language as long as the locale data
                 // is not loaded.
-                {...(isLoadingLocaleData
-                  ? {}
-                  : {
-                      locale,
-                      messages: mergeMessages(
-                        messages,
-                        AsyncLocaleData.getMessagesForLocale(i18n, locale)
-                      ),
-                    })}
+                {...(isLoadingLocaleData ? {} : { locale, messages })}
               >
                 <SetupFlopFlipProvider
                   user={user}

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -10,10 +10,7 @@ import ProjectContainer from '../project-container';
 import FetchUser from '../fetch-user';
 import FetchProject from '../fetch-project';
 import NavBar, { LoadingNavBar } from '../navbar';
-import {
-  getBrowserLocale,
-  mergeMessages,
-} from '../application-shell-provider/utils';
+import { getBrowserLocale } from '../application-shell-provider/utils';
 import ApplicationShell, { RestrictedApplication } from './application-shell';
 
 jest.mock('@commercetools-frontend/storage');
@@ -497,21 +494,6 @@ describe('getBrowserLocale', () => {
     });
     it('should return the default locale, `en`', () => {
       expect(getBrowserLocale(testWindow)).toBe('en');
-    });
-  });
-});
-
-describe('mergeMessages', () => {
-  it('should merge multiple arguments', () => {
-    expect(mergeMessages({ a: 1 }, { b: 2 }, { c: 3 })).toEqual({
-      a: 1,
-      b: 2,
-      c: 3,
-    });
-  });
-  it('should merge even if arguments are not defined', () => {
-    expect(mergeMessages(null, undefined, { c: 3 })).toEqual({
-      c: 3,
     });
   });
 });

--- a/packages/i18n/async-locale-data/async-locale-data.js
+++ b/packages/i18n/async-locale-data/async-locale-data.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { extractLanguageTagFromLocale } from '../utils';
+import { extractLanguageTagFromLocale, mergeMessages } from '../utils';
 import loadI18n from '../load-i18n';
-
-const mergeMessages = (...messages) => Object.assign({}, ...messages);
 
 const getMessagesForLocale = (data, locale) => {
   if (!data || !locale) return {};
@@ -27,7 +25,6 @@ class AsyncLocaleData extends React.Component {
       PropTypes.object,
     ]),
   };
-  static getMessagesForLocale = getMessagesForLocale;
 
   state = {
     isLoading: true,

--- a/packages/i18n/utils.js
+++ b/packages/i18n/utils.js
@@ -1,6 +1,8 @@
 export const extractLanguageTagFromLocale = locale =>
   locale.includes('-') ? locale.split('-')[0] : locale;
 
+export const mergeMessages = (...messages) => Object.assign({}, ...messages);
+
 export const mapLocaleToMomentLocale = locale => {
   if (locale.startsWith('de')) return 'de';
   if (locale.startsWith('es')) return 'es';

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -47,7 +47,7 @@
     "reselect": "^4.0.0"
   },
   "devDependencies": {
-    "@commercetools-frontend/ui-kit": "9.1.2",
+    "@commercetools-frontend/ui-kit": "9.2.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-intl": "2.8.0",

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
     "@commercetools-frontend/mc-http-server": "13.0.0",
     "@commercetools-frontend/permissions": "13.1.0",
     "@commercetools-frontend/sdk": "13.2.0",
-    "@commercetools-frontend/ui-kit": "9.1.2",
+    "@commercetools-frontend/ui-kit": "9.2.0",
     "lodash": "4.17.11",
     "lodash-es": "4.17.11",
     "moment": "^2.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,10 +1026,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@commercetools-frontend/ui-kit@9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@commercetools-frontend/ui-kit/-/ui-kit-9.1.2.tgz#b42f27e8a5f31802a8f5e57110e9bf48af1b031c"
-  integrity sha512-G3gtSY35bbpPpZGOIc1/gTpYKsLKnMmQkbcEF+V5SUkiyubOxdyFBqOh4kUmYHnhdnovwLxiZKXmi7heHv8IfQ==
+"@commercetools-frontend/ui-kit@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-frontend/ui-kit/-/ui-kit-9.2.0.tgz#ca1bf999890d01a710ac92017270344bfd1aa446"
+  integrity sha512-ERpD4sFikgu53yg/rlApzucuBANbhck2p6xp6PJ17H+8G2DEu7f4rCpupnapVvwFGSbxJwLQwVICxiO/IV/WcA==
   dependencies:
     "@emotion/core" "10.0.10"
     "@emotion/styled" "10.0.10"


### PR DESCRIPTION
Following the [suggestions from ui-kit](https://github.com/commercetools/ui-kit/pull/643), we can actually treat the ui-kit translations as we do for the other localization files.