### PR TITLE
feat: add support for action rights though `allAppliedActionRights`

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -42,6 +42,7 @@ describe('rendering', () => {
             currencies: ['USD'],
             languages: ['en'],
             permissions: { canManageProjectSettings: true },
+            actionRights: {},
             // Fields that should not be exposed
             expiry: { isActive: false },
             suspension: { isActive: false },

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -32,6 +32,13 @@ type TApplicationContextUser = {
   projects: TRawUserProjects;
 };
 type TApplicationContextPermissions = { [key: string]: boolean };
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TApplicationContextActionRights = {
+  [key: string]: TActionRight;
+};
+
 type TRawProject = {
   key: string;
   version: number;
@@ -43,6 +50,7 @@ type TRawProject = {
     id: string;
   };
   permissions: TApplicationContextPermissions;
+  actionRights: TApplicationContextActionRights;
 } & AdditionalProperties;
 type TApplicationContextProject = {
   key: string;
@@ -67,6 +75,7 @@ type TApplicationContext<AdditionalEnvironmentProperties extends {}> = {
   user: TApplicationContextUser | null;
   project: TApplicationContextProject | null;
   permissions: TApplicationContextPermissions | null;
+  actionRights: TApplicationContextActionRights | null;
   dataLocale: string | null;
 };
 type ProviderProps<AdditionalEnvironmentProperties extends {}> = {
@@ -140,6 +149,7 @@ const createApplicationContext: <AdditionalEnvironmentProperties extends {}>(
   user: mapUserToApplicationContextUser(user),
   project: mapProjectToApplicationContextProject(project),
   permissions: project && project.permissions ? project.permissions : null,
+  actionRights: project && project.actionRights ? project.actionRights : null,
   dataLocale: projectDataLocale || null,
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -257,6 +257,7 @@ describe('<RestrictedApplication>', () => {
             },
             permissions: { canManageProjectSettings: true },
             menuVisibilities: { hideDashboard: true },
+            actionRights: {},
           };
           wrapperAside = wrapper
             .find('aside')

--- a/packages/application-shell/src/components/fetch-project/fetch-project.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.graphql
@@ -18,6 +18,11 @@ query ProjectQuery($projectKey: String!) {
       name
       value
     }
+    allAppliedActionRights {
+      group
+      name
+      value
+    }
     allAppliedMenuVisibilities {
       name
       value

--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -31,6 +31,18 @@ export const mapAllAppliedToObjectShape = allAppliedShape =>
     }),
     {}
   );
+export const mapAllAppliedToGroupedObjectShape = allAppliedShape =>
+  allAppliedShape.reduce((transformedAllApplied, allApplied) => {
+    const previousAllAppliedGroup = transformedAllApplied[allApplied.group];
+
+    return {
+      ...transformedAllApplied,
+      [allApplied.group]: {
+        ...previousAllAppliedGroup,
+        [allApplied.name]: allApplied.value,
+      },
+    };
+  }, {});
 
 class FetchProject extends React.Component {
   static displayName = 'FetchProject';
@@ -64,6 +76,9 @@ class FetchProject extends React.Component {
                 ...data.project,
                 permissions: mapAllAppliedToObjectShape(
                   data.project.allAppliedPermissions
+                ),
+                actionRights: mapAllAppliedToGroupedObjectShape(
+                  data.project.allAppliedActionRights
                 ),
                 menuVisibilities: mapAllAppliedToObjectShape(
                   data.project.allAppliedMenuVisibilities

--- a/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { renderApp, waitForElement } from '../../test-utils';
 import ProjectQuery from './fetch-project.graphql';
-import FetchProject, { mapAllAppliedToObjectShape } from './fetch-project';
+import FetchProject, {
+  mapAllAppliedToObjectShape,
+  mapAllAppliedToGroupedObjectShape,
+} from './fetch-project';
 
 const renderProject = options =>
   renderApp(
@@ -41,6 +44,14 @@ const createGraphqlResponseForProjectQuery = custom => ({
       {
         __typename: 'AppliedPermission',
         name: 'canManageProjectSettings',
+        value: true,
+      },
+    ],
+    allAppliedActionRights: [
+      {
+        __typename: 'AppliedActionRight',
+        group: 'products',
+        name: 'canEditPrices',
         value: true,
       },
     ],
@@ -143,6 +154,39 @@ describe('helpers', () => {
         expect.objectContaining({
           [firstAppliedPermission.name]: firstAppliedPermission.value,
         })
+      );
+    });
+  });
+  describe('mapAllAppliedToGroupedObjectShape', () => {
+    const allAppliedActionRights = [
+      {
+        group: 'products',
+        name: 'canEditPrices',
+        value: true,
+      },
+      {
+        group: 'orders',
+        name: 'canEditPrices',
+        value: true,
+      },
+      {
+        group: 'products',
+        name: 'canPublishProducts',
+        value: false,
+      },
+    ];
+
+    it('should transform all action rights', () => {
+      expect(mapAllAppliedToGroupedObjectShape(allAppliedActionRights)).toEqual(
+        {
+          products: {
+            canEditPrices: true,
+            canPublishProducts: false,
+          },
+          orders: {
+            canEditPrices: true,
+          },
+        }
       );
     });
   });

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -36,6 +36,7 @@ const createTestProjectProps = custom => ({
     id: 'foo-1',
   },
   permissions: { canManageProjectSettings: true },
+  actionRights: {},
   menuVisibilities: { hideDashboard: true },
   ...custom,
 });

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -70,7 +70,7 @@ const defaultEnvironment = {
 };
 
 const defaultPermissions = {};
-const defaultActionRights = {}
+const defaultActionRights = {};
 
 // Allow consumers of `render` to extend the defaults by passing an object
 // or to completely omit the value by passing `null`

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -70,6 +70,7 @@ const defaultEnvironment = {
 };
 
 const defaultPermissions = {};
+const defaultActionRights = {}
 
 // Allow consumers of `render` to extend the defaults by passing an object
 // or to completely omit the value by passing `null`
@@ -128,6 +129,7 @@ const renderApp = (
     user,
     project,
     permissions = defaultPermissions,
+    actionRights = defaultActionRights,
     dataLocale = 'en',
     ApolloProviderComponent = MockedApolloProvider,
     // gtm-context
@@ -151,6 +153,7 @@ const renderApp = (
                 mergedProject && {
                   ...mergedProject,
                   permissions,
+                  actionRights,
                 }
               }
               environment={mergedEnvironment}

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -47,7 +47,7 @@ export const PERMISSIONS = {
 
 ## Available action rights
 
-An `Action Right` is represented as an object with the shape `{ group: string, name: string }`. The `group` relates to the permission while the `name` is the action right itself. Currently the following action rights for the `products` `group` exist:
+An `ActionRight` is represented as an object with the shape `{ group: string, name: string }`. The `group` relates to the permission while the `name` is the action right itself. Currently the following action rights for the `group: 'products'` exist:
 
 - `PublishProducts`
 - `UnpublishProducts`
@@ -82,7 +82,7 @@ branchOnPermissions(
   unauthorizedComponent: ?UnauthorizedComponent,
   options?: {
     shouldMatchSomePermissions: boolean,
-    actionRights: [ActionRight],
+    actionRights?: [ActionRight],
   }
 ): HoC
 ```
@@ -135,7 +135,7 @@ match, otherwise a fallback component.
 ### Props
 
 - `permissions`: an array of `Permission`, requested by the component
-- `actionRights`: an array of `Action Right`, requested by the component
+- `actionRights`: an array of `ActionRight`, requested by the component
 - `unauthorizedComponent`: (_optional_) a function return an React element to be
   rendered in case the permissions don't match
 - `render`: (_optional_) a function returning an React element or a node to be

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -45,6 +45,32 @@ export const PERMISSIONS = {
 };
 ```
 
+## Available action rights
+
+An `Action Right` is represented as an object with the shape `{ group: string, name: string }`. The `group` relates to the permission while the `name` is the action right itself. Currently the following action rights for the `products` `group` exist:
+
+- `PublishProducts`
+- `UnpublishProducts`
+- `AddPrices`
+- `EditPrices`
+- `DeletePrices`
+- `DeleteProducts`
+- `AddProducts`
+
+We recommend to put the action rights used by your application into a `constants.js` file.
+
+```js
+export const ACTION_RIGHTS = {
+  PublishProducts: { group: 'products', name: 'PublishProducts' },
+  UnpublishProducts: { group: 'products', name: 'UnpublishProducts' },
+  AddPrices: { group: 'products', name: 'AddPrices' },
+  EditPrices: { group: 'products', name: 'EditPrices' },
+  DeletePrices: { group: 'products', name: 'DeletePrices' },
+  DeleteProducts: { group: 'products', name: 'DeleteProducts' },
+  AddProducts: { group: 'products', name: 'AddProducts' },
+};
+```
+
 ## `branchOnPermissions(permissions, [FallbackComponent], [options])`
 
 A HoC that will render a fallback component if the requested permissions don't
@@ -54,7 +80,10 @@ match with the user permissions.
 branchOnPermissions(
   permissions: [Permission],
   unauthorizedComponent: ?UnauthorizedComponent,
-  options: ?Object
+  options?: {
+    shouldMatchSomePermissions: boolean,
+    actionRights: [ActionRight],
+  }
 ): HoC
 ```
 
@@ -64,8 +93,9 @@ branchOnPermissions(
 - `UnauthorizedComponent`: (_optional_) a reference to a React component to be
   rendered in case the permissions don't match
 - `options` (_optional_)
-  - `some`: determines if _some_ or _every_ requested permission should match
+  - `shouldMatchSomePermissions`: determines if _some_ or _every_ requested permission should match
     (default `false`)
+  - `actionRights`: an array of action rights (mentioned above)
 
 ### Example
 
@@ -105,6 +135,7 @@ match, otherwise a fallback component.
 ### Props
 
 - `permissions`: an array of `Permission`, requested by the component
+- `actionRights`: an array of `Action Right`, requested by the component
 - `unauthorizedComponent`: (_optional_) a function return an React element to be
   rendered in case the permissions don't match
 - `render`: (_optional_) a function returning an React element or a node to be
@@ -159,8 +190,9 @@ injectAuthorized(
 - `permissions`: an array of `Permission`, requested for the child component to
   be allowed to render
 - `options` (_optional_)
-  - `some`: determines if _some_ or _every_ requested permission should match
+  - `shouldMatchSomePermissions`: determines if _some_ or _every_ requested permission should match
     (default `false`)
+  - `actionRights`: an array of action rights (mentioned above)
 
 ### Example
 

--- a/packages/permissions/src/components/authorized/authorized.spec.tsx
+++ b/packages/permissions/src/components/authorized/authorized.spec.tsx
@@ -6,10 +6,25 @@ type TPermissionName = string;
 type TPermissions = {
   [key: string]: boolean;
 };
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TActionRights = {
+  [key: string]: TActionRight;
+};
+type TActionRightName = string;
+type TActionRightGroup = string;
+type TDemandedActionRight = {
+  group: TActionRightGroup;
+  name: TActionRightName;
+};
+
 type TestProps = {
   shouldMatchSomePermissions: boolean;
   demandedPermissions: TPermissionName[];
+  demandedActionRights?: TDemandedActionRight[];
   actualPermissions: TPermissions | null;
+  actualActionRights: TActionRights | null;
   render: jest.Mock;
 };
 
@@ -19,6 +34,11 @@ const createTestProps = (custom: Partial<TestProps>) => ({
   actualPermissions: {
     canViewProducts: true,
     canViewOrders: true,
+  },
+  actualActionRights: {
+    products: {
+      canEditPrices: true,
+    },
   },
   render: jest.fn(),
   ...custom,
@@ -109,6 +129,48 @@ describe('rendering', () => {
       });
       it('should pass isAuthorized as "false"', () => {
         expect(props.render).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+  describe('if action rights', () => {
+    describe('if can view products', () => {
+      describe('if can not publish products on products group', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            shouldMatchSomePermissions: true,
+            demandedActionRights: [
+              { group: 'products', name: 'PublishProducts' },
+            ],
+          });
+          shallow(<Authorized {...props} />);
+        });
+        it('should pass isAuthorized as "false"', () => {
+          expect(props.render).toHaveBeenCalledWith(false);
+        });
+      });
+      describe('if can edit prices on products group', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            shouldMatchSomePermissions: true,
+            demandedActionRights: [{ group: 'products', name: 'EditPrices' }],
+          });
+          shallow(<Authorized {...props} />);
+        });
+        it('should pass isAuthorized as "true"', () => {
+          expect(props.render).toHaveBeenCalledWith(true);
+        });
+      });
+      describe('if can edit prices on orders group', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            shouldMatchSomePermissions: true,
+            demandedActionRights: [{ group: 'orders', name: 'EditPrices' }],
+          });
+          shallow(<Authorized {...props} />);
+        });
+        it('should pass isAuthorized as "false"', () => {
+          expect(props.render).toHaveBeenCalledWith(false);
+        });
       });
     });
   });

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -39,6 +39,11 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         currencies: ['USD'],
         languages: ['en'],
         permissions: { canViewProducts: true },
+        actionRights: {
+          products: {
+            canEditPrices: false
+          }
+        },
         owner: { id: 'o1' },
       }}
       projectDataLocale="en"

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -41,8 +41,8 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         permissions: { canViewProducts: true },
         actionRights: {
           products: {
-            canEditPrices: false
-          }
+            canEditPrices: false,
+          },
         },
         owner: { id: 'o1' },
       }}

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -4,11 +4,21 @@ import getDisplayName from '../../utils/get-display-name';
 import Authorized from '../authorized';
 
 type TPermissionName = string;
+type TActionRightName = string;
+type TActionRightGroup = string;
+type TDemandedActionRight = {
+  group: TActionRightGroup;
+  name: TActionRightName;
+};
+type TOptions = {
+  shouldMatchSomePermissions?: boolean;
+  actionRights?: TDemandedActionRight[];
+};
 
 const branchOnPermissions = <OwnProps extends {}>(
   demandedPermissions: TPermissionName[],
   FallbackComponent: React.ComponentType<unknown>,
-  options: { shouldMatchSomePermissions: boolean } = {
+  options: TOptions = {
     shouldMatchSomePermissions: false,
   }
 ) => (
@@ -20,6 +30,7 @@ const branchOnPermissions = <OwnProps extends {}>(
         <Authorized
           shouldMatchSomePermissions={options.shouldMatchSomePermissions}
           demandedPermissions={demandedPermissions}
+          demandedActionRights={options.actionRights}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
           render={isAuthorized => {

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -21,6 +21,7 @@ const branchOnPermissions = <OwnProps extends {}>(
           shouldMatchSomePermissions={options.shouldMatchSomePermissions}
           demandedPermissions={demandedPermissions}
           actualPermissions={applicationContext.permissions}
+          actualActionRights={applicationContext.actionRights}
           render={isAuthorized => {
             if (isAuthorized) {
               return <Component {...props} />;

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -68,6 +68,7 @@ const createApplicationContext = (
   permissions: {
     canManageProjectSettings: true,
   },
+  actionRights: {},
   ...custom,
 });
 

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -8,12 +8,26 @@ type TPermissionName = string;
 type TPermissions = {
   [key: string]: boolean;
 };
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TActionRights = {
+  [key: string]: TActionRight;
+};
+type TActionRightName = string;
+type TActionRightGroup = string;
+type TDemandedActionRight = {
+  group: TActionRightGroup;
+  name: TActionRightName;
+};
 type TApplicationContext = {
   permissions: TPermissions | null;
+  actionRights: TActionRights | null;
 };
 type TestProps = {
   shouldMatchSomePermissions: boolean;
   permissions: TPermissionName[];
+  actionRights?: TDemandedActionRight[];
   applicationContext: TApplicationContext;
   unauthorizedComponent?: React.ComponentType;
   render?: jest.Mock;
@@ -27,6 +41,11 @@ const createTestProps = (custom: Partial<TestProps> = {}) => ({
     permissions: {
       canViewProducts: true,
       canViewOrders: true,
+    },
+    actionRights: {
+      products: {
+        canEditPrices: true,
+      },
     },
   },
   ...custom,

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -8,10 +8,17 @@ const getHasChildren = (children: React.ReactNode) =>
   React.Children.count(children) > 0;
 
 type TPermissionName = string;
+type TActionRightName = string;
+type TActionRightGroup = string;
+type TDemandedActionRight = {
+  group: TActionRightGroup;
+  name: TActionRightName;
+};
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 type Props = {
   shouldMatchSomePermissions?: boolean;
   permissions: TPermissionName[];
+  actionRights?: TDemandedActionRight[];
   unauthorizedComponent?: React.ComponentType;
   render?: TRenderProp;
   children?: TRenderProp | React.ReactNode;
@@ -33,6 +40,7 @@ const RestrictedByPermissions = (props: Props) => {
           shouldMatchSomePermissions={props.shouldMatchSomePermissions}
           demandedPermissions={props.permissions}
           actualPermissions={applicationContext.permissions}
+          actualActionRights={applicationContext.actionRights}
           render={(isAuthorized: boolean) => {
             if (typeof props.children === 'function')
               return props.children({

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -2,6 +2,7 @@ import { useApplicationContext } from '@commercetools-frontend/application-shell
 import {
   hasSomePermissions,
   hasEveryPermissions,
+  hasEveryActionRight,
 } from '../../utils/has-permissions';
 
 type TPermissionName = string;
@@ -9,23 +10,47 @@ type TPermissions = {
   [key: string]: boolean;
 };
 
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TActionRights = {
+  [key: string]: TActionRight;
+};
+
+type TActionRightName = string;
+type TActionRightGroup = string;
+type TDemandedActionRight = {
+  group: TActionRightGroup;
+  name: TActionRightName;
+};
+
 // Forward-compatibility with React Hooks 🎉
 const useIsAuthorized = ({
   demandedPermissions,
+  demandedActionRights,
   shouldMatchSomePermissions = false,
 }: {
   demandedPermissions: TPermissionName[];
+  demandedActionRights?: TDemandedActionRight[];
   shouldMatchSomePermissions: boolean;
 }) => {
   const actualPermissions = useApplicationContext<TPermissions | null>(
     applicationContext => applicationContext.permissions
   );
+  const actualActionRights = useApplicationContext<TActionRights | null>(
+    applicationContext => applicationContext.actionRights
+  );
 
-  const isAuthorized = shouldMatchSomePermissions
+  const hasDemandedPermissions = shouldMatchSomePermissions
     ? hasSomePermissions(demandedPermissions, actualPermissions)
     : hasEveryPermissions(demandedPermissions, actualPermissions);
 
-  return isAuthorized;
+  const hasDemandedActionRights = hasEveryActionRight(
+    demandedActionRights || [],
+    actualActionRights
+  );
+
+  return hasDemandedPermissions && hasDemandedActionRights;
 };
 
 export default useIsAuthorized;

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -1,5 +1,7 @@
 import {
   hasPermission,
+  hasActionRight,
+  hasEveryActionRight,
   hasEveryPermissions,
   hasSomePermissions,
   getInvalidPermissions,
@@ -8,6 +10,18 @@ import {
 type TPermissionName = string;
 type TPermissions = {
   [key: string]: boolean;
+};
+type TActionRightName = string;
+type TActionRightGroup = string;
+type TDemandedActionRight = {
+  group: TActionRightGroup;
+  name: TActionRightName;
+};
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TActionRights = {
+  [key: string]: TActionRight;
 };
 
 describe('hasPermission', () => {
@@ -88,6 +102,86 @@ describe('hasSomePermissions', () => {
         canViewProducts: true,
         canViewOrders: true,
       })
+    ).toBe(false);
+  });
+});
+
+describe('hasActionRight', () => {
+  let demandedActionRight: TDemandedActionRight;
+  let actualActionRights: TActionRights | null;
+
+  describe('when the user has the demanded action right', () => {
+    beforeEach(() => {
+      demandedActionRight = { group: 'products', name: 'EditPrices' };
+      actualActionRights = { products: { canEditPrices: true } };
+    });
+    it('should return true', () => {
+      expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
+        true
+      );
+    });
+  });
+  describe('when the user does not have the demanded action right', () => {
+    describe('with the action right group', () => {
+      beforeEach(() => {
+        demandedActionRight = { group: 'products', name: 'PublishProducts' };
+        actualActionRights = { products: { canEditPrices: true } };
+      });
+      it('should return false', () => {
+        expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
+          false
+        );
+      });
+    });
+    describe('without the action right group', () => {
+      beforeEach(() => {
+        demandedActionRight = { group: 'orders', name: 'EditPrices' };
+        actualActionRights = { products: { canEditPrices: true } };
+      });
+      it('should return false', () => {
+        expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
+          false
+        );
+      });
+    });
+  });
+});
+
+describe('hasEveryActionRight', () => {
+  it('should return true if every demanded action rights match', () => {
+    expect(
+      hasEveryActionRight(
+        [
+          { group: 'orders', name: 'EditPrices' },
+          { group: 'products', name: 'PublishProducts' },
+        ],
+        {
+          orders: {
+            canEditPrices: true,
+          },
+          products: {
+            canPublishProducts: true,
+          },
+        }
+      )
+    ).toBe(true);
+  });
+  it('should return false if at least one demanded action rights do not match', () => {
+    expect(
+      hasEveryActionRight(
+        [
+          { group: 'orders', name: 'EditPrices' },
+          { group: 'products', name: 'PublishProducts' },
+        ],
+        {
+          orders: {
+            canEditPrices: true,
+          },
+          products: {
+            canEditPrices: true,
+          },
+        }
+      )
     ).toBe(false);
   });
 });

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -65,10 +65,10 @@ export const hasPermission = (
 
 // Check the user action rights using one of the defined matchers.
 // The shapes of the arguments are:
-// - demandedActionRights:
-//     '[{ group: 'products', name: 'editPrices' }]'
+// - demandedActionRight:
+//     '{ group: 'products', name: 'editPrices' }'
 // - actualActionRights:
-//     { orders: { editPrices: false }, products: { editPrices: true } }
+//     { orders: { canEditPrices: false }, products: { canEditPrices: true } }
 export const hasActionRight = (
   demandedActionRight: TDemandedActionRight,
   actualActionRights: TActionRights | null
@@ -102,8 +102,8 @@ export const hasEveryPermissions = (
 //       { group: 'products', name: 'editPrices' },
 //       { group: 'products', name: 'publishProducts' },
 //     ]
-// - actualPermissions:
-//     { products: { editPrices: true, publishProducts: true } }
+// - actualActionRights:
+//     { products: { canEditPrices: true, canPublishProducts: true } }
 export const hasEveryActionRight = (
   demandedActionRights: TDemandedActionRight[],
   actualActionRights: TActionRights | null


### PR DESCRIPTION
#### Summary

This pull request builds on our APIs offering an `allAppliedActionRights` while implementing what has been discussed in #879.

#### Description

The addition of action rights touched on:

1. Fetching the project
2. Flushing things down the appliction context
3. Allowing our test-utils to pass things in
4. All Hocs, components and hooks in our permissions package

#### Design Decisions

The `option` argument of components/hocs/hooks now accepts a `actionRights` property of shape `[{ group: string, name: string }]`. This type is called `TDemandedActionRight[]`.

The `allAppliedActionRights` are fetched in a similar shape of `[ group: string, name: string, value: boolean } ]`. Similar do the other `allApplied*`. The `name` here is in can case for consistency with permissions.

The application context then transforms this response to the shape of `{[key: string]: { [key: string]: boolean } }`. Reaosn being consistency to permissions, faster lookup (no array looping on each check) and easier inspection in React's DevTools.

#### APIs

```js
injectAuthorized(
 ['ManageOrders'], 
 { actionRights: [{ group: 'orders', name: 'EditPrices' }] }
);

useIsAuthorized({ 
  demandedPermissions: ['ManageOrders'], 
  demandedActionRights: [{ group: 'orders', name: 'EditPrices' }] 
});
```