### PR TITLE
chore: init github labels config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,2 @@
-GITHUB_AUTH=
+GITHUB_AUTH= # for lerna changelog
+AUTH_TOKEN= # for github labels

--- a/.github-labelsrc.json
+++ b/.github-labelsrc.json
@@ -1,0 +1,170 @@
+[
+  {
+    "id": 1158981072,
+    "name": "Semver: BREAKING",
+    "color": "e3f166",
+    "description": "A breaking change"
+  },
+  {
+    "id": 1158980916,
+    "name": "Semver: FEATURE",
+    "color": "e3f166",
+    "description": "A feature in semver"
+  },
+  {
+    "id": 1158979979,
+    "name": "Semver: FIX",
+    "color": "daf257",
+    "description": "A fix in semver (patch)"
+  },
+  {
+    "id": 1158979615,
+    "name": "Semver: UNRELATED",
+    "color": "e3f166",
+    "description": "A change that does not effect the version"
+  },
+  {
+    "id": 1295395245,
+    "name": "⚠️ Blocked ‼",
+    "color": "db756f",
+    "description": ""
+  },
+  {
+    "id": 1083802571,
+    "name": "⛑ Type: Refactoring",
+    "color": "bfd4f2",
+    "description": ""
+  },
+  {
+    "id": 1083802568,
+    "name": "✍️ Type: Documentation",
+    "color": "fad8c7",
+    "description": ""
+  },
+  {
+    "id": 1083802563,
+    "name": "❌ Type: Invalid",
+    "color": "e4e669",
+    "description": "This doesn't seem right"
+  },
+  {
+    "id": 1083802567,
+    "name": "❓ Type: Question",
+    "color": "d876e3",
+    "description": "Further information is requested"
+  },
+  {
+    "id": 1083802559,
+    "name": "🌊 Resolution: Wont Fix",
+    "color": "ffffff",
+    "description": "This will not be worked on"
+  },
+  {
+    "id": 1083802560,
+    "name": "🌗 good rotation topic",
+    "color": "bfdadc",
+    "description": "Good to rotate a member into Application Kit to work on this topic"
+  },
+  {
+    "id": 1083802556,
+    "name": "🏕 Technical Exploration",
+    "color": "1d76db",
+    "description": "Try out a new library or approach"
+  },
+  {
+    "id": 1083802553,
+    "name": "🏩 help wanted",
+    "color": "008672",
+    "description": "Extra attention is needed"
+  },
+  {
+    "id": 1083802569,
+    "name": "🐛 Type: Bug",
+    "color": "d73a4a",
+    "description": "Something isn't working"
+  },
+  {
+    "id": 1083802558,
+    "name": "👨‍⚕️ Type: Tests",
+    "color": "0b3377",
+    "description": ""
+  },
+  {
+    "id": 1083802557,
+    "name": "👨‍🎨 Status: UI/UX Review",
+    "color": "d4c5f9",
+    "description": "Requires review from design team"
+  },
+  {
+    "id": 1083802555,
+    "name": "👯 Resolution: duplicate",
+    "color": "cfd3d7",
+    "description": "This issue or pull request already exists"
+  },
+  {
+    "id": 1083802561,
+    "name": "👶 good first contribution",
+    "color": "7057ff",
+    "description": "Good for newcomers"
+  },
+  {
+    "id": 1083802566,
+    "name": "💅 Type: Enhancement",
+    "color": "88fca1",
+    "description": "Improves an existing code"
+  },
+  {
+    "id": 1083802573,
+    "name": "💡 Type: Idea",
+    "color": "ffccd7",
+    "description": "Propose a new idea"
+  },
+  {
+    "id": 1084713639,
+    "name": "💥 Type: Breaking Change",
+    "color": "222222",
+    "description": ""
+  },
+  {
+    "id": 1083802570,
+    "name": "📬 Resolution: Accepted",
+    "color": "fef2c0",
+    "description": "An issue was accepted during triaging"
+  },
+  {
+    "id": 1083802572,
+    "name": "🔮 Type: Chore",
+    "color": "98db59",
+    "description": ""
+  },
+  {
+    "id": 1083802565,
+    "name": "🖐 Status: On Hold",
+    "color": "fef2c0",
+    "description": ""
+  },
+  {
+    "id": 1083802562,
+    "name": "🙏 Status: Dev Review",
+    "color": "5319e7",
+    "description": ""
+  },
+  {
+    "id": 1084711241,
+    "name": "🚀 Type: New Feature",
+    "color": "58ce3d",
+    "description": "Something new"
+  },
+  {
+    "id": 1083802554,
+    "name": "🚧 Status: WIP",
+    "color": "d3a550",
+    "description": "Work in progress"
+  },
+  {
+    "id": 1083802564,
+    "name": "🧟 Type: Technical Debt",
+    "color": "be1fdd",
+    "description": ""
+  }
+]

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "website"
   ],
   "devDependencies": {
+    "@commercetools/github-labels": "1.0.1",
     "@commitlint/cli": "8.0.0",
     "@commitlint/config-conventional": "8.0.0",
     "@percy/puppeteer": "1.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,7 +910,20 @@
     lodash.omit "^4.5.0"
     react-display-name "0.2.4"
 
-"@commercetools/http-user-agent@2.1.0":
+"@commercetools/github-labels@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@commercetools/github-labels/-/github-labels-1.0.1.tgz#31f640cd044021acdf9a3c17fb058a1ef11780d3"
+  integrity sha512-+ZXbfzZGUrG5o3U+ocovbKjciPy3eBReDIWYiIUBND3czTm/cjO6EeAiRrcSzL73mPZXbrZw/+ISd9c6rSnC+Q==
+  dependencies:
+    "@commercetools/http-user-agent" "^2.0.0"
+    "@octokit/rest" "^16.25.0"
+    cosmiconfig "^5.2.0"
+    dotenv "^7.0.0"
+    file-system "^2.2.2"
+    mri "^1.1.4"
+    shelljs "^0.8.3"
+
+"@commercetools/http-user-agent@2.1.0", "@commercetools/http-user-agent@^2.0.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@commercetools/http-user-agent/-/http-user-agent-2.1.0.tgz#30b8a617c6e1cb299dd2cd364c1b635fafb8c3de"
   integrity sha512-Dl0hHZWzquB7yM3t1c+J+V8hMYGSBvJhdF5KPlzzn++eD01yYJ656SSVUM5v2TQ3WOfJijZPGVvS6TbztDiEIQ==
@@ -2601,6 +2614,25 @@
   version "16.27.3"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.27.3.tgz#20ad5d0c7043364d1e1f72fa74f825c181771fc0"
   integrity sha512-WWH/SHF4kus6FG+EAfX7/JYH70EjgFYa4AAd2Lf1hgmgzodhrsoxpXPSZliZ5BdJruZPMP7ZYaPoTrYCCKYzmQ==
+  dependencies:
+    "@octokit/request" "^4.0.1"
+    "@octokit/request-error" "^1.0.2"
+    atob-lite "^2.0.0"
+    before-after-hook "^1.4.0"
+    btoa-lite "^1.0.0"
+    deprecation "^2.0.0"
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+    lodash.uniq "^4.5.0"
+    octokit-pagination-methods "^1.1.0"
+    once "^1.4.0"
+    universal-user-agent "^2.0.0"
+    url-template "^2.0.8"
+
+"@octokit/rest@^16.25.0":
+  version "16.28.1"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.28.1.tgz#a10c3d4fe61e994878d66a4c12b9923b18548236"
+  integrity sha512-9H/5F0f2bSVhk78ypu/A9dkK5GCH/aI8CxRJ0L8JU/XEYNIYozxqD6HVC7shsofrCfR61YORfjTE+GxfZ/wasQ==
   dependencies:
     "@octokit/request" "^4.0.1"
     "@octokit/request-error" "^1.0.2"
@@ -7790,6 +7822,11 @@ dotenv@^4.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
   integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
 
+dotenv@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
+  integrity sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==
+
 download@^6.2.2:
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/download/-/download-6.2.5.tgz#acd6a542e4cd0bb42ca70cfc98c9e43b07039714"
@@ -9111,6 +9148,21 @@ file-loader@^1.1.11:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
+
+file-match@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/file-match/-/file-match-1.0.2.tgz#c9cad265d2c8adf3a81475b0df475859069faef7"
+  integrity sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=
+  dependencies:
+    utils-extend "^1.0.6"
+
+file-system@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/file-system/-/file-system-2.2.2.tgz#7d65833e3a2347dcd956a813c677153ed3edd987"
+  integrity sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=
+  dependencies:
+    file-match "^1.0.1"
+    utils-extend "^1.0.4"
 
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
@@ -14795,7 +14847,7 @@ mozjpeg@^6.0.0:
     bin-wrapper "^4.0.0"
     logalot "^2.1.0"
 
-mri@1.1.4:
+mri@1.1.4, mri@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
   integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
@@ -19510,7 +19562,7 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@0.8.3:
+shelljs@0.8.3, shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -21734,6 +21786,11 @@ utila@^0.4.0, utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
+
+utils-extend@^1.0.4, utils-extend@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/utils-extend/-/utils-extend-1.0.8.tgz#ccfd7b64540f8e90ee21eec57769d0651cab8a5f"
+  integrity sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8=
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR simply creates an initial entry in version control about the current github labels. It uses a [new package](https://github.com/commercetools/github-labels) that we built recently to keep the labels in sync with a local config.

The idea is that the labels are managed through a config file, which can be better reviewed as it's in version control. It would also then make it easier to replicate the same config across different repositories.