### PR TITLE
feat(app-shell): add user deleted logout reason

### DIFF
--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -26,6 +26,7 @@ export const LOGOUT_REASONS = {
   USER: 'user',
   UNAUTHORIZED: 'unauthorized',
   INVALID: 'invalid',
+  DELETED: 'deleted',
 };
 
 export const GRAPHQL_TARGETS = {


### PR DESCRIPTION
#### Summary

This pull request adds redirecting a user, given his/her account does not exist, to logout with a `?reason=deleted`. Our internal app can then catch this an render an error accordingly instead of just showing a general "ice cream"-error.