### PR TITLE
refactor(app-shell): to have redirect-to-project-create component

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -286,9 +286,9 @@ export const RestrictedApplication = props => (
                                    * NOTE:
                                    *   Given the user has not been loaded a loading spinner is shown.
                                    *   Given the user was not working on a project previously nor has a default
-                                   *   project she/she will be promted to create one.
-                                   *   Given the user was working in a project previously or has a default
-                                   *   project a redirect to it happens.
+                                   *   project, the user will be prompted to create one.
+                                   *   Given the user was working on a project previously or has a default
+                                   *   project, the application will redirect to that project.
                                    */
 
                                   if (!user) return <ApplicationLoader />;

--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { defaultMemoize } from 'reselect';
-import { Spacings, Text, LinkButton } from '@commercetools-frontend/ui-kit';
 import {
   joinPaths,
   trimLeadingAndTrailingSlashes,
@@ -32,6 +31,7 @@ import NavBar, { LoadingNavBar } from '../navbar';
 import ApplicationLoader from '../application-loader';
 import ErrorApologizer from '../error-apologizer';
 import Redirector from '../redirector';
+import RedirectToProjectCreate from '../redirect-to-project-create';
 import { selectProjectKeyFromUrl, getPreviousProjectKey } from '../../utils';
 import styles from './application-shell.mod.css';
 import QuickAccess from '../quick-access';
@@ -282,42 +282,20 @@ export const RestrictedApplication = props => (
                                     user && user.defaultProjectKey
                                   );
 
+                                  /**
+                                   * NOTE:
+                                   *   Given the user has not been loaded a loading spinner is shown.
+                                   *   Given the user was not working on a project previously nor has a default
+                                   *   project she/she will be promted to create one.
+                                   *   Given the user was working in a project previously or has a default
+                                   *   project a redirect to it happens.
+                                   */
+
                                   if (!user) return <ApplicationLoader />;
-
-                                  if (
-                                    props.environment.servedByProxy !== true &&
-                                    !previousProjectKey
-                                  )
-                                    return (
-                                      <Spacings.Stack scale="m">
-                                        <Text.Headline elementType="h2">
-                                          Development mode without projects
-                                        </Text.Headline>
-                                        <Text.Body>
-                                          You are using the Merchant Center in
-                                          development mode - it is not served by
-                                          a proxy. Moreover, you do not have any
-                                          projects yet. As a result we did not
-                                          redirect you anywhere (e.g. another
-                                          application).
-                                        </Text.Body>
-                                        <Text.Body>
-                                          Please go to the
-                                          `application-accounts` to create a
-                                          project first.
-                                        </Text.Body>
-                                        <LinkButton
-                                          to={`account/projects/new`}
-                                          label="Create project"
-                                        />
-                                      </Spacings.Stack>
-                                    );
-
-                                  // NOTE: Given no previous `projectKey` is found we redirect to the base url.
+                                  if (!previousProjectKey)
+                                    return <RedirectToProjectCreate />;
                                   return (
-                                    <Redirect
-                                      to={`/${previousProjectKey || ''}`}
-                                    />
+                                    <Redirect to={`/${previousProjectKey}`} />
                                   );
                                 }}
                               />

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -5,7 +5,6 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import isNil from 'lodash/isNil';
 import flowRight from 'lodash/flowRight';
-import { Spacings, Text } from '@commercetools-frontend/ui-kit';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { DOMAINS } from '@commercetools-frontend/constants';
 import * as storage from '@commercetools-frontend/storage';
@@ -19,6 +18,7 @@ import FetchProject from '../fetch-project';
 import ProjectNotFound from '../project-not-found';
 import ProjectExpired from '../project-expired';
 import ProjectNotInitialized from '../project-not-initialized';
+import RedirectToProjectCreate from '../redirect-to-project-create';
 import ProjectSuspended from '../project-suspended';
 import ErrorApologizer from '../error-apologizer';
 import messages from './messages';
