### PR TITLE
feat(permissions): allow appliedPermission with Manage to bypass dataFence

### DIFF
--- a/packages/permissions/src/components/authorized/authorized.spec.tsx
+++ b/packages/permissions/src/components/authorized/authorized.spec.tsx
@@ -208,8 +208,8 @@ describe('rendering', () => {
   });
 
   describe('dataFence to view orders on specific store', () => {
-    describe('if cannot view or manage orders', () => {
-      describe('has demanded dataFence to MANAGE orders on the specific store', () => {
+    describe('with general permission', () => {
+      describe('when general permissions is manage', () => {
         beforeEach(() => {
           props = createTestProps({
             actualDataFences: {
@@ -222,9 +222,84 @@ describe('rendering', () => {
               },
             },
             actualPermissions: {
-              canViewOrders: false,
-              canManageOrders: false,
-              canViewProducts: true,
+              canManageOrders: true,
+            },
+            demandedDataFences: [
+              {
+                type: 'store',
+                group: 'orders',
+                name: 'ManageOrders',
+              },
+            ],
+            selectDataFenceData: ({ type }) => {
+              switch (type) {
+                case 'store':
+                  return ['store-1'];
+                default:
+                  return null;
+              }
+            },
+          });
+          shallow(<Authorized {...props} />);
+        });
+        it('should indicate as authorized', () => {
+          expect(props.render).toHaveBeenCalledWith(true);
+        });
+      });
+      describe('when general permissions is view', () => {
+        describe('when data fence permission is manage', () => {
+          beforeEach(() => {
+            props = createTestProps({
+              actualDataFences: {
+                store: {
+                  orders: {
+                    canViewOrders: {
+                      values: ['store-1'],
+                    },
+                  },
+                },
+              },
+              actualPermissions: {
+                canViewOrders: true,
+                canManageOrders: false,
+              },
+              demandedDataFences: [
+                {
+                  type: 'store',
+                  group: 'orders',
+                  name: 'ManageOrders',
+                },
+              ],
+              selectDataFenceData: ({ type }) => {
+                switch (type) {
+                  case 'store':
+                    return ['store-1'];
+                  default:
+                    return null;
+                }
+              },
+            });
+            shallow(<Authorized {...props} />);
+          });
+          it('should indicate as not authorized', () => {
+            expect(props.render).toHaveBeenCalledWith(false);
+          });
+        });
+      });
+    });
+
+    describe('if cannot view or manage orders', () => {
+      describe('has demanded dataFence to MANAGE orders on the specific store', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            actualDataFences: {
+              store: {
+                orders: {
+                  canViewOrders: {
+                    values: ['store-1'],
+                  },
+                },
+              },
             },
             demandedDataFences: [
               {

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -97,6 +97,8 @@ const Authorized = (props: Props) => {
             demandedDataFences: props.demandedDataFences,
             actualDataFences: props.actualDataFences,
             selectDataFenceData: props.selectDataFenceData,
+            actualPermissions: props.actualPermissions,
+            demandedPermissions: props.demandedPermissions,
           })
         )}
       </React.Fragment>

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -91,9 +91,11 @@ const useIsAuthorized = ({
       return false;
     }
     return hasAppliedDataFence({
-      demandedDataFences: demandedDataFences,
-      actualDataFences: actualDataFences,
-      selectDataFenceData: selectDataFenceData,
+      demandedDataFences,
+      actualDataFences,
+      selectDataFenceData,
+      actualPermissions,
+      demandedPermissions,
     });
   }
 


### PR DESCRIPTION
#### Summary

If user has `*Manage` as their appliedPermissions, we simply discard dataFence since they would have permissions to manage orders, regardless what dataFence Permissions they have on their team.

This is because General Permissions overrules DataFence Permissions in the case of GeneralPermissions has `*Manage`

From an implementation POV, it doesn't look great that we "leak" appliedPermissions into `hasAppliedDataFence`, but I was not really sure how I want to ensure separate of concerns