### PR TITLE
chore(circleci): save only node_modules, persist workspace across jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ aliases:
   - &project_directory ~/project
   - &working_directory ~/project/merchant-center-application-kit
   - &project_folder merchant-center-application-kit
+  - &cypress_cache_folder /home/circleci/.cache/Cypress
   - &restore_cache
       name: Restoring yarn cache
       keys:
@@ -27,6 +28,7 @@ executors:
       - image: cypress/base:10
         environment:
           TERM: xterm
+          CYPRESS_CACHE_FOLDER: *cypress_cache_folder
 
 # orbs:
 #   compare-url: iynere/compare-url@1.1.0
@@ -372,7 +374,7 @@ jobs:
       - run:
           name: Run Cypress tests
           command: |
-            npx cypress run \
+            yarn run cypress run \
               <<# parameters.spec>> --spec '<<parameters.spec>>' <</ parameters.spec>> \
               <<# parameters.record >> --record \
                 <<# parameters.group>> --group '<<parameters.group>>' <</ parameters.group>> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,13 @@ aliases:
   - &restore_cache
       name: Restoring yarn cache
       keys:
-        - v3-yarn-cache-{{ checksum "yarn.lock" }}
-        - v3-yarn-cache
+        - v4-yarn-cache-{{ checksum "yarn.lock" }}
+        - v4-yarn-cache
   - &save_cache
       name: Saving yarn cache
-      key: v3-yarn-cache-{{ checksum "yarn.lock" }}
+      key: v4-yarn-cache-{{ checksum "yarn.lock" }}
       paths:
+        - node_modules/
         - ~/.cache/yarn
         - ~/.cache/Cypress
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,10 @@
 version: 2.1
 
 aliases:
+  - &project_directory ~/project
   - &working_directory ~/project/merchant-center-application-kit
+  - &project_folder merchant-center-application-kit
+  - &cypress_cache_folder cypress_cache
 
 executors:
   node_10:
@@ -11,56 +14,67 @@ executors:
   cypress:
     working_directory: *working_directory
     docker:
-      - image: 'cypress/base:10'
+      - image: cypress/base:10
         environment:
           TERM: xterm
+          CYPRESS_CACHE_FOLDER: *cypress_cache_folder
 
 # orbs:
 #   compare-url: iynere/compare-url@1.1.0
 
 commands:
   install_dependencies:
-    description: 'Installing dependencies'
+    description: Installing dependencies
     steps:
       - checkout
       - restore_cache:
-          name: 'Restoring yarn cache'
+          name: Restoring yarn cache
           keys:
-            - v1-yarn-cache-{{ checksum "yarn.lock" }}
-            - v1-yarn-cache
-      - run: yarn install --pure-lockfile
+            - v2-yarn-cache-{{ checksum "yarn.lock" }}
+            - v2-yarn-cache
+      - run:
+          name: Installing dependencies
+          command: yarn install --pure-lockfile
+          environment:
+            CYPRESS_CACHE_FOLDER: *cypress_cache_folder
       - save_cache:
-          name: 'Saving yarn cache'
-          key: v1-yarn-cache-{{ checksum "yarn.lock" }}
+          name: Saving yarn cache
+          key: v2-yarn-cache-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
   restore_workspace:
-    description: 'Restoring workspace'
+    description: Restoring workspace
     steps:
       - attach_workspace:
-          at: ~/project
+          at: *project_directory
   save_workspace:
-    description: 'Persisting workspace'
+    description: Persisting workspace
     steps:
       - persist_to_workspace:
-          root: ~/project
+          root: *project_directory
           paths:
-            - merchant-center-application-kit
+            - *project_folder
   build_artifacts:
-    description: 'Building artifacts'
+    description: Building artifacts
     steps:
       - run: yarn build
   lint:
-    description: 'Running linters'
+    description: Running linters
     steps:
-      - run: yarn run jest --projects jest.eslint.config.js jest.stylelint.config.js --maxWorkers=3 --reporters jest-silent-reporter
-      - run: yarn typecheck
+      - run:
+          name: Running linters
+          command: yarn run jest --projects jest.eslint.config.js jest.stylelint.config.js --maxWorkers=3 --reporters jest-silent-reporter
+      - run:
+          name: Running typescript type checks
+          command: yarn typecheck
   unit_test:
-    description: 'Running tests'
+    description: Running tests
     steps:
-      - run: yarn run jest --projects jest.test.config.js --maxWorkers=3 --reporters jest-silent-reporter
+      - run:
+          name: Running tests
+          command: yarn run jest --projects jest.test.config.js --maxWorkers=3 --reporters jest-silent-reporter
   vrt_test:
-    description: 'Running Visual Regression Tests'
+    description: Running Visual Regression Tests
     steps:
       - run:
           name: Updating (apt-get update)
@@ -261,17 +275,24 @@ commands:
           name: Running Percy
           command: yarn run-if:percy
   build_packages:
-    description: 'Building packages'
+    description: Building packages
     steps:
-      - build_artifacts
+      - run:
+          name: Building packages
+          command: yarn build
+
   build_playground:
-    description: 'Building playground'
+    description: Building playground
     steps:
-      - run: yarn playground:build
+      - run:
+          name: Building playground application
+          command: yarn playground:build
   build_starter:
-    description: 'Building starter'
+    description: Building starter
     steps:
-      - run: yarn template-starter:build
+      - run:
+          name: Building starter application
+          command: yarn template-starter:build
   publish_to_canary:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,7 @@
 version: 2.1
 
 aliases:
