### PR TITLE
fix(circleci): add save test-utils to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ commands:
           root: *working_directory
           paths:
             - packages/**/dist/
+            - packages/**/test-utils/
   restore_package_bundles:
     steps:
       - attach_workspace:


### PR DESCRIPTION
#### Summary

Otherwise these won't be part of a canary.