### PR TITLE
fix: cannot use rerender with app-kit custom render functions

### DIFF
--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -284,7 +284,7 @@ const renderApp = (
   const mergedEnvironment = mergeOptional(defaultEnvironment, environment);
   const mergedGtmTracking = mergeOptional(defaultGtmTracking, gtmTracking);
 
-  const Wrapper = ({ children }) => (
+  const ApplicationProviders = ({ children }) => (
     <IntlProvider locale={locale}>
       <ApolloProviderComponent mocks={mocks} addTypename={addTypename}>
         <ConfigureFlopFlip
@@ -317,14 +317,17 @@ const renderApp = (
       </ApolloProviderComponent>
     </IntlProvider>
   );
-  Wrapper.propTypes = {
+  ApplicationProviders.propTypes = {
     children: PropTypes.node.isRequired,
   };
 
   const rendered = rtl.render(ui, {
     ...renderOptions,
     wrapper: ({ children }) =>
-      wrapIfNeeded(Wrapper, wrapIfNeeded(renderOptions.wrapper, children)),
+      wrapIfNeeded(
+        ApplicationProviders,
+        wrapIfNeeded(renderOptions.wrapper, children)
+      ),
   });
 
   return {
@@ -415,7 +418,7 @@ const renderAppWithRedux = (
     return createReduxStore(storeState, [testingMiddleware]);
   })();
 
-  const Wrapper = ({ children }) => (
+  const ReduxProviders = ({ children }) => (
     <NotificationProviderForCustomComponent
       mapNotificationToComponent={mapNotificationToComponent}
     >
@@ -429,14 +432,17 @@ const renderAppWithRedux = (
       </StoreProvider>
     </NotificationProviderForCustomComponent>
   );
-  Wrapper.propTypes = {
+  ReduxProviders.propTypes = {
     children: PropTypes.node.isRequired,
   };
 
   const rendered = renderApp(ui, {
     ...renderOptions,
     wrapper: ({ children }) =>
-      wrapIfNeeded(Wrapper, wrapIfNeeded(renderOptions.wrapper, children)),
+      wrapIfNeeded(
+        ReduxProviders,
+        wrapIfNeeded(renderOptions.wrapper, children)
+      ),
   });
 
   return {

--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -234,6 +234,9 @@ const denormalizeDataFences = dataFences => {
   );
 };
 
+const wrapIfNeeded = (wrapper, children) =>
+  wrapper ? React.createElement(wrapper, null, children) : children;
+
 // This function renders any component within the application context, as if it
 // was rendered inside <ApplicationShell />.
 // The context is not completely set up yet, some things are missing:
@@ -259,7 +262,7 @@ const renderApp = (
       createMemoryHistory({ initialEntries: [route] })
     ),
     // flopflip
-    adpater = memoryAdapter,
+    adapter = memoryAdapter,
     flags = {},
     // application-context
     environment,
@@ -280,41 +283,53 @@ const renderApp = (
   const mergedProject = mergeOptional(defaultProject, project);
   const mergedEnvironment = mergeOptional(defaultEnvironment, environment);
   const mergedGtmTracking = mergeOptional(defaultGtmTracking, gtmTracking);
-  return {
-    ...rtl.render(
-      <IntlProvider locale={locale}>
-        <ApolloProviderComponent mocks={mocks} addTypename={addTypename}>
-          <ConfigureFlopFlip
-            adapter={adpater}
-            defaultFlags={flags}
-            adapterArgs={defaultFlopflipAdapterArgs}
-          >
-            <ApplicationContextProvider
-              user={mergedUser}
-              project={
-                mergedProject && {
-                  ...mergedProject,
-                  allAppliedPermissions: denormalizePermissions(permissions),
-                  allAppliedActionRights: denormalizeActionRights(actionRights),
-                  allAppliedDataFences: denormalizeDataFences(dataFences),
-                }
+
+  const Wrapper = ({ children }) => (
+    <IntlProvider locale={locale}>
+      <ApolloProviderComponent mocks={mocks} addTypename={addTypename}>
+        <ConfigureFlopFlip
+          adapter={adapter}
+          defaultFlags={flags}
+          adapterArgs={defaultFlopflipAdapterArgs}
+        >
+          <ApplicationContextProvider
+            user={mergedUser}
+            project={
+              mergedProject && {
+                ...mergedProject,
+                allAppliedPermissions: denormalizePermissions(permissions),
+                allAppliedActionRights: denormalizeActionRights(actionRights),
+                allAppliedDataFences: denormalizeDataFences(dataFences),
               }
-              environment={mergedEnvironment}
-              projectDataLocale={dataLocale}
-            >
-              <GtmContext.Provider value={mergedGtmTracking}>
-                <Router history={history}>
-                  <React.Suspense fallback={<LoadingFallback />}>
-                    {ui}
-                  </React.Suspense>
-                </Router>
-              </GtmContext.Provider>
-            </ApplicationContextProvider>
-          </ConfigureFlopFlip>
-        </ApolloProviderComponent>
-      </IntlProvider>,
-      renderOptions
-    ),
+            }
+            environment={mergedEnvironment}
+            projectDataLocale={dataLocale}
+          >
+            <GtmContext.Provider value={mergedGtmTracking}>
+              <Router history={history}>
+                <React.Suspense fallback={<LoadingFallback />}>
+                  {children}
+                </React.Suspense>
+              </Router>
+            </GtmContext.Provider>
+          </ApplicationContextProvider>
+        </ConfigureFlopFlip>
+      </ApolloProviderComponent>
+    </IntlProvider>
+  );
+  Wrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  const rendered = rtl.render(ui, {
+    ...renderOptions,
+    wrapper: ({ children }) =>
+      wrapIfNeeded(Wrapper, wrapIfNeeded(renderOptions.wrapper, children)),
+  });
+
+  return {
+    ...rendered,
+
     // adding `history` to the returned utilities to allow us
     // to reference it in our tests (just try to avoid using
     // this to test implementation details).
@@ -400,22 +415,32 @@ const renderAppWithRedux = (
     return createReduxStore(storeState, [testingMiddleware]);
   })();
 
+  const Wrapper = ({ children }) => (
+    <NotificationProviderForCustomComponent
+      mapNotificationToComponent={mapNotificationToComponent}
+    >
+      <StoreProvider store={reduxStore}>
+        <div>
+          <NotificationsList domain={DOMAINS.GLOBAL} />
+          <NotificationsList domain={DOMAINS.PAGE} />
+          <NotificationsList domain={DOMAINS.SIDE} />
+          {children}
+        </div>
+      </StoreProvider>
+    </NotificationProviderForCustomComponent>
+  );
+  Wrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  const rendered = renderApp(ui, {
+    ...renderOptions,
+    wrapper: ({ children }) =>
+      wrapIfNeeded(Wrapper, wrapIfNeeded(renderOptions.wrapper, children)),
+  });
+
   return {
-    ...renderApp(
-      <NotificationProviderForCustomComponent
-        mapNotificationToComponent={mapNotificationToComponent}
-      >
-        <StoreProvider store={reduxStore}>
-          <div>
-            <NotificationsList domain={DOMAINS.GLOBAL} />
-            <NotificationsList domain={DOMAINS.PAGE} />
-            <NotificationsList domain={DOMAINS.SIDE} />
-            {ui}
-          </div>
-        </StoreProvider>
-      </NotificationProviderForCustomComponent>,
-      renderOptions
-    ),
+    ...rendered,
     // adding `store` to the returned utilities to allow us
     // to reference it in our tests (just try to avoid using
     // this to test implementation details).
@@ -439,6 +464,7 @@ const experimentalRenderAppWithRedux = (ui, renderOptions) => {
     ApolloProviderComponent: RealApolloProvider,
   });
 };
+
 // re-export everything
 export * from '@testing-library/react';
 

--- a/packages/application-shell/src/test-utils/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils/test-utils.spec.js
@@ -276,66 +276,62 @@ describe('router', () => {
 });
 
 describe('custom render functions', () => {
-  describe('wrapper', () => {
-    describe('when provided', () => {
-      const Context = React.createContext();
-      const ProvidedWrapper = ({ children }) => (
-        <Context.Provider value="provided wrapper">{children}</Context.Provider>
-      );
-      ProvidedWrapper.propTypes = {
-        children: PropTypes.node.isRequired,
+  describe('with wrapper', () => {
+    const Context = React.createContext();
+    const ProvidedWrapper = ({ children }) => (
+      <Context.Provider value="provided wrapper">{children}</Context.Provider>
+    );
+    ProvidedWrapper.propTypes = {
+      children: PropTypes.node.isRequired,
+    };
+
+    it('should merge the passed wrapper with renderApp internal wrapper', () => {
+      const TestComponent = () => {
+        // provided wrapper
+        const value = useContext(Context);
+        // own wrapper
+        useIntl();
+
+        return value;
       };
 
-      it('should renderApp merges the provided wrapper with its own wrapper', () => {
-        const TestComponent = () => {
-          // provided wrapper
-          const value = useContext(Context);
-          // own wrapper
-          useIntl();
-
-          return value;
-        };
-
-        const rendered = renderApp(<TestComponent number={1} />, {
-          wrapper: ProvidedWrapper,
-        });
-        rendered.getByText(/provided wrapper/i);
+      const rendered = renderApp(<TestComponent number={1} />, {
+        wrapper: ProvidedWrapper,
       });
-
-      it('should renderAppWithRedux merges the provided wrapper with its own wrapper', () => {
-        const TestComponent = () => {
-          // provided wrapper
-          const value = useContext(Context);
-          // own wrapper
-          useSelector(() => {});
-
-          return value;
-        };
-
-        const rendered = renderAppWithRedux(<TestComponent number={1} />, {
-          wrapper: ProvidedWrapper,
-        });
-        rendered.getByText(/provided wrapper/i);
-      });
+      rendered.getByText(/provided wrapper/i);
     });
 
-    describe('when not provided', () => {
-      it.each([renderApp, renderAppWithRedux])(
-        'should %p still manage',
-        renderFn => {
-          const TestComponent = ({ number }) => {
-            return number;
-          };
+    it('should merge the passed wrapper with renderAppWithRedux internal wrapper', () => {
+      const TestComponent = () => {
+        // provided wrapper
+        const value = useContext(Context);
+        // own wrapper
+        useSelector(() => {});
 
-          const rendered = renderFn(<TestComponent number={1} />);
-          rendered.getByText(/1/);
-        }
-      );
+        return value;
+      };
+
+      const rendered = renderAppWithRedux(<TestComponent number={1} />, {
+        wrapper: ProvidedWrapper,
+      });
+      rendered.getByText(/provided wrapper/i);
     });
   });
 
+  describe('without wrapper', () => {
+    it.each([renderApp, renderAppWithRedux])(
+      'should %p still work',
+      renderFn => {
+        const TestComponent = ({ number }) => number;
+
+        const rendered = renderFn(<TestComponent number={1} />);
+        rendered.getByText(/1/);
+      }
+    );
+  });
+
   describe('rerender', () => {
-    it('should works with renderApp', () => {
+    it('should work with renderApp', () => {
       const TestComponent = ({ number }) => {
         // the error won't be triggered unless one of the providers is used
         useIntl();
@@ -350,7 +346,7 @@ describe('custom render functions', () => {
       expect(rendered.queryByText(/1/)).not.toBeInTheDocument();
     });
 
-    it('should works with renderAppWithRedux', () => {
+    it('should work with renderAppWithRedux', () => {
       const TestComponent = ({ number }) => {
         // the error won't be triggered unless one of the providers is used
         useSelector(() => undefined);
@@ -365,7 +361,7 @@ describe('custom render functions', () => {
       expect(rendered.queryByText(/1/)).not.toBeInTheDocument();
     });
 
-    it('should works with experimentalRenderAppWithRedux', () => {
+    it('should work with experimentalRenderAppWithRedux', () => {
       const TestComponent = ({ number }) => {
         // the error won't be triggered unless one of the providers is used
         new ApolloClient({

--- a/packages/application-shell/src/test-utils/test-utils.spec.js
+++ b/packages/application-shell/src/test-utils/test-utils.spec.js
@@ -275,7 +275,7 @@ describe('router', () => {
   });
 });
 
-describe('custom render function', () => {
+describe('custom render functions', () => {
   describe('wrapper', () => {
     describe('when provided', () => {
       const Context = React.createContext();


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

Currently, it's not possible to use [rerender](https://testing-library.com/docs/react-testing-library/api#rerender). This PR fixes the issue.

#### Description

<!-- provide some context -->

When rendering using one of app-kit custom render functions, `renderApp`, `renderAppWithRedux` or `experimentalRenderAppWithRedux`, using `rerender` on the `rendered` result won't work and will result in errors.

**Why using rerender?**

Even though it's considered to be better to test the component updating the props instead of using `rerender`, we still need to be able to use it without errors when we want to.

> It'd probably be better if you test the component that's doing the prop updating to ensure that the props are being updated correctly (see the Guiding Principles section). That said, if you'd prefer to update the props of a rendered component in your test, this function can be used to update props of the rendered component.

In addition, there are some use cases where using `rerender` is very useful and not tightly related to updating props. Because of the current limitation, testing in those use cases is done by separating what would have been tested using `rerender` in another test instead. Which means that we will have tests as the following

```js
it('scenario 1', () => {
  // test scenario 1
});

it('scenario 2', () => {
  // test scenario 2
})
```

instead of a single test without the boilerplate

```js
it('test all scenarios in a single test', () => {
  // test scenario 1
  const rendered = renderApp(...);

  // test scenario 2
  rendered.rerender(...);
})
```

Being able to use `rerender` will allow us to avoid the first pattern and simplify tests.

**The fix**

The fix is simple, RTL offers, out of the box, wrapping the provided UI into a wrapper, if provided using `wrapper` render option. I adapted app-kit custom render functions to use this feature.

**Requirements**

In order to be able to use this fix, a custom render function using one of the app-kit custom render functions (`renderApp`, `renderAppWithRedux` and `experimentalRenderAppWithRedux`) should from now on use the `wrapper` render option to wrap the provided UI instead of manually wrapping it. This means that the custom render function API should change from

```js
const render = (ui, renderOptions) =>
  renderApp(
    <Provider1>
      <Provider2>
        <Provider3>{ui}</Provider3>
      </Provider2>
    </Provider1>,
    renderOptions
  );
```

to

```js
const Wrapper = ({ children }) => (
  <Provider1>
    <Provider2>
      <Provider3>{children}</Provider3>
    </Provider2>
  </Provider1>
);
Wrapper.propTypes = {
  children: PropTypes.node.isRequired
};

const render = (ui, renderOptions) =>
  renderApp(ui, {
    ...renderOptions
    wrapper: Wrapper,
  });
```

**Limitations**

The fix doesn't work if app-kit custom render function was used with render options other than `wrapper`. I didn't spend so much time trying to fix it as I think that being able to use `rerender` for most of the use cases still a big win. And maybe we can fix the issue in a future separate PR.