### PR TITLE
fix(permissions): do not use shared types, keep them within the component file

### DIFF
--- a/packages/permissions/src/components/authorized/authorized.spec.tsx
+++ b/packages/permissions/src/components/authorized/authorized.spec.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { TPermissions, TPermissionName } from '../../types';
 import { permissions } from '../../constants';
 import Authorized from './authorized';
 
+type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 type TestProps = {
   shouldMatchSomePermissions: boolean;
   demandedPermissions: TPermissionName[];

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import invariant from 'tiny-invariant';
-import { TPermissions, TPermissionName } from '../../types';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   hasSomePermissions,
@@ -8,6 +7,11 @@ import {
   getInvalidPermissions,
 } from '../../utils/has-permissions';
 import getDisplayName from '../../utils/get-display-name';
+
+type TPermissions = {
+  [key: string]: boolean;
+};
+type TPermissionName = string;
 
 const defaultProps = {
   shouldMatchSomePermissions: false,

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { render, waitForElement } from 'react-testing-library';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
-import { TPermissionName } from '../../types';
 import { permissions } from '../../constants';
 import branchOnPermissions from './branch-on-permissions';
 
 const AuthorizedComponent = () => <div>{'Authorized'}</div>;
 const UnauthorizedComponent = () => <div>{'Not authorized'}</div>;
 
-const renderWithPermissions = (demandedPermissions: TPermissionName[]) => {
+const renderWithPermissions = (demandedPermissions: string[]) => {
   const Wrapped = branchOnPermissions(
     demandedPermissions,
     UnauthorizedComponent

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import { TPermissionName } from '../../types';
 import getDisplayName from '../../utils/get-display-name';
 import Authorized from '../authorized';
+
+type TPermissionName = string;
 
 const branchOnPermissions = <OwnProps extends {}>(
   demandedPermissions: TPermissionName[],

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import { TPermissions, TPermissionName } from '../../types';
 import Authorized from '../authorized';
 import RestrictedByPermissions from './restricted-by-permissions';
 
+type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 type TApplicationContext = {
   permissions: TPermissions | null;
 };
-
 type TestProps = {
   shouldMatchSomePermissions: boolean;
   permissions: TPermissionName[];

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import invariant from 'tiny-invariant';
-import { TPermissionName } from '../../types';
 import isNil from 'lodash/isNil';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import Authorized from '../authorized';
@@ -8,6 +7,7 @@ import Authorized from '../authorized';
 const getHasChildren = (children: React.ReactNode) =>
   React.Children.count(children) > 0;
 
+type TPermissionName = string;
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 type Props = {
   shouldMatchSomePermissions?: boolean;

--- a/packages/permissions/src/constants.ts
+++ b/packages/permissions/src/constants.ts
@@ -1,4 +1,6 @@
-import { TPermissionNames } from './types';
+export type TPermissionNames = {
+  [key: string]: string;
+};
 
 const defaultPermissions = {
   ManageProject: 'ManageProject',

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { render } from 'react-testing-library';
-import { TPermissions, TPermissionName } from '../../types';
 import { permissions } from '../../constants';
 import useIsAuthorized from './use-is-authorized';
 
+type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 type TestProps = {
   demandedPermissions: TPermissionName[];
   shouldMatchSomePermissions: boolean;

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -1,10 +1,14 @@
 import React from 'react';
-import { TPermissionName, TPermissionValue, TPermissions } from '../../types';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   hasSomePermissions,
   hasEveryPermissions,
 } from '../../utils/has-permissions';
+
+type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 
 // Forward-compatibility with React Hooks 🎉
 const useIsAuthorized = ({
@@ -13,7 +17,7 @@ const useIsAuthorized = ({
 }: {
   demandedPermissions: TPermissionName[];
   shouldMatchSomePermissions: boolean;
-}): Error | TPermissionValue => {
+}) => {
   if (!React.useContext)
     throw new Error(
       `React hooks do not seem to be available yet in the installed React version "${React.version}". Please check the React Hooks documentation for more info: https://reactjs.org/hooks.`

--- a/packages/permissions/src/types.ts
+++ b/packages/permissions/src/types.ts
@@ -1,8 +1,0 @@
-export type TPermissionName = string;
-export type TPermissionNames = {
-  [key: string]: TPermissionName;
-};
-export type TPermissionValue = boolean;
-export type TPermissions = {
-  [key: string]: TPermissionValue;
-};

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -1,4 +1,3 @@
-import { TPermissionName, TPermissions } from '../types';
 import { permissions } from '../constants';
 import {
   hasPermission,
@@ -6,6 +5,11 @@ import {
   hasSomePermissions,
   getInvalidPermissions,
 } from './has-permissions';
+
+type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 
 describe('hasPermission', () => {
   let demandedPermission: TPermissionName;

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -1,6 +1,10 @@
 import isNil from 'lodash/isNil';
-import { TPermissionName, TPermissions } from '../types';
 import { permissions } from '../constants';
+
+type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 
 // Build the permission key from the definition to match it to the format coming
 // from the API.


### PR DESCRIPTION
So that we can generate proper prop-types. Yes it's a bit repetitive but the duplicated types are very simple, so I think it's worth the effort in this case.

**Before**
<img width="565" alt="Screenshot 2019-06-14 at 23 13 20" src="https://user-images.githubusercontent.com/1110551/59538514-57f2aa00-8efa-11e9-86ec-326440b4791f.png">

**After**
<img width="696" alt="Screenshot 2019-06-14 at 23 12 27" src="https://user-images.githubusercontent.com/1110551/59538525-6345d580-8efa-11e9-9dff-c654edbe4e45.png">
