### PR TITLE
fix: to avoid using Mapped Types as babel plugin does not properly generate prop-types

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -57,10 +57,16 @@ type TApplicationContextGroupedByResourceType = {
  *   }
  * }
  */
-type TApplicationContextDataFenceType = 'store';
+// NOTE: we currently can't use Mapped Types as the babel transfomer does not
+// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
+// type TApplicationContextDataFenceType = 'store';
+// type TApplicationContextDataFences = {
+//   // E.g. { store: {...} }
+//   [key in TApplicationContextDataFenceType]: TApplicationContextGroupedByResourceType;
+// };
 type TApplicationContextDataFences = {
   // E.g. { store: {...} }
-  [key in TApplicationContextDataFenceType]: TApplicationContextGroupedByResourceType;
+  store: TApplicationContextGroupedByResourceType;
 };
 
 type TRawProject = {

--- a/packages/permissions/src/components/authorized/authorized.spec.tsx
+++ b/packages/permissions/src/components/authorized/authorized.spec.tsx
@@ -28,9 +28,15 @@ type TDataFenceGroupedByResourceType = {
   [key: string]: TDataFenceGroupedByPermission | null;
 };
 type TDataFenceType = 'store';
+// NOTE: we currently can't use Mapped Types as the babel transfomer does not
+// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
+// type TDataFences = {
+//   // E.g. { store: {...} }
+//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+// };
 type TDataFences = {
   // E.g. { store: {...} }
-  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+  store: TDataFenceGroupedByResourceType;
 };
 type TDemandedDataFence = {
   group: string;

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -38,9 +38,15 @@ type TDataFenceGroupedByResourceType = {
   [key: string]: TDataFenceGroupedByPermission | null;
 };
 type TDataFenceType = 'store';
+// NOTE: we currently can't use Mapped Types as the babel transfomer does not
+// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
+// type TDataFences = {
+//   // E.g. { store: {...} }
+//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+// };
 type TDataFences = {
   // E.g. { store: {...} }
-  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+  store: TDataFenceGroupedByResourceType;
 };
 type TDemandedDataFence = {
   group: string;

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -27,10 +27,16 @@ type TDataFenceGroupedByResourceType = {
   // E.g. { orders: {...} }
   [key: string]: TDataFenceGroupedByPermission | null;
 };
-type TDataFenceType = 'store';
+// NOTE: we currently can't use Mapped Types as the babel transfomer does not
+// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
+// type TDataFenceType = 'store';
+// type TDataFences = {
+//   // E.g. { store: {...} }
+//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+// };
 type TDataFences = {
   // E.g. { store: {...} }
-  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+  store: TDataFenceGroupedByResourceType;
 };
 type TestProps = {
   demandedPermissions: TPermissionName[];

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -35,9 +35,15 @@ type TDataFenceGroupedByResourceType = {
   [key: string]: TDataFenceGroupedByPermission | null;
 };
 type TDataFenceType = 'store';
+// NOTE: we currently can't use Mapped Types as the babel transfomer does not
+// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
+// type TDataFences = {
+//   // E.g. { store: {...} }
+//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+// };
 type TDataFences = {
   // E.g. { store: {...} }
-  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+  store: TDataFenceGroupedByResourceType;
 };
 type TDemandedDataFence = {
   group: string;

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -29,9 +29,15 @@ type TDataFenceGroupedByResourceType = {
   [key: string]: TDataFenceGroupedByPermission | null;
 };
 type TDataFenceType = 'store';
+// NOTE: we currently can't use Mapped Types as the babel transfomer does not
+// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
+// type TDataFences = {
+//   // E.g. { store: {...} }
+//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+// };
 type TDataFences = {
   // E.g. { store: {...} }
-  [key in TDataFenceType]: TDataFenceGroupedByResourceType;
+  store: TDataFenceGroupedByResourceType;
 };
 type TDemandedDataFence = {
   group: string;


### PR DESCRIPTION
Reported the issue here: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23

<img width="784" alt="image" src="https://user-images.githubusercontent.com/1110551/64687531-f86d5180-d48a-11e9-9a47-2ce86e472c07.png">
