### PR TITLE
chore: remove react-select v1

### DIFF
--- a/application-templates/starter/src/index.js
+++ b/application-templates/starter/src/index.js
@@ -1,4 +1,3 @@
-import 'react-select/dist/react-select.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import EntryPoint from './components/entry-point';

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -82,7 +82,6 @@
     "perfume.js": "1.1.4",
     "prop-types": "15.7.2",
     "qss": "2.0.3",
-    "react-modal": "3.8.1",
     "react-required-if": "1.0.3",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -84,7 +84,6 @@
     "qss": "2.0.3",
     "react-modal": "3.8.1",
     "react-required-if": "1.0.3",
-    "react-select": "1.2.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
     "reselect": "^4.0.0",

--- a/playground/package.json
+++ b/playground/package.json
@@ -35,7 +35,6 @@
     "react-redux": "7.0.3",
     "react-router": "5.0.0",
     "react-router-dom": "5.0.0",
-    "react-select": "1.2.1",
     "redux": "4.0.1"
   },
   "devDependencies": {

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -1,4 +1,3 @@
-import 'react-select/dist/react-select.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import EntryPoint from './components/entry-point';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6960,7 +6960,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6, classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5, classnames@^2.2.6:
+classnames@2.2.6, classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -19780,7 +19780,7 @@ react-hotkeys@2.0.0-pre4:
   dependencies:
     prop-types "^15.6.1"
 
-react-input-autosize@^2.1.2, react-input-autosize@^2.2.1:
+react-input-autosize@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
   integrity sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==
@@ -19910,15 +19910,6 @@ react-router@5.0.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
-
-react-select@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
-  integrity sha512-vaCgT2bEl+uTyE/uKOEgzE5Dc/wLtzhnBvoHCeuLoJWc4WuadN6WQDhoL42DW+TziniZK2Gaqe/wUXydI3NSaQ==
-  dependencies:
-    classnames "^2.2.4"
-    prop-types "^15.5.8"
-    react-input-autosize "^2.1.2"
 
 react-select@2.4.3:
   version "2.4.3"


### PR DESCRIPTION
#### Summary

Now that #617 and #618 are merged, `react-select v1` can be removed as a dependency, and it's CSS import can be removed as well.

Closes #554 