### PR TITLE
feat(app-shell): load actionRights from gql for menu

### DIFF
--- a/packages/application-shell/src/components/with-applications-menu/fetch-applications-menu.graphql
+++ b/packages/application-shell/src/components/with-applications-menu/fetch-applications-menu.graphql
@@ -12,6 +12,10 @@ query FetchApplicationsMenu {
       featureToggle
       menuVisibility
       permissions
+      actionRights {
+        group
+        name
+      }
       submenu {
         key
         uriPath
@@ -22,6 +26,10 @@ query FetchApplicationsMenu {
         featureToggle
         menuVisibility
         permissions
+        actionRights {
+          group
+          name
+        }
       }
     }
     appBar {

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
@@ -32,6 +32,7 @@ const createTestMenuConfig = (key, props) => ({
   uriPath: key,
   icon: 'UserFilledIcon',
   permissions: [],
+  actionRights: null,
   featureToggle: null,
   menuVisibility: `hide${upperFirst(key)}`,
   submenu: [
@@ -41,6 +42,7 @@ const createTestMenuConfig = (key, props) => ({
       menuVisibility: `hide${upperFirst(key)}New`,
       uriPath: `${key}/new`,
       permissions: [],
+      actionRights: null,
       featureToggle: null,
     },
   ],


### PR DESCRIPTION
#### Summary

This pull request adds loading of `actionRights` to the menu.

1. The data is already pushed to the storage bucket from the MC
2. The `navbar` already forwards props accordingly and has been released
3. This is blocked by a change to out internal infrastructure