### PR TITLE
feat(application-shell/navbar): add demandedDataFences and return dataFenceValues given to the user

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.js
+++ b/packages/application-shell/src/components/navbar/navbar.js
@@ -265,10 +265,19 @@ export const RestrictedMenuItem = props => {
     return null;
 
   const permissionsWrapper =
-    props.permissions.length > 0 ? (
+    props.permissions.length > 0 || props.dataFences.length > 0 ? (
       <RestrictedByPermissions
         permissions={props.permissions}
         actionRights={props.actionRights}
+        dataFences={props.dataFences}
+        selectDataFenceData={demandedDataFence => {
+          switch (demandedDataFence.type) {
+            case 'store':
+              return demandedDataFence.actualDataFenceValues;
+            default:
+              return null;
+          }
+        }}
         // Always check that some of the given permissions match.
         shouldMatchSomePermissions={true}
       >
@@ -293,6 +302,13 @@ RestrictedMenuItem.propTypes = {
   menuVisibilities: PropTypes.object.isRequired,
   disabledMenuItems: PropTypes.arrayOf(PropTypes.string),
   keyOfMenuItem: PropTypes.string.isRequired,
+  dataFences: PropTypes.arrayOf(
+    PropTypes.shape({
+      group: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+    })
+  ),
   permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
   actionRights: PropTypes.arrayOf(
     PropTypes.shape({
@@ -304,6 +320,7 @@ RestrictedMenuItem.propTypes = {
 };
 RestrictedMenuItem.defaultProps = {
   permissions: [],
+  dataFences: [],
 };
 export const getIconColor = (isActive, isAlternativeTheme) => {
   if (isActive) return 'primary40';
@@ -330,6 +347,13 @@ export class DataMenu extends React.PureComponent {
         icon: PropTypes.string.isRequired,
         featureToggle: PropTypes.string,
         permissions: PropTypes.arrayOf(PropTypes.string.isRequired),
+        dataFences: PropTypes.arrayOf(
+          PropTypes.shape({
+            group: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+            type: PropTypes.string.isRequired,
+          })
+        ),
         actionRights: PropTypes.arrayOf(
           PropTypes.shape({
             group: PropTypes.string.isRequired,

--- a/packages/application-shell/src/components/navbar/navbar.spec.js
+++ b/packages/application-shell/src/components/navbar/navbar.spec.js
@@ -27,6 +27,7 @@ const createTestMenuConfig = (key, props) => ({
   keyOfMenuItem: key,
   icon: 'UserFilledIcon',
   permissions: [],
+  dataFences: [],
   actionRights: [],
   submenu: [
     {
@@ -501,12 +502,58 @@ describe('rendering', () => {
           it('should not render <RestrictedByPermissions>', () => {
             expect(wrapper).not.toRender(RestrictedByPermissions);
           });
+          describe('with defined dataFences', () => {
+            beforeEach(() => {
+              props = {
+                featureToggle: 'myFeature',
+                permissions: [],
+                dataFences: [
+                  {
+                    name: 'ViewOrders',
+                    group: 'orders',
+                    type: 'store',
+                  },
+                ],
+                actualPermissions: {},
+                menuVisibilities: {},
+                keyOfMenuItem: 'products',
+              };
+              wrapper = shallow(
+                <RestrictedMenuItem {...props}>
+                  <ItemChild />
+                </RestrictedMenuItem>
+              );
+            });
+            it('should render <RestrictedByPermissions>', () => {
+              expect(wrapper).toRender(RestrictedByPermissions);
+            });
+          });
+          describe('without defined dataFences', () => {
+            beforeEach(() => {
+              props = {
+                featureToggle: 'myFeature',
+                permissions: [],
+                actualPermissions: {},
+                menuVisibilities: {},
+                keyOfMenuItem: 'products',
+              };
+              wrapper = shallow(
+                <RestrictedMenuItem {...props}>
+                  <ItemChild />
+                </RestrictedMenuItem>
+              );
+            });
+            it('should not render <RestrictedByPermissions>', () => {
+              expect(wrapper).not.toRender(RestrictedByPermissions);
+            });
+          });
         });
         describe('with defined permissions', () => {
           beforeEach(() => {
             props = {
               featureToggle: 'myFeature',
               permissions: ['ManageOrders'],
+              dataFences: [],
               actionRights: [
                 {
                   group: 'Orders',
@@ -558,6 +605,7 @@ describe('rendering', () => {
             props = {
               featureToggle: undefined,
               permissions: [],
+              dataFences: [],
               actualPermissions: {},
               menuVisibilities: {},
               keyOfMenuItem: 'products',
@@ -580,6 +628,7 @@ describe('rendering', () => {
             props = {
               featureToggle: undefined,
               permissions: ['ManageOrders'],
+              dataFences: [],
               actionRights: [
                 {
                   group: 'Orders',

--- a/packages/application-shell/src/components/with-applications-menu/fetch-applications-menu.graphql
+++ b/packages/application-shell/src/components/with-applications-menu/fetch-applications-menu.graphql
@@ -12,6 +12,11 @@ query FetchApplicationsMenu {
       featureToggle
       menuVisibility
       permissions
+      dataFences {
+        group
+        name
+        type
+      }
       actionRights {
         group
         name

--- a/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
+++ b/packages/application-shell/src/components/with-applications-menu/with-applications-menu.spec.js
@@ -32,6 +32,7 @@ const createTestMenuConfig = (key, props) => ({
   uriPath: key,
   icon: 'UserFilledIcon',
   permissions: [],
+  dataFences: null,
   actionRights: null,
   featureToggle: null,
   menuVisibility: `hide${upperFirst(key)}`,


### PR DESCRIPTION
#### Summary

- adds `dataFences`(demandedDataFence) into RestrictedByPermission for NavBar
- follow up on https://github.com/commercetools/merchant-center-application-kit/pull/990

#### Description

we know that we demand for DataFences to apply on `Authorized`, we are required to provide a `selectDataFenceData`.

For Details/List, we could use the resource to provide values e.g `order.storeRef.key`.
However in Navbar, we do not have any resource. So to "circumvent" this limitation, we let the `Authorized` give us the values we are looking for and return that as the default.

This is to enable the case where user has dataFence permissions but not project permissions
