### PR TITLE
fix(app-shell): to default to menu if no submenus are defined

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -447,7 +447,7 @@ export class DataMenu extends React.PureComponent {
     const hasSubmenu = Boolean(menu.submenu) && menu.submenu.length > 0;
     const namesOfMenuVisibilitiesOfAllSubmenus = hasSubmenu
       ? getMenuVisibilitiesOfSubmenus(menu)
-      : getMenuVisibilityOfMainmenu(menu.menuVisibility);
+      : getMenuVisibilityOfMainmenu(menu);
 
     return (
       <RestrictedMenuItem

--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -288,6 +288,10 @@ export const getIconTheme = (isActive, isAlternativeTheme) => {
   if (isActive) return 'green-light';
   return isAlternativeTheme ? 'grey' : 'white';
 };
+const getMenuVisibilitiesOfSubmenus = menu =>
+  menu.submenu.map(submenu => submenu.menuVisibility).filter(Boolean);
+const getMenuVisibilityOfMainmenu = menu =>
+  [menu.menuVisibility].filter(Boolean);
 export class DataMenu extends React.PureComponent {
   static displayName = 'DataMenu';
   static propTypes = {
@@ -442,8 +446,8 @@ export class DataMenu extends React.PureComponent {
     const isActive = this.state.activeItemIndex === `${menuType}-${index}`;
     const hasSubmenu = Boolean(menu.submenu) && menu.submenu.length > 0;
     const namesOfMenuVisibilitiesOfAllSubmenus = hasSubmenu
-      ? menu.submenu.map(submenu => submenu.menuVisibility).filter(Boolean)
-      : [];
+      ? getMenuVisibilitiesOfSubmenus(menu)
+      : getMenuVisibilityOfMainmenu(menu.menuVisibility);
 
     return (
       <RestrictedMenuItem


### PR DESCRIPTION
#### Summary

This pull request allows hiding main menu items without submenu items.

#### Description

When this was first implemented the dashboard was not hidable as we didn't have the welcome page. Given now we do we can hide menu items which don't have submenus and automatically hide main menus when all submenus are hidden.