@@ -30,31 +30,6 @@ const shouldShowNotificationForTrialExpired = daysLeft =>
   !isNil(daysLeft) &&
   daysLeft <= minDaysToDisplayNotification &&
   daysLeft >= maxDaysToDisplayNotification;
-
-export class RedirectToProjectCreate extends React.Component {
-  static displayName = 'RedirectToProjectCreate';
-  componentDidMount() {
-    window.location.replace('/account/projects/new');
-  }
-  render() {
-    return null;
-  }
-}
-const NoProjects = () => {
-  return (
-    <Spacings.Stack>
-      <Text.Headline elementType="h3">
-        {'Please create a project!'}
-      </Text.Headline>
-      <Text.Detail>
-        {
-          'You do not have any projects and the application is not served by the proxy (`env.json`).'
-        }
-      </Text.Detail>
-    </Spacings.Stack>
-  );
-};
-NoProjects.displayName = 'NoProjects';
 
 export class ProjectContainer extends React.Component {
   static displayName = 'ProjectContainer';
@@ -165,12 +140,7 @@ export class ProjectContainer extends React.Component {
       return (
         <Switch>
           <Route path="/account" render={this.props.render} />
-          {this.props.environment.servedByProxy && (
-            <Route component={RedirectToProjectCreate} />
-          )}
-          {!this.props.environment.servedByProxy && (
-            <Route component={NoProjects} />
-          )}
+          <Route component={RedirectToProjectCreate} />
         </Switch>
       );
 

--- a/packages/application-shell/src/components/redirect-to-project-create/index.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/index.js
@@ -1,0 +1,1 @@
+export { default } from './redirect-to-project-create';

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
@@ -3,39 +3,30 @@ import PropTypes from 'prop-types';
 import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { Spacings, Text, LinkButton } from '@commercetools-frontend/ui-kit';
 
-export class RedirectToProjectCreate extends React.Component {
-  static displayName = 'RedirectToProjectCreate';
-  static propTypes = {
-    servedByProxy: PropTypes.bool.isRequired,
-  };
-  constructor(props) {
-    super(props);
+export const RedirectToProjectCreate = props => {
+  if (props.servedByProxy === true)
+    window.location.replace('/account/projects/new');
 
-    if (this.props.servedByProxy === true)
-      window.location.replace('/account/projects/new');
-  }
-  render() {
-    // NOTE: The redirect occurs in the contructor while if not a "development"
-    // message will be shown as the application does not run behind
-    // our proxy.
-    return (
-      <Spacings.Stack>
-        <Text.Headline elementType="h3">Please create a project!</Text.Headline>
-        <Text.Body>
-          You are using the Merchant Center in development mode - it is not
-          served by a proxy (`env.json`). Moreover, you do not have any projects
-          yet. As a result we did not redirect you anywhere (e.g. another
-          application).
-        </Text.Body>
-        <Text.Body>
-          Please go to the `application-accounts` while having it runnign to
-          create a project first.
-        </Text.Body>
-        <LinkButton to={`account/projects/new`} label="Create project" />
-      </Spacings.Stack>
-    );
-  }
-}
+  return (
+    <Spacings.Stack>
+      <Text.Headline elementType="h3">Please create a project!</Text.Headline>
+      <Text.Body>
+        You are using the Merchant Center in development mode - it is not served
+        by a proxy (`env.json`). Moreover, you do not have any projects yet. As
+        a result we did not redirect you anywhere (e.g. another application).
+      </Text.Body>
+      <Text.Body>
+        Please go to the `application-accounts` while having it runnign to
+        create a project first.
+      </Text.Body>
+      <LinkButton to={`account/projects/new`} label="Create project" />
+    </Spacings.Stack>
+  );
+};
+RedirectToProjectCreate.displayName = 'RedirectToProjectCreate';
+RedirectToProjectCreate.propTypes = {
+  servedByProxy: PropTypes.bool.isRequired,
+};
 
 export default withApplicationContext(applicationContext => ({
   servedByProxy: applicationContext.environment.servedByProxy,

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
@@ -16,8 +16,8 @@ export const RedirectToProjectCreate = props => {
         a result we did not redirect you anywhere (e.g. another application).
       </Text.Body>
       <Text.Body>
-        Please go to the `application-accounts` while having it runnign to
-        create a project first.
+        Please go to the `application-accounts` while having it running to
+        create a project first. Note, that you can do the same on staging.
       </Text.Body>
       <LinkButton to={`account/projects/new`} label="Create project" />
     </Spacings.Stack>

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
@@ -4,6 +4,16 @@ import { withApplicationContext } from '@commercetools-frontend/application-shel
 import { Spacings, Text, LinkButton } from '@commercetools-frontend/ui-kit';
 
 export const RedirectToProjectCreate = props => {
+  /**
+   * NOTE:
+   *   This looks a bit unusual: redirecting in render.
+   *   However, when doing it in `cDM` we loose time
+   *   we we actually do never want to render anything or
+   *   interact with anything rendered. Instead we should should
+   *   redirect away. Using a constructor would result in the same.
+   *   In turn this intends wo make explicit that we never want to
+   *   render and instead just navigate away.
+   */
   if (props.servedByProxy === true)
     window.location.replace('/account/projects/new');
 

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import { Spacings, Text, LinkButton } from '@commercetools-frontend/ui-kit';
+
+export class RedirectToProjectCreate extends React.Component {
+  static displayName = 'RedirectToProjectCreate';
+  static propTypes = {
+    servedByProxy: PropTypes.bool.isRequired,
+  };
+  constructor(props) {
+    super(props);
+
+    if (this.props.servedByProxy === true)
+      window.location.replace('/account/projects/new');
+  }
+  render() {
+    // NOTE: The redirect occurs in the contructor while if not a "development"
+    // message will be shown as the application does not run behind
+    // our proxy.
+    return (
+      <Spacings.Stack>
+        <Text.Headline elementType="h3">Please create a project!</Text.Headline>
+        <Text.Body>
+          You are using the Merchant Center in development mode - it is not
+          served by a proxy (`env.json`). Moreover, you do not have any projects
+          yet. As a result we did not redirect you anywhere (e.g. another
+          application).
+        </Text.Body>
+        <Text.Body>
+          Please go to the `application-accounts` while having it runnign to
+          create a project first.
+        </Text.Body>
+        <LinkButton to={`account/projects/new`} label="Create project" />
+      </Spacings.Stack>
+    );
+  }
+}
+
+export default withApplicationContext(applicationContext => ({
+  servedByProxy: applicationContext.environment.servedByProxy,
+}))(RedirectToProjectCreate);

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.spec.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.spec.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { renderApp } from '../../test-utils';
+import RedirectToProjectCreate from './redirect-to-project-create';
+
+describe('given `servedByProxy`', () => {
+  beforeEach(() => {
+    window.location.replace = jest.fn();
+  });
+  it('should redirect to `projects/new`', () => {
+    renderApp(<RedirectToProjectCreate />, {
+      environment: {
+        servedByProxy: true,
+      },
+    });
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      '/account/projects/new'
+    );
+  });
+});
+
+describe('given not `servedByProxy`', () => {
+  beforeEach(() => {
+    window.location.replace = jest.fn();
+  });
+
+  it('should not redirect to `projects/new`', () => {
+    renderApp(<RedirectToProjectCreate />);
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('should shows development mode message', () => {
+    const { getByText } = renderApp(<RedirectToProjectCreate />);
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(getByText('Please create a project!')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#### Summary

This pull request aims to improve how we redirect to project create while fixing a bug with it.

Generally three cases where we need to cover this exist (apart from multiple cache things):

1. User has previously visited a project _and_ a project key is in the url but his new account doesn't have access to it while she/he has no other projects
   - Redirect to project create
   - Given not served by proxy: show dev message
2. User never or has visited a project but no project key is in the url
   - Redirect to project create
   - Given not served by proxy: show dev message

Given that those cases overlap I extracted the logic into a component for reuse and isolated testing.

Moreover, we should contract (did already) UX/PO about how we may want to scope local stroage. Given you sign in and sign up across various accounts do we really want to attempt to restore the project previously visited.