### PR TITLE
refactor(website): to use custom knobs to control component props

### DIFF
--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.example.js
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.example.js
@@ -45,18 +45,18 @@ const ConfirmationDialogExample = () => {
             title="Open the Confirmation Dialog by clicking on the button"
             buttonLabel="Open Confirmation Dialog"
           >
-            {({ isOpen, toggle }) => (
+            {({ isOpen, setIsOpen }) => (
               <ConfirmationDialog
                 title={values.title}
                 isOpen={isOpen}
-                onClose={() => toggle(false)}
+                onClose={() => setIsOpen(false)}
                 size={values.size}
                 onCancel={() => {
-                  toggle(false);
+                  setIsOpen(false);
                 }}
                 onConfirm={() => {
                   alert('confirmed');
-                  toggle(false);
+                  setIsOpen(false);
                 }}
                 getParentSelector={() =>
                   document.querySelector(`#${containerId}`)

--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.example.js
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.example.js
@@ -2,45 +2,79 @@ import React from 'react';
 import { ConfirmationDialog } from '@commercetools-frontend/application-components';
 import { Spacings, Text } from '@commercetools-frontend/ui-kit';
 import ExampleWrapper from '../../internals/for-docs/example-wrapper';
+import ModalController from '../../internals/for-docs/modal-controller';
 
 // This component is supposed to be used in the mdx documentation
-const ConfirmationDialogExample = () => (
-  <ExampleWrapper
-    containerId="confirmation-dialog"
-    controllerTitle="Open the Confirmation Dialog by clicking on the button"
-    controllerButtonLabel="Open Confirmation Dialog"
-  >
-    {({ isOpen, toggle }) => (
-      <ConfirmationDialog
-        title="Lorem Ipsum"
-        isOpen={isOpen}
-        onClose={() => toggle(false)}
-        size="l"
-        onCancel={() => {
-          toggle(false);
-        }}
-        onConfirm={() => {
-          alert('confirmed');
-          toggle(false);
-        }}
-        getParentSelector={() => document.querySelector(`#confirmation-dialog`)}
-      >
-        <Spacings.Stack scale="m">
-          <Text.Body>
-            {
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.'
-            }
-          </Text.Body>
-          <Text.Body>
-            {
-              'Nam id orci ut risus accumsan pellentesque. Quisque efficitur eu arcu ut tristique. Praesent ornare varius leo, ut consequat lacus rutrum vel. Donec mollis leo id lectus vehicula tempor. Nulla facilisi. Fusce fringilla tellus ac ligula consequat suscipit. Sed consectetur molestie quam eu pulvinar. Interdum et malesuada fames ac ante ipsum primis in faucibus. In hac habitasse platea dictumst.'
-            }
-          </Text.Body>
-        </Spacings.Stack>
-      </ConfirmationDialog>
-    )}
-  </ExampleWrapper>
-);
+const ConfirmationDialogExample = () => {
+  return (
+    <ExampleWrapper
+      knobs={[
+        {
+          kind: 'text',
+          name: 'title',
+          label: 'Title',
+          initialValue:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        },
+        {
+          kind: 'text-multi',
+          name: 'content',
+          label: 'Content',
+          initialValue: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.\nNam id orci ut risus accumsan pellentesque. Quisque efficitur eu arcu ut tristique. Praesent ornare varius leo, ut consequat lacus rutrum vel. Donec mollis leo id lectus vehicula tempor. Nulla facilisi. Fusce fringilla tellus ac ligula consequat suscipit. Sed consectetur molestie quam eu pulvinar. Interdum et malesuada fames ac ante ipsum primis in faucibus. In hac habitasse platea dictumst.`,
+        },
+        {
+          kind: 'select',
+          name: 'size',
+          label: 'Size',
+          valueOptions: [
+            { value: 'm', label: 'm' },
+            { value: 'l', label: 'l' },
+            { value: 'scale', label: 'scale' },
+          ],
+          initialValue: 'scale',
+        },
+      ]}
+    >
+      {({ values, isPlaygroundMode }) => {
+        const containerId = isPlaygroundMode
+          ? 'confirmation-dialog-playground'
+          : 'confirmation-dialog';
+        return (
+          <ModalController
+            containerId={containerId}
+            title="Open the Confirmation Dialog by clicking on the button"
+            buttonLabel="Open Confirmation Dialog"
+          >
+            {({ isOpen, toggle }) => (
+              <ConfirmationDialog
+                title={values.title}
+                isOpen={isOpen}
+                onClose={() => toggle(false)}
+                size={values.size}
+                onCancel={() => {
+                  toggle(false);
+                }}
+                onConfirm={() => {
+                  alert('confirmed');
+                  toggle(false);
+                }}
+                getParentSelector={() =>
+                  document.querySelector(`#${containerId}`)
+                }
+              >
+                <Spacings.Stack scale="m">
+                  {values.content.split('\n').map((text, index) => (
+                    <Text.Body key={index}>{text}</Text.Body>
+                  ))}
+                </Spacings.Stack>
+              </ConfirmationDialog>
+            )}
+          </ModalController>
+        );
+      }}
+    </ExampleWrapper>
+  );
+};
 ConfirmationDialogExample.displayName = 'ConfirmationDialogExample';
 
 export default ConfirmationDialogExample;

--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.spec.js
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.spec.js
@@ -5,14 +5,14 @@ import { render, wait, fireEvent } from '../../../../test-utils';
 import ConfirmationDialog from './confirmation-dialog';
 
 const DialogController = props => {
-  const [isOpen, toggle] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   return (
     <div>
       <SecondaryButton
         label="Open Confirmation Dialog"
-        onClick={() => toggle(true)}
+        onClick={() => setIsOpen(true)}
       />
-      {props.children({ isOpen, toggle })}
+      {props.children({ isOpen, setIsOpen })}
     </div>
   );
 };
@@ -27,11 +27,11 @@ describe('rendering', () => {
     const onConfirm = jest.fn();
     const { queryByText, getByLabelText } = render(
       <DialogController>
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <ConfirmationDialog
             title="Lorem ipsus"
             isOpen={isOpen}
-            onClose={() => toggle(false)}
+            onClose={() => setIsOpen(false)}
             onCancel={onCancel}
             onConfirm={onConfirm}
           >

--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.story.js
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.story.js
@@ -24,12 +24,14 @@ storiesOf('Components|Dialogs', module)
         title="Open the Confirmation Dialog by clicking on the button"
         buttonLabel="Open Confirmation Dialog"
       >
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <ConfirmationDialog
             title={text('title', 'Lorem Ipsum')}
             isOpen={isOpen}
             onClose={
-              boolean('disable close', false) ? undefined : () => toggle(false)
+              boolean('disable close', false)
+                ? undefined
+                : () => setIsOpen(false)
             }
             size={select('size', ['m', 'l', 'scale'], 'l')}
             zIndex={number('z-index', 1000)}
@@ -38,11 +40,11 @@ storiesOf('Components|Dialogs', module)
             isPrimaryButtonDisabled={boolean('isPrimaryButtonDisabled', false)}
             onCancel={() => {
               alert('cancelled');
-              toggle(false);
+              setIsOpen(false);
             }}
             onConfirm={() => {
               alert('confirmed');
-              toggle(false);
+              setIsOpen(false);
             }}
           >
             <Spacings.Stack scale="m">

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.example.js
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.example.js
@@ -40,7 +40,7 @@ const FormDialogExample = () => {
             title="Open the Form Dialog by clicking on the button"
             buttonLabel="Open Form Dialog"
           >
-            {({ isOpen, toggle }) => (
+            {({ isOpen, setIsOpen }) => (
               <Formik
                 initialValues={{ email: '' }}
                 validate={formikValues => {
@@ -51,18 +51,18 @@ const FormDialogExample = () => {
                 }}
                 onSubmit={formikValues => {
                   alert(`email: ${formikValues.email}`);
-                  toggle(false);
+                  setIsOpen(false);
                 }}
                 render={formikProps => (
                   <FormDialog
                     title={values.title}
                     isOpen={isOpen}
-                    onClose={() => toggle(false)}
+                    onClose={() => setIsOpen(false)}
                     size={values.size}
                     isPrimaryButtonDisabled={formikProps.isSubmitting}
                     onSecondaryButtonClick={() => {
                       formikProps.resetForm();
-                      toggle(false);
+                      setIsOpen(false);
                     }}
                     onPrimaryButtonClick={formikProps.handleSubmit}
                     getParentSelector={() =>

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.example.js
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.example.js
@@ -1,62 +1,97 @@
 import React from 'react';
 import { Formik } from 'formik';
 import { FormDialog } from '@commercetools-frontend/application-components';
-import { Spacings, TextField, TextInput } from '@commercetools-frontend/ui-kit';
+import { Spacings, TextField } from '@commercetools-frontend/ui-kit';
 import ExampleWrapper from '../../internals/for-docs/example-wrapper';
+import ModalController from '../../internals/for-docs/modal-controller';
 
 // This component is supposed to be used in the mdx documentation
-const FormDialogExample = () => (
-  <ExampleWrapper
-    containerId="form-dialog"
-    controllerTitle="Open the Form Dialog by clicking on the button"
-    controllerButtonLabel="Open Form Dialog"
-  >
-    {({ isOpen, toggle }) => (
-      <Formik
-        initialValues={{ email: '' }}
-        validate={formikValues => {
-          if (TextInput.isEmpty(formikValues.email)) {
-            return { email: { missing: true } };
-          }
-          return {};
-        }}
-        onSubmit={formikValues => {
-          alert(`email: ${formikValues.email}`);
-          toggle(false);
-        }}
-        render={formikProps => (
-          <FormDialog
-            title="Lorem Ipsum"
-            isOpen={isOpen}
-            onClose={() => toggle(false)}
-            size="l"
-            isPrimaryButtonDisabled={formikProps.isSubmitting}
-            onSecondaryButtonClick={() => {
-              formikProps.resetForm();
-              toggle(false);
-            }}
-            onPrimaryButtonClick={formikProps.handleSubmit}
-            getParentSelector={() => document.querySelector(`#form-dialog`)}
+const FormDialogExample = () => {
+  return (
+    <ExampleWrapper
+      knobs={[
+        {
+          kind: 'text',
+          name: 'title',
+          label: 'Title',
+          initialValue:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        },
+        {
+          kind: 'select',
+          name: 'size',
+          label: 'Size',
+          valueOptions: [
+            { value: 'm', label: 'm' },
+            { value: 'l', label: 'l' },
+            { value: 'scale', label: 'scale' },
+          ],
+          initialValue: 'scale',
+        },
+      ]}
+    >
+      {({ values, isPlaygroundMode }) => {
+        const containerId = isPlaygroundMode
+          ? 'form-dialog-playground'
+          : 'form-dialog';
+        return (
+          <ModalController
+            containerId={containerId}
+            title="Open the Form Dialog by clicking on the button"
+            buttonLabel="Open Form Dialog"
           >
-            <Spacings.Stack scale="m">
-              <TextField
-                name="email"
-                title="Email"
-                isRequired={true}
-                value={formikProps.values.email}
-                errors={formikProps.errors.email}
-                touched={formikProps.touched.email}
-                onChange={formikProps.handleChange}
-                onBlur={formikProps.handleBlur}
-                onFocus={formikProps.handleFocus}
+            {({ isOpen, toggle }) => (
+              <Formik
+                initialValues={{ email: '' }}
+                validate={formikValues => {
+                  if (TextInput.isEmpty(formikValues.email)) {
+                    return { email: { missing: true } };
+                  }
+                  return {};
+                }}
+                onSubmit={formikValues => {
+                  alert(`email: ${formikValues.email}`);
+                  toggle(false);
+                }}
+                render={formikProps => (
+                  <FormDialog
+                    title={values.title}
+                    isOpen={isOpen}
+                    onClose={() => toggle(false)}
+                    size={values.size}
+                    isPrimaryButtonDisabled={formikProps.isSubmitting}
+                    onSecondaryButtonClick={() => {
+                      formikProps.resetForm();
+                      toggle(false);
+                    }}
+                    onPrimaryButtonClick={formikProps.handleSubmit}
+                    getParentSelector={() =>
+                      document.querySelector(`#${containerId}`)
+                    }
+                  >
+                    <Spacings.Stack scale="m">
+                      <TextField
+                        name="email"
+                        title="Email"
+                        isRequired={true}
+                        value={formikProps.values.email}
+                        errors={formikProps.errors.email}
+                        touched={formikProps.touched.email}
+                        onChange={formikProps.handleChange}
+                        onBlur={formikProps.handleBlur}
+                        onFocus={formikProps.handleFocus}
+                      />
+                    </Spacings.Stack>
+                  </FormDialog>
+                )}
               />
-            </Spacings.Stack>
-          </FormDialog>
-        )}
-      />
-    )}
-  </ExampleWrapper>
-);
+            )}
+          </ModalController>
+        );
+      }}
+    </ExampleWrapper>
+  );
+};
 FormDialogExample.displayName = 'FormDialogExample';
 
 export default FormDialogExample;

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.js
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.js
@@ -5,11 +5,14 @@ import { render, wait, fireEvent } from '../../../../test-utils';
 import FormDialog from './form-dialog';
 
 const DialogController = props => {
-  const [isOpen, toggle] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   return (
     <div>
-      <SecondaryButton label="Open Form Dialog" onClick={() => toggle(true)} />
-      {props.children({ isOpen, toggle })}
+      <SecondaryButton
+        label="Open Form Dialog"
+        onClick={() => setIsOpen(true)}
+      />
+      {props.children({ isOpen, setIsOpen })}
     </div>
   );
 };
@@ -24,11 +27,11 @@ describe('rendering', () => {
     const onConfirm = jest.fn();
     const { queryByText, getByLabelText } = render(
       <DialogController>
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <FormDialog
             title="Lorem ipsus"
             isOpen={isOpen}
-            onClose={() => toggle(false)}
+            onClose={() => setIsOpen(false)}
             onSecondaryButtonClick={onCancel}
             onPrimaryButtonClick={onConfirm}
           >

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.story.js
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.story.js
@@ -25,7 +25,7 @@ storiesOf('Components|Dialogs', module)
         title="Open the Form Dialog by clicking on the button"
         buttonLabel="Open Form Dialog"
       >
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <Formik
             initialValues={{ email: '' }}
             validate={formikValues => {
@@ -36,7 +36,7 @@ storiesOf('Components|Dialogs', module)
             }}
             onSubmit={formikValues => {
               alert(`email: ${formikValues.email}`);
-              toggle(false);
+              setIsOpen(false);
             }}
             render={formikProps => (
               <FormDialog
@@ -45,7 +45,7 @@ storiesOf('Components|Dialogs', module)
                 onClose={
                   boolean('disable close', false)
                     ? undefined
-                    : () => toggle(false)
+                    : () => setIsOpen(false)
                 }
                 size={select('size', ['m', 'l', 'scale'], 'l')}
                 zIndex={number('z-index', 1000)}
@@ -57,7 +57,7 @@ storiesOf('Components|Dialogs', module)
                 }
                 onSecondaryButtonClick={() => {
                   alert('cancelled');
-                  toggle(false);
+                  setIsOpen(false);
                 }}
                 onPrimaryButtonClick={formikProps.handleSubmit}
               >

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.example.js
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.example.js
@@ -45,12 +45,12 @@ const InfoDialogExample = () => {
             title="Open the Info Dialog by clicking on the button"
             buttonLabel="Open Info Dialog"
           >
-            {({ isOpen, toggle }) => (
+            {({ isOpen, setIsOpen }) => (
               <InfoDialog
                 title={values.title}
                 size={values.size}
                 isOpen={isOpen}
-                onClose={() => toggle(false)}
+                onClose={() => setIsOpen(false)}
                 getParentSelector={() =>
                   document.querySelector(`#${containerId}`)
                 }

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.example.js
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.example.js
@@ -2,34 +2,72 @@ import React from 'react';
 import { InfoDialog } from '@commercetools-frontend/application-components';
 import { Spacings, Text } from '@commercetools-frontend/ui-kit';
 import ExampleWrapper from '../../internals/for-docs/example-wrapper';
+import ModalController from '../../internals/for-docs/modal-controller';
 
 // This component is supposed to be used in the mdx documentation
-const InfoDialogExample = () => (
-  <ExampleWrapper
-    containerId="info-dialog"
-    controllerTitle="Open the Info Dialog by clicking on the button"
-    controllerButtonLabel="Open Info Dialog"
-  >
-    {({ isOpen, toggle }) => (
-      <InfoDialog
-        title="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        size="scale"
-        isOpen={isOpen}
-        onClose={() => toggle(false)}
-        getParentSelector={() => document.querySelector(`#info-dialog`)}
-      >
-        <Spacings.Stack scale="m">
-          <Text.Body>
-            {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}
-          </Text.Body>
-          <Text.Body>
-            {`Nam id orci ut risus accumsan pellentesque. Quisque efficitur eu arcu ut tristique. Praesent ornare varius leo, ut consequat lacus rutrum vel. Donec mollis leo id lectus vehicula tempor. Nulla facilisi. Fusce fringilla tellus ac ligula consequat suscipit. Sed consectetur molestie quam eu pulvinar. Interdum et malesuada fames ac ante ipsum primis in faucibus. In hac habitasse platea dictumst.`}
-          </Text.Body>
-        </Spacings.Stack>
-      </InfoDialog>
-    )}
-  </ExampleWrapper>
-);
+const InfoDialogExample = () => {
+  return (
+    <ExampleWrapper
+      knobs={[
+        {
+          kind: 'text',
+          name: 'title',
+          label: 'Title',
+          initialValue:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        },
+        {
+          kind: 'text-multi',
+          name: 'content',
+          label: 'Content',
+          initialValue: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.\nNam id orci ut risus accumsan pellentesque. Quisque efficitur eu arcu ut tristique. Praesent ornare varius leo, ut consequat lacus rutrum vel. Donec mollis leo id lectus vehicula tempor. Nulla facilisi. Fusce fringilla tellus ac ligula consequat suscipit. Sed consectetur molestie quam eu pulvinar. Interdum et malesuada fames ac ante ipsum primis in faucibus. In hac habitasse platea dictumst.`,
+        },
+        {
+          kind: 'select',
+          name: 'size',
+          label: 'Size',
+          valueOptions: [
+            { value: 'm', label: 'm' },
+            { value: 'l', label: 'l' },
+            { value: 'scale', label: 'scale' },
+          ],
+          initialValue: 'scale',
+        },
+      ]}
+    >
+      {({ values, isPlaygroundMode }) => {
+        const containerId = isPlaygroundMode
+          ? 'info-dialog-playground'
+          : 'info-dialog';
+        return (
+          <ModalController
+            containerId={containerId}
+            title="Open the Info Dialog by clicking on the button"
+            buttonLabel="Open Info Dialog"
+          >
+            {({ isOpen, toggle }) => (
+              <InfoDialog
+                title={values.title}
+                size={values.size}
+                isOpen={isOpen}
+                onClose={() => toggle(false)}
+                getParentSelector={() =>
+                  document.querySelector(`#${containerId}`)
+                }
+              >
+                <Spacings.Stack scale="m">
+                  {values.content.split('\n').map((text, index) => (
+                    <Text.Body key={index}>{text}</Text.Body>
+                  ))}
+                </Spacings.Stack>
+              </InfoDialog>
+            )}
+          </ModalController>
+        );
+      }}
+    </ExampleWrapper>
+  );
+};
 InfoDialogExample.displayName = 'InfoDialogExample';
 
 export default InfoDialogExample;

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.spec.js
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.spec.js
@@ -5,11 +5,14 @@ import { render, wait, fireEvent } from '../../../../test-utils';
 import InfoDialog from './info-dialog';
 
 const DialogController = props => {
-  const [isOpen, toggle] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   return (
     <div>
-      <SecondaryButton label="Open Info Dialog" onClick={() => toggle(true)} />
-      {props.children({ isOpen, toggle })}
+      <SecondaryButton
+        label="Open Info Dialog"
+        onClick={() => setIsOpen(true)}
+      />
+      {props.children({ isOpen, setIsOpen })}
     </div>
   );
 };
@@ -22,11 +25,11 @@ describe('rendering', () => {
   it('should open the modal and close it by clicking on the close button', async () => {
     const { queryByText, getByLabelText } = render(
       <DialogController>
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <InfoDialog
             title="Lorem ipsus"
             isOpen={isOpen}
-            onClose={() => toggle(false)}
+            onClose={() => setIsOpen(false)}
           >
             {'Hello'}
           </InfoDialog>

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.story.js
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.story.js
@@ -24,11 +24,11 @@ storiesOf('Components|Dialogs', module)
         title="Open the Info Dialog by clicking on the button"
         buttonLabel="Open Info Dialog"
       >
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <InfoDialog
             title={text('title', 'Lorem Ipsum')}
             isOpen={isOpen}
-            onClose={() => toggle(false)}
+            onClose={() => setIsOpen(false)}
             size={select('size', ['m', 'l', 'scale'], 'l')}
             zIndex={number('z-index', 1000)}
           >

--- a/packages/application-components/src/components/internals/for-docs/example-wrapper/example-wrapper.js
+++ b/packages/application-components/src/components/internals/for-docs/example-wrapper/example-wrapper.js
@@ -1,43 +1,199 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Formik } from 'formik';
 import { ThemeProvider } from 'emotion-theming';
+import styled from '@emotion/styled';
 import { IntlProvider } from 'react-intl';
-import { customProperties } from '@commercetools-frontend/ui-kit';
-import ModalController from '../modal-controller';
+import {
+  Spacings,
+  TextField,
+  MultilineTextField,
+  SelectField,
+  customProperties,
+  Tooltip,
+  IconButton,
+  CodeViewIcon,
+} from '@commercetools-frontend/ui-kit';
+import { InfoDialog } from '@commercetools-frontend/application-components';
 
-const ExampleWrapper = props => (
-  <ThemeProvider
-    theme={{
-      // Reset theme to default styles, so that the example uses the default uikit tokens
-      fontFamilyDefault: customProperties.fontFamilyDefault,
-      colorSolid: customProperties.colorsSolid,
-    }}
-  >
-    <IntlProvider locale="en">
-      <div
-        style={{
-          position: 'relative',
-          width: '100%',
-          height: '400px',
-          border: `1px solid ${customProperties.colorNeutral95}`,
-        }}
-      >
-        <div id={props.containerId} style={{ flex: 1 }} />
-        <ModalController
-          title={props.controllerTitle}
-          buttonLabel={props.controllerButtonLabel}
-        >
-          {props.children}
-        </ModalController>
-      </div>
-    </IntlProvider>
-  </ThemeProvider>
-);
+const PreviewContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: ${props => props.height};
+  border: 1px solid ${customProperties.colorNeutral95};
+`;
+const ColumnsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  > * + * {
+    margin: 0 0 0 ${customProperties.spacingM};
+  }
+`;
+const ColumnLeft = styled.div`
+  flex: 2;
+  height: 100%;
+`;
+const ColumnRight = styled.div`
+  flex: 1;
+  height: 100%;
+  overflow: auto;
+`;
+
+const KnobsController = props => {
+  const initialValues = props.knobs.reduce(
+    (mapped, knobConfig) => ({
+      ...mapped,
+      [knobConfig.name]: knobConfig.initialValue,
+    }),
+    {}
+  );
+  return (
+    <Formik
+      initialValues={initialValues}
+      render={formikProps => {
+        const form = (
+          <Spacings.Stack size="m">
+            {props.knobs.map(knobConfig => {
+              switch (knobConfig.kind) {
+                case 'text':
+                  return (
+                    <TextField
+                      key={knobConfig.name}
+                      name={knobConfig.name}
+                      title={knobConfig.label}
+                      value={formikProps.values[knobConfig.name]}
+                      errors={formikProps.errors[knobConfig.name]}
+                      touched={formikProps.touched[knobConfig.name]}
+                      onChange={formikProps.handleChange}
+                      onBlur={formikProps.handleBlur}
+                      onFocus={formikProps.handleFocus}
+                    />
+                  );
+                case 'text-multi':
+                  return (
+                    <MultilineTextField
+                      key={knobConfig.name}
+                      name={knobConfig.name}
+                      title={knobConfig.label}
+                      value={formikProps.values[knobConfig.name]}
+                      errors={formikProps.errors[knobConfig.name]}
+                      touched={formikProps.touched[knobConfig.name]}
+                      onChange={formikProps.handleChange}
+                      onBlur={formikProps.handleBlur}
+                      onFocus={formikProps.handleFocus}
+                    />
+                  );
+                case 'select':
+                  return (
+                    <SelectField
+                      key={knobConfig.name}
+                      name={knobConfig.name}
+                      title={knobConfig.label}
+                      options={knobConfig.valueOptions}
+                      value={formikProps.values[knobConfig.name]}
+                      errors={formikProps.errors[knobConfig.name]}
+                      touched={formikProps.touched[knobConfig.name]}
+                      onChange={formikProps.handleChange}
+                      onBlur={formikProps.handleBlur}
+                      onFocus={formikProps.handleFocus}
+                    />
+                  );
+                default:
+                  throw new Error(`Unknown kind "${knobConfig.kind}"`);
+              }
+            })}
+          </Spacings.Stack>
+        );
+        return props.children({ form, values: formikProps.values });
+      }}
+    />
+  );
+};
+KnobsController.displayName = 'KnobsController';
+KnobsController.propTypes = {
+  knobs: PropTypes.arrayOf(
+    PropTypes.shape({
+      kind: PropTypes.oneOf(['text', 'text-multi', 'select']).isRequired,
+      name: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      initialValue: PropTypes.any.isRequired,
+      valueOptions: PropTypes.arrayOf(
+        PropTypes.shape({
+          value: PropTypes.string.isRequired,
+          label: PropTypes.string.isRequired,
+        }).isRequired
+      ),
+    }).isRequired
+  ).isRequired,
+  children: PropTypes.func.isRequired,
+};
+
+const ExampleWrapper = props => {
+  const [isOpen, toggle] = React.useState(false);
+  return (
+    <ThemeProvider
+      theme={{
+        // Reset theme to default styles, so that the example uses the default uikit tokens
+        fontFamilyDefault: customProperties.fontFamilyDefault,
+        colorSolid: customProperties.colorsSolid,
+      }}
+    >
+      <IntlProvider locale="en">
+        <KnobsController knobs={props.knobs}>
+          {({ form, values }) => (
+            <Spacings.Stack>
+              <PreviewContainer height="400px">
+                {props.children({ values, isPlaygroundMode: false })}
+              </PreviewContainer>
+              <Spacings.Inline>
+                <Tooltip position="top" title="Enter playground mode">
+                  <IconButton
+                    icon={<CodeViewIcon />}
+                    label="Enter playground mode"
+                    onClick={() => toggle(true)}
+                  />
+                </Tooltip>
+              </Spacings.Inline>
+              <InfoDialog
+                title="Playground"
+                size="scale"
+                isOpen={isOpen}
+                onClose={() => toggle(false)}
+                getParentSelector={() => document.body}
+              >
+                <ColumnsContainer>
+                  <ColumnLeft>
+                    <PreviewContainer height="100%">
+                      {props.children({ values, isPlaygroundMode: true })}
+                    </PreviewContainer>
+                  </ColumnLeft>
+                  <ColumnRight>{form}</ColumnRight>
+                </ColumnsContainer>
+              </InfoDialog>
+            </Spacings.Stack>
+          )}
+        </KnobsController>
+      </IntlProvider>
+    </ThemeProvider>
+  );
+};
 ExampleWrapper.displayName = 'ExampleWrapper';
 ExampleWrapper.propTypes = {
-  containerId: PropTypes.string.isRequired,
-  controllerTitle: PropTypes.string.isRequired,
-  controllerButtonLabel: PropTypes.string.isRequired,
+  knobs: PropTypes.arrayOf(
+    PropTypes.shape({
+      kind: PropTypes.oneOf(['text', 'text-multi', 'select']).isRequired,
+      name: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      initialValue: PropTypes.any.isRequired,
+      valueOptions: PropTypes.arrayOf(
+        PropTypes.shape({
+          value: PropTypes.string.isRequired,
+          label: PropTypes.string.isRequired,
+        }).isRequired
+      ),
+    }).isRequired
+  ).isRequired,
   children: PropTypes.func.isRequired,
 };
 

--- a/packages/application-components/src/components/internals/for-docs/example-wrapper/example-wrapper.js
+++ b/packages/application-components/src/components/internals/for-docs/example-wrapper/example-wrapper.js
@@ -130,7 +130,7 @@ KnobsController.propTypes = {
 };
 
 const ExampleWrapper = props => {
-  const [isOpen, toggle] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   return (
     <ThemeProvider
       theme={{
@@ -151,7 +151,7 @@ const ExampleWrapper = props => {
                   <IconButton
                     icon={<CodeViewIcon />}
                     label="Enter playground mode"
-                    onClick={() => toggle(true)}
+                    onClick={() => setIsOpen(true)}
                   />
                 </Tooltip>
               </Spacings.Inline>
@@ -159,7 +159,7 @@ const ExampleWrapper = props => {
                 title="Playground"
                 size="scale"
                 isOpen={isOpen}
-                onClose={() => toggle(false)}
+                onClose={() => setIsOpen(false)}
                 getParentSelector={() => document.body}
               >
                 <ColumnsContainer>

--- a/packages/application-components/src/components/internals/for-docs/modal-controller/modal-controller.js
+++ b/packages/application-components/src/components/internals/for-docs/modal-controller/modal-controller.js
@@ -1,36 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import {
   Spacings,
   Text,
   SecondaryButton,
 } from '@commercetools-frontend/ui-kit';
 
+const GridContainer = styled.div`
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+`;
+const PortalContainer = styled.div`
+  flex: 1;
+`;
+
 const ModalController = props => {
-  const [isOpen, toggle] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   return (
     <>
-      <div id={props.containerId} style={{ flex: 1 }} />
-      <div
-        style={{
-          display: 'grid',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          width: '100%',
-        }}
-      >
+      <PortalContainer id={props.containerId} />
+      <GridContainer>
         <Spacings.Stack>
           <Text.Body>{props.title}</Text.Body>
           <Spacings.Inline>
             <SecondaryButton
               label={props.buttonLabel}
-              onClick={() => toggle(true)}
+              onClick={() => setIsOpen(true)}
             />
           </Spacings.Inline>
-          {props.children({ isOpen, toggle })}
+          {props.children({ isOpen, setIsOpen })}
         </Spacings.Stack>
-      </div>
+      </GridContainer>
     </>
   );
 };

--- a/packages/application-components/src/components/internals/for-docs/modal-controller/modal-controller.js
+++ b/packages/application-components/src/components/internals/for-docs/modal-controller/modal-controller.js
@@ -9,30 +9,34 @@ import {
 const ModalController = props => {
   const [isOpen, toggle] = React.useState(false);
   return (
-    <div
-      style={{
-        display: 'grid',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        width: '100%',
-      }}
-    >
-      <Spacings.Stack>
-        <Text.Body>{props.title}</Text.Body>
-        <Spacings.Inline>
-          <SecondaryButton
-            label={props.buttonLabel}
-            onClick={() => toggle(true)}
-          />
-        </Spacings.Inline>
-        {props.children({ isOpen, toggle })}
-      </Spacings.Stack>
-    </div>
+    <>
+      <div id={props.containerId} style={{ flex: 1 }} />
+      <div
+        style={{
+          display: 'grid',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          width: '100%',
+        }}
+      >
+        <Spacings.Stack>
+          <Text.Body>{props.title}</Text.Body>
+          <Spacings.Inline>
+            <SecondaryButton
+              label={props.buttonLabel}
+              onClick={() => toggle(true)}
+            />
+          </Spacings.Inline>
+          {props.children({ isOpen, toggle })}
+        </Spacings.Stack>
+      </div>
+    </>
   );
 };
 ModalController.displayName = 'ModalController';
 ModalController.propTypes = {
+  containerId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   buttonLabel: PropTypes.string.isRequired,
   children: PropTypes.func.isRequired,

--- a/packages/application-components/src/components/modal-page/modal-page.story.js
+++ b/packages/application-components/src/components/modal-page/modal-page.story.js
@@ -15,7 +15,7 @@ import Readme from './README.md';
 import ModalPage from './modal-page';
 
 const ModalController = props => {
-  const [isOpen, toggle] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   return (
     <div
       style={{
@@ -33,10 +33,10 @@ const ModalController = props => {
         <Spacings.Inline>
           <SecondaryButton
             label="Open Modal Page"
-            onClick={() => toggle(true)}
+            onClick={() => setIsOpen(true)}
           />
         </Spacings.Inline>
-        {props.children({ isOpen, toggle })}
+        {props.children({ isOpen, setIsOpen })}
       </Spacings.Stack>
     </div>
   );
@@ -53,10 +53,10 @@ storiesOf('Components|Modals', module)
     <React.Fragment>
       <div id={PORTALS_CONTAINER_ID} />
       <ModalController>
-        {({ isOpen, toggle }) => (
+        {({ isOpen, setIsOpen }) => (
           <ModalPage
             isOpen={isOpen}
-            onClose={() => toggle(false)}
+            onClose={() => setIsOpen(false)}
             title={'Lorem ipsus'}
             subtitle={<Text.Body>{'Lorem ipsus ...'}</Text.Body>}
             components={{
@@ -82,11 +82,11 @@ storiesOf('Components|Modals', module)
               <Text.Body>{'Lorem ipsus ...'}</Text.Body>
               <ModalController>
                 {/* eslint-disable-next-line no-shadow */}
-                {({ isOpen, toggle }) => (
+                {({ isOpen, setIsOpen }) => (
                   <ModalPage
                     level="two"
                     isOpen={isOpen}
-                    onClose={() => toggle(false)}
+                    onClose={() => setIsOpen(false)}
                   >
                     <Spacings.Stack scale="m">
                       <Text.Body>{'Lorem ipsus ...'}</Text.Body>

--- a/website/src/layouts/content.js
+++ b/website/src/layouts/content.js
@@ -19,7 +19,6 @@ const LayoutContent = props => {
         <LayoutHeader />
         <LayoutSidebar isMenuOpen={isMenuOpen} setMenuOpen={setMenuOpen} />
         <LayoutMain
-          columns={3}
           css={css`
             grid-column: auto;
             grid-row: ${isMenuOpen ? '3' : '2'};

--- a/website/src/layouts/internals/globals.js
+++ b/website/src/layouts/internals/globals.js
@@ -11,8 +11,13 @@ const Globals = () => (
         padding: 0;
         margin: 0;
         height: 100vh;
-        font-family: 'roboto mono', sans-serif;
         color: ${colors.light.text};
+        font-family: 'roboto mono', sans-serif;
+
+        /* Keep it to 13px, so that the component examples have the "correct" size
+        that we use in the MC. The content font size can be adjusted separately in
+        the templates/markdown.js file. */
+        font-size: 13px;
       }
     `}
   />

--- a/website/src/layouts/internals/layout-main.js
+++ b/website/src/layouts/internals/layout-main.js
@@ -7,7 +7,6 @@ const LayoutMain = props => (
     role="main"
     className={props.className}
     css={css`
-      grid-column: ${props.columns};
       grid-row: 2;
       min-width: 0;
       overflow-x: hidden;
@@ -32,7 +31,6 @@ const LayoutMain = props => (
 LayoutMain.displayName = 'LayoutMain';
 LayoutMain.propTypes = {
   className: PropTypes.string,
-  columns: PropTypes.oneOf([1, 2, 3]),
   children: PropTypes.node.isRequired,
 };
 

--- a/website/src/layouts/marketing.js
+++ b/website/src/layouts/marketing.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import LayoutContainer from './internals/layout-container';
 import LayoutHeader from './internals/layout-header';
 import LayoutFooter from './internals/layout-footer';
@@ -11,7 +12,11 @@ const LayoutMarketing = props => (
     <Globals />
     <LayoutContainer>
       <LayoutHeader />
-      <LayoutMain columns={1}>
+      <LayoutMain
+        css={css`
+          grid-column: 1/4;
+        `}
+      >
         {props.children}
         <LayoutFooter />
       </LayoutMain>

--- a/website/src/templates/markdown.js
+++ b/website/src/templates/markdown.js
@@ -12,6 +12,25 @@ import { LayoutContent } from '../layouts';
 import { SEO, CodeBlock, ExternalLink } from '../components';
 import AnchorLinkSvg from '../images/anchor-link.svg';
 
+// Typography sizes have been calculated from https://type-scale.com
+// Ref: https://medium.com/sketch-app-sources/exploring-responsive-type-scales-cf1da541be54
+const typographyScale = {
+  perfectFourth: {
+    h1: '4.209em',
+    h2: '3.157em',
+    h3: '2.369em',
+    h4: '1.777em',
+    h5: '1.333em',
+  },
+  augmentedFourth: {
+    h1: '5.653em',
+    h2: '3.998em',
+    h3: '2.827em',
+    h4: '1.999em',
+    h5: '1.414em',
+  },
+};
+
 const TypographyPage = styled.div`
   font-family: 'Raleway', sans-serif;
   font-weight: 400;
@@ -24,31 +43,29 @@ const headerStyles = () => css`
   margin: 2.75rem 0 1rem;
 `;
 
-// Typography sizes have been calculated from https://type-scale.com
-// Ref: https://medium.com/sketch-app-sources/exploring-responsive-type-scales-cf1da541be54
 const Paragraph = styled.p`
   margin-bottom: 1.25em;
 `;
 const H1 = styled.h1`
   ${headerStyles};
-  font-size: 4.209em;
+  font-size: ${typographyScale.perfectFourth.h1};
   margin-top: 0;
 `;
 const H2 = styled.h2`
   ${headerStyles};
-  font-size: 3.157em;
+  font-size: ${typographyScale.perfectFourth.h2};
 `;
 const H3 = styled.h3`
   ${headerStyles};
-  font-size: 2.369em;
+  font-size: ${typographyScale.perfectFourth.h3};
 `;
 const H4 = styled.h4`
   ${headerStyles};
-  font-size: 1.777em;
+  font-size: ${typographyScale.perfectFourth.h4};
 `;
 const H5 = styled.h5`
   ${headerStyles};
-  font-size: 1.333em;
+  font-size: ${typographyScale.perfectFourth.h5};
 `;
 const H6 = styled.h6`
   ${headerStyles};


### PR DESCRIPTION
In order to provide a similar experience of testing components in storybook, but keeping the content and design of the website, we decided to render some input elements to control some of the component props.

A previous attempt was done in #721 

![2019-06-11 21 44 27](https://user-images.githubusercontent.com/1110551/59301635-59219e00-8c92-11e9-8b3d-c63263c63f2a.gif)
