### PR TITLE
fix(app-shell): use default cache-first fetch policy for user account menu

### DIFF
--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.js
@@ -109,9 +109,6 @@ const MenuItem = styled.div`
 const UserSettingsMenuBody = props => {
   const applicationsMenu = useApplicationsMenu({
     queryOptions: {
-      // We can assume here that the navbar already fetched the data, since this
-      // component gets rendered only when the user opens the menu
-      fetchPolicy: 'cache-only',
       onError: reportErrorToSentry,
     },
     skipRemoteQuery: !props.environment.servedByProxy,


### PR DESCRIPTION
Not sure why it worked before, but when we're in the account section, the navbar does not fetch the menu data and therefore there is no data in the cache.

We should simply use the default `cache-first` policy here.