### PR TITLE
fix(circleci): to use new compare-url orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
           TERM: xterm
 
 orbs:
-  compare-url: iynere/compare-url@0.4.10
+  compare-url: iynere/compare-url@1.0.0
 
 commands:
   install_dependencies:


### PR DESCRIPTION
#### Summary

This release fixes the issue with a PR having one commit without an ancestor. 

https://github.com/iynere/compare-url/pull/23