### PR TITLE
fix(app-shell): project key being set to null

### DIFF
--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -116,7 +116,8 @@ export class ProjectContainer extends React.Component {
 
     // Ensure to sync the `projectKey` from the URL with localStorage.
     const projectKey = this.props.match.params.projectKey;
-    storage.put(STORAGE_KEYS.ACTIVE_PROJECT_KEY, projectKey);
+
+    if (projectKey) storage.put(STORAGE_KEYS.ACTIVE_PROJECT_KEY, projectKey);
   }
   componentDidCatch(error, errorInfo) {
     this.setState({ hasError: true });

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -485,7 +485,7 @@ describe('lifecycle', () => {
         wrapper = shallow(<ProjectContainer {...props} />);
         wrapper.instance().componentDidUpdate(props);
       });
-      it('should store the project key in localStorage', () => {
+      it('should not store the project key in localStorage', () => {
         expect(storage.put).not.toHaveBeenCalled();
       });
     });

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -462,16 +462,32 @@ describe('lifecycle', () => {
   let wrapper;
   describe('componentDidUpdate', () => {
     beforeEach(() => {
-      props = createTestProps({ match: { params: { projectKey: 'p1' } } });
-      storage.get.mockReturnValueOnce('p1');
-      wrapper = shallow(<ProjectContainer {...props} />);
-      wrapper.instance().componentDidUpdate(props);
+      storage.put.mockClear();
     });
-    it('should store the project key in localStorage', () => {
-      expect(storage.put).toHaveBeenCalledWith(
-        STORAGE_KEYS.ACTIVE_PROJECT_KEY,
-        'p1'
-      );
+    describe('when `projectKey` is in url', () => {
+      beforeEach(() => {
+        props = createTestProps({ match: { params: { projectKey: 'p1' } } });
+        storage.get.mockReturnValueOnce('p1');
+        wrapper = shallow(<ProjectContainer {...props} />);
+        wrapper.instance().componentDidUpdate(props);
+      });
+      it('should store the project key in localStorage', () => {
+        expect(storage.put).toHaveBeenCalledWith(
+          STORAGE_KEYS.ACTIVE_PROJECT_KEY,
+          'p1'
+        );
+      });
+    });
+    describe('when `projectKey` is not in url', () => {
+      beforeEach(() => {
+        props = createTestProps({ match: { params: { projectKey: null } } });
+        storage.get.mockReturnValueOnce('p1');
+        wrapper = shallow(<ProjectContainer {...props} />);
+        wrapper.instance().componentDidUpdate(props);
+      });
+      it('should store the project key in localStorage', () => {
+        expect(storage.put).not.toHaveBeenCalled();
+      });
     });
   });
   describe('when the user navigated to a different route', () => {


### PR DESCRIPTION
#### Summary

Given the user navigates to the account app and does not have a project yet and some prop for the project-container change, then the projectkey (which is not in the url) will be set to `null` (string `null`) in local storage. This is leaky as in it could also be handled on the consumer side but I think should be fixed properly here.

![CleanShot 2019-04-29 at 14 20 50@2x](https://user-images.githubusercontent.com/1877073/56895999-ea460800-6a8a-11e9-9008-8584cab8640d.png)

The result of this is that e.g. the logo will redirect to `mc.commercetools.co/null`.
