### PR TITLE
fix(jest/setup): to show actual error logs on CI when something is logged to console

### DIFF
--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -12,8 +12,8 @@ global.window.app = {
 const logOrThrow = (log, method, messages) => {
   const warning = `console.${method} calls not allowed in tests`;
   if (process.env.CI) {
-    log(...messages);
-    throw new Error(warning);
+    log(warning, '\n', ...messages);
+    throw new Error(...messages);
   } else {
     log(colors.bgYellow.black(' WARN '), warning, '\n', ...messages);
   }


### PR DESCRIPTION
No more such "useless" errors like

<img width="914" alt="image" src="https://user-images.githubusercontent.com/1110551/60686947-dca66780-9eab-11e9-8102-b738d8a5f320.png">

Now we get at least a more readable error:

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/1110551/60686932-cdbfb500-9eab-11e9-8624-7b4d07a31ef5.png">
