### PR TITLE
fix(application-components): rewrite conditional props logic, to account prop-types transformer

### DIFF
--- a/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
@@ -7,6 +7,17 @@ import ModalPageHeaderDefaultControls from '../internals/modal-page-header-defau
 import { ContentWrapper } from '../internals/modal-page.styles';
 
 type Label = string | MessageDescriptor;
+// [conditional A]
+type WithCustomControls = {
+  customControls?: React.ReactNode;
+};
+// [conditional B]
+type WithoutCustomControls = {
+  labelSecondaryButton?: Label;
+  labelPrimaryButton?: Label;
+  onSecondaryButtonClick?: (event: React.SyntheticEvent) => void;
+  onPrimaryButtonClick?: (event: React.SyntheticEvent) => void;
+};
 type CommonProps = {
   level?: number;
   title: string;
@@ -26,18 +37,11 @@ type CommonProps = {
   dataAttributesPrimaryButton?: { [key: string]: string };
   dataAttributesSecondaryButton?: { [key: string]: string };
 };
-type PropsWithCustomControls = CommonProps & {
-  customControls: React.ReactNode;
-};
-type PropsWithoutCustomControls = CommonProps & {
-  labelSecondaryButton: Label;
-  labelPrimaryButton: Label;
-  onSecondaryButtonClick: (event: React.SyntheticEvent) => void;
-  onPrimaryButtonClick: (event: React.SyntheticEvent) => void;
-};
-type Props = PropsWithCustomControls | PropsWithoutCustomControls;
+type Props = CommonProps & WithCustomControls & WithoutCustomControls;
+type PropsWithCustomControls = CommonProps & Required<WithCustomControls>;
+type PropsWithoutCustomControls = CommonProps & Required<WithoutCustomControls>;
 const defaultProps: Pick<
-  PropsWithoutCustomControls,
+  Props,
   'labelPrimaryButton' | 'labelSecondaryButton'
 > = {
   labelPrimaryButton: buttonMessages.confirm,
@@ -45,8 +49,35 @@ const defaultProps: Pick<
 };
 
 // Type-guard validation for the correct props, based on the existence `customControls`
-const hasCustomControls = (props: Props): props is PropsWithCustomControls =>
+const hasCustomControls = (
+  props: PropsWithCustomControls | PropsWithoutCustomControls
+): props is PropsWithCustomControls =>
   'customControls' in props && props.customControls !== undefined;
+const getConditionalProps = (props: Props) => {
+  if ('customControls' in props && props.customControls !== undefined) {
+    return props as PropsWithCustomControls;
+  }
+  return props as PropsWithoutCustomControls;
+};
+
+const FormModalPageHeaderControls = (
+  props: PropsWithCustomControls | PropsWithoutCustomControls
+) => {
+  if (hasCustomControls(props)) {
+    return <>{props.customControls}</>;
+  }
+  return (
+    <ModalPageHeaderDefaultControls
+      labelSecondaryButton={props.labelSecondaryButton}
+      labelPrimaryButton={props.labelPrimaryButton}
+      isPrimaryButtonDisabled={props.isPrimaryButtonDisabled}
+      onSecondaryButtonClick={props.onSecondaryButtonClick}
+      onPrimaryButtonClick={props.onPrimaryButtonClick}
+      dataAttributesSecondaryButton={props.dataAttributesSecondaryButton}
+      dataAttributesPrimaryButton={props.dataAttributesPrimaryButton}
+    />
+  );
+};
 
 const FormModalPage = (props: Props) => (
   <ModalPage
@@ -62,19 +93,7 @@ const FormModalPage = (props: Props) => (
     shouldDelayOnClose={props.shouldDelayOnClose}
   >
     <ModalPageHeader title={props.title} subtitle={props.subtitle}>
-      {hasCustomControls(props) ? (
-        props.customControls
-      ) : (
-        <ModalPageHeaderDefaultControls
-          labelSecondaryButton={props.labelSecondaryButton}
-          labelPrimaryButton={props.labelPrimaryButton}
-          isPrimaryButtonDisabled={props.isPrimaryButtonDisabled}
-          onSecondaryButtonClick={props.onSecondaryButtonClick}
-          onPrimaryButtonClick={props.onPrimaryButtonClick}
-          dataAttributesSecondaryButton={props.dataAttributesSecondaryButton}
-          dataAttributesPrimaryButton={props.dataAttributesPrimaryButton}
-        />
-      )}
+      <FormModalPageHeaderControls {...getConditionalProps(props)} />
     </ModalPageHeader>
     <ContentWrapper>{props.children}</ContentWrapper>
   </ModalPage>


### PR DESCRIPTION
**Before**

```js
FormModalPage.propTypes = (_FormModalPage$propTy = {
  level: _pt.number,
  title: _pt.string.isRequired,
  isOpen: _pt.bool.isRequired,
  onClose: _pt.func,
  children: _pt.node.isRequired,
  zIndex: _pt.number,
  baseZIndex: _pt.number,
  getParentSelector: _pt.func,
  shouldDelayOnClose: _pt.bool,
  topBarCurrentPathLabel: _pt.string,
  topBarPreviousPathLabel: _pt.oneOfType([_pt.string, _pt.any]),
  subtitle: _pt.oneOfType([_pt.string, _pt.element]),
  isPrimaryButtonDisabled: _pt.bool,
  dataAttributesPrimaryButton: _pt.objectOf(_pt.string),
  dataAttributesSecondaryButton: _pt.objectOf(_pt.string),
},
_defineProperty(_FormModalPage$propTy, "customControls", _pt.node.isRequired),
_defineProperty(_FormModalPage$propTy, "level", _pt.number),
_defineProperty(_FormModalPage$propTy, "title", _pt.string.isRequired),
_defineProperty(_FormModalPage$propTy, "isOpen", _pt.bool.isRequired),
_defineProperty(_FormModalPage$propTy, "onClose", _pt.func),
_defineProperty(_FormModalPage$propTy, "children", _pt.node.isRequired),
_defineProperty(_FormModalPage$propTy, "zIndex", _pt.number),
_defineProperty(_FormModalPage$propTy, "baseZIndex", _pt.number),
_defineProperty(_FormModalPage$propTy, "getParentSelector", _pt.func), _FormModalPage$propTy);
```

**After**

```js
FormModalPage.propTypes = {
  level: _pt.number,
  title: _pt.string.isRequired,
  isOpen: _pt.bool.isRequired,
  onClose: _pt.func,
  children: _pt.node.isRequired,
  zIndex: _pt.number,
  baseZIndex: _pt.number,
  getParentSelector: _pt.func,
  shouldDelayOnClose: _pt.bool,
  topBarCurrentPathLabel: _pt.string,
  topBarPreviousPathLabel: _pt.oneOfType([_pt.string, _pt.any]),
  subtitle: _pt.oneOfType([_pt.string, _pt.element]),
  isPrimaryButtonDisabled: _pt.bool,
  dataAttributesPrimaryButton: _pt.objectOf(_pt.string),
  dataAttributesSecondaryButton: _pt.objectOf(_pt.string),
  customControls: _pt.node,
  labelSecondaryButton: _pt.oneOfType([_pt.string, _pt.any]),
  labelPrimaryButton: _pt.oneOfType([_pt.string, _pt.any]),
  onSecondaryButtonClick: _pt.func,
  onPrimaryButtonClick: _pt.func
};
```