### PR TITLE
refactor: to prefer type literal instead of interface, to infer type from prop-types

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -27,6 +27,7 @@ rules:
   '@typescript-eslint/no-use-before-define':
     - error
     - functions: false
+  '@typescript-eslint/prefer-interface': 0
   react/jsx-tag-spacing: 0
   import/no-extraneous-dependencies: 0
   import/no-named-as-default: 0

--- a/@types/sentry-testkit/index.d.ts
+++ b/@types/sentry-testkit/index.d.ts
@@ -1,26 +1,26 @@
 declare module 'sentry-testkit' {
   import { TransportClass, Transport } from '@sentry/types';
 
-  interface ExceptionValue {
+  type ExceptionValue = {
     type: string;
     value: string;
-  }
-  interface Exception {
+  };
+  type Exception = {
     values: ExceptionValue[];
-  }
-  interface Report {
+  };
+  type Report = {
     exception: Exception;
     event_id: string;
     extra: object;
-  }
-  interface TestKit {
+  };
+  type TestKit = {
     reports(): Report[];
     reset(): void;
-  }
-  interface SentryTestKit {
+  };
+  type SentryTestKit = {
     testkit: TestKit;
     sentryTransport: TransportClass<Transport>;
-  }
+  };
   const createTestKit: () => SentryTestKit;
   export default createTestKit;
 }

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.4.5",
-    "@sentry/browser": "5.4.0"
+    "@sentry/browser": "5.4.0",
+    "prop-types": "15.7.2"
   },
   "devDependencies": {
     "react": "16.8.6",

--- a/packages/sentry/src/sentry-user-tracker/sentry-user-tracker.tsx
+++ b/packages/sentry/src/sentry-user-tracker/sentry-user-tracker.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
+import * as PropTypes from 'prop-types';
+import { InferPropTypes } from '../type-utils';
 import * as sentry from '../sentry';
 
-interface Props {
-  user?: sentry.User;
-}
+const userTrackerPropTypes = {
+  user: PropTypes.shape(sentry.userPropTypes),
+};
+
+type UserTrackerProps = InferPropTypes<typeof userTrackerPropTypes>;
 
 /**
  * This component will let sentry know if any information about the user has
  * changed.
  */
 
-class SentryUserTracker extends React.PureComponent<Props> {
+class SentryUserTracker extends React.PureComponent<UserTrackerProps> {
   static displayName = 'SentryUserTracker';
+  static propTypes = userTrackerPropTypes;
   componentDidMount() {
     // since the user and project could have been loaded from the apollo cache
     // they could be preset already when mounting

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -1,9 +1,13 @@
+import * as PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
+import { InferPropTypes } from './type-utils';
 
-export interface User {
-  id: string;
-  email: string;
-}
+export const userPropTypes = {
+  id: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
+};
+
+type User = InferPropTypes<typeof userPropTypes>;
 
 export const boot = () => {
   if (window.app.trackingSentry) {

--- a/packages/sentry/src/type-utils.ts
+++ b/packages/sentry/src/type-utils.ts
@@ -1,0 +1,12 @@
+import * as PropTypes from 'prop-types';
+
+// https://dev.to/busypeoples/notes-on-typescript-inferring-react-proptypes-1g88
+export type InferPropTypes<
+  PropTypes,
+  DefaultProps = {},
+  Props = PropTypes.InferProps<PropTypes>
+> = {
+  [Key in keyof Props]: Key extends keyof DefaultProps
+    ? Props[Key] | DefaultProps[Key]
+    : Props[Key]
+};


### PR DESCRIPTION
To expose both type declarations and prop-types, we tried #719 using a babel plugin but unfortunately it currently has some limitations (https://github.com/commercetools/merchant-center-application-kit/pull/719#issuecomment-499959171).

This is another approach that we can use which works the other way around: given prop-types, we infer TS types from them.

https://dev.to/busypeoples/notes-on-typescript-inferring-react-proptypes-1g88