### PR TITLE
fix(mc-scripts): browserlist config

### DIFF
--- a/packages/mc-scripts/config/browserslist.js
+++ b/packages/mc-scripts/config/browserslist.js
@@ -1,6 +1,0 @@
-module.exports = {
-  development: ['chrome', 'firefox'].map(
-    browser => `last 2 ${browser} versions`
-  ),
-  production: ['>1%', 'not op_mini all', 'ie 11'],
-};

--- a/packages/mc-scripts/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-development.js
@@ -10,7 +10,7 @@ const postcssReporter = require('postcss-reporter');
 const postcssCustomProperties = require('postcss-custom-properties');
 const postcssCustomMediaQueries = require('postcss-custom-media');
 const postcssColorModFunction = require('postcss-color-mod-function');
-const browserslist = require('./browserslist');
+const { browserslist } = require('../package.json');
 
 const defaultToggleFlags = {
   // Allow to disable index.html generation in case it's not necessary (e.g. for Storybook)

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -20,7 +20,7 @@ const postcssCustomProperties = require('postcss-custom-properties');
 const postcssCustomMediaQueries = require('postcss-custom-media');
 const postcssColorModFunction = require('postcss-color-mod-function');
 const FinalStatsWriterPlugin = require('../webpack-plugins/final-stats-writer-plugin');
-const browserslist = require('./browserslist');
+const { browserslist } = require('../package.json');
 
 const optimizeCSSConfig = {
   // Since css-loader uses cssnano v3.1.0, it's best to stick with the

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -21,6 +21,17 @@
   "bin": {
     "mc-scripts": "./bin/mc-scripts.js"
   },
+  "browserslist": {
+    "production": [
+      ">1%",
+      "not op_mini all",
+      "ie 11"
+    ],
+    "development": [
+      "last 2 firefox versions",
+      "last 2 chrome versions"
+    ]
+  },
   "dependencies": {
     "@babel/core": "7.4.5",
     "@commercetools-frontend/babel-preset-mc-app": "13.7.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,9 @@ const fs = require('fs');
 const babel = require('rollup-plugin-babel');
 const readPkgUp = require('read-pkg-up');
 const getBabelPreset = require('@commercetools-frontend/babel-preset-mc-app');
-const browserslist = require('@commercetools-frontend/mc-scripts/config/browserslist');
+const {
+  browserslist,
+} = require('@commercetools-frontend/mc-scripts/package.json');
 const resolve = require('rollup-plugin-node-resolve');
 const json = require('rollup-plugin-json');
 const commonjs = require('rollup-plugin-commonjs');


### PR DESCRIPTION
#### Summary

This pull request attempts to solve a regression caused by postcss where it warns about lacking a `browserlistrc`-file.

![image](https://user-images.githubusercontent.com/1877073/59039700-94c4fe00-8875-11e9-9b7b-13bd0b83f65b.png)

I am not 100% sure this solves it but it is closer to what the docs suggest. Furthermore, I couldn't see the `config/browserlist` being used anywhere. Does anybody have an idea?