### PR TITLE
feat: generate proptypes from typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-eslint": "10.0.1",
     "babel-plugin-import-graphql": "2.7.0",
     "babel-plugin-transform-rename-import": "2.3.0",
+    "babel-plugin-typescript-to-proptypes": "0.17.1",
     "cross-env": "5.2.0",
     "cypress": "3.3.1",
     "cypress-testing-library": "3.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,6 +47,7 @@ const createConfig = cliArgs => {
         plugins: [
           babelPluginImportGraphQL.default,
           ...babelOptions.plugins,
+          'babel-plugin-typescript-to-proptypes',
           isFormatEs && [
             'transform-rename-import',
             {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5440,6 +5440,15 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
+babel-plugin-typescript-to-proptypes@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-typescript-to-proptypes/-/babel-plugin-typescript-to-proptypes-0.17.1.tgz#9874735be3565ba4d7fc7f3cafb04fec40f55a83"
+  integrity sha512-yREUfvDlmn6QjM0QbywXUkXBQMD/iFfLVTl+jig4X7ZLUg9lq8ZLuex8HIM2SQ4X3vcjGnWPFowodlMcXhwxdQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
 babel-polyfill@6.26.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
#### Summary

We can generate proptypes from typescript.

This is the output now

```js
SentryUserTracker.propTypes = {
  user: _pt.any
};
```