### PR TITLE
fix(app-shell): add env variable for enabling sign up

### DIFF
--- a/packages/application-shell/src/components/application-shell/__snapshots__/application-shell.spec.js.snap
+++ b/packages/application-shell/src/components/application-shell/__snapshots__/application-shell.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<RestrictedApplication> rendering project container <Route> should match layout structure 1`] = `
 <Fragment>
-  <InjectIntl(withApplicationContext(ProjectContainer))
+  <InjectIntl(ProjectContainer)
     environment={
       Object {
         "cdnUrl": "http://localhost:3001",

--- a/packages/application-shell/src/components/application-shell/__snapshots__/application-shell.spec.js.snap
+++ b/packages/application-shell/src/components/application-shell/__snapshots__/application-shell.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<RestrictedApplication> rendering project container <Route> should match layout structure 1`] = `
 <Fragment>
-  <InjectIntl(injectFeatureToggle(ProjectContainer))
+  <InjectIntl(withApplicationContext(ProjectContainer))
     environment={
       Object {
         "cdnUrl": "http://localhost:3001",

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -6,11 +6,13 @@ import { injectIntl } from 'react-intl';
 import isNil from 'lodash/isNil';
 import flowRight from 'lodash/flowRight';
 import { Spacings, Text } from '@commercetools-frontend/ui-kit';
-import { injectFeatureToggle } from '@flopflip/react-broadcast';
+import {
+  withApplicationContext,
+  ApplicationContextProvider,
+} from '@commercetools-frontend/application-shell-connectors';
 import { DOMAINS } from '@commercetools-frontend/constants';
 import * as storage from '@commercetools-frontend/storage';
 import { Notifier } from '@commercetools-frontend/react-notifications';
-import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { STORAGE_KEYS, SUSPENSION_REASONS } from '../../constants';
 import ApplicationLoader from '../application-loader';
@@ -78,7 +80,7 @@ export class ProjectContainer extends React.Component {
     intl: PropTypes.shape({
       formatMessage: PropTypes.func.isRequired,
     }).isRequired,
-    isAccountCreationEnabled: PropTypes.bool.isRequired,
+    isSignUpEnabled: PropTypes.bool.isRequired,
   };
   state = {
     hasError: false,
@@ -158,11 +160,11 @@ export class ProjectContainer extends React.Component {
      */
     if (
       hasNoProjects &&
-      !this.props.isAccountCreationEnabled &&
+      !this.props.isSignUpEnabled &&
       this.props.environment.servedByProxy
     )
       return <Redirect to="/logout?reason=no-projects" />;
-    if (hasNoProjects && this.props.isAccountCreationEnabled)
+    if (hasNoProjects && this.props.isSignUpEnabled)
       return (
         <Switch>
           <Route path="/account" render={this.props.render} />
@@ -250,5 +252,7 @@ export class ProjectContainer extends React.Component {
 
 export default flowRight(
   injectIntl,
-  injectFeatureToggle('createAccount', 'isAccountCreationEnabled')
+  withApplicationContext(({ environment }) => ({
+    isSignUpEnabled: Boolean(environment.enableSignUp),
+  }))
 )(ProjectContainer);

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -6,10 +6,7 @@ import { injectIntl } from 'react-intl';
 import isNil from 'lodash/isNil';
 import flowRight from 'lodash/flowRight';
 import { Spacings, Text } from '@commercetools-frontend/ui-kit';
-import {
-  withApplicationContext,
-  ApplicationContextProvider,
-} from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { DOMAINS } from '@commercetools-frontend/constants';
 import * as storage from '@commercetools-frontend/storage';
 import { Notifier } from '@commercetools-frontend/react-notifications';
@@ -80,7 +77,6 @@ export class ProjectContainer extends React.Component {
     intl: PropTypes.shape({
       formatMessage: PropTypes.func.isRequired,
     }).isRequired,
-    isSignUpEnabled: PropTypes.bool.isRequired,
   };
   state = {
     hasError: false,
@@ -160,11 +156,11 @@ export class ProjectContainer extends React.Component {
      */
     if (
       hasNoProjects &&
-      !this.props.isSignUpEnabled &&
+      this.props.environment.enableSignUp !== true &&
       this.props.environment.servedByProxy
     )
       return <Redirect to="/logout?reason=no-projects" />;
-    if (hasNoProjects && this.props.isSignUpEnabled)
+    if (hasNoProjects && this.props.environment.enableSignUp)
       return (
         <Switch>
           <Route path="/account" render={this.props.render} />
@@ -250,9 +246,4 @@ export class ProjectContainer extends React.Component {
   }
 }
 
-export default flowRight(
-  injectIntl,
-  withApplicationContext(({ environment }) => ({
-    isSignUpEnabled: Boolean(environment.enableSignUp),
-  }))
-)(ProjectContainer);
+export default flowRight(injectIntl)(ProjectContainer);

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -59,7 +59,7 @@ const createTestProps = custom => ({
     servedByProxy: false,
   },
   render: jest.fn(),
-  isAccountCreationEnabled: true,
+  isSignUpEnabled: true,
   ...custom,
 });
 

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -57,9 +57,9 @@ const createTestProps = custom => ({
     env: 'development',
     cdnUrl: 'http://localhost:3001',
     servedByProxy: false,
+    enableSignUp: true,
   },
   render: jest.fn(),
-  isSignUpEnabled: true,
   ...custom,
 });
 


### PR DESCRIPTION
#### Summary

With new environments being rolled out and sign up being disabled on them for ever I would like to move away from a feature toggle to have an environment variable to enable it. This will also reduce confusing in the `appEnv` and `hubspot` variable as this variable will then take precedence. 

Moreover, having a feature flag doesn't work consistently as it is sometimes not yet fetched when the redirect occurs. 