### PR TITLE
[v14] fix(components): to use first-of-type instead of first-child

### DIFF
--- a/packages/application-components/src/components/modal-pages/internals/modal-page-top-bar.js
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page-top-bar.js
@@ -67,7 +67,7 @@ const ModalPageTopBar = props => {
           overflow: hidden;
 
           /*  specific selector for the svg of the FlatButton */
-          button:first-child svg {
+          button:first-of-type svg {
             height: 12px !important;
             width: 12px !important;
           }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1110551/61447164-b58e7200-a950-11e9-98e8-ebf41d8c97a3.png)
