### PR TITLE
test(setup-tests): ignore CellMeasurerCach warning

### DIFF
--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -9,9 +9,10 @@ global.window.app = {
 };
 
 const shouldSilenceWarnings = (...messages) =>
-  [/Warning: componentWillReceiveProps has been renamed/].some(msgRegex =>
-    messages.some(msg => msgRegex.test(msg))
-  );
+  [
+    /Warning: componentWillReceiveProps has been renamed/,
+    /CellMeasurerCache should only measure a cell's width or height/,
+  ].some(msgRegex => messages.some(msg => msgRegex.test(msg)));
 
 // setup file
 const logOrThrow = (log, method, messages) => {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->
Ignore `CellMeasurerCache` warning when running jest tests on CI.

#### Description

<!-- provide some context -->
The following error is coming from ui-kit `Table` component and causes test failure on CI.

```
CellMeasurerCache should only measure a cell's width or height. You have configured CellMeasurerCache to measure both. This will result in poor performance.
```