### PR TITLE
fix: prop-types for dataFences optional field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ commands:
     steps:
       - attach_workspace:
           at: *working_directory
+  build_packages:
+    description: Building packages
+    steps:
+      - run: yarn build
   lint_and_test:
     description: Running linters and tests
     steps:
@@ -64,11 +68,6 @@ commands:
       - run:
           name: Running linters and tests
           command: yarn run jest --projects jest.{eslint,stylelint,test}.config.js --maxWorkers=3 --reporters jest-silent-reporter
-  build_packages:
-    description: Building packages
-    steps:
-      - run: yarn build
-      - save_package_bundles
   vrt_tests:
     description: Running Visual Regression Tests
     steps:
@@ -107,17 +106,14 @@ commands:
       - run: ./scripts/release_canary.sh
 
 jobs:
-  lint_and_test:
+  build_lint_and_test:
     executor: node_10
     steps:
       - setup_dependencies
       - *save_yarn_cache
-      - lint_and_test
-  build:
-    executor: node_10
-    steps:
-      - setup_dependencies
       - build_packages
+      - lint_and_test
+      - save_package_bundles
   vrt_test:
     executor: node_10
     steps:
@@ -206,17 +202,14 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - lint_and_test
-      - build:
-          requires:
-            - lint_and_test
+      - build_lint_and_test
       - vrt_test:
           requires:
-            - build
+            - build_lint_and_test
       - e2e_test:
           name: e2e_playground
           requires:
-            - build
+            - build_lint_and_test
           spec: 'cypress/integration/playground/**/*.js'
           build: yarn playground:build
           start: yarn playground:start:prod:local
@@ -226,7 +219,7 @@ workflows:
       - e2e_test:
           name: e2e_starter
           requires:
-            - build
+            - build_lint_and_test
           spec: 'cypress/integration/template-starter/**/*.js'
           build: yarn template-starter:build
           start: yarn template-starter:start:prod:local

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -42,8 +42,8 @@ describe('rendering', () => {
             currencies: ['USD'],
             languages: ['en'],
             permissions: { canManageProjectSettings: true },
-            actionRights: {},
-            dataFences: {},
+            actionRights: null,
+            dataFences: null,
             // Fields that should not be exposed
             expiry: { isActive: false },
             suspension: { isActive: false },

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -73,9 +73,9 @@ type TRawProject = {
   owner: {
     id: string;
   };
-  permissions: TApplicationContextPermissions;
-  actionRights: TApplicationContextActionRights;
-  dataFences: TApplicationContextDataFences;
+  permissions: TApplicationContextPermissions | null;
+  actionRights: TApplicationContextActionRights | null;
+  dataFences: TApplicationContextDataFences | null;
 } & AdditionalProperties;
 type TApplicationContextProject = {
   key: string;

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -269,7 +269,8 @@ describe('<RestrictedApplication>', () => {
             },
             permissions: { canManageProjectSettings: true },
             menuVisibilities: { hideDashboard: true },
-            actionRights: {},
+            actionRights: null,
+            dataFences: null,
           };
           wrapperAside = wrapper
             .find({ role: 'aside' })

--- a/packages/application-shell/src/components/fetch-project/fetch-project.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.js
@@ -23,16 +23,24 @@ import ProjectQuery from './fetch-project.graphql';
  * the fetching logic. Given this mapping needs to be used elsewere feel free
  * to move this over to `permissions` and export it there.
  */
-export const mapAllAppliedToObjectShape = allAppliedShape =>
-  allAppliedShape.reduce(
+export const mapAllAppliedToObjectShape = allAppliedShape => {
+  if (allAppliedShape.length === 0) {
+    return null;
+  }
+  return allAppliedShape.reduce(
     (transformedAllApplied, allApplied) => ({
       ...transformedAllApplied,
       [allApplied.name]: allApplied.value,
     }),
     {}
   );
-export const mapAllAppliedToGroupedObjectShape = allAppliedShape =>
-  allAppliedShape.reduce((transformedAllApplied, allApplied) => {
+};
+
+export const mapAllAppliedToGroupedObjectShape = allAppliedShape => {
+  if (allAppliedShape.length === 0) {
+    return null;
+  }
+  return allAppliedShape.reduce((transformedAllApplied, allApplied) => {
     const previousAllAppliedGroup = transformedAllApplied[allApplied.group];
 
     return {
@@ -43,6 +51,7 @@ export const mapAllAppliedToGroupedObjectShape = allAppliedShape =>
       },
     };
   }, {});
+};
 
 const mapAppliedDataFencesByResourceType = dataFences => {
   const groupedByResourceType = dataFences.reduce(
@@ -112,6 +121,9 @@ const mapAppliedDataFencesByResourceType = dataFences => {
 //   }
 // }
 export const mapAllDataFencesToGroupedObjectShape = allAppliedDataFences => {
+  if (allAppliedDataFences.length === 0) {
+    return null;
+  }
   const groupedByType = allAppliedDataFences.reduce(
     (previousGroupsOfSameType, appliedDataFence) => {
       const previousGroup = previousGroupsOfSameType[appliedDataFence.type];

--- a/packages/application-shell/src/components/project-container/project-container.spec.js
+++ b/packages/application-shell/src/components/project-container/project-container.spec.js
@@ -36,7 +36,8 @@ const createTestProjectProps = custom => ({
     id: 'foo-1',
   },
   permissions: { canManageProjectSettings: true },
-  actionRights: {},
+  actionRights: null,
+  dataFences: null,
   menuVisibilities: { hideDashboard: true },
   ...custom,
 });

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -69,10 +69,6 @@ const defaultEnvironment = {
   servedByProxy: false,
 };
 
-const defaultPermissions = {};
-const defaultActionRights = null;
-const defaultDataFences = null;
-
 // Allow consumers of `render` to extend the defaults by passing an object
 // or to completely omit the value by passing `null`
 const mergeOptional = (defaultValue, value) =>
@@ -130,7 +126,7 @@ const renderApp = (
     environment,
     user,
     project,
-    permissions = defaultPermissions,
+    permissions,
     actionRights,
     dataFences,
     dataLocale = 'en',

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -70,8 +70,8 @@ const defaultEnvironment = {
 };
 
 const defaultPermissions = {};
-const defaultActionRights = {};
-const defaultDataFences = {};
+const defaultActionRights = null;
+const defaultDataFences = null;
 
 // Allow consumers of `render` to extend the defaults by passing an object
 // or to completely omit the value by passing `null`
@@ -131,8 +131,8 @@ const renderApp = (
     user,
     project,
     permissions = defaultPermissions,
-    actionRights = defaultActionRights,
-    dataFences = defaultDataFences,
+    actionRights,
+    dataFences,
     dataLocale = 'en',
     ApolloProviderComponent = MockedApolloProvider,
     // gtm-context

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -44,6 +44,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
             canEditPrices: false,
           },
         },
+        dataFences: null,
         owner: { id: 'o1' },
       }}
       projectDataLocale="en"

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -42,6 +42,7 @@ const testRender = ({
         },
         permissions: actualPermissions,
         actionRights: actualActionRights,
+        dataFences: null,
       }}
       environment={{
         applicationName: 'my-app',


### PR DESCRIPTION
Leftover of #941 

I also changed a bit the CI workflow to build the packages first, then run the linters and tests. This way we should be able to catch the prop-types warnings.