### PR TITLE
chore(mc-http-server): to expose prefixed metric

### DIFF
--- a/packages/mc-http-server/server.js
+++ b/packages/mc-http-server/server.js
@@ -35,8 +35,10 @@ const prometheusMetricsMiddleware = createPrometheusMetricsMiddleware({
     accuracies: ['ms'],
     metricTypes: ['httpRequestsHistogram'],
     metricNames: {
-      httpRequestDurationInMilliseconds:
+      httpRequestDurationInMilliseconds: [
         'http_request_duration_buckets_milliseconds',
+        'mc_http_request_duration_milliseconds',
+      ],
     },
     getLabelValues: () => ({
       /**


### PR DESCRIPTION
#### Summary

This pull request comes after OPs intend to prefix request timing and application label metrics. Here we only have one request timing metric.

Why prefix? Cause cardinality explosions in Prometheus occur if you have a single, generically named metric, shared across services with lots of different labels. Promtheus can deal better with different metric names with similar labels. All due to its storage model. This all is aligned with best practices from the web and books.

Note, that by specifying two metrics here we expose both names and are backwards compatible for our dashboards. We can do the clean up after and expose just one.