### PR TITLE
fix(app-shell/test-utils): to not require children

### DIFF
--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -318,7 +318,7 @@ const renderApp = (
     </IntlProvider>
   );
   ApplicationProviders.propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
   };
 
   const rendered = rtl.render(ui, {
@@ -433,7 +433,7 @@ const renderAppWithRedux = (
     </NotificationProviderForCustomComponent>
   );
   ReduxProviders.propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
   };
 
   const rendered = renderApp(ui, {


### PR DESCRIPTION
#### Summary

This pull request removes requiring children on the providers.

#### Description

I am unsure why we set this but I don't see why we have to require children here. This fixes the failing test after the upgrade in the application https://github.com/commercetools/merchant-center-frontend/pull/7968
