### PR TITLE
fix(app-shell): sanitize correlation id parts

### DIFF
--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.js
@@ -1,8 +1,13 @@
 import uuid from 'uuid/v4';
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
 
+const VALID_ID_PART_FORMAT = /^[\w-/]+$/;
+
+const skipMalformedPart = part =>
+  Boolean(part) && VALID_ID_PART_FORMAT.test(part);
+
 export default function getCorrelationId({ userId } = {}) {
   return ['mc', selectProjectKeyFromUrl(), userId, uuid()]
-    .filter(Boolean)
+    .filter(skipMalformedPart)
     .join('/');
 }

--- a/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.spec.js
+++ b/packages/application-shell/src/utils/get-correlation-id/get-correlation-id.spec.js
@@ -25,10 +25,15 @@ describe('getCorrelationId', () => {
     it('should build correlation id', () => {
       expect(correlationId).toBe('mc/test-project-key/user-1/test-uuid');
     });
+  });
 
-    it('should not contain `null`', () => {
-      // NOTE: `'null'` would be stringified.
-      expect(correlationId).not.toEqual(expect.stringContaining('null'));
+  describe('with malformed `userId`', () => {
+    beforeEach(() => {
+      correlationId = getCorrelationId({ userId: ':::' });
+    });
+
+    it('should not include userId in correlationId', () => {
+      expect(correlationId).toBe('mc/test-project-key/test-uuid');
     });
   });
 
@@ -40,10 +45,16 @@ describe('getCorrelationId', () => {
     it('should build correlation id', () => {
       expect(correlationId).toBe('mc/test-project-key/test-uuid');
     });
+  });
 
-    it('should not contain `null`', () => {
-      // NOTE: `'null'` would be stringified.
-      expect(correlationId).not.toEqual(expect.stringContaining('null'));
+  describe('with malformed `projectKey`', () => {
+    beforeEach(() => {
+      selectProjectKeyFromUrl.mockImplementation(() => ':::');
+      correlationId = getCorrelationId({ userId: 'user-1' });
+    });
+
+    it('should not include projectKey in correlationId', () => {
+      expect(correlationId).toBe('mc/user-1/test-uuid');
     });
   });
 });


### PR DESCRIPTION
`X-Correlation-ID` header of requests sent to backend have to be -- quoting CT documentation -- "strings that may only contain alphanumeric characters, underscores and hyphens and have a length of 8 to 256 characters". 

`X-Correlation-ID` is being built using user-provided data (namely, projectKey). In case this data does not satisfies above-mentioned constraints, request fails with an error, describing malformed `correlation id`. This error, in turn is being reported to Sentry, which spoils FLD job. 

In order to avoid reporting this errors, this PR introduces `correlation id` sanitization. Original suggestion was to URL-encode provided `projectKey`, but that wont' work because, basically, `%` character would not pass `X-Correlation-ID` validation. 

Instead, we just gonna drop malformed parts.

### Paying for review

1. https://github.com/commercetools/merchant-center-application-kit/pull/1056#pullrequestreview-288502223
2. https://github.com/commercetools/ui-kit/pull/1061#pullrequestreview-288502543