### PR TITLE
fix(jest-stylelint-runner): include run file

### DIFF
--- a/packages/jest-stylelint-runner/package.json
+++ b/packages/jest-stylelint-runner/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "package.json",
+    "run.js",
     "LICENSE",
     "README.md"
   ],

--- a/packages/jest-stylelint-runner/package.json
+++ b/packages/jest-stylelint-runner/package.json
@@ -21,6 +21,7 @@
   "files": [
     "package.json",
     "run.js",
+    "index.js",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
#### Summary

The `run` file was omitted from package.json of `jest-stylelint-runner`. This PR adds that file.