### PR TITLE
feat(app-shell): add passing `teamId` in link and middleware

### DIFF
--- a/packages/application-shell/src/apollo-links/__snapshots__/header-link.spec.js.snap
+++ b/packages/application-shell/src/apollo-links/__snapshots__/header-link.spec.js.snap
@@ -7,6 +7,7 @@ Object {
     "X-Correlation-Id": "test-correlation-id",
     "X-Graphql-Target": "mc",
     "X-Project-Key": "project-1",
+    "X-Team-Id": "team-1",
   },
 }
 `;
@@ -18,6 +19,19 @@ Object {
     "X-Correlation-Id": "test-correlation-id",
     "X-Graphql-Target": "mc",
     "X-Project-Key": "test-project-key",
+    "X-Team-Id": "team-1",
+  },
+}
+`;
+
+exports[`with valid target with team id in variables should set headers matching snapshot 1`] = `
+Object {
+  "credentials": "include",
+  "headers": Object {
+    "X-Correlation-Id": "test-correlation-id",
+    "X-Graphql-Target": "mc",
+    "X-Project-Key": "project-1",
+    "X-Team-Id": "test-team-id",
   },
 }
 `;

--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -3,6 +3,7 @@ import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import {
   getCorrelationId,
   selectProjectKeyFromUrl,
+  selectTeamIdFromLocalStorage,
   selectUserId,
 } from '../utils';
 
