### PR TITLE
chore: define command to publish an alpha release [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "yarn playground:start",
     "prerelease": "yarn build",
     "release": "lerna publish --exact --dist-tag next",
+    "release:alpha": "lerna publish --exact --dist-tag alpha --no-git-tag-version --no-push",
     "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes",
     "release:from-next-to-latest": "lerna exec --no-bail --no-private --no-sort --stream -- '[ -n \"$(npm v . dist-tags.next)\" ] && npm dist-tag add ${LERNA_PACKAGE_NAME}@$(npm v . dist-tags.next) latest'",
     "test": "jest --config jest.test.config.js",


### PR DESCRIPTION
Thought it would be useful to have it listed. This is what I usually use to publish an alpha release of all packages, without creating a git tag/push.
You will be prompted to select/enter the version of your choice, select one of the `pre` versions:

<img width="740" alt="image" src="https://user-images.githubusercontent.com/1110551/62519830-a488a080-b82c-11e9-8554-e180ae0e2d36.png">
