### PR TITLE
chore(app-shell): to not fetch project without key

### DIFF
--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -35,8 +35,12 @@ export const mapAllAppliedToObjectShape = allAppliedShape =>
 class FetchProject extends React.Component {
   static displayName = 'FetchProject';
   static propTypes = {
-    projectKey: PropTypes.string.isRequired,
+    projectKey: PropTypes.string,
+    skip: PropTypes.bool,
     children: PropTypes.func.isRequired,
+  };
+  static defaultProps = {
+    skip: false,
   };
   shouldComponentUpdate(nextProps) {
     return !deepEqual(this.props, nextProps);
@@ -49,6 +53,7 @@ class FetchProject extends React.Component {
           target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
           projectKey: this.props.projectKey,
         }}
+        skip={this.props.skip}
       >
         {({ data, loading, error }) =>
           this.props.children({

--- a/packages/application-shell/src/components/project-container/project-container.js
+++ b/packages/application-shell/src/components/project-container/project-container.js
@@ -43,6 +43,7 @@ export class ProjectContainer extends React.Component {
       pathname: PropTypes.string.isRequired,
     }).isRequired,
     user: PropTypes.shape({
+      defaultProjectKey: PropTypes.string,
       projects: PropTypes.shape({
         total: PropTypes.number.isRequired,
       }).isRequired,
@@ -146,7 +147,10 @@ export class ProjectContainer extends React.Component {
 
     return (
       <React.Suspense fallback={<ApplicationLoader />}>
-        <FetchProject projectKey={this.props.match.params.projectKey}>
+        <FetchProject
+          skip={!this.props.user.defaultProjectKey}
+          projectKey={this.props.match.params.projectKey}
+        >
           {({ isLoading: isProjectLoading, project }) => {
             // TODO: do something if there is an `error`?
             if (isProjectLoading) return <ApplicationLoader />;

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.js
@@ -14,8 +14,11 @@ export const RedirectToProjectCreate = props => {
    *   In turn this intends wo make explicit that we never want to
    *   render and instead just navigate away.
    */
-  if (props.servedByProxy === true)
+  if (props.servedByProxy === true) {
     window.location.replace('/account/projects/new');
+
+    return null;
+  }
 
   return (
     <Spacings.Stack>


### PR DESCRIPTION
#### Summary

This avoids a uncalled-for round trip and makes sign up smoother. Given the user doesn't have a project:

1. Either not in the url (claims she/he has one)
2. Or actually no `defaultProjectKey` from the users query which is `projects[0]`

Then we can omit the request. This makes the redirect smoother and less janky.