### PR TITLE
fix(mc-html-template): to load headers not from csp

### DIFF
--- a/packages/mc-html-template/lib/load-headers.js
+++ b/packages/mc-html-template/lib/load-headers.js
@@ -130,7 +130,9 @@ module.exports = (env, options) => {
   // Attempt to load the JSON config for custom CSP and feature policy headers provided by each application
   // For backwards compatibilty the `cspPath` can still be used but the `headerPath` takes precedence.
 
-  const shouldUseDeprecatedCspPath = Boolean(options.cspPath);
+  const shouldUseDeprecatedCspPath = Boolean(
+    options.cspPath && !options.headersPath
+  );
 
   const customHeaders = loadCustomConfiguration(options.headersPath);
 


### PR DESCRIPTION
#### Summary

This pull request fixes an issue where the webpack-dev-server would not respect the new `--headers` option.

#### Description

The `loadHeaders` are used from multiple parts: mc-http-server, webpack-dev-server etc. 

The `webpack-dev-server` passes both `cspPath` and `headersPath` as options 

https://github.com/commercetools/merchant-center-application-kit/blob/436cef0c9db8e67ed290068da6f2b9e0ed5705b1/packages/mc-scripts/config/webpack-dev-server.config.js#L12-L15

this is totally adequate cause it makes the transition backwards compatible. However the `loadHeaders` as a result does not not only have to check if `options.cspPath` is set but also if there is no `options.headersPath`. Otherwise the `headersPath` will never be picked up through webpack.

Loads of text for a few lines of changes :)
