### PR TITLE
data locale should be one of the project languages

### DIFF
--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -38,7 +38,7 @@ const defaultProject = {
   name: 'Test with big data',
   countries: ['de', 'en'],
   currencies: ['EUR', 'GBP'],
-  languages: ['de', 'en-GB'],
+  languages: ['de', 'en-GB', 'en'],
   owner: {
     id: 'project-id-1',
   },
@@ -268,7 +268,7 @@ const renderApp = (
     permissions, // <-- deprecated option, use `{ project: { allAppliedPermissions } }`
     actionRights, // <-- deprecated option, use `{ project: { allAppliedActionRights } }`
     dataFences, // <-- deprecated option, use `{ project: { allAppliedDataFences } }`
-    dataLocale = 'en-GB',
+    dataLocale = 'en',
     ApolloProviderComponent = MockedApolloProvider,
     // gtm-context
     gtmTracking = defaultGtmTracking,

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -268,7 +268,7 @@ const renderApp = (
     permissions, // <-- deprecated option, use `{ project: { allAppliedPermissions } }`
     actionRights, // <-- deprecated option, use `{ project: { allAppliedActionRights } }`
     dataFences, // <-- deprecated option, use `{ project: { allAppliedDataFences } }`
-    dataLocale = 'en',
+    dataLocale = 'en-GB',
     ApolloProviderComponent = MockedApolloProvider,
     // gtm-context
     gtmTracking = defaultGtmTracking,

--- a/packages/application-shell/src/test-utils/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils/test-utils.spec.js
@@ -143,7 +143,7 @@ describe('ApplicationContext', () => {
           name: 'Test with big data',
           countries: ['de', 'en'],
           currencies: ['EUR', 'GBP'],
-          languages: ['de', 'en-GB'],
+          languages: ['de', 'en-GB', 'en'],
           owner: {
             id: 'project-id-1',
           },


### PR DESCRIPTION
this leads to tests failing when using 'LocalizedTextInput.createLocalizedString' because we pass the locales from the project and then in the test we check the locale the user chose.

