### PR TITLE
fix(app-shell): routing to project without key

### DIFF
--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -32,8 +32,21 @@ BackToProjectLink.displayName = 'BackToProjectLink';
 BackToProjectLink.propTypes = {
   projectKey: PropTypes.string.isRequired,
 };
+
+const getPreviousProjectKey = defaultProjectKeyOfUser => {
+  const previouslyUsedProjectKeyFromLocalStorage = selectProjectKeyFromLocalStorage();
+
+  if (previouslyUsedProjectKeyFromLocalStorage)
+    return previouslyUsedProjectKeyFromLocalStorage;
+  if (defaultProjectKeyOfUser) return defaultProjectKeyOfUser;
+
+  return '';
+};
 const AppBar = props => {
-  const previouslyUsedProjectKey = selectProjectKeyFromLocalStorage();
+  const previousProjectKey = getPreviousProjectKey(
+    props.user && props.user.defaultProjectKey
+  );
+
   return (
     <div className={styles['app-bar']} data-test="top-navigation">
       <Spacings.Inline>
@@ -41,10 +54,7 @@ const AppBar = props => {
           {!props.user ? (
             <img src={LogoSVG} className={styles['logo-img']} alt="Logo" />
           ) : (
-            <Link
-              to={`/${previouslyUsedProjectKey ||
-                props.user.defaultProjectKey}`}
-            >
+            <Link to={`/${previousProjectKey}`}>
               <img src={LogoSVG} className={styles['logo-img']} alt="Logo" />
             </Link>
           )}
@@ -78,7 +88,7 @@ const AppBar = props => {
                       // to a project.
                       projectKey={
                         props.projectKeyFromUrl ||
-                        previouslyUsedProjectKey ||
+                        previousProjectKey ||
                         props.user.defaultProjectKey
                       }
                       total={props.user.projects.total}
@@ -89,7 +99,7 @@ const AppBar = props => {
                 return (
                   <BackToProjectLink
                     projectKey={
-                      previouslyUsedProjectKey || props.user.defaultProjectKey
+                      previousProjectKey || props.user.defaultProjectKey
                     }
                   />
                 );

--- a/packages/application-shell/src/components/app-bar/app-bar.spec.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.spec.js
@@ -203,6 +203,28 @@ describe('rendering', () => {
             });
           });
         });
+        describe('when user has not projects', () => {
+          describe('<ProjectSwitcher>', () => {
+            beforeEach(() => {
+              props = createTestProps({
+                user: {
+                  ...props.user,
+                  defaultProjectKey: null,
+                  projects: { total: 0 },
+                },
+              });
+              wrapper = shallow(<AppBar {...props} />);
+            });
+            it('should not render <ProjectSwitcher>', () => {
+              expect(wrapper).not.toRender(ProjectSwitcher);
+            });
+
+            it('should not render <Link> without path to previous project', () => {
+              expect(wrapper).toRender(Link);
+              expect(wrapper.find(Link).last()).toHaveProp('to', `/`);
+            });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
#### Summary

This pull request fixes a previously non-existing case (or adds it).

Given a user creates his/her first project the `url` will be `mc.commercetools.co/null` instead of just the domain. This happens cause the user neither has a project key in localstorage, nor in the url nor on the user query. As a result we have to redirect to root and let the next pull page refresh handle it.