### PR TITLE
fix(app-shell): Switcher counter not properly centered

### DIFF
--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.mod.css
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.mod.css
@@ -12,13 +12,13 @@
 .language-counter {
   width: 22px;
   height: 22px;
-  border-radius: 22px;
-  padding: 3px;
+  border-radius: 100%;
   background: var(--color-accent-40);
   color: var(--color-surface);
-  display: inline-block;
   font-size: 0.9rem;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .label {

--- a/packages/application-shell/src/components/project-switcher/project-switcher.mod.css
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.mod.css
@@ -41,13 +41,13 @@
 .project-counter {
   width: 22px;
   height: 22px;
-  border-radius: 22px;
-  padding: 3px;
+  border-radius: 100%;
   background: var(--color-accent-40);
   color: var(--color-surface);
-  display: inline-block;
   font-size: 0.9rem;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .item-text-main {


### PR DESCRIPTION
I saw this on our latest TGIF post:
![Screen Shot 2019-05-17 at 10 22 32](https://user-images.githubusercontent.com/2941328/58094191-5c17fa00-7bd0-11e9-8b54-dedc8ef02c87.png)
and noticed the counter gets misaligned with more than 2 digits.

This PR fixes that. The number will now remain center aligned in the counter no matter how many digits it has.

![image](https://user-images.githubusercontent.com/2941328/58094398-dea0b980-7bd0-11e9-9fb9-4db4b708fb75.png)

