### PR TITLE
chore: update yarn to 1.19.0 due to security vulnerability

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 # See https://yarnpkg.com/en/docs/yarnrc#yarn-path-
 # TL;DR; We want to ensure that everyone uses the same yarn version, both locally and on CI.
-yarn-path ".yarn/releases/yarn-1.17.2.js"
+yarn-path ".yarn/releases/yarn-1.19.0.js"


### PR DESCRIPTION
#### Summary

As you may know the older versions of yarn have a security vulnerability. Given that we now also use this version on dev machines and don't allow them to use their own there should be even more reason to keep is up-to-date.
