### PR TITLE
refactor(renovate): update config to have one pr per week

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,7 +2,23 @@
   "extends": [
     "config:base",
     ":pinOnlyDevDependencies",
-    "group:monorepos",
-    "schedule:weekly"
+    "schedule:weekly",
+    {
+      "groupName": "all dependencies",
+      "separateMajorMinor": true,
+      "groupSlug": "all",
+      "packageRules": [
+        {
+          "packagePatterns": [
+            "*"
+          ],
+          "groupName": "all dependencies",
+          "groupSlug": "all"
+        }
+      ],
+      "lockFileMaintenance": {
+        "enabled": true
+      }
+    }
   ]
 }


### PR DESCRIPTION
#### Summary

This pull request changes renovate's behaviour to have one PR a week while splitting major and minor updates.

#### Description

This is often seen as an anti-pattern and was also a feature request to Greenkeeper as far as I recall.

The downside is, that one breaking dependency update it is hard to spot.
The upside is, that we don't need to merge all updates by hand.

The alternative would be to enable automerging. However, that comes at the downside of releasing a canary per dep update while having long changelogs as a result.

Ref to GitHub: https://github.com/renovatebot/renovate/issues/48

<img width="761" alt="CleanShot 2019-09-02 at 11 07 16@2x" src="https://user-images.githubusercontent.com/1877073/64103301-30c9ad00-cd72-11e9-83c4-c1a1f84f8fe0.png">
<img width="543" alt="CleanShot 2019-09-02 at 11 07 28@2x" src="https://user-images.githubusercontent.com/1877073/64103302-30c9ad00-cd72-11e9-92f4-c449c3b5c716.png">

