### PR TITLE
fix(app-shell): portal container height to fix tabbing in modals

### DIFF
--- a/packages/application-shell/src/components/portals-container/portals-container.js
+++ b/packages/application-shell/src/components/portals-container/portals-container.js
@@ -9,6 +9,8 @@ const PortalsContainer = () => (
     id={PORTALS_CONTAINER_ID}
     css={css`
       display: flex;
+      height: 1px;
+      margin-top: -1px;
     `}
   />
 );

--- a/packages/application-shell/src/components/portals-container/portals-container.js
+++ b/packages/application-shell/src/components/portals-container/portals-container.js
@@ -7,6 +7,7 @@ import { PORTALS_CONTAINER_ID } from '@commercetools-frontend/constants';
 const PortalsContainer = () => (
   <div
     id={PORTALS_CONTAINER_ID}
+    // The container needs a height in order to be tabbable: https://reactjs/react-modal#774
     css={css`
       display: flex;
       height: 1px;


### PR DESCRIPTION
#### Summary

This PR fixes [the bug reported by Support](https://jira.commercetools.com/browse/SUPPORT-7309) about not being able to use the Tab key to navigate between elements when inside a Modal.

Apparently, the latest `react-modal` release now ignores focusing a Modal if its parent container doesn't have any `height` or `width`. See https://github.com/reactjs/react-modal/pull/774.

This PR simply adds a `height` to the `PortalsContainer` but keeping it hidden from sight, fixing the problem.