### PR TITLE
PCM-1473: add revert message to Form Modal button messages

### DIFF
--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -41,6 +41,7 @@
   "AppKit.Shared.inactive": "Inactive",
   "AppKit.Shared.open": "Open",
   "AppKit.Shared.remove": "Remove",
+  "AppKit.Shared.revert": "Revert",
   "AppKit.Shared.save": "Save",
   "AppKit.Shared.update": "Update",
   "Components.ModalPage.TopBar.Back": "Go Back",

--- a/packages/i18n/src/shared-messages.ts
+++ b/packages/i18n/src/shared-messages.ts
@@ -9,6 +9,10 @@ const messages = defineMessages({
     id: 'AppKit.Shared.cancel',
     defaultMessage: 'Cancel',
   },
+  revert: {
+    id: 'AppKit.Shared.revert',
+    defaultMessage: 'Revert',
+  },
   confirm: {
     id: 'AppKit.Shared.confirm',
     defaultMessage: 'Confirm',


### PR DESCRIPTION
add revert message to Form Modal button messages for use in MC-frontend in context of custom form controls, e.g.

`label={this.props.intl.formatMessage(FormModalPage.Intl.revert)}`

as a part of this ticket https://jira.commercetools.com/browse/PCM-1473