### PR TITLE
fix(react-notifications): to use errorByExtension field

### DIFF
--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.js
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.js
@@ -8,7 +8,7 @@ import messages from './messages';
 const regexInvalidOperationRequiredAttribute = /Required attribute '(.*)' cannot be removed/;
 
 export const ApiErrorMessage = props => {
-  if (props.error.localizedMessage) {
+  if (props.error.errorByExtension) {
     const localizedMessage = props.error.localizedMessage[props.intl.locale];
 
     return localizedMessage || props.error.message;


### PR DESCRIPTION
#### Summary

This pull request changes the detection when rendering the `localizedMessage` coming from an request having gone through an API Extension.

Note that the response of an API Extension contains:

```json
"errorByExtension": {
   "id": "<extension-id>",
   "key": "my-extension"
}
```

The `localizedMessage` does not have to be present but can be set by the user of the API Extension.

More can be found here: https://docs.commercetools.com/http-api-projects-api-extensions.html#error-cases