### PR TITLE
chore: check npm authentication on prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "auth": "npm_config_registry=https://registry.npmjs.org npm whoami",
     "changelog": "node scripts/changelog.js",
     "i18n:build": "./packages/mc-scripts/bin/mc-scripts.js extract-intl --output-path=$(pwd)/packages/i18n/data 'packages/**/!(*.spec|*.d).{js,ts,tsx}'",
     "l10n:build": "pushd packages/l10n; yarn generate-data",
@@ -20,7 +21,7 @@
     "format:yaml": "prettier --write --parser yaml '**/*.yaml'",
     "format:graphql": "prettier --write --parser graphql '**/*.graphql'",
     "start": "yarn playground:start",
-    "prerelease": "npm_config_registry=https://registry.npmjs.org npm whoami && yarn build && yarn typecheck",
+    "prerelease": "yarn auth && yarn build && yarn typecheck",
     "release": "lerna publish --exact --dist-tag next",
     "release:alpha": "lerna publish --exact --dist-tag alpha --no-git-tag-version --no-push",
     "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format:yaml": "prettier --write --parser yaml '**/*.yaml'",
     "format:graphql": "prettier --write --parser graphql '**/*.graphql'",
     "start": "yarn playground:start",
-    "prerelease": "yarn build && yarn typecheck",
+    "prerelease": "npm_config_registry=https://registry.npmjs.org npm whoami && yarn build && yarn typecheck",
     "release": "lerna publish --exact --dist-tag next",
     "release:alpha": "lerna publish --exact --dist-tag alpha --no-git-tag-version --no-push",
     "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes",


### PR DESCRIPTION
Same as https://github.com/commercetools/ui-kit/pull/1219.

> When doing a `yarn release`, if you forgot to log in to the `npm` CLI, lerna will still perform some of the steps but then fail on the `npm publish` process, resulting in dirty state (see https://github.com/lerna/lerna/issues/455).
> This PR prevents this problem by checking if the user is logged in to npm on the `prerelease` step.