### PR TITLE
refactor(jest-preset): to split typescript config from default preset

### DIFF
--- a/jest.test.config.js
+++ b/jest.test.config.js
@@ -1,7 +1,7 @@
 const vendorsToTranspile = require('./packages/jest-preset-mc-app/vendors-to-transpile');
 
 module.exports = {
-  preset: './packages/jest-preset-mc-app',
+  preset: './packages/jest-preset-mc-app/jest-preset-for-typescript',
   moduleDirectories: [
     'application-templates',
     'packages',

--- a/packages/jest-preset-mc-app/jest-preset-for-typescript.js
+++ b/packages/jest-preset-mc-app/jest-preset-for-typescript.js
@@ -1,0 +1,11 @@
+const defaultPreset = require('./jest-preset');
+
+module.exports = {
+  ...defaultPreset,
+  moduleFileExtensions: ['ts', 'tsx', ...defaultPreset.moduleFileExtensions],
+  testRegex: '\\.spec\\.[j|t]sx?$',
+  transform: {
+    ...defaultPreset.transform,
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+};

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -13,7 +13,7 @@ module.exports = {
       NODE_ENV: 'test',
     },
   },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  moduleFileExtensions: ['js', 'jsx', 'json'],
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolveRelativePath(
@@ -32,10 +32,9 @@ module.exports = {
   testEnvironment: 'jsdom',
   testURL: 'https://mc.commercetools.com/',
   testPathIgnorePatterns: ['node_modules', 'cypress'],
-  testRegex: '\\.spec\\.[j|t]sx?$',
+  testRegex: '\\.spec\\.jsx?$',
   transform: {
     '^.+\\.js$': resolveRelativePath('./transform-babel-jest.js'),
-    '^.+\\.tsx?$': 'ts-jest',
     '^.+\\.graphql$': 'jest-transform-graphql',
   },
   transformIgnorePatterns: [`node_modules/(?!(${vendorsToTranspile})/)`],


### PR DESCRIPTION
Projects that do not use typescript should not have typescript specific config into the default jest preset.

To use the TS preset, simply import the jest preset as following:

```js
// jest.config.js

module.exports = {
  preset: '@commercetools-frontend/jest-preset-mc-app/jest-preset-for-typescript',
};
```