### PR TITLE
chore: add babel plugin transform react constant

### DIFF
--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -126,6 +126,7 @@ module.exports = function getBabePresetConfigForMcApp() {
           async: false,
         },
       ],
+      require('@babel/plugin-transform-react-constant-elements').default,
       require('@babel/plugin-proposal-do-expressions').default,
       require('@babel/plugin-proposal-optional-chaining').default,
       require('@babel/plugin-proposal-nullish-coalescing-operator').default,


### PR DESCRIPTION
As discussed on slack, we add `babel-plugin-transform-react-constant-elements` to our list of babel plugins 😇 

[ref](https://babeljs.io/docs/en/next/babel-plugin-transform-react-constant-elements.html)

