### PR TITLE
refactor: only some subset of demanded DF values should belong to actual DF values

### DIFF
--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -5,6 +5,7 @@ import {
   hasEveryPermissions,
   hasSomePermissions,
   getInvalidPermissions,
+  hasAppliedDataFence,
 } from './has-permissions';
 
 type TPermissionName = string;
@@ -202,6 +203,181 @@ describe('getInvalidPermissions', () => {
           canManageOrders: true,
         })
       ).toEqual(expect.arrayContaining(['ViewStars']));
+    });
+  });
+});
+
+describe('hasAppliedDataFence', () => {
+  describe('user has not datafence permissions', () => {
+    it('should return false', () => {
+      expect(
+        hasAppliedDataFence({
+          actualDataFences: null,
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('no demanded dataFence exists in actual dataFences', () => {
+    it('should return "false"', () => {
+      expect(
+        hasAppliedDataFence({
+          actualDataFences: {
+            store: {
+              orders: {
+                canViewOrders: {
+                  values: ['store-1'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
+        })
+      ).toBe(false);
+    });
+  });
+  describe('some demanded dataFences exist in actual dataFences', () => {
+    it('should return "true"', () => {
+      expect(
+        hasAppliedDataFence({
+          actualDataFences: {
+            store: {
+              orders: {
+                canViewOrders: {
+                  values: ['store-1'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
+        })
+      ).toBe(true);
+    });
+  });
+  describe('all demanded dataFences exist in actual dataFences', () => {
+    it('should return "true"', () => {
+      expect(
+        hasAppliedDataFence({
+          actualDataFences: {
+            store: {
+              orders: {
+                canViewOrders: {
+                  values: ['store-1'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
+        })
+      ).toBe(true);
+    });
+  });
+  describe('no value from demanded dataFence exists in actual DataFence values', () => {
+    it('should return "false"', () => {
+      expect(
+        hasAppliedDataFence({
+          actualDataFences: {
+            store: {
+              orders: {
+                canManageOrders: {
+                  values: ['store-1'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-2'],
+        })
+      ).toBe(false);
+    });
+  });
+  describe('some values from demanded dataFence exist in actual DataFence values', () => {
+    it('should return "true"', () => {
+      const hasDF = hasAppliedDataFence({
+        actualDataFences: {
+          store: {
+            customers: {
+              canManageCustomers: {
+                values: ['store-1'],
+              },
+            },
+          },
+        },
+        demandedDataFences: [
+          {
+            type: 'store',
+            group: 'customers',
+            name: 'ManageCustomers',
+          },
+        ],
+        selectDataFenceData: () => ['store-1', 'store-2'],
+      });
+      expect(hasDF).toBe(true);
+    });
+  });
+  describe('all values from demanded dataFence exist in actual DataFence values', () => {
+    it('should return "true"', () => {
+      expect(
+        hasAppliedDataFence({
+          actualDataFences: {
+            store: {
+              orders: {
+                canManageOrders: {
+                  values: ['store-1', 'store-2'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1', 'store-2'],
+        })
+      ).toBe(true);
     });
   });
 });

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -218,7 +218,8 @@ const hasDemandedDataFence = (options: {
     return false;
   }
 
-  return selectedDataFenceData.every(value =>
+  // it is enough to only have a subset of demanded dataFence data belonging to actual dataFence values
+  return selectedDataFenceData.some(value =>
     options.actualDataFence.dataFenceValue.values.includes(value)
   );
 };


### PR DESCRIPTION
As we are integrating dataFences more in the merchant center, we have encountered so far three use case: 
1- on the route level: check if the user has `manage` or `view` permissions in order to render the route. in this case, the demanded dataFence values are all always the `actualDataFenceValues`.
```
      getSelectDataFenceData: () => ({ actualDataFenceValues }) =>
        actualDataFenceValues || [],
```

2- for orders: we check if the `order.store.key` is inside the `acualDataFenceValues`:
```
const createSelectOrderDataFenceData = componentProps => demandedDataFence => {
  switch (demandedDataFence.type) {
    case 'store':
      return componentProps.order.store?.key
        ? [componentProps.order.store.key]
        : [];
    default:
      return null;
  }
};
```

3- for customers. we also check if the `customer.stores` are inside `actualDataFenceValues` 
```
const createSelectCustomerDataFenceData = componentProps => demandedDataFence => {
  switch (demandedDataFence.type) {
    case 'store':
      return (componentProps.customer?.stores ?? []).map(
        customerStore => customerStore.key
      );
    default:
      return null;
  }
};
```

For cases 1 and 2, the old code works because we are either checking if an array belongs to itself (which would always be true), or if one value belongs to an array (because an order can only belong to one store).

For case 3, however, the issue is that a customer might belong to multiple stores, but the user has the permission to manage only a subset of those stores, in which case we still want him to manage that customer, but our code does not allow him to (`isAuthorized` is `false` in this scenario`)


## the fix
The fix, for now, is to use `some` instead of `every` for checking the demanded dataFence values against the actual ones. 

If in the future we encounter a use case where we want to have a strict matching requirement, we might introduce a flag like `shouldMatchSomePermissions` but specifically for DataFence values.

We have not faced such a use case yet so I refrain from adding complexity to the code now. 