### PR TITLE
refactor(permissions/has-permissions): pass `actualDataFenceValues` into `selectDataFenceData`

### DIFF
--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -114,7 +114,7 @@ useIsAutorized(options: HookOptions): boolean
   be allowed to render
 - `demandedAtionRights`: (_optional_) an array of action rights (mentioned above)
 - `demandedDataFences`: (_optional_) an array of `DataFence` (mentioned above)
-- `selectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called on each specified `dataFence` and should return the mapped value specific to the data fence. The function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
+- `selectDataFenceData`: (_optional_ unless `dataFences` is specified) the function is called on each specified `dataFence` and should return the mapped value specific to the data fence. The function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 - `shouldMatchSomePermissions`: (_optional_) determines if _some_ or _every_ requested permission should match (default `false`)
 
 ### Example
@@ -154,7 +154,7 @@ injectAuthorized(
     (default `false`)
   - `actionRights`: (_optional_) an array of action rights (mentioned above)
   - `dataFences`: (_optional_) an array of `DataFence` (mentioned above)
-  - `getSelectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called with the component `props` and must return a new function that will be called on each specified `dataFence` and should return the mapped value specific to the data fence. The returned function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
+  - `getSelectDataFenceData`: (_optional_ unless `dataFences` is specified) the function is called with the component `props` and must return a new function that will be called on each specified `dataFence` and should return the mapped value specific to the data fence. The returned function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 
 ### Example
 
@@ -193,7 +193,7 @@ match, otherwise a fallback component.
 - `permissions`: an array of `Permission`, requested by the component
 - `actionRights`: (_optional_) an array of `ActionRight`, requested by the component
 - `dataFences`: (_optional_) an array of `DataFence`, requested by the component
-- `selectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called on each specified `dataFence` and should return the mapped value specific to the data fence. The function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
+- `selectDataFenceData`: (_optional_ unless `dataFences` is specified) the function is called on each specified `dataFence` and should return the mapped value specific to the data fence. The function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 - `unauthorizedComponent`: (_optional_) a function return an React element to be
   rendered in case the permissions don't match
 - `render`: (_optional_) a function returning an React element or a node to be
@@ -242,7 +242,7 @@ branchOnPermissions(
     shouldMatchSomePermissions: boolean,
     actionRights?: [ActionRight],
     dataFences?: [DataFence],
-    getSelectDataFenceDataByType?: ownProps => func
+    getSelectDataFenceData?: ownProps => func
   }
 ): HoC
 ```
@@ -257,7 +257,7 @@ branchOnPermissions(
     (default `false`)
   - `actionRights`: an array of `ActionRight` (mentioned above)
   - `dataFences`: an array of `DataFence` (mentioned above)
-  - `getSelectDataFenceDataByType`: (_optional_ unless `dataFences` is specified) the function is called with the component `props` and must return a new function that will be called on each specified `dataFence` and should return the mapped value specific to the data fence. The returned function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
+  - `getSelectDataFenceData`: (_optional_ unless `dataFences` is specified) the function is called with the component `props` and must return a new function that will be called on each specified `dataFence` and should return the mapped value specific to the data fence. The returned function usually contains a switch-case logic based on the data fence `type`, with the return value based on the `props`. For example, with `type: 'order'`, the return value would be something like `ownProps.order.storeRef.key`.
 
 ### Example
 
@@ -282,7 +282,7 @@ const LastOrder = ({ order : { store: "Germany" }}) =>
         type: 'store'
       }
     ],
