### PR TITLE
feat(app-shell): add allowing to pass ldTrackingTenant alone

### DIFF
--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.js
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.js
@@ -16,13 +16,18 @@ export class SetupFlopFlipProvider extends React.PureComponent {
   static displayName = 'SetupFlopFlipProvider';
   static propTypes = {
     projectKey: PropTypes.string,
-    user: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      launchdarklyTrackingId: PropTypes.string.isRequired,
-      launchdarklyTrackingGroup: PropTypes.string.isRequired,
-      launchdarklyTrackingTeam: PropTypes.array.isRequired,
-      launchdarklyTrackingTenant: PropTypes.string.isRequired,
-    }),
+    user: PropTypes.oneOfType([
+      PropTypes.shape({
+        launchdarklyTrackingTenant: PropTypes.string.isRequired,
+      }),
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        launchdarklyTrackingId: PropTypes.string.isRequired,
+        launchdarklyTrackingGroup: PropTypes.string.isRequired,
+        launchdarklyTrackingTeam: PropTypes.array.isRequired,
+        launchdarklyTrackingTenant: PropTypes.string.isRequired,
+      }),
+    ]),
     defaultFlags: PropTypes.object,
     appEnv: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,


### PR DESCRIPTION
#### Summary

This pull request adds the ability to add the `launchdarklyTrackingTenant` alone without the other user information.

Today we learned that sign up will not be available on all environments at the same time. Given this needs to be toggled, we need to be able to at least specify the `launchdarklyTrackingTenant`. When running the sign up application we don't have any other user information (as there is no user). 
Before we assumed that we can "get way" with toggling for all environments we deploy to equally.