### PR TITLE
feat(app-shell): export npm version

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.js
@@ -385,6 +385,8 @@ export default class ApplicationShell extends React.Component {
   static defaultProps = {
     trackingEventWhitelist: {},
   };
+  static version = process.env.npm_package_version;
+
   redirectTo = targetUrl => window.location.replace(targetUrl);
   componentDidMount() {
     this.props.onRegisterErrorListeners({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,6 +1045,11 @@
     react-modal "3.8.1"
     warning "4.0.3"
 
+"@commercetools-frontend/assets@13.3.5":
+  version "13.3.5"
+  resolved "https://registry.yarnpkg.com/@commercetools-frontend/assets/-/assets-13.3.5.tgz#16806a319c11223e75ae228b9c5de42ccdbd5633"
+  integrity sha512-PvXjkHbsGwgp34acuq7tKoHti2Nd31g7WVe4Tw/ho/XhjLvfi85iolFVeVdwZnkJ6qxg+EOKDCwaIocuhWfMMw==
+
 "@commercetools-frontend/ui-kit@9.8.1":
   version "9.8.1"
   resolved "https://registry.yarnpkg.com/@commercetools-frontend/ui-kit/-/ui-kit-9.8.1.tgz#16b1971ebe5999805f5cd7540b3e696607d43052"


### PR DESCRIPTION
#### Summary

This pull request adds a `version` export to the app-shell by reading the `npm_package_version`.

#### Description

This version can be used to e.g. send it to a metrics service or a logging system. 

1. Another appraoch of this would be to have a json plugin in rollup and read it from the package.json. However in that case you always get "one version" down as you build before you publish and bump the version.
2. Also the `version` could be exported through the `index.js`. However then it quickly looses context and can. `ApplicationShell.version` seems more intuitive to me.
