### PR TITLE
chore(app-shell): extract logic into util

### DIFF
--- a/packages/application-shell/src/components/app-bar/app-bar.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.js
@@ -8,9 +8,9 @@ import {
   LinkButton,
 } from '@commercetools-frontend/ui-kit';
 import LogoSVG from '@commercetools-frontend/assets/images/logo.svg';
-import { selectProjectKeyFromLocalStorage } from '../../utils';
 import UserSettingsMenu from '../user-settings-menu';
 import ProjectSwitcher from '../project-switcher';
+import { getPreviousProjectKey } from '../../utils';
 import LoadingPlaceholder from '../loading-placeholder';
 import { REQUESTS_IN_FLIGHT_LOADER_DOM_ID } from '../requests-in-flight-loader/constants';
 import messages from './messages';
@@ -20,7 +20,7 @@ export const BackToProjectLink = props => (
   <FormattedMessage {...messages.backToProjectLink}>
     {backToProjectMessage => (
       <LinkButton
-        to={`/${props.projectKey}`}
+        to={`/${props.projectKey || ''}`}
         iconLeft={<AngleLeftIcon />}
         label={backToProjectMessage}
       />
@@ -30,18 +30,9 @@ export const BackToProjectLink = props => (
 BackToProjectLink.displayName = 'BackToProjectLink';
 
 BackToProjectLink.propTypes = {
-  projectKey: PropTypes.string.isRequired,
+  projectKey: PropTypes.string,
 };
 
-const getPreviousProjectKey = defaultProjectKeyOfUser => {
-  const previouslyUsedProjectKeyFromLocalStorage = selectProjectKeyFromLocalStorage();
-
-  if (previouslyUsedProjectKeyFromLocalStorage)
-    return previouslyUsedProjectKeyFromLocalStorage;
-  if (defaultProjectKeyOfUser) return defaultProjectKeyOfUser;
-
-  return '';
-};
 const AppBar = props => {
   const previousProjectKey = getPreviousProjectKey(
     props.user && props.user.defaultProjectKey
@@ -54,7 +45,7 @@ const AppBar = props => {
           {!props.user ? (
             <img src={LogoSVG} className={styles['logo-img']} alt="Logo" />
           ) : (
-            <Link to={`/${previousProjectKey}`}>
+            <Link to={`/${previousProjectKey || ''}`}>
               <img src={LogoSVG} className={styles['logo-img']} alt="Logo" />
             </Link>
           )}
@@ -86,23 +77,13 @@ const AppBar = props => {
                       // the dropdown will still be rendered but no project will be selected.
                       // This is fine becase the user has still the possibility to "switch"
                       // to a project.
-                      projectKey={
-                        props.projectKeyFromUrl ||
-                        previousProjectKey ||
-                        props.user.defaultProjectKey
-                      }
+                      projectKey={props.projectKeyFromUrl || previousProjectKey}
                       total={props.user.projects.total}
                     />
                   );
                 if (!props.user.defaultProjectKey) return '';
 
-                return (
-                  <BackToProjectLink
-                    projectKey={
-                      previousProjectKey || props.user.defaultProjectKey
-                    }
-                  />
-                );
+                return <BackToProjectLink projectKey={previousProjectKey} />;
               })()}
             </Spacings.Inline>
           </div>

--- a/packages/application-shell/src/components/app-bar/app-bar.spec.js
+++ b/packages/application-shell/src/components/app-bar/app-bar.spec.js
@@ -5,8 +5,6 @@ import ProjectSwitcher from '../project-switcher';
 import UserSettingsMenu from '../user-settings-menu';
 import AppBar, { BackToProjectLink } from './app-bar';
 
-jest.mock('../../utils');
-
 const createTestProps = props => ({
   user: {
     projects: {

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -31,10 +31,7 @@ import NavBar, { LoadingNavBar } from '../navbar';
 import ApplicationLoader from '../application-loader';
 import ErrorApologizer from '../error-apologizer';
 import Redirector from '../redirector';
-import {
-  selectProjectKeyFromLocalStorage,
-  selectProjectKeyFromUrl,
-} from '../../utils';
+import { selectProjectKeyFromUrl, getPreviousProjectKey } from '../../utils';
 import styles from './application-shell.mod.css';
 import QuickAccess from '../quick-access';
 
@@ -279,19 +276,21 @@ export const RestrictedApplication = props => (
                               <Route
                                 exact={true}
                                 path="/"
-                                render={() =>
-                                  user ? (
-                                    // This is the only case where we need to look into localStorage
-                                    // to attempt to get the previously known `projectKey`.
-                                    // If none is found, we use the `defaultProjectKey` set by the API.
+                                render={() => {
+                                  const previousProjectKey = getPreviousProjectKey(
+                                    user && user.defaultProjectKey
+                                  );
+
+                                  if (!user) return <ApplicationLoader />;
+
+                                  // NOTE: Given no previous `projectKey` is found,
+                                  // we redirect to the base url.
+                                  return (
                                     <Redirect
-                                      to={`/${selectProjectKeyFromLocalStorage() ||
-                                        user.defaultProjectKey}`}
+                                      to={`/${previousProjectKey || ''}`}
                                     />
-                                  ) : (
-                                    <ApplicationLoader />
-                                  )
-                                }
+                                  );
+                                }}
                               />
                               <Route
                                 exact={false}

--- a/packages/application-shell/src/utils/get-previous-project-key/get-previous-project-key.js
+++ b/packages/application-shell/src/utils/get-previous-project-key/get-previous-project-key.js
@@ -1,0 +1,12 @@
+import selectProjectKeyFromLocalStorage from '../select-project-key-from-local-storage';
+
+const getPreviousProjectKey = defaultProjectKeyOfUser => {
+  const previouslyUsedProjectKeyFromLocalStorage = selectProjectKeyFromLocalStorage();
+  if (previouslyUsedProjectKeyFromLocalStorage)
+    return previouslyUsedProjectKeyFromLocalStorage;
+  if (defaultProjectKeyOfUser) return defaultProjectKeyOfUser;
+
+  return null;
+};
+
+export default getPreviousProjectKey;

--- a/packages/application-shell/src/utils/get-previous-project-key/index.js
+++ b/packages/application-shell/src/utils/get-previous-project-key/index.js
@@ -1,0 +1,1 @@
+export { default } from './get-previous-project-key';

--- a/packages/application-shell/src/utils/index.js
+++ b/packages/application-shell/src/utils/index.js
@@ -6,3 +6,4 @@ export {
 } from './select-project-key-from-url';
 export { default as selectUserId } from './select-user-id';
 export { default as getCorrelationId } from './get-correlation-id';
+export { default as getPreviousProjectKey } from './get-previous-project-key';


### PR DESCRIPTION
#### Summary

This pull request extracts the project key determination logic into a little module. The whole ternary business is a bit spread out across the code base while essentially it's almost always the same.

1. Did the user select one (localStorage)
2. Does the user have a default one (mc-be)
3. Then either rendering something or not, redirect or not