### PR TITLE
fix(app-shell): add flags used in menu

### DIFF
--- a/packages/application-shell/src/feature-toggles.js
+++ b/packages/application-shell/src/feature-toggles.js
@@ -9,8 +9,20 @@
  *   fetched from LaunchDarkly (without default values flopflip will default
  *   them to off until fetched).
  */
+
+// NOTE:
+//   These are used within the menu and need to be
+//   made available within custom applications.
 export const PROJECT_EXTENSIONS = 'projectExtensions';
+export const PIM_SEARCH = 'pimSearch';
+export const LEGACY_PRODUCT_LIST = 'legacyProductList';
+export const CAN_VIEW_DASHBOARD = 'canViewDashboard';
+export const CUSTOM_APPLICATIONS = 'customApplications';
 
 export const FLAGS = {
+  [CAN_VIEW_DASHBOARD]: true,
+  [PIM_SEARCH]: false,
+  [LEGACY_PRODUCT_LIST]: true,
+  [CUSTOM_APPLICATIONS]: false,
   [PROJECT_EXTENSIONS]: true,
 };


### PR DESCRIPTION
#### Summary

Otherwise these menu items will not show up in custom apps.