### PR TITLE
chore(app-shell): remove org list toggle

### DIFF
--- a/packages/application-shell/src/components/quick-access/create-commands.js
+++ b/packages/application-shell/src/components/quick-access/create-commands.js
@@ -398,7 +398,7 @@ export default ({
       ],
       action: { type: 'go', to: `/account/projects` },
     },
-    featureToggles.organizationsList && {
+    {
       id: 'go/manage-organizations',
       text: intl.formatMessage(messages.openManageOrganizations),
       keywords: [

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -353,7 +353,6 @@ export default flowRight(
   injectIntl,
   injectFeatureToggles([
     'pimSearch',
-    'organizationsList',
     'customApplications',
     'canViewOrders',
     'canViewCategories',

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -37,7 +37,6 @@ const managePermissions = { canManageProject: true };
 
 const flags = {
   pimSearch: true,
-  organizationsList: true,
   customApplications: true,
   canViewOrders: true,
   canViewCategories: true,

--- a/packages/application-shell/src/feature-toggles.js
+++ b/packages/application-shell/src/feature-toggles.js
@@ -11,4 +11,3 @@
  */
 
 // eslint-disable-next-line import/prefer-default-export
-export const ORGANIZATIONS_LIST = 'organizationsList';


### PR DESCRIPTION
#### Summary

This removes the feature toggle for the org list. This may seem a bit quick given the release happened Thursday last week. However, the AC's views are to be turned off today too and we already rolled out 2-3 fixes.