### PR TITLE
Update description in cloudfront example

### DIFF
--- a/website/src/content/deployment/example-aws-s3-cloudfront.mdx
+++ b/website/src/content/deployment/example-aws-s3-cloudfront.mdx
@@ -24,7 +24,7 @@ distribution backed by a [Lambda@Edge](https://us-east-2.console.aws.amazon.com/
    ```json
    {
      "AWSTemplateFormatVersion": "2010-09-09",
-     "Description": "Creates a static website using S3 and CloudFront for deploying Merchant Center Extensions",
+     "Description": "Creates a static website using S3 and CloudFront for deploying Merchant Center Custom Applications",
      "Parameters": {
        "BucketName": {
          "Type": "String",


### PR DESCRIPTION
Replace "Merchant Center extensions" with "Merchant Center custom applications"

#### Summary

Replace "Merchant Center extensions" with "Merchant Center custom applications"

#### Description

We no longer refer to these applications as "extensions". Updated with the new terminology.
