### PR TITLE
fix: percy snapshots for website

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -2,7 +2,3 @@ version: 1
 snapshot:
   widths: [1024]
   min-height: 1024
-static-snapshots:
-  base-url: /
-  snapshot-files: '**/*.html,**/*.htm'
-  ignore-files: 'code-snippets/**/*.html,404.html,404/index.html'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:e2e:playground": "cypress run --spec cypress/integration/playground/**/*.js",
     "test:e2e:template-starter": "cypress run --spec cypress/integration/template-starter/**/*.js",
     "vrt:components": "percy exec -- jest --config jest.visual.config.js --runInBand",
-    "vrt:website": "percy snapshot website/public",
+    "vrt:website": "yarn --cwd website vrt",
     "vrt:e2e": "percy exec -- cypress run",
     "playground:build": "yarn --cwd playground build",
     "playground:start": "yarn --cwd playground start",

--- a/website/.percy.yml
+++ b/website/.percy.yml
@@ -1,0 +1,8 @@
+version: 1
+snapshot:
+  widths: [512, 1024, 1634]
+  min-height: 1024
+static-snapshots:
+  base-url: /
+  snapshot-files: '**/*.html,**/*.htm'
+  ignore-files: '404.html,404/index.html'

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "gatsby build",
     "start": "gatsby develop",
-    "serve": "gatsby serve"
+    "serve": "gatsby serve",
+    "vrt": "percy snapshot public"
   },
   "dependencies": {
     "@babel/core": "7.5.5",

--- a/website/src/layouts/internals/layout-container.js
+++ b/website/src/layouts/internals/layout-container.js
@@ -9,6 +9,11 @@ const LayoutContainer = styled.div`
   grid-template-rows: 50px ${props => (props.isMenuOpen ? 'auto 1fr' : '1fr')};
   grid-template-columns: auto 1fr auto;
   font-size: 1.3rem;
+
+  @media only percy {
+    /* Unset the 100vh to make view scrollable in order to take full page snapshots */
+    height: auto;
+  }
 `;
 
 // eslint-disable-next-line react/display-name


### PR DESCRIPTION
I contacted Percy support:

> Hi Percy team, we're very happy with your product so far but I have a couple of questions as I can't figure out how to do it:
> 1. we have a multi project setup (because of a monorepo) but the `.percy.yaml` is defined globally. I would like to specify different widths based on the percy project. Is that possible?
> 2. one of the projects uses static snapshots for a gatsby website. However, the snapshots do not take the full height of the page resulting in the page being "cut off" (https://percy.io/commercetools-GmbH/app-kit-website). Is this a known problem? Is that related to how the page layout is built? For instance, the layout consists in a css-grid with only the central column being scrollable.

And their answer:

> Hey Nicola,
>
> Thanks for reaching out! These are really good questions.
>
> 1. The .percy.yml is loaded based on your current working directory. So basically, where ever the command is executed from, we'll try to locate the .percy.yml in that file path. With that in mind, you could have the .percy.yml various projects and run the visual tests from that directory. If you set LOG_LEVEL=debug , one of the first lines of debugging that's logged is where we're looking for the config file: https://github.com/percy/percy-agent/blob/master/src/services/configuration-service.ts#L25 That should be helpful to debug if it's not working.
> 2. You're right -- that does have to do with how the page is built. I pulled down a snapshot from one of those builds and it looks like the html and body elements have 100vh  height set. You can see this happen locally if you open the page with Chrome and use their screenshot functionality in dev tools. 
>
>
![unnamed](https://user-images.githubusercontent.com/1110551/62901814-f914aa00-bd5d-11e9-940a-e7a04a1f0be8.png)
>
> Since the contents height is only 1200 px, that's all that will be captured. If you wanted to get this to work in Percy, you could use Percy specific CSS to unset the vh unit on those elements.  That should get you to be able to take full page screenshots 