### PR TITLE
fix(babel-preset): to remove plugin-transform-react-constant-elements

### DIFF
--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -126,7 +126,6 @@ module.exports = function getBabePresetConfigForMcApp() {
           async: false,
         },
       ],
-      require('@babel/plugin-transform-react-constant-elements').default,
       require('@babel/plugin-proposal-do-expressions').default,
       require('@babel/plugin-proposal-optional-chaining').default,
       require('@babel/plugin-proposal-nullish-coalescing-operator').default,

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -32,7 +32,6 @@
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
     "@babel/plugin-transform-classes": "7.4.4",
     "@babel/plugin-transform-destructuring": "7.4.4",
-    "@babel/plugin-transform-react-constant-elements": "7.2.0",
     "@babel/plugin-transform-react-display-name": "7.2.0",
     "@babel/plugin-transform-regenerator": "7.4.5",
     "@babel/plugin-transform-runtime": "7.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,7 +617,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-react-constant-elements@7.2.0", "@babel/plugin-transform-react-constant-elements@^7.0.0":
+"@babel/plugin-transform-react-constant-elements@^7.0.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz#ed602dc2d8bff2f0cb1a5ce29263dbdec40779f7"
   integrity sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==
@@ -9121,9 +9121,9 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
-"favicons-webpack-plugin@git+https://github.com/Creatiwity/favicons-webpack-plugin.git#0872de414061baaad0a2853c77ae75bc38b8bbbf":
+"favicons-webpack-plugin@https://github.com/Creatiwity/favicons-webpack-plugin.git#0872de414061baaad0a2853c77ae75bc38b8bbbf":
   version "0.0.9"
-  resolved "git+https://github.com/Creatiwity/favicons-webpack-plugin.git#0872de414061baaad0a2853c77ae75bc38b8bbbf"
+  resolved "https://github.com/Creatiwity/favicons-webpack-plugin.git#0872de414061baaad0a2853c77ae75bc38b8bbbf"
   dependencies:
     core-js "^2.5.7"
     favicons "^5.1.1"


### PR DESCRIPTION
#### Summary

This breaks the MC tests in many ways. 

![CleanShot 2019-06-27 at 18 02 05](https://user-images.githubusercontent.com/1877073/60281796-ebb67400-9905-11e9-8c4e-3a7ea4a013cb.gif)

It's hard to say what the issue is as the plugin seems to massage the jsx. I would remove it to unblock the app-kit release. If we really have a case for the plugin we need to investigate some more.