### PR TITLE
refactor(application-shell): use ui kit select input for locale switcher

### DIFF
--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.js
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.js
@@ -4,7 +4,7 @@ import { SelectInput, WorldIcon } from '@commercetools-frontend/ui-kit';
 import styles from './locale-switcher.mod.css';
 
 export const SingleValue = props => (
-  <div className={styles.singleValueContainer}>
+  <div className={styles['single-value-container']}>
     <WorldIcon size="big" />
     <span className={styles.label}>{props.children}</span>
     <span className={styles['language-counter']}>{props.localeCount}</span>

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.js
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { SelectInput, WorldIcon } from '@commercetools-frontend/ui-kit';
 import styles from './locale-switcher.mod.css';
 
-const SingleValue = props => (
+export const SingleValue = props => (
   <div className={styles.singleValueContainer}>
     <WorldIcon size="big" />
     <span className={styles.label}>{props.children}</span>

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.js
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.js
@@ -1,8 +1,25 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Select from 'react-select';
-import { WorldIcon } from '@commercetools-frontend/ui-kit';
+import { SelectInput, WorldIcon } from '@commercetools-frontend/ui-kit';
 import styles from './locale-switcher.mod.css';
+
+// have access to SelectInput.defaultComponents :)
+// and access to SelectInput.customizedComponents :)
+
+const SingleValue = props => (
+  <div className={styles.singleValueContainer}>
+    <WorldIcon size="big" />
+    <span className={styles.label}>{props.children}</span>
+    <span className={styles['language-counter']}>{props.localeCount}</span>
+  </div>
+);
+
+SingleValue.propTypes = {
+  children: PropTypes.node.isRequired,
+  localeCount: PropTypes.number.isRequired,
+};
+
+SingleValue.displayName = 'SingleValue';
 
 export default class LocaleSwitcher extends React.PureComponent {
   static displayName = 'LocaleSwitcher';
@@ -13,41 +30,31 @@ export default class LocaleSwitcher extends React.PureComponent {
     availableLocales: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   };
 
-  handleSelection = ({ key: language }) => {
-    this.props.setProjectDataLocale(language);
-  };
-
-  renderLabel = () => (
-    <span>
-      <div className={styles.icon}>
-        <WorldIcon size="big" />
-      </div>
-      <span className={styles.label}>{`${this.props.projectDataLocale}`}</span>
-      <span className={styles['language-counter']}>
-        {this.props.availableLocales.length}
-      </span>
-    </span>
-  );
+  handleSelection = event =>
+    this.props.setProjectDataLocale(event.target.value);
 
   render() {
     return (
       <div className={styles.container} data-track-component="LocaleSwitch">
-        <Select
-          valueRenderer={this.renderLabel}
-          labelKey="name"
-          valueKey="key"
-          className={styles['react-select-container']}
+        <SelectInput
           value={this.props.projectDataLocale}
           name="locale-switcher"
           onChange={this.handleSelection}
-          autoBlur={true}
           options={this.props.availableLocales.map(locale => ({
-            name: locale,
-            key: locale,
+            label: locale,
+            value: locale,
           }))}
-          clearable={false}
-          backspaceRemoves={false}
-          searchable={false}
+          components={{
+            SingleValue: props => (
+              <SingleValue
+                {...props}
+                localeCount={this.props.availableLocales.length}
+              />
+            ),
+          }}
+          isClearable={false}
+          backspaceRemovesValue={false}
+          isSearchable={false}
         />
       </div>
     );

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.js
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.js
@@ -3,9 +3,6 @@ import React from 'react';
 import { SelectInput, WorldIcon } from '@commercetools-frontend/ui-kit';
 import styles from './locale-switcher.mod.css';
 
-// have access to SelectInput.defaultComponents :)
-// and access to SelectInput.customizedComponents :)
-
 const SingleValue = props => (
   <div className={styles.singleValueContainer}>
     <WorldIcon size="big" />

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.mod.css
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.mod.css
@@ -1,28 +1,15 @@
-.text {
-  margin-right: 10px;
-  color: var(--color-accent);
-  position: relative;
-  bottom: 13px;
+.singleValueContainer {
+  flex: 1;
+  align-items: center;
+  display: flex;
 }
 
-.react-select-container {
+.container {
   position: relative;
-}
-
-.react-select-container :global(.Select-control) {
-  background: var(--color-neutral-95);
-  color: var(--color-solid);
-  border-radius: 6px;
-  cursor: pointer;
   width: 160px;
-  right: 0;
 }
 
-.react-select-container :global(.Select-control:hover) {
-  box-shadow: none;
-}
-
-.counter {
+.language-counter {
   width: 22px;
   height: 22px;
   border-radius: 22px;
@@ -32,24 +19,10 @@
   display: inline-block;
   font-size: 0.9rem;
   text-align: center;
-  position: absolute;
-  margin-top: 3px;
-  line-height: 17px;
-}
-
-.language-counter {
-  composes: counter;
-  right: 33px;
-}
-
-.icon {
-  float: left;
-  margin: 3px 5px 0 -5px;
-  font-size: 1.6em;
 }
 
 .label {
-  display: inline-block;
-  margin: 2px 5px 0 0;
+  margin-left: 2px;
+  flex: 1;
   color: var(--color-accent);
 }

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.mod.css
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.mod.css
@@ -1,4 +1,4 @@
-.singleValueContainer {
+.single-value-container {
   flex: 1;
   align-items: center;
   display: flex;
@@ -6,7 +6,7 @@
 
 .container {
   position: relative;
-  width: 160px;
+  width: var(--constraint-s);
 }
 
 .language-counter {

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.spec.js
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.spec.js
@@ -1,7 +1,8 @@
 import { shallow } from 'enzyme';
 import PropTypes from 'prop-types';
+import { SelectInput } from '@commercetools-frontend/ui-kit';
 import React from 'react';
-import LocaleSwitcher from './locale-switcher';
+import LocaleSwitcher, { SingleValue } from './locale-switcher';
 
 const createTestProps = props => ({
   projectDataLocale: 'en',
@@ -21,20 +22,21 @@ describe('render base elements', () => {
   });
 
   it('should render Select component', () => {
-    expect(wrapper).toRender('Select');
+    expect(wrapper).toRender(SelectInput);
   });
 
   describe('dropdown label', () => {
     let wrapperLabel;
     beforeEach(() => {
       const props = createTestProps();
-      wrapper = shallow(<LocaleSwitcher {...props} />);
       wrapperLabel = shallow(
-        <TestLabel>{wrapper.instance().renderLabel()}</TestLabel>
+        <SingleValue localeCount={props.availableLocales.length}>
+          {props.projectDataLocale}
+        </SingleValue>
       );
     });
     it('should render dropdown label', () => {
-      expect(wrapperLabel).toIncludeText('en3');
+      expect(wrapperLabel).toIncludeText('3');
     });
     it('should render WorldIcon', () => {
       expect(wrapperLabel).toRender('WorldIcon');
@@ -47,7 +49,7 @@ describe('callbacks', () => {
   beforeEach(() => {
     props = createTestProps();
     const wrapper = shallow(<LocaleSwitcher {...props} />);
-    wrapper.find('Select').prop('onChange')({ key: 'de' });
+    wrapper.find(SelectInput).prop('onChange')({ target: { value: 'de' } });
   });
 
   it('should call setProjectDataLocale', () => {

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.spec.js
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.spec.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import PropTypes from 'prop-types';
-import { SelectInput } from '@commercetools-frontend/ui-kit';
+import { SelectInput, WorldIcon } from '@commercetools-frontend/ui-kit';
 import React from 'react';
 import LocaleSwitcher, { SingleValue } from './locale-switcher';
 
@@ -39,7 +39,7 @@ describe('render base elements', () => {
       expect(wrapperLabel).toIncludeText('3');
     });
     it('should render WorldIcon', () => {
-      expect(wrapperLabel).toRender('WorldIcon');
+      expect(wrapperLabel).toRender(WorldIcon);
     });
   });
 });


### PR DESCRIPTION
Experiment: Use `ui-kit` for the locale switcher instead of using react-select v1.

Before

![localeswitchbefore](https://user-images.githubusercontent.com/2425013/57372467-07b75800-7196-11e9-99a1-fdac33be29d4.gif)

After

![afterlocaleswicher](https://user-images.githubusercontent.com/2425013/57372475-0be37580-7196-11e9-89e6-b933b9f5bbc9.gif)
