### PR TITLE
fix(app-shell): do not re-export the version field from flopflip

### DIFF
--- a/packages/application-shell/src/index.js
+++ b/packages/application-shell/src/index.js
@@ -36,4 +36,17 @@ export { default as version } from './version';
  *
  *    More information can be found here: https://github.com/commercetools/fe-chapter-notes/issues/61
  */
-export * from '@flopflip/react-broadcast';
+export {
+  // NOTE: do not re-export the `version` field, otherwise it will break the bundle as it conflicts
+  // with our own exported `version` field.
+  //    TypeError: Cannot set property version of [object Object] which has only a getter
+  ToggleFeature,
+  injectFeatureToggle,
+  injectFeatureToggles,
+  branchOnFeatureToggle,
+  ConfigureFlopFlip,
+  ReconfigureFlopFlip,
+  useFeatureToggle,
+  useAdapterStatus,
+  useAdapterReconfiguration,
+} from '@flopflip/react-broadcast';


### PR DESCRIPTION
Fixes the error

```
TypeError: Cannot set property version of [object Object] which has only a getter
```

This is caused by the proxy export of flopflip, which also contains a `version` field that conflicts with the app-shell `version` export. The reason is that the exported keys in cjs are exported as following:

```js
Object.keys(reactBroadcast).forEach(function (key) {
  Object.defineProperty(exports, key, {
    enumerable: true,
    get: function () {
      return reactBroadcast[key];
    }
  });
});
```