### PR TITLE
fix(application-components): ui-kit peer dep

### DIFF
--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -65,7 +65,7 @@
     "storybook-readme": "5.0.3"
   },
   "peerDependencies": {
-    "@commercetools-frontend/ui-kit": "9.x",
+    "@commercetools-frontend/ui-kit": "> 9.2",
     "react": "16.x",
     "react-dom": "16.x",
     "react-intl": "2.x",

--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -65,7 +65,7 @@
     "storybook-readme": "5.0.3"
   },
   "peerDependencies": {
-    "@commercetools-frontend/ui-kit": "> 9.2",
+    "@commercetools-frontend/ui-kit": "^9.2",
     "react": "16.x",
     "react-dom": "16.x",
     "react-intl": "2.x",


### PR DESCRIPTION
#### Summary

Our peer dependency for `ui-kit` is wrong, because in `application-components`, we use customProperties that were added in version `9.2.0`. [ref](https://github.com/commercetools/merchant-center-application-kit/blob/877818249aa324bbe6af447aed2517fe4183d579/packages/application-components/src/components/dialogs/internals/dialog-container.js#L92)

#### Approach

Updates the peer dep in application components to `^9.2`.

#### Open questions

Do we need to also update it in `application-shell`? Or will application-shell resolve it from `application-components`? 