### PR TITLE
[v14] refactor(l10n): to use class component in tests until react 16.9

### DIFF
--- a/packages/l10n/src/create-l10n-injector/create-l10n-injector.spec.tsx
+++ b/packages/l10n/src/create-l10n-injector/create-l10n-injector.spec.tsx
@@ -51,7 +51,7 @@ describe('loading data', () => {
         useL10n('en')
       );
       expect(result.current.isLoading).toBe(true);
-      expect(result.current.data).not.toBeDefined();
+      expect(result.current.data).toEqual({});
       expect(result.current.error).not.toBeDefined();
 
       await waitForNextUpdate();
@@ -69,7 +69,7 @@ describe('error loading data', () => {
         useL10n('en')
       );
       expect(result.current.isLoading).toBe(true);
-      expect(result.current.data).not.toBeDefined();
+      expect(result.current.data).toEqual({});
       expect(result.current.error).not.toBeDefined();
 
       await waitForNextUpdate();


### PR DESCRIPTION
This is a bit of a workaround, due to the issue with react 16.8 and `act`.

I still want to use the hook implementation under the hood though, but when running tests (and when react is still 16.8) we can fall back to use the class component.