### PR TITLE
feat(permissions/authorized): add support for demandedDataFences for injectAuthorized

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -57,9 +57,10 @@ type TApplicationContextGroupedByResourceType = {
  *   }
  * }
  */
+type TApplicationContextDataFenceType = 'store';
 type TApplicationContextDataFences = {
   // E.g. { store: {...} }
-  [key: string]: TApplicationContextGroupedByResourceType;
+  [key in TApplicationContextDataFenceType]: TApplicationContextGroupedByResourceType;
 };
 
 type TRawProject = {

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -134,7 +134,7 @@ Like `branchOnPermissions`, but without the `FallbackComponent`.
 
 ```js
 injectAuthorized(
-  permissions: [Permission],
+  permissions: [Permissions.ManageOrders],
   options: ?Object
 ): HoC
 ```

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -148,7 +148,7 @@ injectAuthorized(
     (default `false`)
   - `actionRights`: (_optional_) an array of action rights (mentioned above)
   - `dataFences`: (_optional_) an array of `DataFence` (mentioned above)
-  - `getSelectDataFenceDataByType`: (_optional_) if `dataFences` option is specified, `getSelectDataFenceDataByType` will be called with the component's `ownProps`. The result is a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence.
+  - `getSelectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called with the component `props` and must return a new function that will be called on each specified `dataFence` and should return the mapped value specific to the data fence. The returned function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 
 ### Example
 

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -160,7 +160,7 @@ const InputField = props => (
   />
 );
 
-injectAuthorized(['ViewProducts', 'ViewOrders'])(InputField);
+injectAuthorized([Permissions.ViewProducts, Permissions.ViewOrders])(InputField);
 ```
 
 ## `<RestrictedByPermissions>`

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -190,7 +190,7 @@ match, otherwise a fallback component.
 - `permissions`: an array of `Permission`, requested by the component
 - `actionRights`: (_optional_) an array of `ActionRight`, requested by the component
 - `dataFences`: (_optional_) an array of `DataFence`, requested by the component
-- `selectDataFenceDataByType`: (_optional_) a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence when `dataFences` option is specified
+- `selectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called on each specified `dataFence` and should return the mapped value specific to the data fence. The function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 - `unauthorizedComponent`: (_optional_) a function return an React element to be
   rendered in case the permissions don't match
 - `render`: (_optional_) a function returning an React element or a node to be

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -71,6 +71,30 @@ export const ACTION_RIGHTS = {
 };
 ```
 
+## Available dataFences
+
+A `DataFence` is represented as an object with the shape `{ group: string, name: string, type: string }`. currently there is only dataFences of type `store`. The `group` relates to what the permission applies to and the `name` is the permission itself. Currently the following datafences for the `group: 'orders'` exist:
+
+- `ViewOrders`
+- `ManageOrders`
+
+We recommend to put the dataFences used by your application into a `constants.js` file.
+
+```js
+export const DATA_FENCES = {
+  ViewOrders: {
+    type: 'store',
+    group: 'orders',
+    name: 'ViewOrders',
+  },
+  ManageOrders: {
+    type: 'store',
+    group: 'orders',
+    name: 'ManageOrders',
+  },
+};
+```
+
 ## `branchOnPermissions(permissions, [FallbackComponent], [options])`
 
 A HoC that will render a fallback component if the requested permissions don't
@@ -83,6 +107,8 @@ branchOnPermissions(
   options?: {
     shouldMatchSomePermissions: boolean,
     actionRights?: [ActionRight],
+    dataFences?: [DataFence],
+    getSelectDataFenceDataByType?: ownProps => func
   }
 ): HoC
 ```
@@ -95,7 +121,9 @@ branchOnPermissions(
 - `options` (_optional_)
   - `shouldMatchSomePermissions`: determines if _some_ or _every_ requested permission should match
     (default `false`)
-  - `actionRights`: an array of action rights (mentioned above)
+  - `actionRights`: an array of `ActionRight` (mentioned above)
+  - `dataFences`: an array of `DataFence` (mentioned above)
+  - `getSelectDataFenceDataByType`: if `dataFences` option is specified, `getSelectDataFenceDataByType` will be called with the component's `ownProps`. The result is a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence.
 
 ### Example
 
@@ -105,6 +133,30 @@ const TopFiveProducts = () =>
   // ...
 
   branchOnPermissions(['ViewProducts', 'ViewOrders'])(TopFiveProducts);
+```
+
+```js
+// Only render a component when the user has the the requested dataFence
+const LastOrder = ({ order : { store: "Germany" }}) =>
+  // ...
+
+  branchOnPermissions([], options: {
+    dataFences: [
+      {
+        name: 'ManageOrders',
+        group: 'orders',
+        type: 'store'
+      }
+    ],
+    getSelectDataFenceDataByType: ownProps => ({ type }) => {
+      switch (type) {
+        case 'store':
+          return [ownProps.order.store];
+        default:
+          return null
+      }
+    }
+  })(LastOrder);
 ```
 
 ```js
@@ -135,7 +187,9 @@ match, otherwise a fallback component.
 ### Props
 
 - `permissions`: an array of `Permission`, requested by the component
-- `actionRights`: an array of `ActionRight`, requested by the component
+- `actionRights`: (_optional_) an array of `ActionRight`, requested by the component
+- `dataFences`: (_optional_) an array of `DataFence`, requested by the component
+- `selectDataFenceDataByType`: (_optional_) a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence when `dataFences` option is specified
 - `unauthorizedComponent`: (_optional_) a function return an React element to be
   rendered in case the permissions don't match
 - `render`: (_optional_) a function returning an React element or a node to be
@@ -190,9 +244,11 @@ injectAuthorized(
 - `permissions`: an array of `Permission`, requested for the child component to
   be allowed to render
 - `options` (_optional_)
-  - `shouldMatchSomePermissions`: determines if _some_ or _every_ requested permission should match
+  - `shouldMatchSomePermissions`: (_optional_) determines if _some_ or _every_ requested permission should match
     (default `false`)
-  - `actionRights`: an array of action rights (mentioned above)
+  - `actionRights`: (_optional_) an array of action rights (mentioned above)
+  - `dataFences`: (_optional_) an array of `DataFence` (mentioned above)
+  - `getSelectDataFenceDataByType`: (_optional_) if `dataFences` option is specified, `getSelectDataFenceDataByType` will be called with the component's `ownProps`. The result is a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence.
 
 ### Example
 

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -77,6 +77,7 @@ export const ACTION_RIGHTS = {
 > This is a **beta** feature and should be used with caution. For more information, please [open an issue](https://github.com/commercetools/merchant-center-application-kit/issues/new/choose).
 
 A `DataFence` is represented as an object with the shape `{ group: string, name: string, type: string }`, where:
+
 - `type`: is one of `['store']`
 - `name`: is the `Permission` value
 - `group`: is one of the resource types (e.g. `orders`)
@@ -120,10 +121,10 @@ useIsAutorized(options: HookOptions): boolean
 
 ```js
 const Test = () => {
-  const canAccessProducts = useIsAuthorized({
+  const canManageProducts = useIsAuthorized({
     demandedPermissions: ['ManageProducts'],
   });
-  if (canAccessProducts) {
+  if (canManageProducts) {
     return <span>{'Authorized'}</span>;
   }
   return <span>{'Not authorized'}</span>;
@@ -165,7 +166,9 @@ const InputField = props => (
   />
 );
 
-injectAuthorized([Permissions.ViewProducts, Permissions.ViewOrders])(InputField);
+injectAuthorized([Permissions.ViewProducts, Permissions.ViewOrders])(
+  InputField
+);
 ```
 
 ## `<RestrictedByPermissions>`

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -113,7 +113,7 @@ useIsAutorized(options: HookOptions): boolean
   be allowed to render
 - `demandedAtionRights`: (_optional_) an array of action rights (mentioned above)
 - `demandedDataFences`: (_optional_) an array of `DataFence` (mentioned above)
-- `getSelectDataFenceDataByType`: (_optional_) if `dataFences` option is specified, `getSelectDataFenceDataByType` will be called with the component's `ownProps`. The result is a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence.
+- `selectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called on each specified `dataFence` and should return the mapped value specific to the data fence. The function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 - `shouldMatchSomePermissions`: (_optional_) determines if _some_ or _every_ requested permission should match (default `false`)
 
 ### Example

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -254,7 +254,7 @@ branchOnPermissions(
     (default `false`)
   - `actionRights`: an array of `ActionRight` (mentioned above)
   - `dataFences`: an array of `DataFence` (mentioned above)
-  - `getSelectDataFenceDataByType`: if `dataFences` option is specified, `getSelectDataFenceDataByType` will be called with the component's `ownProps`. The result is a mapper function which we can use to pick the necessary data to compare with depending on the `type` of the dataFence.
+  - `getSelectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called with the component `props` and must return a new function that will be called on each specified `dataFence` and should return the mapped value specific to the data fence. The returned function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 
 ### Example
 

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -74,7 +74,12 @@ export const ACTION_RIGHTS = {
 
 ## Available dataFences
 
-A `DataFence` is represented as an object with the shape `{ group: string, name: string, type: string }`. currently there is only dataFences of type `store`. The `group` relates to what the permission applies to and the `name` is the permission itself. Currently the following datafences for the `group: 'orders'` exist:
+> This is a **beta** feature and should be used with caution. For more information, please [open an issue](https://github.com/commercetools/merchant-center-application-kit/issues/new/choose).
+
+A `DataFence` is represented as an object with the shape `{ group: string, name: string, type: string }`, where:
+- `type`: is one of `['store']`
+- `name`: is the `Permission` value
+- `group`: is one of the resource types (e.g. `orders`)
 
 - `ViewOrders`
 - `ManageOrders`

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -41,7 +41,7 @@ type Props = {
   demandedActionRights?: TDemandedActionRight[];
   actualPermissions: TPermissions | null;
   actualActionRights: TActionRights | null;
-  demandedDataFence?: TDemandedDataFence;
+  demandedDataFences?: TDemandedDataFence[];
   actualDataFences: TDataFence | null;
   render: (isAuthorized: boolean) => React.ReactNode;
   children?: never;
@@ -76,9 +76,11 @@ const Authorized = (props: Props) => {
     props.actualActionRights
   );
 
-  const isAuthorized = props.demandedDataFence
+  const isAuthorized = Boolean(
+    props.demandedDataFences && props.demandedDataFences.length
+  )
     ? createHasAppliedDataFence({
-        demandedDataFence: props.demandedDataFence,
+        demandedDataFences: props.demandedDataFences,
         actualPermissions: props.actualPermissions,
         actualDataFences: props.actualDataFences,
       })
@@ -91,7 +93,7 @@ Authorized.defaultProps = defaultProps;
 type TInjectAuthorizedOptions = {
   shouldMatchSomePermissions?: boolean;
   actionRights?: TDemandedActionRight[];
-  dataFence?: TDemandedDataFence;
+  dataFences?: TDemandedDataFence[];
 };
 
 type TResourceToApplyDataFence = {
@@ -112,26 +114,24 @@ const injectAuthorized = <
 ) => (
   Component: React.ComponentType<OwnProps>
 ): React.ComponentType<OwnProps & InjectedProps> => {
-  const WrappedComponent = (props: OwnProps) => {
-    return (
-      <ApplicationContext
-        render={applicationContext => (
-          <Authorized
-            shouldMatchSomePermissions={options.shouldMatchSomePermissions}
-            demandedPermissions={demandedPermissions}
-            demandedActionRights={options.actionRights}
-            demandedDataFence={options.dataFence}
-            actualPermissions={applicationContext.permissions}
-            actualActionRights={applicationContext.actionRights}
-            actualDataFences={applicationContext.dataFences}
-            render={isAuthorized => (
-              <Component {...props} {...{ [propName]: isAuthorized }} />
-            )}
-          />
-        )}
-      />
-    );
-  };
+  const WrappedComponent = (props: OwnProps) => (
+    <ApplicationContext
+      render={applicationContext => (
+        <Authorized
+          shouldMatchSomePermissions={options.shouldMatchSomePermissions}
+          demandedPermissions={demandedPermissions}
+          demandedActionRights={options.actionRights}
+          demandedDataFences={options.dataFences}
+          actualPermissions={applicationContext.permissions}
+          actualActionRights={applicationContext.actionRights}
+          actualDataFences={applicationContext.dataFences}
+          render={isAuthorized => (
+            <Component {...props} {...{ [propName]: isAuthorized }} />
+          )}
+        />
+      )}
+    />
+  );
   WrappedComponent.displayName = `withUserPermissions(${getDisplayName<
     OwnProps
   >(Component)})`;

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -85,16 +85,25 @@ const Authorized = (props: Props) => {
     props.actualActionRights
   );
 
-  const isAuthorized = Boolean(
-    props.demandedDataFences && props.demandedDataFences.length
-  )
-    ? createHasAppliedDataFence({
-        demandedDataFences: props.demandedDataFences,
-        actualPermissions: props.actualPermissions,
-        actualDataFences: props.actualDataFences,
-      })
-    : hasDemandedPermissions && hasDemandedActionRights;
-  return <React.Fragment>{props.render(isAuthorized)}</React.Fragment>;
+  if (Boolean(props.demandedDataFences && props.demandedDataFences.length)) {
+    return (
+      <React.Fragment>
+        {props.render(
+          createHasAppliedDataFence({
+            demandedDataFences: props.demandedDataFences,
+            actualPermissions: props.actualPermissions,
+            actualDataFences: props.actualDataFences,
+          })
+        )}
+      </React.Fragment>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      {props.render(hasDemandedPermissions && hasDemandedActionRights)}
+    </React.Fragment>
+  );
 };
 Authorized.displayName = 'Authorized';
 Authorized.defaultProps = defaultProps;

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -32,9 +32,18 @@ type TActionRights = {
   [key: string]: TActionRight;
 };
 type TDataFence = {
-  // E.g. { store: {...} }
   [key: string]: {};
 };
+type TResourceToApplyDataFence = {
+  id: string;
+  // Orders
+  storeRef?: {
+    key?: string;
+  };
+  // Customers
+  storesRef?: TKeyReference[];
+};
+type TAuthorizationContext = TResourceToApplyDataFence;
 type Props = {
   shouldMatchSomePermissions?: boolean;
   demandedPermissions: TPermissionName[];
@@ -96,15 +105,11 @@ type TInjectAuthorizedOptions = {
   dataFences?: TDemandedDataFence[];
 };
 
-type TResourceToApplyDataFence = {
-  id: string;
-};
-
 const injectAuthorized = <
   OwnProps extends {
     isAuthorized?:
       | boolean
-      | ((resourceToApplyDataFence: TResourceToApplyDataFence) => boolean);
+      | ((authorizationContext: TAuthorizationContext) => boolean);
   },
   InjectedProps extends OwnProps & { [key: string]: boolean }
 >(

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -68,6 +68,34 @@ const defaultProps: Pick<Props, 'shouldMatchSomePermissions'> = {
 };
 
 const Authorized = (props: Props) => {
+  // Check first for data fences
+  if (
+    props.actualDataFences &&
+    props.demandedDataFences &&
+    props.demandedDataFences.length > 0
+  ) {
+    if (!props.selectDataFenceDataByType) {
+      reportErrorToSentry(
+        new Error(
+          `@commercetools-frontend/permissions/Authorized: Missing data fences selector "selectDataFenceDataByType".`
+        )
+      );
+      return <React.Fragment>{props.render(false)}</React.Fragment>;
+    }
+    return (
+      <React.Fragment>
+        {props.render(
+          hasAppliedDataFence({
+            demandedDataFences: props.demandedDataFences,
+            actualDataFences: props.actualDataFences,
+            selectDataFenceDataByType: props.selectDataFenceDataByType,
+          })
+        )}
+      </React.Fragment>
+    );
+  }
+
+  // If no data fences have been provided, fall back to normal permissions + action rights.
   if (!props.actualPermissions)
     return <React.Fragment>{props.render(false)}</React.Fragment>;
 
@@ -92,28 +120,6 @@ const Authorized = (props: Props) => {
     props.demandedActionRights || [],
     props.actualActionRights
   );
-
-  if (
-    props.actualDataFences &&
-    props.demandedDataFences &&
-    props.demandedDataFences.length > 0
-  ) {
-    if (!props.selectDataFenceDataByType) {
-      console.error('DataFences are demanded but no selector provided');
-      return <React.Fragment>{props.render(false)}</React.Fragment>;
-    }
-    return (
-      <React.Fragment>
-        {props.render(
-          hasAppliedDataFence({
-            demandedDataFences: props.demandedDataFences,
-            actualDataFences: props.actualDataFences,
-            selectDataFenceDataByType: props.selectDataFenceDataByType,
-          })
-        )}
-      </React.Fragment>
-    );
-  }
 
   return (
     <React.Fragment>

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -106,7 +106,6 @@ const Authorized = (props: Props) => {
       <React.Fragment>
         {props.render(
           hasAppliedDataFence({
-            actualPermissions: props.actualPermissions,
             demandedDataFences: props.demandedDataFences,
             actualDataFences: props.actualDataFences,
             selectDataFenceDataByType: props.selectDataFenceDataByType,

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -6,25 +6,21 @@ import {
   hasEveryPermissions,
   hasEveryActionRight,
   getInvalidPermissions,
-  createHasAppliedDataFence,
+  hasAppliedDataFence,
 } from '../../utils/has-permissions';
 import getDisplayName from '../../utils/get-display-name';
 
+// Permissions
+type TPermissionName = string;
 type TPermissions = {
   [key: string]: boolean;
 };
-type TPermissionName = string;
+// Action rights
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
-};
-type TDataFenceType = 'store';
-type TDemandedDataFence = {
-  group: string;
-  name: string;
-  type: TDataFenceType;
 };
 type TActionRight = {
   [key: string]: boolean;
@@ -32,17 +28,24 @@ type TActionRight = {
 type TActionRights = {
   [key: string]: TActionRight;
 };
+// Data fences
 type TDataFenceGroupedByPermission = {
   // E.g. { canManageOrders: { values: [] } }
-  [key: string]: { values: string[] };
+  [key: string]: { values: string[] } | null;
 };
 type TDataFenceGroupedByResourceType = {
   // E.g. { orders: {...} }
-  [key: string]: TDataFenceGroupedByPermission;
+  [key: string]: TDataFenceGroupedByPermission | null;
 };
+type TDataFenceType = 'store';
 type TDataFences = {
   // E.g. { store: {...} }
-  [key: string]: TDataFenceGroupedByResourceType;
+  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+};
+type TDemandedDataFence = {
+  group: string;
+  name: string;
+  type: TDataFenceType;
 };
 type TSelectDataFenceDataByType = (dataFenceWithType: {
   type: TDataFenceType;
@@ -102,7 +105,7 @@ const Authorized = (props: Props) => {
     return (
       <React.Fragment>
         {props.render(
-          createHasAppliedDataFence({
+          hasAppliedDataFence({
             actualPermissions: props.actualPermissions,
             demandedDataFences: props.demandedDataFences,
             actualDataFences: props.actualDataFences,

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -10,9 +10,15 @@ type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
+type TDemandedDataFence = {
+  group: string;
+  name: string;
+  type: string;
+};
 type TOptions = {
   shouldMatchSomePermissions?: boolean;
   actionRights?: TDemandedActionRight[];
+  dataFences?: TDemandedDataFence[];
 };
 
 const branchOnPermissions = <OwnProps extends {}>(
@@ -31,8 +37,10 @@ const branchOnPermissions = <OwnProps extends {}>(
           shouldMatchSomePermissions={options.shouldMatchSomePermissions}
           demandedPermissions={demandedPermissions}
           demandedActionRights={options.actionRights}
+          demandedDataFences={options.dataFences}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
+          actualDataFences={applicationContext.dataFences}
           render={isAuthorized => {
             if (isAuthorized) {
               return <Component {...props} />;

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -16,10 +16,15 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
+type TSelectDataFenceDataByType = (dataFenceWithType: {
+  type: TDataFenceType;
+}) => string[] | null;
+
 type TOptions = {
   shouldMatchSomePermissions?: boolean;
   actionRights?: TDemandedActionRight[];
   dataFences?: TDemandedDataFence[];
+  selectDataFenceDataByType?: TSelectDataFenceDataByType;
 };
 
 const branchOnPermissions = <OwnProps extends {}>(
@@ -36,12 +41,13 @@ const branchOnPermissions = <OwnProps extends {}>(
       render={applicationContext => (
         <Authorized
           shouldMatchSomePermissions={options.shouldMatchSomePermissions}
-          demandedPermissions={demandedPermissions}
-          demandedActionRights={options.actionRights}
-          demandedDataFences={options.dataFences}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
           actualDataFences={applicationContext.dataFences}
+          demandedPermissions={demandedPermissions}
+          demandedActionRights={options.actionRights}
+          demandedDataFences={options.dataFences}
+          selectDataFenceDataByType={options.selectDataFenceDataByType}
           render={isAuthorized => {
             if (isAuthorized) {
               return <Component {...props} />;

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -20,17 +20,19 @@ type TSelectDataFenceDataByType = (dataFenceWithType: {
   type: TDataFenceType;
 }) => string[] | null;
 
-type TOptions = {
+type TOptions<OwnProps extends {}> = {
   shouldMatchSomePermissions?: boolean;
   actionRights?: TDemandedActionRight[];
   dataFences?: TDemandedDataFence[];
-  selectDataFenceDataByType?: TSelectDataFenceDataByType;
+  getSelectDataFenceDataByType?: (
+    ownProps: OwnProps
+  ) => TSelectDataFenceDataByType;
 };
 
 const branchOnPermissions = <OwnProps extends {}>(
   demandedPermissions: TPermissionName[],
   FallbackComponent: React.ComponentType<unknown>,
-  options: TOptions = {
+  options: TOptions<OwnProps> = {
     shouldMatchSomePermissions: false,
   }
 ) => (
@@ -47,7 +49,10 @@ const branchOnPermissions = <OwnProps extends {}>(
           demandedPermissions={demandedPermissions}
           demandedActionRights={options.actionRights}
           demandedDataFences={options.dataFences}
-          selectDataFenceDataByType={options.selectDataFenceDataByType}
+          selectDataFenceDataByType={
+            options.getSelectDataFenceDataByType &&
+            options.getSelectDataFenceDataByType(props)
+          }
           render={isAuthorized => {
             if (isAuthorized) {
               return <Component {...props} />;

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -10,10 +10,11 @@ type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
+type TDataFenceType = 'store';
 type TDemandedDataFence = {
   group: string;
   name: string;
-  type: string;
+  type: TDataFenceType;
 };
 type TOptions = {
   shouldMatchSomePermissions?: boolean;

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -3,13 +3,16 @@ import { ApplicationContext } from '@commercetools-frontend/application-shell-co
 import getDisplayName from '../../utils/get-display-name';
 import Authorized from '../authorized';
 
+// Permissions
 type TPermissionName = string;
+// Action rights
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
+// Data fences
 type TDataFenceType = 'store';
 type TDemandedDataFence = {
   group: string;

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -45,7 +45,6 @@ const RestrictedByPermissions = (props: Props) => {
           shouldMatchSomePermissions={props.shouldMatchSomePermissions}
           demandedPermissions={props.permissions}
           demandedActionRights={props.actionRights}
-          demandedDataFences={props.dataFences}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
           actualDataFences={applicationContext.dataFences}

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -14,11 +14,17 @@ type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
+type TDemandedDataFence = {
+  group: string;
+  name: string;
+  type: string;
+};
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 type Props = {
   shouldMatchSomePermissions?: boolean;
   permissions: TPermissionName[];
   actionRights?: TDemandedActionRight[];
+  dataFences?: TDemandedDataFence[];
   unauthorizedComponent?: React.ComponentType;
   render?: TRenderProp;
   children?: TRenderProp | React.ReactNode;
@@ -32,7 +38,6 @@ const RestrictedByPermissions = (props: Props) => {
     ),
     '@commercetools-frontend/permissions/RestrictedByPermissions: You provided both `children` and `unauthorizedComponent`. Please provide only one of them.'
   );
-
   return (
     <ApplicationContext
       render={applicationContext => (
@@ -40,8 +45,10 @@ const RestrictedByPermissions = (props: Props) => {
           shouldMatchSomePermissions={props.shouldMatchSomePermissions}
           demandedPermissions={props.permissions}
           demandedActionRights={props.actionRights}
+          demandedDataFences={props.dataFences}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
+          actualDataFences={applicationContext.dataFences}
           render={(isAuthorized: boolean) => {
             if (typeof props.children === 'function')
               return props.children({

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -7,22 +7,28 @@ import Authorized from '../authorized';
 const getHasChildren = (children: React.ReactNode) =>
   React.Children.count(children) > 0;
 
+// Permissions
 type TPermissionName = string;
+// Action rights
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
+// Data fences
+type TDataFenceType = 'store';
 type TDemandedDataFence = {
   group: string;
   name: string;
-  type: string;
+  type: TDataFenceType;
 };
 type TSelectDataFenceDataByType = (dataFenceWithType: {
   type: TDataFenceType;
 }) => string[] | null;
+
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
+
 type Props = {
   shouldMatchSomePermissions?: boolean;
   permissions: TPermissionName[];

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -19,12 +19,16 @@ type TDemandedDataFence = {
   name: string;
   type: string;
 };
+type TSelectDataFenceDataByType = (dataFenceWithType: {
+  type: TDataFenceType;
+}) => string[] | null;
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 type Props = {
   shouldMatchSomePermissions?: boolean;
   permissions: TPermissionName[];
   actionRights?: TDemandedActionRight[];
   dataFences?: TDemandedDataFence[];
+  selectDataFenceDataByType?: TSelectDataFenceDataByType;
   unauthorizedComponent?: React.ComponentType;
   render?: TRenderProp;
   children?: TRenderProp | React.ReactNode;
@@ -43,11 +47,13 @@ const RestrictedByPermissions = (props: Props) => {
       render={applicationContext => (
         <Authorized
           shouldMatchSomePermissions={props.shouldMatchSomePermissions}
-          demandedPermissions={props.permissions}
-          demandedActionRights={props.actionRights}
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
           actualDataFences={applicationContext.dataFences}
+          demandedPermissions={props.permissions}
+          demandedActionRights={props.actionRights}
+          demandedDataFences={props.dataFences}
+          selectDataFenceDataByType={props.selectDataFenceDataByType}
           render={(isAuthorized: boolean) => {
             if (typeof props.children === 'function')
               return props.children({

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -19,12 +19,18 @@ type TActionRight = {
 type TActionRights = {
   [key: string]: TActionRight;
 };
+type TDataFenceGroupedByPermission = {
+  // E.g. { canManageOrders: { values: [] } }
+  [key: string]: { values: string[] } | null;
+};
+type TDataFenceGroupedByResourceType = {
+  // E.g. { orders: {...} }
+  [key: string]: TDataFenceGroupedByPermission | null;
+};
+type TDataFenceType = 'store';
 type TDataFences = {
-  [key: string]: {
-    [key: string]: {
-      [key: string]: { values: string[] };
-    };
-  };
+  // E.g. { store: {...} }
+  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
 };
 type TestProps = {
   demandedPermissions: TPermissionName[];
@@ -50,8 +56,8 @@ const testRender = ({
   demandedActionRights,
   shouldMatchSomePermissions,
   actualPermissions = { canManageProjectSettings: true },
-  actualActionRights = {},
-  actualDataFences = {},
+  actualActionRights = null,
+  actualDataFences = null,
 }: {
   demandedPermissions: TPermissionName[];
   demandedActionRights?: TDemandedActionRight[];

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -40,7 +40,6 @@ const useIsAuthorized = ({
   const actualActionRights = useApplicationContext<TActionRights | null>(
     applicationContext => applicationContext.actionRights
   );
-
   const hasDemandedPermissions = shouldMatchSomePermissions
     ? hasSomePermissions(demandedPermissions, actualPermissions)
     : hasEveryPermissions(demandedPermissions, actualPermissions);

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -1,37 +1,65 @@
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import {
   hasSomePermissions,
   hasEveryPermissions,
   hasEveryActionRight,
+  hasAppliedDataFence,
 } from '../../utils/has-permissions';
 
+// Permissions
 type TPermissionName = string;
 type TPermissions = {
   [key: string]: boolean;
 };
-
+// Action rights
 type TActionRight = {
   [key: string]: boolean;
 };
 type TActionRights = {
   [key: string]: TActionRight;
 };
-
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
+// Data fences
+type TDataFenceGroupedByPermission = {
+  // E.g. { canManageOrders: { values: [] } }
+  [key: string]: { values: string[] } | null;
+};
+type TDataFenceGroupedByResourceType = {
+  // E.g. { orders: {...} }
+  [key: string]: TDataFenceGroupedByPermission | null;
+};
+type TDataFenceType = 'store';
+type TDataFences = {
+  // E.g. { store: {...} }
+  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+};
+type TDemandedDataFence = {
+  group: string;
+  name: string;
+  type: TDataFenceType;
+};
+type TSelectDataFenceDataByType = (dataFenceWithType: {
+  type: TDataFenceType;
+}) => string[] | null;
 
 // Forward-compatibility with React Hooks 🎉
 const useIsAuthorized = ({
   demandedPermissions,
   demandedActionRights,
+  demandedDataFences,
+  selectDataFenceDataByType,
   shouldMatchSomePermissions = false,
 }: {
   demandedPermissions: TPermissionName[];
   demandedActionRights?: TDemandedActionRight[];
+  demandedDataFences?: TDemandedDataFence[];
+  selectDataFenceDataByType?: TSelectDataFenceDataByType;
   shouldMatchSomePermissions: boolean;
 }) => {
   const actualPermissions = useApplicationContext<TPermissions | null>(
@@ -40,6 +68,28 @@ const useIsAuthorized = ({
   const actualActionRights = useApplicationContext<TActionRights | null>(
     applicationContext => applicationContext.actionRights
   );
+  const actualDataFences = useApplicationContext<TDataFences | null>(
+    applicationContext => applicationContext.dataFences
+  );
+
+  // Check first for data fences
+  if (actualDataFences && demandedDataFences && demandedDataFences.length > 0) {
+    if (!selectDataFenceDataByType) {
+      reportErrorToSentry(
+        new Error(
+          `@commercetools-frontend/permissions/Authorized: Missing data fences selector "selectDataFenceDataByType".`
+        )
+      );
+      return false;
+    }
+    return hasAppliedDataFence({
+      demandedDataFences: demandedDataFences,
+      actualDataFences: actualDataFences,
+      selectDataFenceDataByType: selectDataFenceDataByType,
+    });
+  }
+
+  // If no data fences have been provided, fall back to normal permissions + action rights.
   const hasDemandedPermissions = shouldMatchSomePermissions
     ? hasSomePermissions(demandedPermissions, actualPermissions)
     : hasEveryPermissions(demandedPermissions, actualPermissions);

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -46,6 +46,7 @@ type TResourceToApplyDataFence = {
   // Customers
   storesRef?: TKeyReference[];
 };
+type TAuthorizationContext = TResourceToApplyDataFence;
 type TOptionsForAppliedDataFence = {
   demandedDataFences: TDemandedDataFence[];
   actualDataFences: TDataFence[];
@@ -178,7 +179,7 @@ export const getInvalidPermissions = (
 };
 
 const hasDemandedDataFenceForStore = (
-  resourceToApplyDataFence: TResourceToApplyDataFence,
+  authorizationContext: TAuthorizationContext,
   options: {
     actualDataFence: TActualDataFence;
     demandedDataFence: TDemandedDataFence;
@@ -191,9 +192,8 @@ const hasDemandedDataFenceForStore = (
   switch (options.demandedDataFence.group) {
     case DATA_FENCE_GROUPS.ORDERS: {
       return options.actualDataFence.dataFenceValue.values.includes(
-        resourceToApplyDataFence.storeRef &&
-          resourceToApplyDataFence.storeRef.key
-          ? resourceToApplyDataFence.storeRef.key
+        authorizationContext.storeRef && authorizationContext.storeRef.key
+          ? authorizationContext.storeRef.key
           : ''
       );
     }
@@ -204,7 +204,7 @@ const hasDemandedDataFenceForStore = (
 
 export const createHasAppliedDataFence = (
   options: TOptionsForAppliedDataFence
-) => (resourceToApplyDataFence: TResourceToApplyDataFence): boolean =>
+) => (authorizationContext: TAuthorizationContext): boolean =>
   options.demandedDataFences.every(
     (demandedDataFence: TDemandedDataFence): boolean => {
       // First check that the demanded dataFence is enforced on `projectPermissions`
@@ -229,7 +229,7 @@ export const createHasAppliedDataFence = (
         ).every(([name, value]): boolean => {
           switch (demandedDataFence.type) {
             case 'store':
-              return hasDemandedDataFenceForStore(resourceToApplyDataFence, {
+              return hasDemandedDataFenceForStore(authorizationContext, {
                 actualDataFence: { name, dataFenceValue: value },
                 demandedDataFence,
               });

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -1,6 +1,10 @@
 import isNil from 'lodash/isNil';
 import get from 'lodash/get';
 
+const DATA_FENCE_GROUPS = {
+  ORDERS: 'orders',
+};
+
 type TPermissionName = string;
 type TPermissions = {
   [key: string]: boolean;
@@ -185,7 +189,7 @@ const hasDemandedDataFenceForStore = (
   });
   if (!hasDemandedPermission) return false;
   switch (options.demandedDataFence.group) {
-    case 'orders': {
+    case DATA_FENCE_GROUPS.ORDERS: {
       return options.actualDataFence.dataFenceValue.values.includes(
         resourceToApplyDataFence.storeRef &&
           resourceToApplyDataFence.storeRef.key

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -1,5 +1,6 @@
 import isNil from 'lodash/isNil';
 import get from 'lodash/get';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 
 const DATA_FENCE_GROUPS = {
   ORDERS: 'orders',
@@ -197,8 +198,22 @@ const hasDemandedDataFenceForStore = (
           : ''
       );
     }
-    default:
+    default: {
+      if (process.env.NODE_ENV !== 'production') {
+        throw new Error(
+          'Trying to map dataFence permissions for unsupported "group"'
+        );
+      }
+      reportErrorToSentry(
+        new Error(
+          'Trying to map dataFence permissions for unsupported "group"'
+        ),
+        {
+          extra: options.demandedDataFence,
+        }
+      );
       return false;
+    }
   }
 };
 
@@ -233,8 +248,22 @@ export const createHasAppliedDataFence = (
                 actualDataFence: { name, dataFenceValue: value },
                 demandedDataFence,
               });
-            default:
-              false;
+            default: {
+              if (process.env.NODE_ENV !== 'production') {
+                throw new Error(
+                  'Trying to map dataFence permissions for unsupported "type"'
+                );
+              }
+              reportErrorToSentry(
+                new Error(
+                  'Trying to map dataFence permissions for unsupported "type"'
+                ),
+                {
+                  extra: demandedDataFence,
+                }
+              );
+              return false;
+            }
           }
           return false;
         });

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -18,11 +18,11 @@ type TActionRights = {
   [key: string]: TActionRight;
 };
 type TDataFence = {
-  // E.g. { store: {...} }
   [key: string]: {};
 };
-type TDataFenceByPermissionName = TDataFence & {
-  values: string[];
+type TActualDataFence = {
+  name: string;
+  dataFenceValue: { values: string[] };
 };
 type TDemandedDataFence = {
   group: string;
@@ -176,18 +176,17 @@ export const getInvalidPermissions = (
 const hasDemandedDataFenceForStore = (
   resourceToApplyDataFence: TResourceToApplyDataFence,
   options: {
-    actualDataFence: TDataFenceByPermissionName;
-    actualDataFenceName: string;
+    actualDataFence: TActualDataFence;
     demandedDataFence: TDemandedDataFence;
   }
 ): boolean => {
   const hasDemandedPermission = hasPermission(options.demandedDataFence.name, {
-    [options.actualDataFenceName]: true,
+    [options.actualDataFence.name]: true,
   });
   if (!hasDemandedPermission) return false;
   switch (options.demandedDataFence.group) {
     case 'orders': {
-      return options.actualDataFence.values.includes(
+      return options.actualDataFence.dataFenceValue.values.includes(
         resourceToApplyDataFence.storeRef &&
           resourceToApplyDataFence.storeRef.key
           ? resourceToApplyDataFence.storeRef.key
@@ -223,12 +222,11 @@ export const createHasAppliedDataFence = (
       if (actualDataFenceByResourceGroup) {
         const hasDemandedDataFence = Object.entries(
           actualDataFenceByResourceGroup
-        ).every(([actualDataFenceName, actualDataFence]): boolean => {
+        ).every(([name, value]): boolean => {
           switch (demandedDataFence.type) {
             case 'store':
               return hasDemandedDataFenceForStore(resourceToApplyDataFence, {
-                actualDataFenceName,
-                actualDataFence,
+                actualDataFence: { name, dataFenceValue: value },
                 demandedDataFence,
               });
             default:

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -49,7 +49,6 @@ type TActualDataFence = {
 type TOptionsForAppliedDataFence = {
   demandedDataFences: TDemandedDataFence[];
   actualDataFences: TDataFences;
-  actualPermissions: TPermissions;
   selectDataFenceDataByType: TSelectDataFenceDataByType;
 };
 
@@ -221,11 +220,6 @@ const getDataFenceByPermissionGroup = (
 
 export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) =>
   options.demandedDataFences.every((demandedDataFence: TDemandedDataFence) => {
-    // First check that the demanded dataFence is enforced on `projectPermissions`
-    const hasDemandedProjectPermission = hasPermission(
-      demandedDataFence.name,
-      options.actualPermissions
-    );
     // Given that dataFence structure on `applicationContext`, we get the value by a path
     // e.g given dataFence with { store: { orders: { canManageOrders: { values: } } } }
     // we read the dataFence by the [type] and [group]

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -185,6 +185,7 @@ const hasDemandedDataFenceByType = (options: {
   const hasDemandedPermission = hasPermission(options.demandedDataFence.name, {
     [options.actualDataFence.name]: true,
   });
+
   if (!hasDemandedPermission) return false;
 
   const selectedDataFenceData = options.selectDataFenceDataByType({
@@ -226,7 +227,6 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) =>
     // dataFence[type][group] = dataFence.store.group
     // with value = there is a dataFence to apply, overrules `hasDemandedProjectPermissions`
     // without value = there is no dataFence to apply, overruled by `hasDemandedProjectPermissions`
-
     const actualDataFenceByPermissionGroup = getDataFenceByPermissionGroup(
       options.actualDataFences,
       demandedDataFence.type,
@@ -246,8 +246,8 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) =>
         }
         return false;
       });
-      return hasDemandedProjectPermission || hasDemandedDataFence;
+      return hasDemandedDataFence;
     }
 
-    return hasDemandedProjectPermission;
+    return false;
   });

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -236,10 +236,10 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) =>
     if (actualDataFenceByPermissionGroup) {
       const hasDemandedDataFence = Object.entries(
         actualDataFenceByPermissionGroup
-      ).every(([name, value]) => {
-        if (value) {
+      ).every(([dataFenceName, dataFenceValue]) => {
+        if (dataFenceValue) {
           return hasDemandedDataFenceByType({
-            actualDataFence: { name, dataFenceValue: value },
+            actualDataFence: { name: dataFenceName, dataFenceValue },
             demandedDataFence,
             selectDataFenceDataByType: options.selectDataFenceDataByType,
           });


### PR DESCRIPTION
#### Summary 

- adds support for `demandedDataFence` on `injectAuthorized`
- return `isAuthorized` as closure when `dataFence` is demanded on client

#### Description

##### Status quo

Until now, we supported `demandedPermissions` and `demandedActionRights` which key-value objects and easy to with their actualPermissions and actualActionRights counterparts from the MC-API

##### With dataFences

With `dataFences` however, we're adding another dimension to match with. Namely the values stored a key on a resource. This is to fulfil the following scenario:

```
GIVEN User A
WITH no projectPermission ManageOrders
AND WITH dataFencePermission ManageOrders
for orders of store A

GIVEN Order of store A 
THEN User A can manage order in the order details
```

----

#### For the Future

At the moment, the problem I'm solving is allowing the user to view and manage orders.. **for the OrderDetails**, and not the OrderList.
This is a small limitation that we should iterate on, because the need and use case is not there yet from the MC-Frontend side.

But, with the proposed change on the API and especially that `isAuthorized` is closure as a result of `demandedDataFence`, the support to delegate permission on the UI wouldn't require a lot of effort to add. It's just not there yet.

---

#### Can we see this in action?

I have a written POC [here](https://github.com/commercetools/merchant-center-application-kit/compare/adnasa-add-data-fence-injectAuthorized...adnasa-data-fence-poc?expand=1) . **PLEASE** have a look at this to see why the closure is needed

The component tree on the client side is not perfect, however I'm happy with what is there now. I look forward to add branching on MC-FE

This is a draft PR. With approval on the approach, I will

- [ ] Update tests
- [ ] Update docs
- Anything else?