### PR TITLE
feat: add ability to specify feature policies

### DIFF
--- a/packages/mc-html-template/README.md
+++ b/packages/mc-html-template/README.md
@@ -44,13 +44,14 @@ This method will attempt to load and parse the `env.json` file, performing some 
 
 This method will attempt to load and parse the `env.json` file, performing some validation and returning the parsed JSON.
 
-#### `loadHeaders(env: Object, { cspPath: String }): Object`
+#### `loadHeaders(env: Object, { cspPath: String, featurePoliciesPath: String }): Object`
 
 This method will return the security headers to be used on the server response, serving the `index.html`.
 
 The `env` argument, is the parsed `env.json` file (see `loadEnv`).
 
 Optionally, you can pass the path to the `csp.json` that contains custom CSP directives. Those will be merged with the default ones.
+Optionally, you can pass the path to the `feature-policies.json` that contains custom feature policy directives.
 
 The final headers object contains the following headers:
 
@@ -60,7 +61,8 @@ The final headers object contains the following headers:
   "X-XSS-Protection": "1; mode=block",
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
-  "Content-Security-Policy": "..."
+  "Content-Security-Policy": "...",
+  "Feature-Policies": "..."
 }
 ```
 

--- a/packages/mc-html-template/README.md
+++ b/packages/mc-html-template/README.md
@@ -59,7 +59,7 @@ Optionally, you can pass the path to a `headers.json` that contains custom CSP a
 }
 ```
 
-The `cspPath` has been deprecated in favour of the `headerpath option. To migrate away from the`cspPath`please use the`headerPath`while moving the contents of a e.g.`csp.json`into e.g. a`headers.json`behind a`csp`property while passing`headerPath`.
+The `cspPath` has been **deprecated** in favour of the `headerpath` option. You can migrate to the new option by creating a `headers.json` (previously `csp.json`) and assigning the content of the `csp.json` into the `csp` field in the `headers.json` file.
 
 The final headers object contains the following headers:
 

--- a/packages/mc-html-template/README.md
+++ b/packages/mc-html-template/README.md
@@ -40,11 +40,7 @@ At the moment we define the following placeholders:
 
 This method will attempt to load and parse the `env.json` file, performing some validation and returning the parsed JSON.
 
-#### `loadEnv(configPath: String): Object`
-
-This method will attempt to load and parse the `env.json` file, performing some validation and returning the parsed JSON.
-
-#### `loadHeaders(env: Object, { headersPath: String }): Object`
+#### `loadHeaders(env: Object, { headersPath: String, cspPath?: String }): Object`
 
 This method will return the security headers to be used on the server response, serving the `index.html`.
 
@@ -62,6 +58,8 @@ Optionally, you can pass the path to a `headers.json` that contains custom CSP a
   }
 }
 ```
