### PR TITLE
fix: remove first input delay

### DIFF
--- a/packages/application-shell/src/components/performance-timing/measure-first-paint.js
+++ b/packages/application-shell/src/components/performance-timing/measure-first-paint.js
@@ -59,10 +59,7 @@ export class MeasureFirstPaint extends React.Component {
      *   on Perfume. Once resolved all other values are statically
      *   available.
      */
-    Promise.all([
-      perfume.observeFirstContentfulPaint,
-      perfume.observeFirstInputDelay,
-    ]).then(([firstContentfulPaintMs, firstInputDelayMs]) => {
+    perfume.observeFirstContentfulPaint.then(firstContentfulPaintMs => {
       const paintMetrics = [
         {
           name: 'firstPaint',
@@ -71,10 +68,6 @@ export class MeasureFirstPaint extends React.Component {
         {
           name: 'firstContentfulPaint',
           durationMs: firstContentfulPaintMs,
-        },
-        {
-          name: 'firstInputDelay',
-          durationMs: firstInputDelayMs,
         },
       ]
         .filter(paintMeasurement => Boolean(paintMeasurement.durationMs))

--- a/packages/application-shell/src/components/performance-timing/measure-first-paint.spec.js
+++ b/packages/application-shell/src/components/performance-timing/measure-first-paint.spec.js
@@ -15,7 +15,6 @@ jest.mock('perfume.js', () =>
   jest.fn(() => ({
     firstPaintDuration: 1,
     observeFirstContentfulPaint: Promise.resolve(2),
-    observeFirstInputDelay: Promise.resolve(1234.22),
   }))
 );
 
@@ -50,17 +49,6 @@ describe('lifecycle', () => {
             expect.objectContaining({
               metricName:
                 'browser_duration_first_contentful_paint_buckets_milliseconds',
-            }),
-          ]),
-        });
-      });
-
-      it('should push the first input delay metric as a histograms', () => {
-        expect(props.pushMetricHistogram).toHaveBeenCalledWith({
-          payload: expect.arrayContaining([
-            expect.objectContaining({
-              metricName:
-                'browser_duration_first_input_delay_buckets_milliseconds',
             }),
           ]),
         });


### PR DESCRIPTION
#### Summary

This pull request removes the first input delay tracking from the measure first paint component.

First input delay is triggered when the user typed for the first time. This is not really a metric we want to track here. Plus it prevents metrics being sent _until_ the user typed something the first time.