### PR TITLE
refactor(http-server): to unset cookie only for local development

### DIFF
--- a/packages/mc-http-server/README.md
+++ b/packages/mc-http-server/README.md
@@ -40,4 +40,3 @@ Besides generating and serving the `index.html`, the HTTP server does additional
 
 - gathers `/metrics` for Prometheus
 - provides a `/version` endpoint with the current revision hash (git SHA)
-- intercepts `/logout` redirects to clear the HTTP cookie for the access token

--- a/packages/mc-http-server/routes/logout.js
+++ b/packages/mc-http-server/routes/logout.js
@@ -1,27 +1,8 @@
 const devAuthentication = require('@commercetools-frontend/mc-dev-authentication');
 
-/* eslint-disable global-require */
-// If the file is required in "production" mode, we additionally check
-// if the MC_ENV is development or not. The only case where this might
-// happen is when you start the server locally to test the app in
-// production mode.
-const isDev =
-  process.env.NODE_ENV !== 'production' || process.env.MC_ENV === 'development';
-
 module.exports = env => (request, response, next) => {
-  devAuthentication.routes.logout(
-    response,
-    isDev
-      ? []
-      : [
-          `Domain=${
-            require('../load-options').env.frontendHost.split('mc.')[1]
-          }`,
-          'Secure',
-        ]
-  );
-
   if (!env.servedByProxy) {
+    devAuthentication.routes.logout(response);
     response.render('logout', { env });
   } else {
     next();


### PR DESCRIPTION
This might seem a breaking change, but for production usage it does not affect any one (besides our internal auth app).