### PR TITLE
chore: move with-mouse-over-state internal

### DIFF
--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 import Downshift from 'downshift';
 import { ToggleFeature } from '@flopflip/react-broadcast';
 import {
-  withMouseOverState,
   CaretDownIcon,
   Text,
   Spacings,
@@ -19,6 +18,7 @@ import {
 } from '@commercetools-frontend/constants';
 import { MCSupportFormURL } from '../../constants';
 import withApplicationsMenu from '../with-applications-menu';
+import withMouseOverState from '../with-mouse-over-state';
 import handleApolloErrors from '../handle-apollo-errors';
 import styles from './user-settings-menu.mod.css';
 import messages from './messages';

--- a/packages/application-shell/src/components/with-mouse-over-state/README.md
+++ b/packages/application-shell/src/components/with-mouse-over-state/README.md
@@ -1,0 +1,33 @@
+# HoCs: withMouseOverState
+
+## Usage
+
+```js
+import withMouseOverState from '../with-mouse-over-state';
+
+const FooElement = props => (
+  <div onMouseOver={props.handleMouseOver} onMouseOut={props.handleMouseOut}>
+    {props.isMouseOver ? 'Mouse is over' : 'Mouse is out'}
+  </div>
+);
+
+export default withMouseOverState(FooElement);
+```
+
+#### Description
+
+Manages the state of `isMouseOver` injecting it into a wrapped component.
+Moreover, the handlers injected must be used to update the state in the HoC.
+
+#### Properties
+
+| Props             | Type   | Required | Values | Default | Description                                                      |
+| ----------------- | ------ | :------: | ------ | ------- | ---------------------------------------------------------------- |
+| `isMouseOver`     | `bool` |    ✅    | -      | -       | Indicates if the mouse is currently over the element             |
+| `handleMouseOver` | `func` |    ✅    | -      | -       | Callback function to update the state whenever the mouse is over |
+| `handleMouseOut`  | `func` |    ✅    | -      | -       | Callback function to update the state whenever the mouse is out  |
+
+Main Functions and use cases are:
+
+- Buttons and icons _example: icon needs change in theme whenever button is
+  hovered_

--- a/packages/application-shell/src/components/with-mouse-over-state/index.js
+++ b/packages/application-shell/src/components/with-mouse-over-state/index.js
@@ -1,0 +1,1 @@
+export { default } from './with-mouse-over-state';

--- a/packages/application-shell/src/components/with-mouse-over-state/with-mouse-over-state.js
+++ b/packages/application-shell/src/components/with-mouse-over-state/with-mouse-over-state.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import wrapDisplayName from '../wrap-display-name';
+
+const withMouseOverState = BaseComponent => {
+  class WithMouseOverState extends React.Component {
+    static displayName = wrapDisplayName(BaseComponent, 'withMouseOverState');
+
+    state = {
+      isMouseOver: false,
+    };
+
+    setMouseOver = nextMouseOver =>
+      this.setState({ isMouseOver: nextMouseOver });
+
+    handleMouseOver = () => this.setMouseOver(true);
+    handleMouseOut = () => this.setMouseOver(false);
+
+    render() {
+      const injectedProps = {
+        isMouseOver: this.state.isMouseOver,
+        handleMouseOver: this.handleMouseOver,
+        handleMouseOut: this.handleMouseOut,
+      };
+
+      return <BaseComponent {...{ ...this.props, ...injectedProps }} />;
+    }
+  }
+
+  return WithMouseOverState;
+};
+
+export default withMouseOverState;

--- a/packages/application-shell/src/components/with-mouse-over-state/with-mouse-over-state.spec.js
+++ b/packages/application-shell/src/components/with-mouse-over-state/with-mouse-over-state.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import withMouseOverState from './with-mouse-over-state';
+
+const Component = withMouseOverState(props => (
+  <div
+    data-testid="div"
+    onMouseOver={props.handleMouseOver}
+    onMouseOut={props.handleMouseOut}
+  >
+    {props.isMouseOver ? 'mouse over' : 'mouse not over'}
+  </div>
+));
+
+it('should provide isMouseOver as "false" by default', () => {
+  const { getByTestId } = render(<Component />);
+  expect(getByTestId('div')).toHaveTextContent('mouse not over');
+});
+
+it('should work through the whole cycle', () => {
+  const { getByTestId } = render(<Component />);
+
+  // it should provide isMouseOver as "true" when mouse is over
+  fireEvent(
+    getByTestId('div'),
+    new MouseEvent('mouseover', { bubbles: true, cancelable: true })
+  );
+  expect(getByTestId('div')).toHaveTextContent('mouse over');
+
+  // it should provide isMouseOver as "false" when mouse is up again
+  fireEvent(
+    getByTestId('div'),
+    new MouseEvent('mouseout', { bubbles: true, cancelable: true })
+  );
+  expect(getByTestId('div')).toHaveTextContent('mouse not over');
+});

--- a/packages/application-shell/src/components/wrap-display-name/index.js
+++ b/packages/application-shell/src/components/wrap-display-name/index.js
@@ -1,0 +1,1 @@
+export { default } from './wrap-display-name';

--- a/packages/application-shell/src/components/wrap-display-name/wrap-display-name.js
+++ b/packages/application-shell/src/components/wrap-display-name/wrap-display-name.js
@@ -1,0 +1,5 @@
+export default (BaseComponent, hocName) => {
+  const previousDisplayName = BaseComponent.displayName || BaseComponent.name;
+
+  return `${hocName}(${previousDisplayName || 'Component'})`;
+};

--- a/packages/application-shell/src/components/wrap-display-name/wrap-display-name.spec.js
+++ b/packages/application-shell/src/components/wrap-display-name/wrap-display-name.spec.js
@@ -1,0 +1,19 @@
+import wrapDisplayName from './wrap-display-name';
+
+function BaseComponent() {
+  return 'BaseComponent';
+}
+BaseComponent.displayName = 'BaseComponent';
+
+describe('rendering', () => {
+  const hocName = 'testHoc';
+  let wrappedDisplayName;
+
+  beforeEach(() => {
+    wrappedDisplayName = wrapDisplayName(BaseComponent, hocName);
+  });
+
+  it('should include `hocName` in wrapped display name', () => {
+    expect(wrappedDisplayName).toContain(hocName);
+  });
+});


### PR DESCRIPTION
#### Summary

Moves the HOC `withMouseOverState` from UI-Kit internal.

FYI, I tried to refactor to not use it, but it's not so easy since `Avatar` accepts that prop and changes the image opacity and background colour of it's div. I guess we can modify Avatar to accept custom styling through (maybe accepting a default component?) and deal with it that way. But as the current Avatar component states, it's hard to change the appearance on hover without relying on it's implementation details... 