### PR TITLE
feat(app-shell): add version export

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -28,6 +28,7 @@
     "README.md"
   ],
   "scripts": {
+    "prepare": "./../../scripts/version amend",
     "prebuild": "rimraf dist/** test-utils/**",
     "build": "npm run build:es && npm run build:cjs && npm run build:test-utils:cjs",
     "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].cjs.js --entryFileNames application-shell-[name].cjs.js",

--- a/packages/application-shell/src/version.js
+++ b/packages/application-shell/src/version.js
@@ -1,0 +1,2 @@
+// NOTE: This string will be replaced in the a `prepare` run script by the `scripts/version.js` file.
+export default '__@APPLICATION_KIT_PACKAGE/VERSION_OF_RELEASE__';

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/* eslint-disable */
+
+const mri = require('mri');
+const path = require('path');
+const replace = require('replace');
+
+const versionOfPackage = process.env.npm_package_version;
+const nameOfPackage = process.env.npm_package_name;
+const pwd = process.env.PWD;
+
+const flags = mri(process.argv.slice(2), { alias: { help: ['h'] } });
+const commands = flags._;
+
+if (commands.length === 0 || (flags.help && commands.length === 0)) {
+  console.log(`
+    Usage: version [command] [options]
+    Commands:
+    print        Print the version
+    amend        Amends the version to the built files
+  `);
+  process.exit(0);
+}
+
+const command = commands[0];
+
+switch (command) {
+  case 'print': {
+    console.log(
+      `Version for ${nameOfPackage} of release will be ${versionOfPackage}`
+    );
+    break;
+  }
+  case 'amend': {
+    const distFolder = path.join(pwd, 'dist');
+    const paths = [distFolder];
+
+    replace({
+      regex: '__@APPLICATION_KIT_PACKAGE/VERSION_OF_RELEASE__',
+      replacement: version,
+      paths,
+      recursive: true,
+      silent: true,
+    });
+
+    console.log(`Amended for ${nameOfPackage} for release ${versionOfPackage}`);
+    break;
+  }
+  default:
+    console.log(`Unknown script "${command}".`);
+    break;
+}


### PR DESCRIPTION
#### Summary

This pull request is another attempt at getting us a version export in app-shell for now and later any package.

#### Description

Where are we coming from:

1. We decided to have a `import version from 'packageA/version` instead of `ApplicationShell.version`
   - The latter would be easy to add
2. The complication comes from adding the version after buiding, it being up-to-date and not having to go crazy while doing it

This solution I tried out in flopflip. It looks rather simple, I hope, but took me about 10 canary releases there until I found the `prepare` run-script. 

Things I like:

1. It's easy to understand and follows npm patterns
2. It integrates with lerna and is super easy to add to other packages
   - Even when independent versioning is on in lerna
3. Not having to find/replace some `module.exports` code (like React does)

Things I don't like:

1. Magic strings

Given this I would like to hear your feedback. Note that the `scripts/version.js` might be a bit over done but I just wanted it to follow the mc-scripts style patterns.