+
+The `cspPath` has been deprecated in favour of the `headerpath option. To migrate away from the`cspPath`please use the`headerPath`while moving the contents of a e.g.`csp.json`into e.g. a`headers.json`behind a`csp`property while passing`headerPath`.
 
 The final headers object contains the following headers:
 

--- a/packages/mc-html-template/README.md
+++ b/packages/mc-html-template/README.md
@@ -44,14 +44,24 @@ This method will attempt to load and parse the `env.json` file, performing some 
 
 This method will attempt to load and parse the `env.json` file, performing some validation and returning the parsed JSON.
 
-#### `loadHeaders(env: Object, { cspPath: String, featurePoliciesPath: String }): Object`
+#### `loadHeaders(env: Object, { headersPath: String }): Object`
 
 This method will return the security headers to be used on the server response, serving the `index.html`.
 
 The `env` argument, is the parsed `env.json` file (see `loadEnv`).
 
-Optionally, you can pass the path to the `csp.json` that contains custom CSP directives. Those will be merged with the default ones.
-Optionally, you can pass the path to the `feature-policies.json` that contains custom feature policy directives.
+Optionally, you can pass the path to a `headers.json` that contains custom CSP and feature directives such as:
+
+```json
+{
+  "csp": {
+    "script-src": ["storage.googleapis.com/my-bucket-path/"]
+  },
+  "featurePolicies": {
+    "microphone": "none"
+  }
+}
+```
 
 The final headers object contains the following headers:
 

--- a/packages/mc-html-template/lib/compile-html.js
+++ b/packages/mc-html-template/lib/compile-html.js
@@ -6,12 +6,13 @@ const loadHeaders = require('./load-headers');
 const replaceHtmlPlaceholders = require('./utils/replace-html-placeholders');
 
 const requiredOptions = ['envPath', 'publicAssetsPath'];
+const deprecatedOptions = ['cspPath'];
 
 /**
  * Options:
  * - envPath
  * - cspPath
- * - featurePoliciesPath
+ * - headersPath
  * - publicAssetsPath
  * - useLocalAssets
  */
@@ -22,10 +23,18 @@ module.exports = async function compileHtml(options) {
     }
   });
 
+  deprecatedOptions.forEach(key => {
+    if (options[key]) {
+      console.warn(
+        '⚠️ [@commercetools-frontend/mc-html-template]: `cspPath` has been deprecated. Please use `headerPath` instead while nesting CSPs into a `csp`-property in e.g. a `headers.json`.'
+      );
+    }
+  });
+
   const env = loadEnv(options.envPath);
   const headers = loadHeaders(env, {
     cspPath: options.cspPath,
-    featurePoliciesPath: options.featurePoliciesPath,
+    headersPath: options.headersPath,
   });
 
   if (options.useLocalAssets) {

--- a/packages/mc-html-template/lib/compile-html.js
+++ b/packages/mc-html-template/lib/compile-html.js
@@ -26,7 +26,7 @@ module.exports = async function compileHtml(options) {
   deprecatedOptions.forEach(key => {
     if (options[key]) {
       console.warn(
-        '⚠️ [@commercetools-frontend/mc-html-template]: `cspPath` has been deprecated. Please use `headerPath` instead while nesting CSPs into a `csp`-property in e.g. a `headers.json`.'
+        '⚠️ [@commercetools-frontend/mc-html-template]: `cspPath` has been deprecated. Please use `headerPath`. More info here: https://github.com/commercetools/merchant-center-application-kit/blob/master/packages/mc-html-template/README.md.'
       );
     }
   });

--- a/packages/mc-html-template/lib/compile-html.js
+++ b/packages/mc-html-template/lib/compile-html.js
@@ -11,7 +11,7 @@ const deprecatedOptions = ['cspPath'];
 /**
  * Options:
  * - envPath
-  * - cspPath (deprecated)
+ * - cspPath (deprecated)
  * - headersPath
  * - publicAssetsPath
  * - useLocalAssets

--- a/packages/mc-html-template/lib/compile-html.js
+++ b/packages/mc-html-template/lib/compile-html.js
@@ -11,7 +11,7 @@ const deprecatedOptions = ['cspPath'];
 /**
  * Options:
  * - envPath
- * - cspPath
+  * - cspPath (deprecated)
  * - headersPath
  * - publicAssetsPath
  * - useLocalAssets

--- a/packages/mc-html-template/lib/compile-html.js
+++ b/packages/mc-html-template/lib/compile-html.js
@@ -11,6 +11,7 @@ const requiredOptions = ['envPath', 'publicAssetsPath'];
  * Options:
  * - envPath
  * - cspPath
+ * - featurePoliciesPath
  * - publicAssetsPath
  * - useLocalAssets
  */
@@ -22,7 +23,10 @@ module.exports = async function compileHtml(options) {
   });
 
   const env = loadEnv(options.envPath);
-  const headers = loadHeaders(env, { cspPath: options.cspPath });
+  const headers = loadHeaders(env, {
+    cspPath: options.cspPath,
+    featurePoliciesPath: options.featurePoliciesPath,
+  });
 
   if (options.useLocalAssets) {
     const indexHtmlContent = fs.readFileSync(

--- a/packages/mc-html-template/lib/load-headers.js
+++ b/packages/mc-html-template/lib/load-headers.js
@@ -37,7 +37,7 @@ const mergeCspDirectives = (...csps) =>
       ),
     {}
   );
-const toHeaderString = directives =>
+const toHeaderString = (directives = {}) =>
   Object.entries(directives)
     .map(
       ([directive, value]) =>
@@ -142,7 +142,7 @@ module.exports = (env, options) => {
   // Recursively merge the directives
   const mergedCsp = mergeCspDirectives(
     cspDirectives,
-    customHeaders.cors || customCspDirectivesFromDeprecatedPath
+    customHeaders.csp || customCspDirectivesFromDeprecatedPath
   );
 
   return {
@@ -152,6 +152,8 @@ module.exports = (env, options) => {
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'same-origin',
     'Content-Security-Policy': toHeaderString(mergedCsp),
-    'Feature-Policy': toHeaderString(customHeaders.featurePolicies),
+    ...(customHeaders.featurePolicies && {
+      'Feature-Policy': toHeaderString(customHeaders.featurePolicies),
+    }),
   };
 };

--- a/packages/mc-html-template/lib/load-headers.js
+++ b/packages/mc-html-template/lib/load-headers.js
@@ -130,19 +130,18 @@ module.exports = (env, options) => {
   // Attempt to load the JSON config for custom CSP and feature policy headers provided by each application
   // For backwards compatibilty the `cspPath` can still be used but the `headerPath` takes precedence.
 
+  const shouldUseDeprecatedCspPath = Boolean(options.cspPath);
+
   const customHeaders = loadCustomConfiguration(options.headersPath);
 
-  let customCspDirectivesFromDeprecatedPath;
-
-  if (!customHeaders.csp && options.cspPath)
-    customCspDirectivesFromDeprecatedPath = loadCustomConfiguration(
-      options.cspPath
-    );
+  const customCspDirectives = shouldUseDeprecatedCspPath
+    ? loadCustomConfiguration(options.cspPath)
+    : customHeaders.csp;
 
   // Recursively merge the directives
   const mergedCsp = mergeCspDirectives(
     cspDirectives,
-    customHeaders.csp || customCspDirectivesFromDeprecatedPath
+    customCspDirectives || {}
   );
 
   return {

--- a/packages/mc-html-template/lib/load-headers.js
+++ b/packages/mc-html-template/lib/load-headers.js
@@ -39,7 +39,10 @@ const mergeCspDirectives = (...csps) =>
   );
 const toHeaderString = directives =>
   Object.entries(directives)
-    .map(([directive, value]) => `${directive} ${value.join(' ')}`)
+    .map(
+      ([directive, value]) =>
+        `${directive} ${Array.isArray(value) ? value.join(' ') : value}`
+    )
     .join('; ');
 
 module.exports = (env, options) => {
@@ -139,7 +142,7 @@ module.exports = (env, options) => {
   // Recursively merge the directives
   const mergedCsp = mergeCspDirectives(
     cspDirectives,
-    customHeaders.csp || customCspDirectivesFromDeprecatedPath
+    customHeaders.cors || customCspDirectivesFromDeprecatedPath
   );
 
   return {

--- a/packages/mc-html-template/lib/load-headers.js
+++ b/packages/mc-html-template/lib/load-headers.js
@@ -125,7 +125,7 @@ module.exports = (env, options) => {
   );
 
   // Attempt to load the JSON config for custom CSP and feature policy headers provided by each application
-  // For backwards compatibilty the `cspPath` is used too while the `headerPath` has preference.
+  // For backwards compatibilty the `cspPath` can still be used but the `headerPath` takes precedence.
 
   const customHeaders = loadCustomConfiguration(options.headersPath);
 

--- a/packages/mc-http-server/bin/start-mc.js
+++ b/packages/mc-http-server/bin/start-mc.js
@@ -21,6 +21,7 @@ if (flags.help) {
   Options:
   --config=<path>           (required) The path to the environment config (defined as a JSON file, e.g. "env.json").
   --csp=<path>              (optional) The path to the custom CSP directives config (defined as a JSON file, e.g. "csp.json").
+  --featurePolicies=<path>  (optional) The path to the feature policy directives config (defined as a JSON file, e.g. "feature-policies.json").
   --use-local-assets        (optional) If this option is enabled, the "dist/assets" will be used to start the http-server package. This requires that the assets have been built before running this script.
   `);
 }
