### PR TITLE
chore: remove regenerator-runtime

### DIFF
--- a/packages/mc-scripts/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-development.js
@@ -56,7 +56,6 @@ module.exports = ({
     app: [
       require.resolve('./application-runtime'),
       require.resolve('core-js/stable'),
-      require.resolve('regenerator-runtime/runtime'),
       // Include an alternative client for WebpackDevServer. A client's job is to
       // connect to WebpackDevServer by a socket and get notified about changes.
       // When you save a file, the client will either apply hot updates (in case

--- a/packages/mc-scripts/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/config/create-webpack-config-for-production.js
@@ -132,7 +132,6 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
       app: [
         require.resolve('./application-runtime'),
         require.resolve('core-js/stable'),
-        require.resolve('regenerator-runtime/runtime'),
         entryPoint,
       ],
     },

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -66,7 +66,6 @@
     "postcss-reporter": "6.0.1",
     "postcss-safe-parser": "4.0.1",
     "react-dev-utils": "9.0.1",
-    "regenerator-runtime": "0.13.3",
     "shelljs": "0.8.3",
     "style-loader": "0.23.1",
     "svg-url-loader": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19173,11 +19173,6 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-
 regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"


### PR DESCRIPTION
#### Summary

The pull request removes the `regenerator-runtime` which to my understanding we only use to support `async`-fns in browsers which don't support them natively.

<img width="1338" alt="CleanShot 2019-07-26 at 14 55 00@2x" src="https://user-images.githubusercontent.com/1877073/61952910-5dd9b180-afb5-11e9-81cc-bfe93eae1b31.png">

However, this illustrates with the removal of IE11 support async functions are actually supported by all our targeted browsers. As a result we can remove this (I'd hope).