@@ -37,12 +38,14 @@ const headerLink = new ApolloLink((operation, forward) => {
    */
   const projectKey =
     operation.variables.projectKey || selectProjectKeyFromUrl();
+  const teamId = operation.variables.teamId || selectTeamIdFromLocalStorage();
   const userId = selectUserId({ apolloCache: cache });
 
   operation.setContext({
     credentials: 'include',
     headers: {
       'X-Project-Key': projectKey,
+      'X-Team-Id': teamId,
       'X-Correlation-Id': getCorrelationId({ userId }),
       'X-Graphql-Target': target,
     },

--- a/packages/application-shell/src/apollo-links/header-link.js
+++ b/packages/application-shell/src/apollo-links/header-link.js
@@ -45,9 +45,9 @@ const headerLink = new ApolloLink((operation, forward) => {
     credentials: 'include',
     headers: {
       'X-Project-Key': projectKey,
-      'X-Team-Id': teamId,
       'X-Correlation-Id': getCorrelationId({ userId }),
       'X-Graphql-Target': target,
+      ...(teamId && { 'X-Team-Id': teamId }),
     },
   });
   return forward(operation);

--- a/packages/application-shell/src/apollo-links/header-link.spec.js
+++ b/packages/application-shell/src/apollo-links/header-link.spec.js
@@ -8,6 +8,7 @@ import headerLink from './header-link';
 jest.mock('../utils/', () => ({
   getCorrelationId: jest.fn(() => 'test-correlation-id'),
   selectProjectKeyFromUrl: jest.fn(() => 'project-1'),
+  selectTeamIdFromLocalStorage: jest.fn(() => 'team-1'),
   selectUserId: jest.fn(() => 'user-1'),
 }));
 
@@ -62,6 +63,14 @@ describe('with valid target', () => {
     );
   });
 
+  it('should set `X-Team-Id`-Header', () => {
+    expect(context.headers).toEqual(
+      expect.objectContaining({
+        'X-Team-Id': 'team-1',
+      })
+    );
+  });
+
   it('should set `X-Graphql-Target`-Header', () => {
     expect(context.headers).toEqual(
       expect.objectContaining({
@@ -105,6 +114,34 @@ describe('with valid target', () => {
       expect(context.headers).toEqual(
         expect.objectContaining({
           'X-Project-Key': projectKey,
+        })
+      );
+    });
+  });
+
+  describe('with team id in variables', () => {
+    const teamId = 'test-team-id';
+
+    beforeEach(async () => {
+      await waitFor(
+        execute(link, {
+          query,
+          variables: {
+            target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+            teamId,
+          },
+        })
+      );
+    });
+
+    it('should set headers matching snapshot', () => {
+      expect(context).toMatchSnapshot();
+    });
+
+    it('should set `X-Team-Id`-Header', () => {
+      expect(context.headers).toEqual(
+        expect.objectContaining({
+          'X-Team-Id': teamId,
         })
       );
     });

--- a/packages/application-shell/src/configure-store.js
+++ b/packages/application-shell/src/configure-store.js
@@ -14,6 +14,7 @@ import apolloClient from './configure-apollo';
 import {
   getCorrelationId,
   selectProjectKeyFromUrl,
+  selectTeamIdFromLocalStorage,
   selectUserId,
 } from './utils';
 
@@ -35,6 +36,7 @@ const createInternalReducer = (injectedReducers = {}) =>
 const sdkMiddleware = createSdkMiddleware({
   getCorrelationId: patchedGetCorrelationId,
   getProjectKey: selectProjectKeyFromUrl,
+  getTeamId: selectTeamIdFromLocalStorage,
 });
 
 export const applyDefaultMiddlewares = (...middlewares) =>

--- a/packages/application-shell/src/constants.js
+++ b/packages/application-shell/src/constants.js
@@ -3,6 +3,7 @@ export const STORAGE_KEYS = {
   NONCE: 'nonce',
   IS_AUTHENTICATED: 'isAuthenticated',
   ACTIVE_PROJECT_KEY: 'activeProjectKey',
+  ACTIVE_TEAM_ID: 'activeTeamId',
   SELECTED_DATA_LOCALE: 'selectedDataLocale',
   IS_FORCED_MENU_OPEN: 'isForcedMenuOpen',
   LOGIN_STRATEGY: 'loginStrategy',

--- a/packages/application-shell/src/utils/index.js
+++ b/packages/application-shell/src/utils/index.js
@@ -2,6 +2,9 @@ export {
   default as selectProjectKeyFromLocalStorage,
 } from './select-project-key-from-local-storage';
 export {
+  default as selectTeamIdFromLocalStorage,
+} from './select-team-id-from-local-storage';
+export {
   default as selectProjectKeyFromUrl,
 } from './select-project-key-from-url';
 export { default as selectUserId } from './select-user-id';

--- a/packages/application-shell/src/utils/select-team-id-from-local-storage/index.js
+++ b/packages/application-shell/src/utils/select-team-id-from-local-storage/index.js
@@ -1,0 +1,1 @@
+export { default } from './select-team-id-from-local-storage';

--- a/packages/application-shell/src/utils/select-team-id-from-local-storage/select-team-id-from-local-storage.js
+++ b/packages/application-shell/src/utils/select-team-id-from-local-storage/select-team-id-from-local-storage.js
@@ -1,0 +1,6 @@
+import { STORAGE_KEYS } from '../../constants';
+
+// Attempt to load the `teamId` from localStorage
+export default function selectTeamIdFromLocalStorage() {
+  return window.localStorage.getItem(STORAGE_KEYS.ACTIVE_TEAM_ID);
+}

--- a/packages/sdk/src/middleware/middleware.js
+++ b/packages/sdk/src/middleware/middleware.js
@@ -72,7 +72,7 @@ export default function createSdkMiddleware({
           ...(action.payload.headers || {}),
           ...(shouldRenewToken ? { 'X-Force-Token': 'true' } : {}),
           'X-Project-Key': projectKey,
-          'X-Team-Id': teamId,
+          ...(teamId && { 'X-Team-Id': teamId }),
         };
         const body =
           action.payload.method === 'POST' ? action.payload.payload : undefined;

--- a/packages/sdk/src/middleware/middleware.js
+++ b/packages/sdk/src/middleware/middleware.js
@@ -30,11 +30,13 @@ const actionToUri = (action, projectKey) => {
 export default function createSdkMiddleware({
   getCorrelationId,
   getProjectKey,
+  getTeamId,
 }) {
   const client = createClient({ getCorrelationId });
 
   return ({ dispatch }) => next => action => {
     const projectKey = getProjectKey();
+    const teamId = getTeamId();
     if (!action) return next(action);
 
     if (action.type === 'SDK') {
@@ -70,6 +72,7 @@ export default function createSdkMiddleware({
           ...(action.payload.headers || {}),
           ...(shouldRenewToken ? { 'X-Force-Token': 'true' } : {}),
           'X-Project-Key': projectKey,
+          'X-Team-Id': teamId,
         };
         const body =
           action.payload.method === 'POST' ? action.payload.payload : undefined;

--- a/packages/sdk/src/middleware/middleware.spec.js
+++ b/packages/sdk/src/middleware/middleware.spec.js
@@ -330,6 +330,7 @@ describe('when the projectKey is not defined', () => {
       createMiddleware({
         getCorrelationId: jest.fn(),
         getProjectKey: jest.fn(() => null),
+        getTeamId: jest.fn(() => null),
       })({ dispatch })(next)(action)
     ).toThrow(
       'Expected projectKey to be defined for action service "productTypes" (method "GET")'

--- a/packages/sdk/src/middleware/middleware.spec.js
+++ b/packages/sdk/src/middleware/middleware.spec.js
@@ -8,6 +8,7 @@ jest.mock('../utils');
 const middlewareOptions = {
   getCorrelationId: jest.fn(),
   getProjectKey: jest.fn(() => 'test-project'),
+  getTeamId: jest.fn(() => 'test-team'),
 };
 
 describe('when the action is of type SDK', () => {


### PR DESCRIPTION
_This PR is not needed before v14. It's just a spike or thought experiment_

#### Summary

This pull request adds passing along the `teamId` in the Apollo link or Redux middleware.

#### Description

At some point the MC likely will have a team switcher. This allows e.g. admins to view permissions etc as if they were a member of another team.

All of the queries in the mc-be already work with a `teamId`, it's just not passed. The idea is for now to not have the switcher as a UI element but allow us to set the `teamId` somehow.

My first gut feeling is not to have the `teamId` as `?teamId=<UUID>` in the url. It's not really a sub-resource to anything, doesn't have to be passed around in a link. As a result we could start with the `teamId` in local storage (just like the `projectKey`). This would allow us to try this feature out silently and not to have to change all urls/links in the MC.
