### PR TITLE
fix(app-shell): back to project link colour

### DIFF
--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Spacings, Text, AngleLeftIcon } from '@commercetools-frontend/ui-kit';
+import { FormattedMessage } from 'react-intl';
+import {
+  Spacings,
+  AngleLeftIcon,
+  LinkButton,
+} from '@commercetools-frontend/ui-kit';
 import LogoSVG from '@commercetools-frontend/assets/images/logo.svg';
 import { selectProjectKeyFromLocalStorage } from '../../utils';
 import UserSettingsMenu from '../user-settings-menu';
@@ -12,14 +17,18 @@ import messages from './messages';
 import styles from './app-bar.mod.css';
 
 export const BackToProjectLink = props => (
-  <Link to={`/${props.projectKey}`}>
-    <Spacings.Inline alignItems="center" data-test="back-to-project">
-      <AngleLeftIcon theme="green" size="small" />
-      <Text.Detail intlMessage={messages.backToProjectLink} />
-    </Spacings.Inline>
-  </Link>
+  <LinkButton
+    to={`/${props.projectKey}`}
+    iconLeft={<AngleLeftIcon />}
+    label={
+      <FormattedMessage {...messages.backToProjectLink}>
+        {txt => txt}
+      </FormattedMessage>
+    }
+  />
 );
 BackToProjectLink.displayName = 'BackToProjectLink';
+
 BackToProjectLink.propTypes = {
   projectKey: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
#### Summary

This refactors the back to project link to be a normal LinkButton. Design requested it to be a FlatButton but actually intends the colour to not be black like now

<img width="228" alt="CleanShot 2019-04-23 at 17 57 28@2x" src="https://user-images.githubusercontent.com/1877073/56596879-a4ec8b00-65f1-11e9-81c2-3b94ebf0bd4f.png">

but primary liks this

<img width="215" alt="CleanShot 2019-04-23 at 17 58 48@2x" src="https://user-images.githubusercontent.com/1877073/56596895-ac139900-65f1-11e9-8a6b-e69f9945c109.png">