### PR TITLE
refactor(rollup): to build multiple bundles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Once it's done, you can run `yarn start` or `yarn test` (`yarn test:watch`) to d
 
 To develop locally, you can use the `playground` application to test the changes in some of the packages. Make sure to `yarn build` the packages before starting the `playground` app because the app consumes the packages as normal "transpiled" dependencies.
 
-You can also run the build in watch mode `yarn build:es:watch` alongside with `yarn playground:start` to rebundle and rebuild the application on each change.
+You can also run the build in watch mode `yarn build:bundles:watch` alongside with `yarn playground:start` to rebundle and rebuild the application on each change.
 
 ## Cutting a Release
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Build the application bundles
 $ yarn build
 
 # or
-$ yarn build:es:watch
+$ yarn build:bundles:watch
 ```
 
 Start the [playground application](./playground):
@@ -53,7 +53,7 @@ Start the [playground application](./playground):
 
 ```bash
 // Terminal process 1
-$ yarn build:es:watch
+$ yarn build:bundles:watch
 
 // Terminal process 2
 $ yarn playground:start

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "template-starter:start:prod:local": "yarn --cwd application-templates/starter start:prod:local",
     "build": "NODE_ENV=production lerna run build --no-private",
     "build:typings": "NODE_ENV=production lerna run build:typings --no-private",
-    "build:es": "NODE_ENV=production lerna run build:es --no-private",
-    "build:es:watch": "NODE_ENV=development lerna run --no-private --parallel build:es:watch",
+    "build:bundles": "NODE_ENV=production lerna run build:bundles --no-private",
+    "build:bundles:watch": "NODE_ENV=development lerna run --no-private --parallel build:bundles:watch",
     "labels:sync": "github-labels sync",
     "get-schemas": "graphql get-schema"
   },

--- a/packages/actions-global/package.json
+++ b/packages/actions-global/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/actions-global.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/actions-global.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -32,10 +32,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/application-components.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/application-components.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/application-shell-connectors/package.json
+++ b/packages/application-shell-connectors/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./index.ts -o ./dist/application-shell-connectors.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./index.ts -o ./dist/application-shell-connectors.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -30,11 +30,10 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/** test-utils/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:test-utils:cjs",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].cjs.js --entryFileNames application-shell-[name].cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.js --dir ./dist --chunkFileNames application-shell-[name]-[hash].es.js --entryFileNames application-shell-[name].es.js",
-    "build:es:watch": "yarn build:es -w",
-    "build:test-utils:cjs": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js  -f cjs ./src/test-utils/index.js --o ./test-utils/index.js"
+    "build": "yarn build:bundles && yarn build:test-utils",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.js -d dist",
+    "build:bundles:watch": "yarn build:bundles -w",
+    "build:test-utils": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -i ./src/test-utils/index.js"
   },
   "dependencies": {
     "@apollo/react-testing": "3.1.0",

--- a/packages/browser-history/package.json
+++ b/packages/browser-history/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/browser-history.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/browser-history.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/constants.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/constants.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts --dir ./dist --chunkFileNames i18n-[name]-[hash].cjs.js --entryFileNames i18n-[name].cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts --dir ./dist --chunkFileNames i18n-[name]-[hash].es.js --entryFileNames i18n-[name].es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts --dir dist",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/l10n/package.json
+++ b/packages/l10n/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts --dir ./dist --chunkFileNames l10n-[name]-[hash].cjs.js --entryFileNames l10n-[name].cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts --dir ./dist --chunkFileNames l10n-[name]-[hash].es.js --entryFileNames l10n-[name].es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts -d dist",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings",
     "generate-data": "node ./scripts/generate-l10n-data.js"
   },

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/notifications.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/notifications.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/permissions.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/permissions.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/react-notifications.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/react-notifications.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,12 +32,11 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/** test-utils/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:test-utils:cjs && yarn build:typings",
+    "build": "yarn build:bundles && yarn build:test-utils && yarn build:typings",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/sdk.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/sdk.es.js",
-    "build:es:watch": "yarn build:es -w",
-    "build:test-utils:cjs": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js  -f cjs ./src/test-utils/index.ts --o ./test-utils/index.js"
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
+    "build:test-utils": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -i ./src/test-utils/index.ts"
   },
   "dependencies": {
     "@commercetools-frontend/constants": "15.0.0",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -31,11 +31,10 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
+    "build": "yarn build:bundles && yarn build:typings",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/sentry.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/sentry.es.js",
-    "build:es:watch": "yarn build:es -w"
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.6.0",

--- a/packages/url-utils/package.json
+++ b/packages/url-utils/package.json
@@ -31,10 +31,9 @@
   "scripts": {
     "prepare": "./../../scripts/version.js replace",
     "prebuild": "rimraf dist/**",
-    "build": "yarn build:es && yarn build:cjs && yarn build:typings",
-    "build:cjs": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f cjs ./src/index.ts -o ./dist/url-utils.cjs.js",
-    "build:es": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js  -f es ./src/index.ts -o ./dist/url-utils.es.js",
-    "build:es:watch": "yarn build:es -w",
+    "build": "yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -i ./src/index.ts",
+    "build:bundles:watch": "yarn build:bundles -w",
     "build:typings": "cross-env tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {

--- a/playground/README.md
+++ b/playground/README.md
@@ -58,7 +58,7 @@ A project for developing a Merchant Center Application usually consists of the f
 
 Make sure to `yarn build` the packages before starting the `playground` app because the app consumes the packages as normal "transpiled" dependencies.
 
-You can also run the build in watch mode `yarn build:es:watch` alongside with `yarn playground:start` to rebundle and rebuild the application on each change.
+You can also run the build in watch mode `yarn build:bundles:watch` alongside with `yarn playground:start` to rebundle and rebuild the application on each change.
 
 To start the development server, run:
 


### PR DESCRIPTION
After I [refactored Rollup](https://github.com/commercetools/nodejs/pull/1397) in the nodejs repo to build multiple outputs, I thought to do the same here.

Main benefits:
- faster build (_actually it varies a bit, I think it's more or less the same_ 😔 )
- simpler and centralized config (less boilerplate in the each `package.json`)