### PR TITLE
fix(actions-global): distinguish unknown/api errors based on presence of body field

### DIFF
--- a/packages/actions-global/src/actions/handle-action-error.spec.ts
+++ b/packages/actions-global/src/actions/handle-action-error.spec.ts
@@ -1,0 +1,68 @@
+import { TStatusCode } from '@commercetools-frontend/constants';
+import handleActionError from './handle-action-error';
+
+let dispatch: jest.Mock;
+beforeEach(() => {
+  dispatch = jest.fn();
+  console.error = jest.fn();
+});
+
+describe('handleActionError', () => {
+  it('notifies user about unknown error', () => {
+    const error = new Error('oupsy, something went wrong');
+    handleActionError(error)(dispatch);
+    expect(dispatch).toHaveBeenCalledWith({
+      meta: {
+        dismissAfter: 0,
+      },
+      payload: {
+        domain: 'page',
+        id: 0,
+        kind: 'unexpected-error',
+        values: {},
+      },
+      type: 'ADD_NOTIFICATION',
+    });
+  });
+
+  it('notifies user about sdk error', () => {
+    class FakeSdkError extends Error {
+      statusCode: TStatusCode;
+      body: {
+        message: string;
+      };
+
+      constructor(statusCode: TStatusCode, message: string) {
+        super();
+        this.statusCode = statusCode;
+        this.body = {
+          message,
+        };
+      }
+    }
+
+    const error = new FakeSdkError(
+      401,
+      "Required attribute 'key-required' cannot be removed."
+    );
+    handleActionError(error)(dispatch);
+    expect(dispatch).toHaveBeenCalledWith({
+      meta: {
+        dismissAfter: 0,
+      },
+      payload: {
+        domain: 'page',
+        id: 0,
+        kind: 'api-error',
+        values: {
+          errors: [
+            {
+              message: "Required attribute 'key-required' cannot be removed.",
+            },
+          ],
+        },
+      },
+      type: 'ADD_NOTIFICATION',
+    });
+  });
+});

--- a/packages/actions-global/src/actions/handle-action-error.spec.ts
+++ b/packages/actions-global/src/actions/handle-action-error.spec.ts
@@ -25,8 +25,8 @@ describe('handleActionError', () => {
     });
   });
 
-  it('notifies user about sdk error', () => {
-    class FakeSdkError extends Error {
+  it('notifies user about API error', () => {
+    class FakeApiError extends Error {
       statusCode: TStatusCode;
       body: {
         message: string;
@@ -41,7 +41,7 @@ describe('handleActionError', () => {
       }
     }
 
-    const error = new FakeSdkError(
+    const error = new FakeApiError(
       401,
       "Required attribute 'key-required' cannot be removed."
     );

--- a/packages/actions-global/src/actions/handle-action-error.ts
+++ b/packages/actions-global/src/actions/handle-action-error.ts
@@ -9,7 +9,7 @@ import browserHistory from '@commercetools-frontend/browser-history';
 import showApiErrorNotification from './show-api-error-notification';
 import showUnexpectedErrorNotification from './show-unexpected-error-notification';
 
-type SdkError = {
+type ApiError = {
   statusCode: TStatusCode;
   body: {
     message: string;
@@ -17,10 +17,10 @@ type SdkError = {
   };
 };
 
-type ActionError = Error | SdkError;
+type ActionError = Error | ApiError;
 
-function isSdkError(error: ActionError): error is SdkError {
-  return (error as SdkError).body !== undefined;
+function isApiError(error: ActionError): error is ApiError {
+  return (error as ApiError).body !== undefined;
 }
 
 export default function handleActionError(error: ActionError) {
@@ -35,7 +35,7 @@ export default function handleActionError(error: ActionError) {
     if (window.app.env !== 'production')
       console.error(error, error instanceof Error && error.stack);
 
-    if (!isSdkError(error)) return dispatch(showUnexpectedErrorNotification());
+    if (!isApiError(error)) return dispatch(showUnexpectedErrorNotification());
 
     // logout when unauthorized
     if (error.statusCode === STATUS_CODES.UNAUTHORIZED) {


### PR DESCRIPTION
Customers keep complaining about obscure error messages show in MC (in `application-products` in particular), whenever CRUD operations are failing because of not passing server-side validation.

What happening in this case is that `handleActionError` tries to distinguish between `sdk errors` and `unknown errors` based on a wrong assumption that `sdk errors` are never subclasses of `Error` class. After that it strips away all valuable information about the actual failure from passed `sdk error` object. In reality though, `sdk errors` are always instances of `Error` class.

With this PR we are changing the way described check is made so that it will be based on presence of absence of `body` field of supplied error object.  