### PR TITLE
fix(app-shell): quick access env not always set

### DIFF
--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -77,7 +77,7 @@ class QuickAccess extends React.Component {
     getPimSearchStatus: PropTypes.func.isRequired,
     environment: PropTypes.shape({
       useFullRedirectsForLinks: PropTypes.bool,
-    }).isRequired,
+    }),
   };
 
   state = {
@@ -319,7 +319,10 @@ class QuickAccess extends React.Component {
         // and always open other pages in a new window
         if (meta.openInNewTab || !command.action.to.startsWith('/')) {
           open(command.action.to, '_blank');
-        } else if (this.props.environment.useFullRedirectsForLinks) {
+        } else if (
+          this.props.environment &&
+          this.props.environment.useFullRedirectsForLinks
+        ) {
           window.location.replace(command.action.to);
         } else {
           this.props.history.push(command.action.to);


### PR DESCRIPTION
#### Summary

We should not assume an env always to be set when evaluating here. This breaks quick access in the accounts app cause it currently doesn't have any custom env passed.