### PR TITLE
feat(sdk): allow to pass a mcApiProxyTarget, to the SDK action

### DIFF
--- a/packages/application-shell/src/components/performance-timing/actions.js
+++ b/packages/application-shell/src/components/performance-timing/actions.js
@@ -3,6 +3,7 @@ import { actions as sdkActions } from '@commercetools-frontend/sdk';
 // eslint-disable-next-line import/prefer-default-export
 export const pushMetricHistogram = ({ payload }) =>
   sdkActions.post({
-    uri: '/proxy/mc-metrics/metrics/histograms',
+    uri: '/metrics/histograms',
+    uriPrefix: '/proxy/mc-metrics',
     payload: JSON.stringify(payload),
   });

--- a/packages/application-shell/src/components/performance-timing/actions.js
+++ b/packages/application-shell/src/components/performance-timing/actions.js
@@ -1,9 +1,10 @@
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 
 // eslint-disable-next-line import/prefer-default-export
 export const pushMetricHistogram = ({ payload }) =>
   sdkActions.post({
     uri: '/metrics/histograms',
-    uriPrefix: '/proxy/mc-metrics',
+    mcApiProxyTarget: MC_API_PROXY_TARGETS.MC_METRICS,
     payload: JSON.stringify(payload),
   });

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -9,7 +9,10 @@ import { withApollo } from 'react-apollo';
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
 import { oneLineTrim } from 'common-tags';
 import debounce from 'debounce-async';
-import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import {
+  GRAPHQL_TARGETS,
+  MC_API_PROXY_TARGETS,
+} from '@commercetools-frontend/constants';
 import { hasSomePermissions } from '@commercetools-frontend/permissions';
 import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import Butler from './butler';