@@ -41,6 +42,7 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 const paths = {
   envPath: flags.config,
   cspPath: flags.csp,
+  featurePoliciesPath: flags.featurePolicies,
   publicAssetsPath: path.join(__dirname, '../public'),
   // NOTE: previously, for running the prod server locally, we were copying
   // assets into public/assets and compiling the index.html into public folder.
@@ -87,6 +89,7 @@ const start = async () => {
   const compiled = await compileHtml({
     envPath: paths.envPath,
     cspPath: paths.cspPath,
+    featurePoliciesPath: paths.featurePoliciesPath,
     publicAssetsPath: paths.publicAssetsPath,
     useLocalAssets,
   });

--- a/packages/mc-http-server/bin/start-mc.js
+++ b/packages/mc-http-server/bin/start-mc.js
@@ -20,8 +20,8 @@ if (flags.help) {
 
   Options:
   --config=<path>           (required) The path to the environment config (defined as a JSON file, e.g. "env.json").
-  --csp=<path>              (optional) The path to the custom CSP directives config (defined as a JSON file, e.g. "csp.json").
-  --featurePolicies=<path>  (optional) The path to the feature policy directives config (defined as a JSON file, e.g. "feature-policies.json").
+  --csp=<path>              (optional) Deprecated: the path to the custom CSP directives config (defined as a JSON file, e.g. "csp.json").
+  --headers=<path>          (optional) The path to the headers containing CSP and feature policy configs (defined as a JSON file, e.g. "headers.json").
   --use-local-assets        (optional) If this option is enabled, the "dist/assets" will be used to start the http-server package. This requires that the assets have been built before running this script.
   `);
 }
@@ -42,7 +42,7 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 const paths = {
   envPath: flags.config,
   cspPath: flags.csp,
-  featurePoliciesPath: flags.featurePolicies,
+  headersPath: flags.headers,
   publicAssetsPath: path.join(__dirname, '../public'),
   // NOTE: previously, for running the prod server locally, we were copying
   // assets into public/assets and compiling the index.html into public folder.
@@ -89,7 +89,7 @@ const start = async () => {
   const compiled = await compileHtml({
     envPath: paths.envPath,
     cspPath: paths.cspPath,
-    featurePoliciesPath: paths.featurePoliciesPath,
+    headersPath: paths.headersPath,
     publicAssetsPath: paths.publicAssetsPath,
     useLocalAssets,
   });

--- a/packages/mc-scripts/compile-html.js
+++ b/packages/mc-scripts/compile-html.js
@@ -31,6 +31,7 @@ if (flags.help) {
   Options:
   --config=<path>           (required) The path to the environment config (defined as a JSON file, e.g. "env.json").
   --csp=<path>              (optional) The path to the custom CSP directives config (defined as a JSON file, e.g. "csp.json").
+  --featurePolicies=<path>  (optional) The path to the feature policy directives config (defined as a JSON file, e.g. "feature-policies.json").
   --use-local-assets        (optional) If this option is enabled, the index.html.template will be taken from the local "dist/assets" folder, otherwise it will be downloaded from the remove URL provided in "cdnUrl" in the "env.json" file (requires "mc-scripts build" to run before) [default "false"]
   --transformer=<path>      (optional) The path to a JS module that can be used to generate a configuration for a specific cloud provider (e.g. Netlify, Now).
   `);
@@ -48,6 +49,7 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const paths = {
   envPath: flags.config,
+  featurePoliciesPath: flags.featurePolicies,
   cspPath: flags.csp,
   publicAssetsPath: resolveApp('public'),
   // NOTE: previously, for running the prod server locally, we were copying
@@ -95,6 +97,7 @@ const generateStatic = async () => {
   const compiled = await compileHtml({
     envPath: paths.envPath,
     cspPath: paths.cspPath,
+    featurePoliciesPath: paths.featurePoliciesPath,
     publicAssetsPath: paths.publicAssetsPath,
     useLocalAssets,
   });

--- a/packages/mc-scripts/compile-html.js
+++ b/packages/mc-scripts/compile-html.js
@@ -30,8 +30,8 @@ if (flags.help) {
 
   Options:
   --config=<path>           (required) The path to the environment config (defined as a JSON file, e.g. "env.json").
-  --csp=<path>              (optional) The path to the custom CSP directives config (defined as a JSON file, e.g. "csp.json").
-  --featurePolicies=<path>  (optional) The path to the feature policy directives config (defined as a JSON file, e.g. "feature-policies.json").
+  --csp=<path>              (optional) Deprecated: the path to the custom CSP directives config (defined as a JSON file, e.g. "csp.json").
+  --headers=<path>          (optional) The path to the headers containing CSP and feature policy configs (defined as a JSON file, e.g. "headers.json").
   --use-local-assets        (optional) If this option is enabled, the index.html.template will be taken from the local "dist/assets" folder, otherwise it will be downloaded from the remove URL provided in "cdnUrl" in the "env.json" file (requires "mc-scripts build" to run before) [default "false"]
   --transformer=<path>      (optional) The path to a JS module that can be used to generate a configuration for a specific cloud provider (e.g. Netlify, Now).
   `);
@@ -97,7 +97,7 @@ const generateStatic = async () => {
   const compiled = await compileHtml({
     envPath: paths.envPath,
     cspPath: paths.cspPath,
-    featurePoliciesPath: paths.featurePoliciesPath,
+    headersPath: paths.headersPath,
     publicAssetsPath: paths.publicAssetsPath,
     useLocalAssets,
   });

--- a/packages/mc-scripts/config/webpack-dev-server.config.js
+++ b/packages/mc-scripts/config/webpack-dev-server.config.js
@@ -11,7 +11,7 @@ const sourcePath = process.cwd();
 const localEnv = loadEnv(path.join(sourcePath, 'env.json'));
 const headers = loadHeaders(localEnv, {
   cspPath: path.join(sourcePath, 'csp.json'),
-  featurePoliciesPath: path.join(sourcePath, 'feature-policies.json'),
+  headersPath: path.join(sourcePath, 'headers.json'),
 });
 
 const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';

--- a/packages/mc-scripts/config/webpack-dev-server.config.js
+++ b/packages/mc-scripts/config/webpack-dev-server.config.js
@@ -11,6 +11,7 @@ const sourcePath = process.cwd();
 const localEnv = loadEnv(path.join(sourcePath, 'env.json'));
 const headers = loadHeaders(localEnv, {
   cspPath: path.join(sourcePath, 'csp.json'),
+  featurePoliciesPath: path.join(sourcePath, 'feature-policies.json'),
 });
 
 const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';

--- a/playground/README.md
+++ b/playground/README.md
@@ -48,7 +48,8 @@ A project for developing a Merchant Center Application usually consists of the f
   - `cdnUrl`: the URL where the static assets are stored
   - `servedByProxy`: a flag to indicate if this application is running behind the Merchant Center proxy or not, usually `true` for production and `false` for local development
     Check the `<ApplicationContext>` in [`application-shell-connectors`](../packages/application-shell-connectors) for more information about it.
-- `csp.json` contains additional directives for CSP, specific to the domain hosting the app (_more on that will come soon_)
+- `headers.json`: contains headers such as additional directives for CSP (under a `csp`-property) or `Feature Policies` (under a `featurePolicies`-property). These are specific to the domain hosting the app
+- `csp.json` (deprecated): contains additional directives for CSP, specific to the domain hosting the app
 - `webpack.config.<env>.js` contains the setup for getting the webpack configurations for dev/prod (having those files is important as they are read by `mc-scripts`)
 
 ## Development
@@ -98,7 +99,7 @@ This will output a `dist` folder containing the JS bundles in the `dist/assets` 
 
 The HTTP server comes shipped with the [`mc-http-server`](../packages/mc-http-server) package and provides a binary to start the server (`mc-http-server`). The server will make sure to serve a valid `index.html` and it provides additional tools like _security headers, etc._.
 
-To start the server, you need to provide the path to the environment file `--config=$(pwd)/env.json` and the Content Security Policy file `--csp=$(pwd)/csp.json`. We recommend to have a separate `env.prod.json` for production usage.
+To start the server, you need to provide the path to the environment file `--config=$(pwd)/env.json` and the headers file containing Content Security Policies `--headers=$(pwd)/headers.json`. We recommend to have a separate `env.prod.json` for production usage.
 
 In case you host the JS bundles on an **external CDN**, you need to point the `cdnUrl` in the `env.json` config to the URL serving the assets. However, if you keep the assets within the server itself, you need to pass `--use-local-assets` to the command and point the `cdnUrl` to the root folder:
 

--- a/playground/csp.json
+++ b/playground/csp.json
@@ -1,5 +1,0 @@
-{
-  "script-src": ["mc-extensions-channels.now.sh"],
-  "connect-src": ["mc-extensions-channels.now.sh"],
-  "style-src": ["mc-extensions-channels.now.sh"]
-}

--- a/playground/headers.json
+++ b/playground/headers.json
@@ -1,0 +1,7 @@
+{
+  "csp": {
+    "script-src": ["mc-extensions-channels.now.sh"],
+    "connect-src": ["mc-extensions-channels.now.sh"],
+    "style-src": ["mc-extensions-channels.now.sh"]
+  }
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "mc-scripts build",
     "start": "mc-scripts start",
-    "compile-html:eu": "mc-scripts compile-html --csp=$(pwd)/production-eu.csp.json --config=$(pwd)/production-eu.env.json --use-local-assets --transformer $(pwd)/config/transformer-now.js",
-    "compile-html:us": "mc-scripts compile-html --csp=$(pwd)/production-us.csp.json --config=$(pwd)/production-us.env.json --use-local-assets --transformer $(pwd)/config/transformer-now.js",
+    "compile-html:eu": "mc-scripts compile-html --headers=$(pwd)/production-eu.headers.json --config=$(pwd)/production-eu.env.json --use-local-assets --transformer $(pwd)/config/transformer-now.js",
+    "compile-html:us": "mc-scripts compile-html --headers=$(pwd)/production-us.headers.json --config=$(pwd)/production-us.env.json --use-local-assets --transformer $(pwd)/config/transformer-now.js",
     "start:prod:local": "NODE_ENV=production mc-http-server --csp=$(pwd)/csp.json --config=$(pwd)/env.json --use-local-assets",
     "i18n:build": "mc-scripts extract-intl --output-path=$(pwd)/src/i18n/data 'src/**/!(*.spec).js' --build-translations",
     "deploy": "yarn build && yarn deploy:eu && yarn deploy:us",

--- a/playground/production-eu.csp.json
+++ b/playground/production-eu.csp.json
@@ -1,5 +1,0 @@
-{
-  "script-src": ["mc-app-state-machines-production-eu.now.sh"],
-  "connect-src": ["mc-app-state-machines-production-eu.now.sh"],
-  "style-src": ["mc-app-state-machines-production-eu.now.sh"]
-}

--- a/playground/production-eu.headers.json
+++ b/playground/production-eu.headers.json
@@ -1,0 +1,7 @@
+{
+  "csp": {
+    "script-src": ["mc-app-state-machines-production-eu.now.sh"],
+    "connect-src": ["mc-app-state-machines-production-eu.now.sh"],
+    "style-src": ["mc-app-state-machines-production-eu.now.sh"]
+  }
+}

--- a/playground/production-us.csp.json
+++ b/playground/production-us.csp.json
@@ -1,5 +1,0 @@
-{
-  "script-src": ["mc-app-state-machines-production-us.now.sh"],
-  "connect-src": ["mc-app-state-machines-production-us.now.sh"],
-  "style-src": ["mc-app-state-machines-production-us.now.sh"]
-}

--- a/playground/production-us.headers.json
+++ b/playground/production-us.headers.json
@@ -1,0 +1,7 @@
+{
+  "csp": {
+    "script-src": ["mc-app-state-machines-production-us.now.sh"],
+    "connect-src": ["mc-app-state-machines-production-us.now.sh"],
+    "style-src": ["mc-app-state-machines-production-us.now.sh"]
+  }
+}

--- a/website/content/deployment/example-aws-s3-cloudfront.mdx
+++ b/website/content/deployment/example-aws-s3-cloudfront.mdx
@@ -352,17 +352,19 @@ First, you need to create an `env.prod.json` file with the following JSON:
 }
 ```
 
-You also need a `csp.json` file. You can also have a `csp.prod.json` file if you want to use a different configuration for `development`.
+You also need a `headers.json` file. You can also have a `headers.prod.json` file if you want to use a different configuration for `development`.
 
 ```json
 {
-  "script-src": ["[cloudfront-domain]"],
-  "connect-src": ["[cloudfront-domain]"],
-  "style-src": ["[cloudfront-domain]"]
+  "csp": {
+    "script-src": ["[cloudfront-domain]"],
+    "connect-src": ["[cloudfront-domain]"],
+    "style-src": ["[cloudfront-domain]"]
+  }
 }
 ```
 
-For both `env.prod.json` and `csp.json`, `[cloudfront-domain]` should be replaced with your CloudFront domain obtained from the last step of the previous section.
+For both `env.prod.json` and `headers.json`, `[cloudfront-domain]` should be replaced with your CloudFront domain obtained from the last step of the previous section.
 
 ## Build and Compilation
 
@@ -428,7 +430,7 @@ In your project's `package.json` add the following script:
 
 ```json
 {
-  "compile-html:aws": "mc-scripts compile-html -—csp=$(pwd)/csp.json -—config=$(pwd)/env.prod.json -—use-local-assets -—transformer $(pwd)/config/transformer-aws.js"
+  "compile-html:aws": "mc-scripts compile-html -—headers=$(pwd)/headers.json -—config=$(pwd)/env.prod.json -—use-local-assets -—transformer $(pwd)/config/transformer-aws.js"
 }
 ```
 

--- a/website/content/deployment/example-firebase.mdx
+++ b/website/content/deployment/example-firebase.mdx
@@ -137,17 +137,19 @@ First, you need to create an `env.prod.json` file with the following JSON:
 }
 ```
 
-You also need a `csp.json` file. You can also have a `csp.prod.json` file if you want to use a different configuration for `development`.
+You also need a `headers.json` file. You can also have a `headers.prod.json` file if you want to use a different configuration for `development`.
 
 ```json
 {
-  "script-src": ["[projectID].firebaseapp.com"],
-  "connect-src": ["[projectID].firebaseapp.com"],
-  "style-src": ["[projectID].firebaseapp.com"]
+  "csp": {
+    "script-src": ["[projectID].firebaseapp.com"],
+    "connect-src": ["[projectID].firebaseapp.com"],
+    "style-src": ["[projectID].firebaseapp.com"]
+  }
 }
 ```
 
-For both `env.prod.json` and `csp.json`, `[projectID]` should be replaced with your Firebase project ID.
+For both `env.prod.json` and `headers.json`, `[projectID]` should be replaced with your Firebase project ID.
 
 ## Build and Compilation
 
@@ -213,7 +215,7 @@ In your project's `package.json` add the following script:
 
 ```json
 {
-  "compile-html:firebase": "mc-scripts compile-html -—csp=$(pwd)/csp.json -—config=$(pwd)/env.prod.json -—use-local-assets -—transformer $(pwd)/config/transformer-firebase.js"
+  "compile-html:firebase": "mc-scripts compile-html -—headers=$(pwd)/headers.json -—config=$(pwd)/env.prod.json -—use-local-assets -—transformer $(pwd)/config/transformer-firebase.js"
 }
 ```
 

--- a/website/content/deployment/example-now-v1.mdx
+++ b/website/content/deployment/example-now-v1.mdx
@@ -35,7 +35,7 @@ The first thing to do is to define a `now.json` file to configure the deployment
   "name": "mc-examples-starter",
   "alias": "mc-examples-starter",
   "regions": ["bru"],
-  "files": ["dist", "csp.json", "env.prod.json", "now.json", "package.json"]
+  "files": ["dist", "headers.json", "env.prod.json", "now.json", "package.json"]
 }
 ```
 
@@ -57,13 +57,15 @@ Next, we need to create an `env.prod.json` file with the following JSON:
 }
 ```
 
-We also need a `csp.json` file. You can also have a `csp.prod.json` file if you want to use a different configuration for `development`.
+We also need a `headers.json` file. You can also have a `headers.prod.json` file if you want to use a different configuration for `development`.
 
 ```json
 {
-  "script-src": ["mc-examples-starter.now.sh"],
-  "connect-src": ["mc-examples-starter.now.sh"],
-  "style-src": ["mc-examples-starter.now.sh"]
+  "csp": {
+    "script-src": ["mc-examples-starter.now.sh"],
+    "connect-src": ["mc-examples-starter.now.sh"],
+    "style-src": ["mc-examples-starter.now.sh"]
+  }
 }
 ```
 

--- a/website/content/deployment/http-server.mdx
+++ b/website/content/deployment/http-server.mdx
@@ -15,12 +15,12 @@ We **recommend using** our [`@commercetools-frontend/mc-http-server`](https://ww
 The [`@commercetools-frontend/mc-http-server`](https://www.npmjs.com/package/@commercetools-frontend/mc-http-server) has built-in functionality that is necessary for the application to work. Most importantly:
 
 - Compiling the `index.html.template` into `index.html` (to inject the runtime configuration in the [`env.json`](./runtime-configuration) file).
-- Preparing the HTTP response headers, including the custom [`csp.json`](./runtime-configuration) configuration (**Content Security Policy**).
+- Preparing the HTTP response headers, including the custom [`headers.json`](./runtime-configuration) configuration (**Content Security Policy**).
 
 The package comes with a binary `mc-http-server` that sets up all the necessary configurations and starts a small Node.JS server.
 
 ```zsh
-$ mc-http-server --config $(pwd)/env.json --csp $(pwd)/csp.json
+$ mc-http-server --config $(pwd)/env.json --headers $(pwd)/headers.json
 ```
 
 ## Docker image
@@ -34,7 +34,7 @@ $ docker run \
   -p 8080:8080 \
   eu.gcr.io/ct-images/mc-http-server \
   --config /etc/app/env.json \
-  --csp /etc/app/csp.json
+  --headers /etc/app/headers.json
 ```
 
 The version of the **Docker image** is the same as the [last release of the `merchant-center-application-kit`](https://github.com/commercetools/merchant-center-application-kit/releases).

--- a/website/content/deployment/runtime-configuration.mdx
+++ b/website/content/deployment/runtime-configuration.mdx
@@ -57,23 +57,25 @@ An example configuration for local development:
 }
 ```
 
-## `csp.json`
+## `headers.json`
 
 When you deploy your application to a server and domain of your choice, the application will fail to make requests to the [API Gateway](../main-concepts/api-gateway) as the custom domain is not whitelisted. This is why the application can only be accessed through the [Proxy Router](../main-concepts/api-gateway). Setting the `servedByProxy` in the `env.json` is also important.
 
 However, there are additional security measures that prevents requests or scripts to be executed, based on the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). You can enhance the policy by whitelisting the domains where the application is hosted.
-To do so, you can specify a `csp.json` file where you configure some of the CSP directives. This is important as e.g. [static assets](./serving-static-assets) may be served by a CDN that is not whitelisted.
+To do so, you can specify a `headers.json` file where you configure headers such as the CSP directives. This is important as e.g. [static assets](./serving-static-assets) may be served by a CDN that is not whitelisted.
 
 For `production`, we recommended defining at a minimum the following directives, where `my-apps.com` is the domain hosting the Custom Application:
 
 ```json
 {
-  "script-src": ["my-apps.com"],
-  "connect-src": ["my-apps.com"],
-  "style-src": ["my-apps.com"]
+  "csp": {
+    "script-src": ["my-apps.com"],
+    "connect-src": ["my-apps.com"],
+    "style-src": ["my-apps.com"]
+  }
 }
 ```
 
 You can find the list of default directives in the `load-headers.js` file in the `@commercetools-frontend/mc-html-template` package.
 
-> Note: For `development` this configuration is **optional**. If you use it, the `csp.json` file must be in the root path of the project and is automatically loaded by the webpack dev-server.
+> Note: For `development` this configuration is **optional**. If you use it, the `headers.json` file must be in the root path of the project and is automatically loaded by the webpack dev-server.

--- a/website/content/deployment/runtime-configuration.mdx
+++ b/website/content/deployment/runtime-configuration.mdx
@@ -57,6 +57,24 @@ An example configuration for local development:
 }
 ```
 
+## `csp.json`
+
+This file as been deprecated by the `headers.json` mentioned below.
+
+To migrate nest the contents of your `csp.json` into the `csp`-property of the `headers.json`:
+
+```json
+{
++  "csp": {
+    "script-src": ["my-apps.com"],
+    "connect-src": ["my-apps.com"],
+    "style-src": ["my-apps.com"]
++  }
+}
+```
+
+Additionally, use the `--headers` over the `--csp` CLI option to point to the new `headers.json`.
+
 ## `headers.json`
 
 When you deploy your application to a server and domain of your choice, the application will fail to make requests to the [API Gateway](../main-concepts/api-gateway) as the custom domain is not whitelisted. This is why the application can only be accessed through the [Proxy Router](../main-concepts/api-gateway). Setting the `servedByProxy` in the `env.json` is also important.

--- a/website/content/deployment/runtime-configuration.mdx
+++ b/website/content/deployment/runtime-configuration.mdx
@@ -65,11 +65,11 @@ To migrate, nest the contents of your `csp.json` into the `csp`-property of the 
 
 ```json
 {
-+  "csp": {
+  "csp": {
     "script-src": ["my-apps.com"],
     "connect-src": ["my-apps.com"],
     "style-src": ["my-apps.com"]
-+  }
+  }
 }
 ```
 

--- a/website/content/deployment/runtime-configuration.mdx
+++ b/website/content/deployment/runtime-configuration.mdx
@@ -61,7 +61,7 @@ An example configuration for local development:
 
 This file as been deprecated by the `headers.json` mentioned below.
 
-To migrate nest the contents of your `csp.json` into the `csp`-property of the `headers.json`:
+To migrate, nest the contents of your `csp.json` into the `csp`-property of the `headers.json`:
 
 ```json
 {


### PR DESCRIPTION
#### Summary

This pull request suggests to add the ability to add feature policies via the respective HTTP header.

#### Description

Feature policies (as outlined [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)) are a way to restrict what browser features an application should be able to request on a given "allow-list".

An example would be to:

1. Allow the microphone only to be used in the document
2. Allow geolocation in an iframe

Note that this also overlapps (the example of the iFrame) with CSPs.

In general I would suggest, for now, not to default feature policies as:

1. It should (likely can) be considered a breaking change was all of a sudden a custom app can't e.g. use the mic
2. The merging is a bit more complicated as zipping up a `connect-src` whitelist

If we want to support meaningful defaults we coould do that later maybe. Right now I would suggest that the MC itself can disable most things using this feature.