### PR TITLE
fix: Modal Pages custom controls 

### DIFF
--- a/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
@@ -44,9 +44,9 @@ const defaultProps: Pick<
   labelSecondaryButton: buttonMessages.cancel,
 };
 
-// Type-guard validation for the correct props, based on the existance `customControls`
+// Type-guard validation for the correct props, based on the existence `customControls`
 const hasCustomControls = (props: Props): props is PropsWithCustomControls =>
-  'customControls' in props;
+  'customControls' in props && props.customControls !== undefined;
 
 const FormModalPage = (props: Props) => (
   <ModalPage

--- a/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
@@ -19,7 +19,7 @@ type CommonProps = {
   shouldDelayOnClose?: boolean;
   // TopBar Props
   topBarCurrentPathLabel?: string;
-  topBarPreviousPathLabel: Label;
+  topBarPreviousPathLabel?: Label;
   // Header Props
   subtitle?: string | React.ReactElement;
   isPrimaryButtonDisabled?: boolean;

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
@@ -48,7 +48,7 @@ type Props = {
   // TopBar props:
   topBarColor?: 'surface' | 'neutral';
   currentPathLabel?: string;
-  previousPathLabel: Label;
+  previousPathLabel?: Label;
 };
 const defaultProps: Pick<
   Props,

--- a/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
@@ -21,7 +21,7 @@ type CommonProps = {
   shouldDelayOnClose?: boolean;
   // TopBar Props
   topBarCurrentPathLabel?: string;
-  topBarPreviousPathLabel: Label;
+  topBarPreviousPathLabel?: Label;
   // Replaces the title/subtitle row with a custom one (for special use cases)
   customTitleRow?: React.ReactNode;
   // Pass tab components

--- a/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
@@ -50,9 +50,9 @@ const defaultProps: Pick<
   labelSecondaryButton: buttonMessages.cancel,
 };
 
-// Type-guard validation for the correct props, based on the existance `customControls`
+// Type-guard validation for the correct props, based on the existence `customControls`
 const hasCustomControls = (props: Props): props is PropsWithCustomControls =>
-  'customControls' in props;
+  'customControls' in props && props.customControls !== undefined;
 
 const TabularModalPage = (props: Props) => (
   <ModalPage


### PR DESCRIPTION
This PR fixes the website not correctly displaying the default form controls in FormModalPage and TabularModalPage, because the type-guard for the `customControls` prop checks for the existence of it on the prop list, but it can exist and be `undefined`, which also needs to be checked.

This PR also changes the `topBarPreviousPathLabel` to not be required in the ModalPages, because it has a default value in ModalPageTopBar and thus it should not be required in the parents. It was throwing warnings because of it.