-    getSelectDataFenceDataByType: ownProps => (demandedDataFence) => {
+    getSelectDataFenceData: ownProps => (demandedDataFence) => {
       switch (demandedDataFence.type) {
         case 'store':
           return [ownProps.order.storeRef.key];

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -282,10 +282,10 @@ const LastOrder = ({ order : { store: "Germany" }}) =>
         type: 'store'
       }
     ],
-    getSelectDataFenceDataByType: ownProps => ({ type }) => {
-      switch (type) {
+    getSelectDataFenceDataByType: ownProps => (demandedDataFence) => {
+      switch (demandedDataFence.type) {
         case 'store':
-          return [ownProps.order.store];
+          return [ownProps.order.storeRef.key];
         default:
           return null
       }

--- a/packages/permissions/src/components/authorized/authorized.spec.tsx
+++ b/packages/permissions/src/components/authorized/authorized.spec.tsx
@@ -37,7 +37,7 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
-type TSelectDataFenceDataByType = (dataFenceWithType: {
+type TSelectDataFenceData = (dataFenceWithType: {
   type: TDataFenceType;
 }) => string[] | null;
 
@@ -49,7 +49,7 @@ type TestProps = {
   actualPermissions: TPermissions | null;
   actualActionRights: TActionRights | null;
   actualDataFences: TDataFences | null;
-  selectDataFenceDataByType?: TSelectDataFenceDataByType;
+  selectDataFenceData?: TSelectDataFenceData;
   render: jest.Mock;
 };
 
@@ -239,7 +239,7 @@ describe('rendering', () => {
                   name: 'ManageOrders',
                 },
               ],
-              selectDataFenceDataByType: ({ type }) => ['store-1'],
+              selectDataFenceData: ({ type }) => ['store-1'],
             }),
           };
           shallow(<Authorized {...props} />);
@@ -261,7 +261,7 @@ describe('rendering', () => {
                   name: 'ViewOrders',
                 },
               ],
-              selectDataFenceDataByType: ({ type }) => ['store-1'],
+              selectDataFenceData: ({ type }) => ['store-1'],
             }),
           };
           shallow(<Authorized {...props} />);

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -47,16 +47,18 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
-type TSelectDataFenceDataByType = (dataFenceWithType: {
-  type: TDataFenceType;
-}) => string[] | null;
+type TSelectDataFenceData = (
+  demandedDataFenceWithActualValues: TDemandedDataFence & {
+    actualDataFenceValues: string[];
+  }
+) => string[] | null;
 
 type Props = {
   shouldMatchSomePermissions?: boolean;
   demandedPermissions: TPermissionName[];
   demandedActionRights?: TDemandedActionRight[];
   demandedDataFences?: TDemandedDataFence[];
-  selectDataFenceDataByType?: TSelectDataFenceDataByType;
+  selectDataFenceData?: TSelectDataFenceData;
   actualPermissions: TPermissions | null;
   actualActionRights: TActionRights | null;
   actualDataFences: TDataFences | null;
@@ -74,10 +76,10 @@ const Authorized = (props: Props) => {
     props.demandedDataFences &&
     props.demandedDataFences.length > 0
   ) {
-    if (!props.selectDataFenceDataByType) {
+    if (!props.selectDataFenceData) {
       reportErrorToSentry(
         new Error(
-          `@commercetools-frontend/permissions/Authorized: Missing data fences selector "selectDataFenceDataByType".`
+          `@commercetools-frontend/permissions/Authorized: Missing data fences selector "selectDataFenceData".`
         )
       );
       return <React.Fragment>{props.render(false)}</React.Fragment>;
@@ -88,7 +90,7 @@ const Authorized = (props: Props) => {
           hasAppliedDataFence({
             demandedDataFences: props.demandedDataFences,
             actualDataFences: props.actualDataFences,
-            selectDataFenceDataByType: props.selectDataFenceDataByType,
+            selectDataFenceData: props.selectDataFenceData,
           })
         )}
       </React.Fragment>
@@ -135,9 +137,7 @@ type TInjectAuthorizedOptions<OwnProps extends {}> = {
   actionRights?: TDemandedActionRight[];
   dataFences?: TDemandedDataFence[];
 
-  getSelectDataFenceDataByType?: (
-    ownProps: OwnProps
-  ) => TSelectDataFenceDataByType;
+  getSelectDataFenceData?: (ownProps: OwnProps) => TSelectDataFenceData;
 };
 
 const injectAuthorized = <
@@ -163,9 +163,9 @@ const injectAuthorized = <
           actualPermissions={applicationContext.permissions}
           actualActionRights={applicationContext.actionRights}
           actualDataFences={applicationContext.dataFences}
-          selectDataFenceDataByType={
-            options.getSelectDataFenceDataByType &&
-            options.getSelectDataFenceDataByType(props)
+          selectDataFenceData={
+            options.getSelectDataFenceData &&
+            options.getSelectDataFenceData(props)
           }
           render={isAuthorized => (
             <Component {...props} {...{ [propName]: isAuthorized }} />

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.tsx
@@ -19,17 +19,17 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
-type TSelectDataFenceDataByType = (dataFenceWithType: {
-  type: TDataFenceType;
-}) => string[] | null;
+type TSelectDataFenceData = (
+  demandedDataFenceWithActualValues: TDemandedDataFence & {
+    actualDataFenceValues: string[];
+  }
+) => string[] | null;
 
 type TOptions<OwnProps extends {}> = {
   shouldMatchSomePermissions?: boolean;
   actionRights?: TDemandedActionRight[];
   dataFences?: TDemandedDataFence[];
-  getSelectDataFenceDataByType?: (
-    ownProps: OwnProps
-  ) => TSelectDataFenceDataByType;
+  getSelectDataFenceData?: (ownProps: OwnProps) => TSelectDataFenceData;
 };
 
 const branchOnPermissions = <OwnProps extends {}>(
@@ -52,9 +52,9 @@ const branchOnPermissions = <OwnProps extends {}>(
           demandedPermissions={demandedPermissions}
           demandedActionRights={options.actionRights}
           demandedDataFences={options.dataFences}
-          selectDataFenceDataByType={
-            options.getSelectDataFenceDataByType &&
-            options.getSelectDataFenceDataByType(props)
+          selectDataFenceData={
+            options.getSelectDataFenceData &&
+            options.getSelectDataFenceData(props)
           }
           render={isAuthorized => {
             if (isAuthorized) {

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -23,9 +23,11 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
-type TSelectDataFenceDataByType = (dataFenceWithType: {
-  type: TDataFenceType;
-}) => string[] | null;
+type TSelectDataFenceData = (
+  demandedDataFenceWithActualValues: TDemandedDataFence & {
+    actualDataFenceValues: string[];
+  }
+) => string[] | null;
 
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 
@@ -34,7 +36,7 @@ type Props = {
   permissions: TPermissionName[];
   actionRights?: TDemandedActionRight[];
   dataFences?: TDemandedDataFence[];
-  selectDataFenceDataByType?: TSelectDataFenceDataByType;
+  selectDataFenceData?: TSelectDataFenceData;
   unauthorizedComponent?: React.ComponentType;
   render?: TRenderProp;
   children?: TRenderProp | React.ReactNode;
@@ -59,7 +61,7 @@ const RestrictedByPermissions = (props: Props) => {
           demandedPermissions={props.permissions}
           demandedActionRights={props.actionRights}
           demandedDataFences={props.dataFences}
-          selectDataFenceDataByType={props.selectDataFenceDataByType}
+          selectDataFenceData={props.selectDataFenceData}
           render={(isAuthorized: boolean) => {
             if (typeof props.children === 'function')
               return props.children({

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -44,22 +44,24 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
-type TSelectDataFenceDataByType = (dataFenceWithType: {
-  type: TDataFenceType;
-}) => string[] | null;
+type TSelectDataFenceData = (
+  demandedDataFenceWithActualValues: TDemandedDataFence & {
+    actualDataFenceValues: string[];
+  }
+) => string[] | null;
 
 // Forward-compatibility with React Hooks 🎉
 const useIsAuthorized = ({
   demandedPermissions,
   demandedActionRights,
   demandedDataFences,
-  selectDataFenceDataByType,
+  selectDataFenceData,
   shouldMatchSomePermissions = false,
 }: {
   demandedPermissions: TPermissionName[];
   demandedActionRights?: TDemandedActionRight[];
   demandedDataFences?: TDemandedDataFence[];
-  selectDataFenceDataByType?: TSelectDataFenceDataByType;
+  selectDataFenceData?: TSelectDataFenceData;
   shouldMatchSomePermissions: boolean;
 }) => {
   const actualPermissions = useApplicationContext<TPermissions | null>(
@@ -74,10 +76,10 @@ const useIsAuthorized = ({
 
   // Check first for data fences
   if (actualDataFences && demandedDataFences && demandedDataFences.length > 0) {
-    if (!selectDataFenceDataByType) {
+    if (!selectDataFenceData) {
       reportErrorToSentry(
         new Error(
-          `@commercetools-frontend/permissions/Authorized: Missing data fences selector "selectDataFenceDataByType".`
+          `@commercetools-frontend/permissions/Authorized: Missing data fences selector "selectDataFenceData".`
         )
       );
       return false;
@@ -85,7 +87,7 @@ const useIsAuthorized = ({
     return hasAppliedDataFence({
       demandedDataFences: demandedDataFences,
       actualDataFences: actualDataFences,
-      selectDataFenceDataByType: selectDataFenceDataByType,
+      selectDataFenceData: selectDataFenceData,
     });
   }
 

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -43,8 +43,8 @@ type TDemandedDataFenceWithValues = TDemandedDataFence & {
   actualDataFenceValues: string[];
 };
 
-type TSelectDataFenceDataByType = (
-  dataFenceWithType: TDemandedDataFenceWithValues
+type TSelectDataFenceData = (
+  demandedDataFenceWithActualValues: TDemandedDataFenceWithValues
 ) => string[] | null;
 
 type TActualDataFence = {
@@ -55,7 +55,7 @@ type TActualDataFence = {
 type TOptionsForAppliedDataFence = {
   demandedDataFences: TDemandedDataFence[];
   actualDataFences: TDataFences;
-  selectDataFenceDataByType: TSelectDataFenceDataByType;
+  selectDataFenceData: TSelectDataFenceData;
 };
 
 // Build the permission key from the definition to match it to the format coming
@@ -183,10 +183,10 @@ export const getInvalidPermissions = (
   );
 };
 
-const hasDemandedDataFenceByType = (options: {
+const hasDemandedDataFence = (options: {
   actualDataFence: TActualDataFence;
   demandedDataFence: TDemandedDataFence;
-  selectDataFenceDataByType: TSelectDataFenceDataByType;
+  selectDataFenceData: TSelectDataFenceData;
 }): boolean => {
   const hasDemandedPermission = hasPermission(options.demandedDataFence.name, {
     [options.actualDataFence.name]: true,
@@ -194,7 +194,7 @@ const hasDemandedDataFenceByType = (options: {
 
   if (!hasDemandedPermission) return false;
 
-  const selectedDataFenceData = options.selectDataFenceDataByType({
+  const selectedDataFenceData = options.selectDataFenceData({
     type: options.demandedDataFence.type,
     group: options.demandedDataFence.group,
     name: options.demandedDataFence.name,
@@ -243,19 +243,18 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) =>
     );
 
     if (actualDataFenceByPermissionGroup) {
-      const hasDemandedDataFence = Object.entries(
-        actualDataFenceByPermissionGroup
-      ).every(([dataFenceName, dataFenceValue]) => {
-        if (dataFenceValue) {
-          return hasDemandedDataFenceByType({
-            actualDataFence: { name: dataFenceName, dataFenceValue },
-            demandedDataFence,
-            selectDataFenceDataByType: options.selectDataFenceDataByType,
-          });
+      return Object.entries(actualDataFenceByPermissionGroup).every(
+        ([dataFenceName, dataFenceValue]) => {
+          if (dataFenceValue) {
+            return hasDemandedDataFence({
+              actualDataFence: { name: dataFenceName, dataFenceValue },
+              demandedDataFence,
+              selectDataFenceData: options.selectDataFenceData,
+            });
+          }
+          return false;
         }
-        return false;
-      });
-      return hasDemandedDataFence;
+      );
     }
 
     return false;

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -38,9 +38,15 @@ type TDemandedDataFence = {
   name: string;
   type: TDataFenceType;
 };
-type TSelectDataFenceDataByType = (dataFenceWithType: {
-  type: TDataFenceType;
-}) => string[] | null;
+
+type TDemandedDataFenceWithValues = TDemandedDataFence & {
+  actualDataFenceValues: string[];
+};
+
+type TSelectDataFenceDataByType = (
+  dataFenceWithType: TDemandedDataFenceWithValues
+) => string[] | null;
+
 type TActualDataFence = {
   name: string;
   dataFenceValue: { values: string[] };
@@ -190,6 +196,9 @@ const hasDemandedDataFenceByType = (options: {
 
   const selectedDataFenceData = options.selectDataFenceDataByType({
     type: options.demandedDataFence.type,
+    group: options.demandedDataFence.group,
+    name: options.demandedDataFence.name,
+    actualDataFenceValues: options.actualDataFence.dataFenceValue.values,
   });
 
   if (!selectedDataFenceData) {


### PR DESCRIPTION
#### Summary

- passes `actualDataFence.values` into `selectDataFenceData` (previously named `selectDataFenceDataByType`

#### Description

Previously we wrote `selectDataFenceDataByType` with the assumption that the data returned from `selectDataFenceDataByType` will come only from the resource we demand a dataFence for e.g `Orders`.  This is true in the case for Details and List Views.  

And it will look as the following:

```
{ 
  dataFences: [
    // N number of datafences
  ],
  selectDataFenceData: ownProps => ({ type }) => {
    switch(type) {
      ...
    }
  }
}
```

---

In the Navbar, we also need to apply datafences.
This is especially necessary because in the MC-API, [we are distinguishing](https://github.com/commercetools/merchant-center-services/pulls?q=is%3Apr+is%3Aclosed+author%3Aamine-benselim) project permissions (via `allAppliedPermissions`) and dataFence permissions (`allAppliedDataFences`).

As a result for this, when the following permissions are applied on the user

```
GIVEN no project permissions
AND user has ManageOrders on dataFence permission
```

Then `appliedPermissions` will imply false on `ManageOrders` which leads to the menu not displaying.

#### Approach to solve this

- we demanded dataFence on `NavBar`
- we pass in demandedDataFence (coming from elsewhere)
- we pass in `selectDataFenceData`
  - at this point, we will receive `actualDataFenceValues`. Because the rule is if there are dataFences, we display the application menu, so we return `actualDataFenceValues`

With the approach discussed above, we make sure the `authorized` works for both NavBar and Details/List view. The difference is the on NavBar, it will always be true.

If there are no dataFence values, we "fall back" to the project permission (general permission)

--- 

This is the outcome of yesterday's meeting. A PR with changes to `NavBar` will follow