@@ -366,7 +369,7 @@ export default flowRight(
         dispatch(
           sdkActions.post({
             uri: `/${ownProps.applicationContext.project.key}/search/products`,
-            uriPrefix: '/proxy/pim-search',
+            mcApiProxyTarget: MC_API_PROXY_TARGETS.PIM_SEARCH,
             payload: {
               query: {
                 fullText: {
@@ -402,7 +405,7 @@ export default flowRight(
           // instead to keep the payload minimal
           sdkActions.post({
             uri: `/${ownProps.applicationContext.project.key}/search/products`,
-            uriPrefix: '/proxy/pim-search',
+            mcApiProxyTarget: MC_API_PROXY_TARGETS.PIM_SEARCH,
             payload: {
               query: {
                 fullText: {

--- a/packages/application-shell/src/components/quick-access/quick-access.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.js
@@ -365,7 +365,8 @@ export default flowRight(
       pimSearchProductIds: searchText =>
         dispatch(
           sdkActions.post({
-            uri: `/proxy/pim-search/${ownProps.applicationContext.project.key}/search/products`,
+            uri: `/${ownProps.applicationContext.project.key}/search/products`,
+            uriPrefix: '/proxy/pim-search',
             payload: {
               query: {
                 fullText: {
@@ -400,7 +401,8 @@ export default flowRight(
           // error, so we send a regular request for now and limit to no results
           // instead to keep the payload minimal
           sdkActions.post({
-            uri: `/proxy/pim-search/${ownProps.applicationContext.project.key}/search/products`,
+            uri: `/${ownProps.applicationContext.project.key}/search/products`,
+            uriPrefix: '/proxy/pim-search',
             payload: {
               query: {
                 fullText: {

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { customProperties } from '@commercetools-frontend/ui-kit';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 import {
   renderAppWithRedux,
   fireEvent,
@@ -71,7 +72,8 @@ const createPimAvailabilityCheckSdkMock = (projectDataLocale = 'en') => ({
     type: 'SDK',
     payload: {
       method: 'POST',
-      uri: '/proxy/pim-search/test-with-big-data/search/products',
+      uri: '/test-with-big-data/search/products',
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.PIM_SEARCH,
       payload: {
         query: {
           fullText: {
@@ -96,7 +98,8 @@ const createPimSearchSdkMock = (
     type: 'SDK',
     payload: {
       method: 'POST',
-      uri: '/proxy/pim-search/test-with-big-data/search/products',
+      uri: '/test-with-big-data/search/products',
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.PIM_SEARCH,
       payload: {
         query: {
           fullText: {
@@ -1425,7 +1428,8 @@ describe('QuickAccess', () => {
               type: 'SDK',
               payload: {
                 method: 'POST',
-                uri: '/proxy/pim-search/test-with-big-data/search/products',
+                uri: '/test-with-big-data/search/products',
+                mcApiProxyTarget: MC_API_PROXY_TARGETS.PIM_SEARCH,
                 payload: {
                   query: {
                     fullText: {

--- a/packages/application-shell/src/components/version-tracker/actions.js
+++ b/packages/application-shell/src/components/version-tracker/actions.js
@@ -1,9 +1,10 @@
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 
 // eslint-disable-next-line import/prefer-default-export
 export const pushDependencyVersionCounter = ({ payload }) =>
   sdkActions.post({
     uri: '/metrics/counters',
-    uriPrefix: '/proxy/mc-metrics',
+    mcApiProxyTarget: MC_API_PROXY_TARGETS.MC_METRICS,
     payload: JSON.stringify(payload),
   });

--- a/packages/application-shell/src/components/version-tracker/actions.js
+++ b/packages/application-shell/src/components/version-tracker/actions.js
@@ -3,6 +3,7 @@ import { actions as sdkActions } from '@commercetools-frontend/sdk';
 // eslint-disable-next-line import/prefer-default-export
 export const pushDependencyVersionCounter = ({ payload }) =>
   sdkActions.post({
-    uri: '/proxy/mc-metrics/metrics/counters',
+    uri: '/metrics/counters',
+    uriPrefix: '/proxy/mc-metrics',
     payload: JSON.stringify(payload),
   });

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -123,3 +123,11 @@ export const GRAPHQL_TARGETS = {
   ADMINISTRATION_SERVICE: 'administration',
 } as const;
 export type TGraphQLTargets = (typeof GRAPHQL_TARGETS)[keyof typeof GRAPHQL_TARGETS];
+
+export const MC_API_PROXY_TARGETS = {
+  COMMERCETOOLS_PLATFORM: 'ctp',
+  MACHINE_LEARNING: 'ml',
+  PIM_SEARCH: 'pim-search',
+  MC_METRICS: 'mc-metrics',
+} as const;
+export type TApiProxyTargets = (typeof MC_API_PROXY_TARGETS)[keyof typeof MC_API_PROXY_TARGETS];

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -51,27 +51,29 @@ import { actions as sdkActions } from '@commercetools-frontend/sdk';
 
 #### Methods
 
-There are three action creators which all have the same behavior and API. The only difference is the resulting HTTP method:
+The supported action creators are:
 
-- `sdkActions.get(description)`: `GET`
-- `sdkActions.post(description)`: `POST`
-- `sdkActions.del(description)`: `DELETE`
+- `sdkActions.get(config)`: sends a HTTP `GET`
+- `sdkActions.post(config)`: sends a HTTP `POST`
+- `sdkActions.del(config)`: sends a HTTP `DELETE`
+- `sdkActions.head(config)`: sends a HTTP `HEAD`
 
 #### Specifying an endpoint
 
 There are two ways to describe an endpoint:
 
-- direct: `description.uri` is used as-is
-- combined: `description.service` and `description.options` are combined to form a `uri`
+- by `uri`: pass the URI as string
+- by `service`: uses the `@commercetools/api-request-builder` to build the URI. You can pass `config.options` to supply the necessary request parameters
 
-A `payload` can be provided in either case. It is only used by the `sdkActions.post` action creator. It contains the request payload.
+The `post` action creator additionally requires a `config.payload` object or string, containing the request payload.
 
 ##### Usage with `uri`
 
 ```js
 {
   uri: String,
-  payload: Object | String
+  uriPrefix?: String,
+  payload?: Object | String
 }
 ```
 
@@ -87,7 +89,8 @@ When both, `uri` and `options` (or `service`) are present, the `uri` takes prece
 {
   service: String,
   options: Object,
-  payload: Object | String
+  uriPrefix?: String,
+  payload?: Object | String
 }
 ```
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -67,12 +67,14 @@ There are two ways to describe an endpoint:
 
 The `post` action creator additionally requires a `config.payload` object or string, containing the request payload.
 
+> The `mcApiProxyTarget` values are exposed from the `@commercetools-frontend/constants` package, as `MC_API_PROXY_TARGETS`. The value will be used to build a prefix to the `uri` as `/proxy/<mcApiProxyTarget>/<uri>`.
+
 ##### Usage with `uri`
 
 ```js
 {
   uri: String,
-  uriPrefix?: String,
+  mcApiProxyTarget?: ApiProxyTarget,
   payload?: Object | String
 }
 ```
@@ -89,7 +91,7 @@ When both, `uri` and `options` (or `service`) are present, the `uri` takes prece
 {
   service: String,
   options: Object,
-  uriPrefix?: String,
+  mcApiProxyTarget?: ApiProxyTarget,
   payload?: Object | String
 }
 ```

--- a/packages/sdk/src/middleware/middleware.js
+++ b/packages/sdk/src/middleware/middleware.js
@@ -41,8 +41,8 @@ export default function createSdkMiddleware({
 
     if (action.type === 'SDK') {
       const uri = [
-        action.payload.uriPrefix &&
-          action.payload.uriPrefix.replace(/\/?$/, ''),
+        action.payload.mcApiProxyTarget &&
+          `/proxy/${action.payload.mcApiProxyTarget}`,
         actionToUri(action, projectKey),
       ]
         .filter(Boolean)

--- a/packages/sdk/src/middleware/middleware.js
+++ b/packages/sdk/src/middleware/middleware.js
@@ -40,7 +40,13 @@ export default function createSdkMiddleware({
     if (!action) return next(action);
 
     if (action.type === 'SDK') {
-      const uri = actionToUri(action, projectKey);
+      const uri = [
+        action.payload.uriPrefix &&
+          action.payload.uriPrefix.replace(/\/?$/, ''),
+        actionToUri(action, projectKey),
+      ]
+        .filter(Boolean)
+        .join('');
 
       // This `requestName` is never really used.
       //

--- a/packages/sdk/src/middleware/middleware.spec.js
+++ b/packages/sdk/src/middleware/middleware.spec.js
@@ -57,6 +57,32 @@ describe('when the action is of type SDK', () => {
         expect(next).toHaveBeenCalledTimes(0);
       });
     });
+    describe('when there is a uriPrefix', () => {
+      const dispatch = jest.fn();
+      const action = {
+        type: 'SDK',
+        payload: { uri: '/foo', uriPrefix: '/proxy/ctp', method: 'GET' },
+      };
+      const next = jest.fn();
+      const response = { body: 'foo', headers: {} };
+      let execute;
+      beforeEach(() => {
+        execute = jest.fn(() => Promise.resolve(response));
+        createClient.mockReturnValue({
+          execute,
+        });
+
+        return createMiddleware(middlewareOptions)({ dispatch })(next)(action);
+      });
+
+      it('should call `client.execute` with uri with prefix', () => {
+        expect(execute).toHaveBeenCalledWith(
+          expect.objectContaining({
+            uri: '/proxy/ctp/foo',
+          })
+        );
+      });
+    });
     describe('when the request is successful', () => {
       const dispatch = jest.fn();
       const action = {

--- a/packages/sdk/src/middleware/middleware.spec.js
+++ b/packages/sdk/src/middleware/middleware.spec.js
@@ -1,4 +1,8 @@
-import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
+import {
+  SHOW_LOADING,
+  HIDE_LOADING,
+  MC_API_PROXY_TARGETS,
+} from '@commercetools-frontend/constants';
 import createMiddleware from './middleware';
 import createClient from './client';
 
@@ -57,11 +61,15 @@ describe('when the action is of type SDK', () => {
         expect(next).toHaveBeenCalledTimes(0);
       });
     });
-    describe('when there is a uriPrefix', () => {
+    describe('when there is a mcApiProxyTarget', () => {
       const dispatch = jest.fn();
       const action = {
         type: 'SDK',
-        payload: { uri: '/foo', uriPrefix: '/proxy/ctp', method: 'GET' },
+        payload: {
+          uri: '/foo',
+          mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
+          method: 'GET',
+        },
       };
       const next = jest.fn();
       const response = { body: 'foo', headers: {} };

--- a/packages/sdk/src/test-utils/README.md
+++ b/packages/sdk/src/test-utils/README.md
@@ -39,7 +39,7 @@ const action = {
   payload: {
     method: 'GET',
     uri: '/foo/bar',
-    uriPrefix: '/proxy/ctp',
+    mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     headers: {
       Authorization: 'foo-bar',
     },

--- a/packages/sdk/src/test-utils/README.md
+++ b/packages/sdk/src/test-utils/README.md
@@ -39,6 +39,7 @@ const action = {
   payload: {
     method: 'GET',
     uri: '/foo/bar',
+    uriPrefix: '/proxy/ctp',
     headers: {
       Authorization: 'foo-bar',
     },

--- a/playground/src/components/state-machines-details/actions.js
+++ b/playground/src/components/state-machines-details/actions.js
@@ -1,8 +1,9 @@
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 
 export const fetchStateMachine = id =>
   sdkActions.get({
-    uriPrefix: '/proxy/ctp',
+    mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     service: 'states',
     options: { id },
   });

--- a/playground/src/components/state-machines-details/actions.js
+++ b/playground/src/components/state-machines-details/actions.js
@@ -2,6 +2,7 @@ import { actions as sdkActions } from '@commercetools-frontend/sdk';
 
 export const fetchStateMachine = id =>
   sdkActions.get({
+    uriPrefix: '/proxy/ctp',
     service: 'states',
     options: { id },
   });

--- a/playground/src/components/state-machines-list-connector/actions.js
+++ b/playground/src/components/state-machines-list-connector/actions.js
@@ -1,5 +1,5 @@
-import { createRequestBuilder } from '@commercetools/api-request-builder';
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 import { actionTypes } from '../../reducers/cache';
 
 export const setStateMachines = payload => ({
@@ -7,16 +7,9 @@ export const setStateMachines = payload => ({
   payload,
 });
 
-export const getStateMachinesUri = (options, meta) => {
-  const requestBuilder = createRequestBuilder({ projectKey: meta.projectKey });
-  const service = requestBuilder.states;
-  service.page(options.page).perPage(options.perPage);
-  return service.build();
-};
-
-export const fetchStateMachines = (requestOptions, meta) =>
+export const fetchStateMachines = requestOptions =>
   sdkActions.get({
-    uriPrefix: '/proxy/ctp',
+    mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     service: 'states',
-    uri: getStateMachinesUri(requestOptions, meta),
+    options: requestOptions,
   });

--- a/playground/src/components/state-machines-list-connector/actions.js
+++ b/playground/src/components/state-machines-list-connector/actions.js
@@ -16,6 +16,7 @@ export const getStateMachinesUri = (options, meta) => {
 
 export const fetchStateMachines = (requestOptions, meta) =>
   sdkActions.get({
+    uriPrefix: '/proxy/ctp',
     service: 'states',
     uri: getStateMachinesUri(requestOptions, meta),
   });

--- a/playground/src/components/state-machines-list-connector/state-machines-list-connector.js
+++ b/playground/src/components/state-machines-list-connector/state-machines-list-connector.js
@@ -8,7 +8,6 @@ class StateMachinesListConnector extends React.Component {
   static displayName = 'StateMachinesListConnector';
   static propTypes = {
     children: PropTypes.func.isRequired,
-    projectKey: PropTypes.string.isRequired,
     // Action creators
     setStateMachines: PropTypes.func.isRequired,
   };
@@ -16,9 +15,7 @@ class StateMachinesListConnector extends React.Component {
     return (
       <Sdk.Get
         actionCreator={requestParams =>
-          actions.fetchStateMachines(requestParams, {
-            projectKey: this.props.projectKey,
-          })
+          actions.fetchStateMachines(requestParams)
         }
         actionCreatorArgs={[
           {

--- a/playground/src/components/state-machines-list/state-machines-list.js
+++ b/playground/src/components/state-machines-list/state-machines-list.js
@@ -46,7 +46,7 @@ const StateMachinesList = props => {
     <Spacings.Inset scale="m">
       <Spacings.Stack scale="m">
         <Text.Headline as="h2" intlMessage={messages.title} />
-        <StateMachinesListConnector projectKey={props.projectKey}>
+        <StateMachinesListConnector>
           {({ isLoading, result, error, hasNoResults /* , refresh */ }) => {
             if (isLoading) return <LoadingSpinner />;
             if (error) return <div>{getErrorMessage(error)}</div>;
@@ -111,7 +111,6 @@ const StateMachinesList = props => {
 StateMachinesList.displayName = 'StateMachinesList';
 StateMachinesList.propTypes = {
   goToStateMachineDetail: PropTypes.func.isRequired,
-  projectKey: PropTypes.string.isRequired,
 };
 
 export default StateMachinesList;

--- a/playground/src/components/state-machines-list/state-machines-list.spec.js
+++ b/playground/src/components/state-machines-list/state-machines-list.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 import {
   renderAppWithRedux,
   waitForElement,
@@ -14,7 +15,11 @@ const createStateMachinesListSdkMock = () => ({
     payload: {
       method: 'GET',
       service: 'states',
-      uri: '/my-project/states?limit=25&offset=0',
+      options: {
+        perPage: 25,
+        page: 1,
+      },
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     },
   },
   response: {
@@ -34,6 +39,7 @@ const createStateMachinesDetailSdkMockForId1 = () => ({
       method: 'GET',
       service: 'states',
       options: { id: 'sm1' },
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     },
   },
   response: {
@@ -51,6 +57,7 @@ const createStateMachinesDetailSdkMockForId2 = () => ({
       method: 'GET',
       service: 'states',
       options: { id: 'sm2' },
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     },
   },
   response: {
@@ -68,6 +75,7 @@ const createStateMachinesDetailSdkErrorMock = () => ({
       method: 'GET',
       service: 'states',
       options: { id: 'sm1' },
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     },
   },
   error: {

--- a/playground/src/routes.js
+++ b/playground/src/routes.js
@@ -42,13 +42,12 @@ const ApplicationRoutes = props => {
           }}
         />
         <Route
-          render={routerProps => {
+          render={() => {
             if (!canViewDeveloperSettings) {
               return <PageUnauthorized />;
             }
             return (
               <StateMachinesList
-                projectKey={routerProps.match.params.projectKey}
                 goToStateMachineDetail={id => {
                   props.history.push(`${props.match.url}/${id}`);
                 }}

--- a/website/content/main-concepts/data-fetching.mdx
+++ b/website/content/main-concepts/data-fetching.mdx
@@ -88,6 +88,7 @@ import { actions as sdkActions } from '@commercetools-frontend/sdk';
 
 const fetchChannelById = id =>
   sdkActions.get({
+    uriPrefix: '/proxy/ctp',
     service: 'channels',
     options: { id },
   });

--- a/website/content/main-concepts/data-fetching.mdx
+++ b/website/content/main-concepts/data-fetching.mdx
@@ -75,9 +75,9 @@ That's it, Apollo will then take care of data normalization, caching, etc.
 Some enpdoints or APIs might not be available as GraphQL, which means that we need to fetch the data using a normal HTTP REST endpoint.
 There are different options here: you can build and send requests manually, using e.g. the [`fetch`](https://github.github.io/fetch/) library or any HTTP client.
 
-However, we recommend to use our own declarative fetching library [`@commercetools-frontend/sdk`](https://www.npmjs.com/package/@commercetools-frontend/sdk), which builds on top of the [SDK client](https://commercetools.github.io/nodejs/sdk/api/sdkClient.html) and [Redux](https://redux.js.org/) and is already configured within the [`<ApplicationShell>`](./application-shell).
+However, we recommend to use our own declarative fetching library [`@commercetools-frontend/sdk`](https://www.npmjs.com/package/@commercetools-frontend/sdk), which builds on top of the [JS SDK client](https://commercetools.github.io/nodejs/sdk/api/sdkClient.html) and [Redux](https://redux.js.org/) and is already configured within the [`<ApplicationShell>`](./application-shell).
 
-> The library does not include features like data normalization, caching, etc. You will need to build those on your onw.
+> The library does not include features like data normalization, caching, etc. You will need to build those on your own. The **playground** application includes an example of setting up data normalization and caching.
 
 In the example below, we fetch a [Channel](https://docs.commercetools.com/http-api-projects-channels).
 First we define the action creator:

--- a/website/content/main-concepts/data-fetching.mdx
+++ b/website/content/main-concepts/data-fetching.mdx
@@ -85,10 +85,11 @@ First we define the action creator:
 ```js
 // actions.js
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 
 const fetchChannelById = id =>
   sdkActions.get({
-    uriPrefix: '/proxy/ctp',
+    mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
     service: 'channels',
     options: { id },
   });

--- a/website/content/main-concepts/graphql.mdx
+++ b/website/content/main-concepts/graphql.mdx
@@ -30,7 +30,7 @@ Requests to the `/graphql` endpoint require one or more HTTP headers, to determi
   - `mc`: to target the **Merchant Center users** API
   - `settings`: to target the **Merchant Center settings** API
 
-  These values are available in the `@commercetools-frontend/constants` package.
-  When sending queries from React components, you need to pass the value as a `variables.target`. For an example of a fully constructed request, see [Data fetching](./getting-started/development#data-fetching).
+  These values are available in the `@commercetools-frontend/constants` package as `GRAPHQL_TARGETS` variable.
+  When sending queries from React components, you need to pass the value as a `variables.target`. For an example of a fully constructed request, see [Data fetching](./data-fetching).
 
 - `X-Project-Key` (_optional_): Specifies the project key to be used by the targeted GraphQL server. This value is not always required (depending on the query), but it's recommended to always send it whenever possible.

--- a/website/content/main-concepts/proxy-endpoints.mdx
+++ b/website/content/main-concepts/proxy-endpoints.mdx
@@ -18,7 +18,7 @@ The following proxy endpoints are available:
 - `/proxy/ml`: Proxies requests to the [machine learning API](https://docs.commercetools.com/http-api-ml.html)
 - _other endpoints that are only used for internal services_
 
-In addition to those endpoints, there is a [`/graphql`][./graphql] endpoint that also works as a proxy.
+In addition to those endpoints, there is a [`/graphql`](./graphql) endpoint that also works as a proxy.
 
 ## Request format
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7019,15 +7019,6 @@ create-jest-runner@^0.5.3:
     jest-worker "^24.0.0"
     throat "^4.1.0"
 
-create-react-class@^15.6.0:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 create-react-context@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
@@ -9355,7 +9346,7 @@ fbjs-css-vars@^1.0.0:
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
 
-fbjs@^0.8.0, fbjs@^0.8.9:
+fbjs@^0.8.0:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -18372,18 +18363,7 @@ react-virtualized@9.21.1:
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
 
-react@15:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  integrity sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
-react@16.8.6, react@^16.3.0, react@^16.8.4:
+react@15, react@16.8.6, react@^16.3.0, react@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==


### PR DESCRIPTION
All requests (apart from graphql) to the MC API should be prefixed with `/proxy/<service>`.

This PR adds support for a `mcApiProxyTarget,` option in the SDK action creators to make it easier for consumers to configure the action. The available proxy target are also exposed as constants `MC_API_PROXY_TARGETS`.

PS: one of the reasons for having this is to help migrate our current action creators to use the `/proxy/ctp` endpoint instead of the legacy one (which is without the prefix).
Eventually we can remove the legacy route from the MC API.