### PR TITLE
feat(app-shell/navbar): add ability to hide menu by action rights

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -268,6 +268,7 @@ export const RestrictedMenuItem = props => {
     props.permissions.length > 0 ? (
       <RestrictedByPermissions
         permissions={props.permissions}
+        actionRights={props.actionRights}
         // Always check that some of the given permissions match.
         shouldMatchSomePermissions={true}
       >
@@ -293,6 +294,12 @@ RestrictedMenuItem.propTypes = {
   disabledMenuItems: PropTypes.arrayOf(PropTypes.string),
   keyOfMenuItem: PropTypes.string.isRequired,
   permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
+  actionRights: PropTypes.arrayOf(
+    PropTypes.shape({
+      group: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }).isRequired
+  ),
   children: PropTypes.element.isRequired,
 };
 RestrictedMenuItem.defaultProps = {
@@ -323,6 +330,12 @@ export class DataMenu extends React.PureComponent {
         icon: PropTypes.string.isRequired,
         featureToggle: PropTypes.string,
         permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
+        actionRights: PropTypes.arrayOf(
+          PropTypes.shape({
+            group: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+          }).isRequired
+        ),
         submenu: PropTypes.arrayOf(
           PropTypes.shape({
             key: PropTypes.string.isRequired,
@@ -335,6 +348,12 @@ export class DataMenu extends React.PureComponent {
             uriPath: PropTypes.string.isRequired,
             featureToggle: PropTypes.string,
             permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
+            actionRights: PropTypes.arrayOf(
+              PropTypes.shape({
+                group: PropTypes.string.isRequired,
+                name: PropTypes.string.isRequired,
+              }).isRequired
+            ),
             menuVisibility: PropTypes.string,
           })
         ),
@@ -476,6 +495,7 @@ export class DataMenu extends React.PureComponent {
         keyOfMenuItem={menu.key}
         featureToggle={menu.featureToggle}
         permissions={menu.permissions}
+        actionRights={menu.actionRights}
         menuVisibilities={this.props.menuVisibilities}
         namesOfMenuVisibilities={namesOfMenuVisibilitiesOfAllSubmenus}
         disabledMenuItems={this.props.environment.disabledMenuItems}
@@ -529,6 +549,7 @@ export class DataMenu extends React.PureComponent {
                     keyOfMenuItem={submenu.key}
                     featureToggle={submenu.featureToggle}
                     permissions={submenu.permissions}
+                    actionRights={submenu.actionRights}
                     menuVisibilities={this.props.menuVisibilities}
                     namesOfMenuVisibilities={[submenu.menuVisibility]}
                     disabledMenuItems={this.props.environment.disabledMenuItems}

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -27,12 +27,14 @@ const createTestMenuConfig = (key, props) => ({
   keyOfMenuItem: key,
   icon: 'UserFilledIcon',
   permissions: [],
+  actionRights: [],
   submenu: [
     {
       key: `${key}-new`,
       labelAllLocales: [{ locale: 'en', value: `${upperFirst(key)} new` }],
       uriPath: `${key}/new`,
       permissions: [],
+      actionRights: [],
     },
   ],
   ...props,
@@ -181,6 +183,12 @@ describe('rendering', () => {
                   ...ordersMenu.submenu[0],
                   featureToggle: 'ordersList',
                   permissions: ['ViewOrders'],
+                  actionRights: [
+                    {
+                      group: 'Orders',
+                      name: 'AddOrders',
+                    },
+                  ],
                   menuVisibility: 'hideAddOrder',
                 },
               ],
@@ -197,6 +205,14 @@ describe('rendering', () => {
       });
       it('should pass permissions as prop', () => {
         expect(restrictedMenuItem).toHaveProp('permissions', ['ViewOrders']);
+      });
+      it('should pass actionRights as prop', () => {
+        expect(restrictedMenuItem).toHaveProp('actionRights', [
+          {
+            group: 'Orders',
+            name: 'AddOrders',
+          },
+        ]);
       });
       it('should pass names of menu visibilities of submenus as prop', () => {
         expect(restrictedMenuItem).toHaveProp('namesOfMenuVisibilities', [
@@ -343,6 +359,12 @@ describe('rendering', () => {
                     ...ordersMenu.submenu[0],
                     featureToggle: 'ordersList',
                     permissions: ['ViewOrders'],
+                    actionRights: [
+                      {
+                        group: 'Orders',
+                        name: 'AddOrders',
+                      },
+                    ],
                     menuVisibility: 'hideAddOrder',
                     keyOfMenuItem: 'add-orders',
                   },
@@ -369,6 +391,14 @@ describe('rendering', () => {
           it('should pass permissions as prop', () => {
             expect(restrictedMenuItemWrapper).toHaveProp('permissions', [
               'ViewOrders',
+            ]);
+          });
+          it('should pass actionRights as prop', () => {
+            expect(restrictedMenuItemWrapper).toHaveProp('actionRights', [
+              {
+                group: 'Orders',
+                name: 'AddOrders',
+              },
             ]);
           });
           it('should pass menu visibilities as prop', () => {
@@ -477,6 +507,12 @@ describe('rendering', () => {
             props = {
               featureToggle: 'myFeature',
               permissions: ['ManageOrders'],
+              actionRights: [
+                {
+                  group: 'Orders',
+                  name: 'AddOrders',
+                },
+              ],
               actualPermissions: {},
               menuVisibilities: {},
               keyOfMenuItem: 'products',
@@ -500,6 +536,12 @@ describe('rendering', () => {
             expect(wrapper.find(RestrictedByPermissions)).toHaveProp(
               'permissions',
               props.permissions
+            );
+          });
+          it('should pass "actionRights" as prop to <RestrictedByPermissions>', () => {
+            expect(wrapper.find(RestrictedByPermissions)).toHaveProp(
+              'actionRights',
+              props.actionRights
             );
           });
           it('should pass "shouldMatchSomePermissions" as prop to <RestrictedByPermissions>', () => {
@@ -538,6 +580,12 @@ describe('rendering', () => {
             props = {
               featureToggle: undefined,
               permissions: ['ManageOrders'],
+              actionRights: [
+                {
+                  group: 'Orders',
+                  name: 'AddOrders',
+                },
+              ],
               actualPermissions: {},
               menuVisibilities: {},
               keyOfMenuItem: 'products',
@@ -560,6 +608,12 @@ describe('rendering', () => {
               props.permissions
             );
           });
+          it('should pass "actionRights" as prop to <RestrictedByPermissions>', () => {
+            expect(wrapper.find(RestrictedByPermissions)).toHaveProp(
+              'actionRights',
+              props.actionRights
+            );
+          });
           it('should pass "shouldMatchSomePermissions" as prop to <RestrictedByPermissions>', () => {
             expect(wrapper.find(RestrictedByPermissions)).toHaveProp(
               'shouldMatchSomePermissions',
@@ -577,6 +631,12 @@ describe('rendering', () => {
         beforeEach(() => {
           props = {
             permissions: ['ViewProducts'],
+            actionRights: [
+              {
+                group: 'Orders',
+                name: 'AddOrders',
+              },
+            ],
             menuVisibilities: {},
             keyOfMenuItem: 'products',
           };
@@ -590,6 +650,17 @@ describe('rendering', () => {
           expect(wrapper.find(RestrictedByPermissions)).toHaveProp(
             'permissions',
             ['ViewProducts']
+          );
+        });
+        it('should pass actionRights as prop', () => {
+          expect(wrapper.find(RestrictedByPermissions)).toHaveProp(
+            'actionRights',
+            [
+              {
+                group: 'Orders',
+                name: 'AddOrders',
+              },
+            ]
           );
         });
         it('should pass shouldMatchSomePermissions as prop (true)', () => {


### PR DESCRIPTION
#### Summary

This pull request adds the ability to hide menu items by action rights. This is eventually needed to hide e.g. "Add Products" or "Add Category".

To achieve this we basically just need to pass the config to the respective component.