### PR TITLE
fix(permissions/has-permissions): use `hasExactPermission` in `hasAppliedDataFences`

### DIFF
--- a/packages/permissions/src/components/authorized/authorized.spec.tsx
+++ b/packages/permissions/src/components/authorized/authorized.spec.tsx
@@ -212,6 +212,7 @@ describe('rendering', () => {
       describe('when general permissions is manage', () => {
         beforeEach(() => {
           props = createTestProps({
+            demandedPermissions: ['ManageOrders'],
             actualDataFences: {
               store: {
                 orders: {
@@ -250,6 +251,7 @@ describe('rendering', () => {
         describe('when data fence permission is manage', () => {
           beforeEach(() => {
             props = createTestProps({
+              demandedPermissions: ['ViewOrders'],
               actualDataFences: {
                 store: {
                   orders: {

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -241,9 +241,9 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) => {
   const hasAppliedManagePermission = options.demandedPermissions.some(
     demandedPermission => {
       if (options.actualPermissions) {
-        return hasManagePermission(
-          demandedPermission,
-          options.actualPermissions
+        return (
+          demandedPermission.startsWith('Manage') &&
+          hasExactPermission(demandedPermission, options.actualPermissions)
         );
       }
       return false;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

- use `startsWith` and `hasExactPermissions` for `hasAppliedDataFences`

#### Description

previously I wrote this to use `hasManagePermission`. The issue is that `hasManagePermissions` returns a truth value if `demandedPermission` starts with `View*`. 

In the case of `hasAppliedDataFence`, we want to:

1. check if the demanded Permissions is `Manage*`
2. use `hasExactPermission` to `actualPermissions`