### PR TITLE
fix(renovate): config to not nest

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,23 +2,21 @@
   "extends": [
     "config:base",
     ":pinOnlyDevDependencies",
-    "schedule:weekly",
+    "schedule:weekly"
+  ],
+  "separateMajorMinor": true,
+  "groupName": "all dependencies",
+  "groupSlug": "all",
+  "packageRules": [
     {
-      "groupName": "all dependencies",
-      "separateMajorMinor": true,
-      "groupSlug": "all",
-      "packageRules": [
-        {
-          "packagePatterns": [
-            "*"
-          ],
-          "groupName": "all dependencies",
-          "groupSlug": "all"
-        }
+      "packagePatterns": [
+        "*"
       ],
-      "lockFileMaintenance": {
-        "enabled": true
-      }
+      "groupName": "all dependencies",
+      "groupSlug": "all"
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
#### Summary

- Closes #1024 

The combination of different config snippets isn't really clear to me in the docs. This might be correct. What made me not "do it" at first was the global "groupName" which felt like one should be able to specify more than one of.