### PR TITLE
refactor: default props type declarations

### DIFF
--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -26,10 +26,6 @@ type TActionRights = {
   [key: string]: TActionRight;
 };
 
-const defaultProps = {
-  shouldMatchSomePermissions: false,
-};
-type DefaultProps = typeof defaultProps;
 type Props = {
   shouldMatchSomePermissions?: boolean;
   demandedPermissions: TPermissionName[];
@@ -38,7 +34,10 @@ type Props = {
   actualActionRights: TActionRights | null;
   render: (isAuthorized: boolean) => React.ReactNode;
   children?: never;
-} & DefaultProps;
+};
+const defaultProps: Pick<Props, 'shouldMatchSomePermissions'> = {
+  shouldMatchSomePermissions: false,
+};
 
 const Authorized = (props: Props) => {
   if (!props.actualPermissions)

--- a/packages/react-notifications/src/components/notification/notification.spec.tsx
+++ b/packages/react-notifications/src/components/notification/notification.spec.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { IntlProvider } from 'react-intl';
+import { render, RenderResult, fireEvent } from '@testing-library/react';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
 import Notification, { Props } from './notification';
 
-const TestComponent = () => <div />;
+const TestComponent = () => <div>{'Test'}</div>;
 
 type CustomDataAttributes = {
   'data-track-component': string;
@@ -25,51 +26,27 @@ const createTestProps = (
   ...props,
 });
 
+const renderComponent = (props: ReturnType<typeof createTestProps>) =>
+  render(
+    <IntlProvider locale="en" messages={{}}>
+      <Notification {...props} />
+    </IntlProvider>
+  );
+
 describe('rendering', () => {
-  let wrapper: ShallowWrapper;
-  let props;
+  let rendered: RenderResult;
+  let props: ReturnType<typeof createTestProps>;
   beforeEach(() => {
     props = createTestProps();
-    wrapper = shallow(<Notification {...props} />);
+    rendered = renderComponent(props);
   });
 
   it('should render children', () => {
-    expect(wrapper).toRender(TestComponent);
+    expect(rendered.queryByText('Test')).toBeInTheDocument();
   });
 
-  describe('with data-* props', () => {
-    beforeEach(() => {
-      props = createTestProps({
-        'data-track-component': 'Notification',
-        'data-track-label': 'Notification',
-        'data-track-event': 'click',
-        'data-test': 'notification',
-      });
-      wrapper = shallow(<Notification {...props} />);
-    });
-    it('should apply given `data-track-component` to Notification', () => {
-      expect(wrapper).toHaveProp(
-        'data-track-component',
-        expect.stringMatching('Notification')
-      );
-    });
-    it('should apply given `data-track-event` to Notification', () => {
-      expect(wrapper).toHaveProp(
-        'data-track-event',
-        expect.stringMatching('click')
-      );
-    });
-    it('should apply given `data-track-label` to Notification', () => {
-      expect(wrapper).toHaveProp(
-        'data-track-label',
-        expect.stringMatching('Notification')
-      );
-    });
-    it('should apply given `data-test` to Notification', () => {
-      expect(wrapper).toHaveProp(
-        'data-test',
-        expect.stringMatching('notification')
-      );
-    });
+  it('should trigger onCloseClick', async () => {
+    fireEvent.click(rendered.getByLabelText('Hide notification'));
+    expect(props.onCloseClick).toHaveBeenCalled();
   });
 });

--- a/packages/react-notifications/src/components/notification/notification.tsx
+++ b/packages/react-notifications/src/components/notification/notification.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import {
   CloseBoldIcon,
   ErrorIcon,
@@ -40,42 +40,40 @@ const NotificationIcon = (props: PropsIcon) => {
 };
 NotificationIcon.displayName = 'NotificationIcon';
 
-const defaultProps = {
-  fixed: false,
-};
-type DefaultProps = typeof defaultProps;
 export type Props = {
   domain: TAppNotificationDomain;
   type: TAppNotificationKind;
   fixed: boolean;
   onCloseClick: (event: React.SyntheticEvent) => void;
   children: React.ReactNode;
-} & DefaultProps;
+};
+const defaultProps: Pick<Props, 'fixed'> = {
+  fixed: false,
+};
 
-const Notification = (props: Props) => (
-  <div css={getStylesForNotification(props)} {...filterDataAttributes(props)}>
-    <div css={getStylesForContent(props)}>{props.children}</div>
-    {props.onCloseClick ? (
-      <div>
-        <FormattedMessage {...messages.hideNotification}>
-          {label => (
-            <IconButton
-              label={label}
-              onClick={props.onCloseClick}
-              icon={<CloseBoldIcon />}
-              size="medium"
-            />
-          )}
-        </FormattedMessage>
-      </div>
-    ) : null}
-    {props.domain === NOTIFICATION_DOMAINS.SIDE ? (
-      <div css={getStylesForIcon(props)}>
-        <NotificationIcon type={props.type} color="surface" />
-      </div>
-    ) : null}
-  </div>
-);
+const Notification = (props: Props) => {
+  const intl = useIntl();
+  return (
+    <div css={getStylesForNotification(props)} {...filterDataAttributes(props)}>
+      <div css={getStylesForContent(props)}>{props.children}</div>
+      {props.onCloseClick ? (
+        <div>
+          <IconButton
+            label={intl.formatMessage(messages.hideNotification)}
+            onClick={props.onCloseClick}
+            icon={<CloseBoldIcon />}
+            size="medium"
+          />
+        </div>
+      ) : null}
+      {props.domain === NOTIFICATION_DOMAINS.SIDE ? (
+        <div css={getStylesForIcon(props)}>
+          <NotificationIcon type={props.type} color="surface" />
+        </div>
+      ) : null}
+    </div>
+  );
+};
 Notification.displayName = 'Notification';
 Notification.defaultProps = defaultProps;
 

--- a/packages/react-notifications/src/components/notifier/notifier.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.tsx
@@ -8,18 +8,17 @@ import {
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
 
-const defaultProps = {
-  domain: NOTIFICATION_DOMAINS.SIDE,
-  kind: NOTIFICATION_KINDS_SIDE.success,
-};
-type DefaultProps = typeof defaultProps;
 type Props = {
   domain: TAppNotificationDomain;
   kind: TAppNotificationKind;
   text?: string;
   meta?: { [key: string]: unknown };
   dismissAfter?: number;
-} & DefaultProps;
+};
+const defaultProps: Pick<Props, 'domain' | 'kind'> = {
+  domain: NOTIFICATION_DOMAINS.SIDE,
+  kind: NOTIFICATION_KINDS_SIDE.success,
+};
 
 const Notifier = (props: Props) => {
   const showNotification = globalActions.useShowNotification<

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "preserveSymlinks": true,
     "pretty": true,
     "removeComments": true,
     "sourceMap": true,


### PR DESCRIPTION
As I'm writing and testing the type declarations for ui-kit components (https://github.com/commercetools/ui-kit/pull/860) I noticed that the way we defined the `defaultProps` for TS is wrong.

After researching things a bit I found this solution, and actually since TS 3 they have much better support for `defaultProps`.

PS: in the future React will probably "deprecate" default props for functional components, preferring variable initializers.

