### PR TITLE
fix(permissions): to drill props

### DIFF
--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -39,6 +39,7 @@ const RestrictedByPermissions = (props: Props) => {
         <Authorized
           shouldMatchSomePermissions={props.shouldMatchSomePermissions}
           demandedPermissions={props.permissions}
+          demandedActionRights={props.actionRights}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
           render={(isAuthorized: boolean) => {


### PR DESCRIPTION
#### Summary

This pull request fixes drilling the props through RestrictedByPermissions to Authorized. It's the only occurance where we missed this. 

The RestrictedByPermissions is still tested via shallow rendering which is why tests nor typing barked at us. I plan to refactor those after the fix is out this or early next week. 