### PR TITLE
feat(configure-apollo): add special mapping for Store entity

### DIFF
--- a/packages/application-shell/src/configure-apollo.js
+++ b/packages/application-shell/src/configure-apollo.js
@@ -64,7 +64,12 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData,
 });
 
-const typeNamesWithoutIdAsIdentifier = ['Project', 'BaseMenu', 'NavbarMenu'];
+const typeNamesWithoutIdAsIdentifier = [
+  'Project',
+  'BaseMenu',
+  'NavbarMenu',
+  'Store',
+];
 
 export const createApolloClient = () =>
   new ApolloClient({


### PR DESCRIPTION
#### Summary

Now that we are starting to play with Stores in orders, we need a filter for stores in the orders list.

Because we want to use our `ReferenceFilter` this means that we will use GraphQL for reading values from the cache when it is needed.

The "problem" is that the main attribute for identifying a store is the `key` rather than the `id` as clarified by @yanns (👏 ) and similar to the  `project` entity from Core API. So we need a special mapping for it in the apollo cache 🚀 