### PR TITLE
fix(app-shell): to support admin service target

### DIFF
--- a/packages/application-shell/src/apollo-links/token-retry-link.js
+++ b/packages/application-shell/src/apollo-links/token-retry-link.js
@@ -1,11 +1,21 @@
 import { RetryLink } from 'apollo-link-retry';
-import { STATUS_CODES } from '@commercetools-frontend/constants';
+import {
+  STATUS_CODES,
+  GRAPHQL_TARGETS,
+} from '@commercetools-frontend/constants';
 
 // This link retries requests to the CTP API that have been rejected
 // because of an invalid/expired oauth token.
 // To do so, we resend the request with the header "X-Force-Token: true"
 // so that the MC BE can issue a new token.
 // NOTE: the retry is not meant to work for the MC access token.
+
+export const getDoesGraphQLTargetSupportTokenRetry = requestHeaders =>
+  [
+    GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
+    GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
+  ].includes(requestHeaders['X-Graphql-Target']);
+
 const tokenRetryLink = new RetryLink({
   attempts: (count, operation, error) => {
     const { headers: requestHeaders } = operation.getContext();
@@ -13,7 +23,7 @@ const tokenRetryLink = new RetryLink({
       error &&
       error.statusCode &&
       error.statusCode === STATUS_CODES.UNAUTHORIZED &&
-      requestHeaders['X-Graphql-Target'] === 'ctp' &&
+      getDoesGraphQLTargetSupportTokenRetry(requestHeaders) &&
       count === 1
     ) {
       operation.setContext(({ headers }) => ({

--- a/packages/application-shell/src/apollo-links/token-retry-link.spec.js
+++ b/packages/application-shell/src/apollo-links/token-retry-link.spec.js
@@ -1,7 +1,10 @@
 import { ApolloLink, execute, Observable } from 'apollo-link';
 import gql from 'graphql-tag';
 import waitFor from 'wait-for-observables';
-import tokenRetryLink from './token-retry-link';
+import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import tokenRetryLink, {
+  getDoesGraphQLTargetSupportTokenRetry,
+} from './token-retry-link';
 
 const query = gql`
   {
@@ -36,7 +39,7 @@ describe('tokenRetryLink', () => {
         const headerLink = new ApolloLink((operation, forward) => {
           operation.setContext({
             headers: {
-              'X-Graphql-Target': 'ctp',
+              'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
             },
           });
           return forward(operation);
@@ -44,7 +47,7 @@ describe('tokenRetryLink', () => {
         debugLink = new ApolloLink((operation, forward) => {
           operation.setContext(({ headers }) => ({
             ...headers,
-            'X-Graphql-Target': 'ctp',
+            'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
           }));
           context = operation.getContext();
           return forward(operation);
@@ -95,7 +98,7 @@ describe('tokenRetryLink', () => {
         const headerLink = new ApolloLink((operation, forward) => {
           operation.setContext({
             headers: {
-              'X-Graphql-Target': 'ctp',
+              'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
             },
           });
           return forward(operation);
@@ -176,5 +179,31 @@ describe('tokenRetryLink', () => {
         })
       );
     });
+  });
+});
+
+describe('supported GraphQL targets', () => {
+  it('should support the `ctp` GraphQL target', () => {
+    expect(
+      getDoesGraphQLTargetSupportTokenRetry({
+        'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
+      })
+    ).toBe(true);
+  });
+
+  it('should support the `administration` GraphQL target', () => {
+    expect(
+      getDoesGraphQLTargetSupportTokenRetry({
+        'X-Graphql-Target': GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
+      })
+    ).toBe(true);
+  });
+
+  it('should not support the `dashboard service` GraphQL target', () => {
+    expect(
+      getDoesGraphQLTargetSupportTokenRetry({
+        'X-Graphql-Target': GRAPHQL_TARGETS.DASHBOARD_SERVICE,
+      })
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
#### Summary

This adds the admnistration service to support token retries. This is needed as when one creates an organization or project we will add a new permission which invalidates previous tokens while the request to load the just created project or org will fail as a result without generating a new token.