### PR TITLE
feat(permissions): add use-is-authorized hook

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.js
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.js
@@ -150,6 +150,7 @@ const useApplicationContext = React.useContext
 
 // Exports
 export {
+  Context,
   ApplicationContext,
   ApplicationContextProvider,
   withApplicationContext,

--- a/packages/application-shell-connectors/src/components/application-context/index.js
+++ b/packages/application-shell-connectors/src/components/application-context/index.js
@@ -1,4 +1,5 @@
 export {
+  Context,
   ApplicationContext,
   ApplicationContextProvider,
   withApplicationContext,

--- a/packages/application-shell-connectors/src/index.js
+++ b/packages/application-shell-connectors/src/index.js
@@ -1,4 +1,5 @@
 export {
+  Context,
   ApplicationContext,
   ApplicationContextProvider,
   withApplicationContext,

--- a/packages/permissions/src/hooks/use-is-authorized/index.js
+++ b/packages/permissions/src/hooks/use-is-authorized/index.js
@@ -1,0 +1,1 @@
+export { default } from './use-is-authorized';

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.js
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Context } from '@commercetools-frontend/application-shell-connectors';
+import {
+  hasSomePermissions,
+  hasEveryPermissions,
+} from '../../utils/has-permissions';
+
+// Forward-compatibility with React Hooks 🎉
+const useIsAuthorized = React.useContext
+  ? ({ demandedPermissions, shouldMatchSomePermissions = false }) => {
+      const applicationContext = React.useContext(Context);
+      const actualPermissions = applicationContext.permissions;
+
+      const isAuthorized = shouldMatchSomePermissions
+        ? hasSomePermissions(demandedPermissions, actualPermissions)
+        : hasEveryPermissions(demandedPermissions, actualPermissions);
+
+      return isAuthorized;
+    }
+  : () => {
+      throw new Error(
+        `React hooks do not seem to be available yet in the installed React version "${
+          React.version
+        }". Please check the React Hooks documentation for more info: https://reactjs.org/hooks.`
+      );
+    };
+
+export default useIsAuthorized;

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.js
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { renderApp } from '@commercetools-frontend/application-shell/test-utils';
+import { permissions } from '../../constants';
+import useIsAuthorized from './use-is-authorized';
+
+const TestComponent = props => {
+  const isAuthorized = useIsAuthorized({
+    demandedPermissions: props.demandedPermissions,
+    shouldMatchSomePermissions: props.shouldMatchSomePermissions,
+  });
+  return (
+    <ul>
+      <li>Is authorized: {isAuthorized ? 'Yes' : 'No'}</li>
+    </ul>
+  );
+};
+TestComponent.propTypes = {
+  shouldMatchSomePermissions: PropTypes.bool,
+  demandedPermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const render = ({
+  demandedPermissions,
+  shouldMatchSomePermissions,
+  actualPermissions,
+}) =>
+  renderApp(
+    <TestComponent
+      demandedPermissions={demandedPermissions}
+      shouldMatchSomePermissions={shouldMatchSomePermissions}
+    />,
+    {
+      permissions: actualPermissions,
+    }
+  );
+
+describe('when only one permission matches', () => {
+  describe('when it should match some permission', () => {
+    it('should indicate being authorized', () => {
+      const { queryByText } = render({
+        demandedPermissions: [
+          permissions.ManageCustomers,
+          permissions.ManageOrders,
+        ],
+        actualPermissions: {
+          canManageCustomers: true,
+        },
+        shouldMatchSomePermissions: true,
+      });
+
+      expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
+    });
+  });
+  describe('when it should not match some permission', () => {
+    describe('when `ManageProject` permission is set', () => {
+      it('should indicate being authorized', () => {
+        const { queryByText } = render({
+          demandedPermissions: [
+            permissions.ManageCustomers,
+            permissions.ManageProject,
+          ],
+          shouldMatchSomePermissions: false,
+        });
+
+        expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
+      });
+    });
+    describe('when `ManageProject` permission is not set', () => {
+      it('should indicate being not authorized', () => {
+        const { queryByText } = render({
+          actualPermissions: {
+            canManageCustomers: true,
+          },
+          demandedPermissions: [
+            permissions.ManageCustomers,
+            permissions.ManageProject,
+          ],
+          shouldMatchSomePermissions: false,
+        });
+
+        expect(queryByText('Is authorized: No')).toBeInTheDocument();
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### Summary

This pull request adds a `useIsAuthorized()` hook. It should be pretty self explanatory from the specs.