### PR TITLE
fix(app-shell): use first input delay

### DIFF
--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -82,7 +82,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",
     "omit-empty-es": "1.0.3",
-    "perfume.js": "1.2.1",
+    "perfume.js": "2.1.2",
     "prop-types": "15.7.2",
     "qss": "2.0.3",
     "react-required-if": "1.0.3",

--- a/packages/application-shell/src/components/performance-timing/measure-first-paint.js
+++ b/packages/application-shell/src/components/performance-timing/measure-first-paint.js
@@ -59,7 +59,10 @@ export class MeasureFirstPaint extends React.Component {
      *   on Perfume. Once resolved all other values are statically
      *   available.
      */
-    perfume.observeFirstInputDelay.then(firstInputDelayMs => {
+    Promise.all([
+      perfume.observeFirstContentfulPaint,
+      perfume.observeFirstInputDelay,
+    ]).then(([firstContentfulPaintMs, firstInputDelayMs]) => {
       const paintMetrics = [
         {
           name: 'firstPaint',
@@ -67,7 +70,7 @@ export class MeasureFirstPaint extends React.Component {
         },
         {
           name: 'firstContentfulPaint',
-          durationMs: MeasureFirstPaint.tracker.firstContentfulPaintDuration,
+          durationMs: firstContentfulPaintMs,
         },
         {
           name: 'firstInputDelay',

--- a/packages/application-shell/src/components/performance-timing/measure-first-paint.js
+++ b/packages/application-shell/src/components/performance-timing/measure-first-paint.js
@@ -27,7 +27,7 @@ const perfume = new Perfume({
   logging: false,
   firstContentfulPaint: true,
   firstPaint: true,
-  timeToInteractive: true,
+  firstInputDelay: true,
 });
 
 export class MeasureFirstPaint extends React.Component {
@@ -59,7 +59,7 @@ export class MeasureFirstPaint extends React.Component {
      *   on Perfume. Once resolved all other values are statically
      *   available.
      */
-    perfume.observeTimeToInteractive.then(timeToInteractiveMs => {
+    perfume.observeFirstInputDelay.then(firstInputDelayMs => {
       const paintMetrics = [
         {
           name: 'firstPaint',
@@ -70,8 +70,8 @@ export class MeasureFirstPaint extends React.Component {
           durationMs: MeasureFirstPaint.tracker.firstContentfulPaintDuration,
         },
         {
-          name: 'timeToInteractive',
-          durationMs: timeToInteractiveMs,
+          name: 'firstInputDelay',
+          durationMs: firstInputDelayMs,
         },
       ]
         .filter(paintMeasurement => Boolean(paintMeasurement.durationMs))

--- a/packages/application-shell/src/components/performance-timing/measure-first-paint.spec.js
+++ b/packages/application-shell/src/components/performance-timing/measure-first-paint.spec.js
@@ -14,7 +14,7 @@ const createTestProps = custom => ({
 jest.mock('perfume.js', () =>
   jest.fn(() => ({
     firstPaintDuration: 1,
-    firstContentfulPaintDuration: 2,
+    observeFirstContentfulPaint: Promise.resolve(2),
     observeFirstInputDelay: Promise.resolve(1234.22),
   }))
 );
@@ -55,7 +55,7 @@ describe('lifecycle', () => {
         });
       });
 
-      it('should push the time to interactive metric as a histograms', () => {
+      it('should push the first input delay metric as a histograms', () => {
         expect(props.pushMetricHistogram).toHaveBeenCalledWith({
           payload: expect.arrayContaining([
             expect.objectContaining({

--- a/packages/application-shell/src/components/performance-timing/measure-first-paint.spec.js
+++ b/packages/application-shell/src/components/performance-timing/measure-first-paint.spec.js
@@ -15,7 +15,7 @@ jest.mock('perfume.js', () =>
   jest.fn(() => ({
     firstPaintDuration: 1,
     firstContentfulPaintDuration: 2,
-    observeTimeToInteractive: Promise.resolve(1234.22),
+    observeFirstInputDelay: Promise.resolve(1234.22),
   }))
 );
 
@@ -60,7 +60,7 @@ describe('lifecycle', () => {
           payload: expect.arrayContaining([
             expect.objectContaining({
               metricName:
-                'browser_duration_time_to_interactive_buckets_milliseconds',
+                'browser_duration_first_input_delay_buckets_milliseconds',
             }),
           ]),
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8322,6 +8322,11 @@ detab@2.0.2, detab@^2.0.0:
   dependencies:
     repeat-string "^1.5.4"
 
+detect-browser@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-4.0.0.tgz#e66ea9e777c86916f042057b0a15227fb77eb64d"
+  integrity sha512-L4aOcjXh6IHFC/Gw/LTrGTPPYA91fi0IZNG42fMzSjYr5YO2UbqqIEpN+31D54rF0FyIBR6vc/mKAcBwjYg+7Q==
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -10334,7 +10339,7 @@ findup-sync@3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
-first-input-delay@^0.1.3:
+first-input-delay@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/first-input-delay/-/first-input-delay-0.1.3.tgz#5506fb95a9537ba9706096b9c159bfd3f38f6f62"
   integrity sha512-hZ1mI+BWYIBr8jlp2bDPnRvnmSICBxpZRwdc0nhiQn2uyMxSKZEBbkO8V0/s26AMeX8p/AD4g09+liRrhXvKKQ==
@@ -12442,6 +12447,11 @@ identity-obj-proxy@3.0.0:
   integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
   dependencies:
     harmony-reflect "^1.4.6"
+
+idlize@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/idlize/-/idlize-0.1.1.tgz#2bcb49d11f4c306e8274548a7d3a8f9aa1960ead"
+  integrity sha512-G4Qgr53MHUwT0JGXP5asyy+4ztcNDkFQKB+MWRRxsQ9LqAf0RWLKk+QU20u3cUAsndQfTMO6F19i5xZm9/8c5A==
 
 ieee754@^1.1.4:
   version "1.1.13"
@@ -17748,13 +17758,14 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-perfume.js@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/perfume.js/-/perfume.js-1.2.1.tgz#bcfe653f0d28f5482726d39842d387e0bab075e1"
-  integrity sha512-pHWrJTBiG5n/X/CGTCWeY7ApswLGIJQNLE+ofE0OgscJpp0fklH3dpZ1d11LexNOYWeY0IGDBmL/FbqhjMTb+g==
+perfume.js@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/perfume.js/-/perfume.js-2.1.2.tgz#71e81449eec0b55c7895b030a0a8c53b9da9c3d8"
+  integrity sha512-xKZc8ok0mzww8H45B3FVG5O9rvzY4tuCDELdtwM79OeeP4nVeX1d9Sr3ZNgbUDFQKiEJa1Prc/t8b+XxvSd9fQ==
   dependencies:
-    first-input-delay "^0.1.3"
-    tti-polyfill "^0.2.2"
+    detect-browser "4.0.0"
+    first-input-delay "0.1.3"
+    idlize "0.1.1"
 
 phin@^2.9.1:
   version "2.9.3"
@@ -23022,11 +23033,6 @@ tsutils@^3.17.1, tsutils@^3.7.0:
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   dependencies:
     tslib "^1.8.1"
-
-tti-polyfill@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/tti-polyfill/-/tti-polyfill-0.2.2.tgz#f7bbf71b13afa9edf60c8bb0d0c05f134e1513b9"
-  integrity sha512-URIoJxvsHThbQEJij29hIBUDHx9UNoBBCQVjy7L8PnzkqY8N6lsAI6h8JrT1Wt2lA0avus/DkuiJxd9qpfCpqw==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
#### Summary

Time to interactive is a metric which is not recommended anymore. It also is not exposed by most metric libraries as a result.

With this we use the First Input Delay which is said to reflect more what users experience. 

Before this is rolled out in our applications I will make sure our prometheus gateway is configured to consume it.