-  - &working_directory ~/merchant-center-application-kit
-
-  - &restore_yarn_cache
-    name: 'Restoring yarn cache'
-    keys:
-      - v1-yarn-cache-{{ checksum "yarn.lock" }}
-      - v1-yarn-cache
-
-  - &save_yarn_cache
-    name: 'Saving yarn cache'
-    key: v1-yarn-cache-{{ checksum "yarn.lock" }}
-    paths:
-      - node_modules/
+  - &working_directory ~/project/merchant-center-application-kit
 
 executors:
   node_10:
@@ -35,26 +23,33 @@ commands:
     description: 'Installing dependencies'
     steps:
       - checkout
-      - restore_cache: *restore_yarn_cache
+      - restore_cache:
+          name: 'Restoring yarn cache'
+          keys:
+            - v1-yarn-cache-{{ checksum "yarn.lock" }}
+            - v1-yarn-cache
       - run: yarn install --pure-lockfile
-      - save_cache: *save_yarn_cache
+      - save_cache:
+          name: 'Saving yarn cache'
+          key: v1-yarn-cache-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules/
+  restore_workspace:
+    description: 'Restoring workspace'
+    steps:
+      - attach_workspace:
+          at: ~/project
+  save_workspace:
+    description: 'Persisting workspace'
+    steps:
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - merchant-center-application-kit
   build_artifacts:
     description: 'Building artifacts'
     steps:
       - run: yarn build
-  save_workspace:
-    steps:
-      - persist_to_workspace:
-          root: *working_directory
-          paths:
-            - packages
-            - playground
-            - visual-testing-app
-            - application-templates
-  restore_workspace:
-    steps:
-      - attach_workspace:
-          at: *working_directory
   lint:
     description: 'Running linters'
     steps:
@@ -266,9 +261,9 @@ commands:
           name: Running Percy
           command: yarn run-if:percy
   build_packages:
+    description: 'Building packages'
     steps:
       - build_artifacts
-      - save_workspace
   build_playground:
     description: 'Building playground'
     steps:
@@ -287,18 +282,20 @@ jobs:
   lint_and_test:
     executor: node_10
     steps:
+      - restore_workspace
       - install_dependencies
       - lint
       - unit_test
+      - save_workspace
   build:
     executor: node_10
     steps:
-      - install_dependencies
+      - restore_workspace
       - build_packages
+      - save_workspace
   vrt_test:
     executor: node_10
     steps:
-      - install_dependencies
       - restore_workspace
       - vrt_test
   e2e_test:
@@ -332,7 +329,6 @@ jobs:
         type: boolean
         default: false
     steps:
-      - install_dependencies
       - restore_workspace
       - when:
           condition: <<parameters.build>>
@@ -372,8 +368,6 @@ jobs:
   publish:
     executor: node_10
     steps:
-      - checkout
-      - install_dependencies
       - restore_workspace
       - publish_to_canary
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,17 @@ aliases:
   - &project_directory ~/project
   - &working_directory ~/project/merchant-center-application-kit
   - &project_folder merchant-center-application-kit
-  - &cypress_cache_folder cypress_cache
+  - &restore_cache
+      name: Restoring yarn cache
+      keys:
+        - v3-yarn-cache-{{ checksum "yarn.lock" }}
+        - v3-yarn-cache
+  - &save_cache
+      name: Saving yarn cache
+      key: v3-yarn-cache-{{ checksum "yarn.lock" }}
+      paths:
+        - ~/.cache/yarn
+        - ~/.cache/Cypress
 
 executors:
   node_10:
@@ -17,7 +27,6 @@ executors:
       - image: cypress/base:10
         environment:
           TERM: xterm
-          CYPRESS_CACHE_FOLDER: *cypress_cache_folder
 
 # orbs:
 #   compare-url: iynere/compare-url@1.1.0
@@ -27,21 +36,11 @@ commands:
     description: Installing dependencies
     steps:
       - checkout
-      - restore_cache:
-          name: Restoring yarn cache
-          keys:
-            - v2-yarn-cache-{{ checksum "yarn.lock" }}
-            - v2-yarn-cache
+      - restore_cache: *restore_cache
       - run:
           name: Installing dependencies
-          command: yarn install --pure-lockfile
-          environment:
-            CYPRESS_CACHE_FOLDER: *cypress_cache_folder
-      - save_cache:
-          name: Saving yarn cache
-          key: v2-yarn-cache-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules/
+          command: yarn install --frozen-lockfile
+      - save_cache: *save_cache
   restore_workspace:
     description: Restoring workspace
     steps:
@@ -303,7 +302,6 @@ jobs:
   lint_and_test:
     executor: node_10
     steps:
-      - restore_workspace
       - install_dependencies
       - lint
       - unit_test
@@ -351,6 +349,7 @@ jobs:
         default: false
     steps:
       - restore_workspace
+      - restore_cache: *restore_cache
       - when:
           condition: <<parameters.build>>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ aliases:
     name: 'Saving yarn cache'
     key: v1-yarn-cache-{{ checksum "yarn.lock" }}
     paths:
-      - ~/.cache/yarn
-      - node_modules
+      - node_modules/
 
 executors:
   node_10:

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,43 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml
+
+# misc
+*.md


### PR DESCRIPTION
Previously we were storing both `node_modules` and yarn cache folder. This lead to circleci having to store > 900 Mb of data, which increases the job time for restoring the cache:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/1110551/59973509-22585b80-95a1-11e9-8a9e-7b0382c4936c.png">

Let's see if this helps, yarn [has this config](https://github.com/yarnpkg/yarn/blob/01713684fa5cc6b6d6143ac0bbea2c4f889d5fd8/.circleci/config.yml#L33-L37) as well.

Additionally, we also persist the project folder to the workspace and use it across jobs. Yarn [does the same](https://github.com/yarnpkg/yarn/blob/01713684fa5cc6b6d6143ac0bbea2c4f889d5fd8/.circleci/config.yml#L38-L41).