### PR TITLE
fix(app-shell): retry unauthenticated requests for graphql errors

### DIFF
--- a/packages/application-shell/src/apollo-links/error-link.js
+++ b/packages/application-shell/src/apollo-links/error-link.js
@@ -7,10 +7,31 @@ import history from '@commercetools-frontend/browser-history';
 
 // Checks response from GraphQL in order to scan 401 errors and redirect the
 // user to the login page resetting the store and showing the proper message
-const errorLink = onError(({ networkError }) => {
-  if (networkError && networkError.statusCode === STATUS_CODES.UNAUTHORIZED) {
-    history.push(`/logout?reason=${LOGOUT_REASONS.UNAUTHORIZED}`);
+const errorLink = onError(
+  ({ graphQLErrors, networkError, operation, forward }) => {
+    if (networkError && networkError.statusCode === STATUS_CODES.UNAUTHORIZED) {
+      history.push(`/logout?reason=${LOGOUT_REASONS.UNAUTHORIZED}`);
+    }
+    // In case of graphql errors, we want to retry unauthenticated requests by
+    // forcing our API to fetch a new token, using the `X-Force-Token` header.
+    // https://www.apollographql.com/docs/link/links/error/#retrying-failed-requests
+    // We need to do this as the `token-retry-link` only works for network errors.
+    // https://www.apollographql.com/docs/link/links/retry/
+    if (graphQLErrors) {
+      for (const err of graphQLErrors) {
+        if (err.extensions.code === 'UNAUTHENTICATED') {
+          operation.setContext(({ headers }) => ({
+            headers: {
+              ...headers,
+              'X-Force-Token': true,
+            },
+          }));
+          // retry the request, returning the new observable
+          return forward(operation);
+        }
+      }
+    }
   }
-});
+);
 
 export default errorLink;


### PR DESCRIPTION
Apparently the "apollo-link-retry" does not handle graphql errors, only network errors: https://www.apollographql.com/docs/link/links/retry/

<img width="801" alt="Screenshot 2019-12-30 at 10 16 20" src="https://user-images.githubusercontent.com/1110551/71575548-a742a580-2aed-11ea-9ef5-6627b1ab18c7.png">

We do want however to retry unauthenticated requests for graphql, to automatically refetch an access token as we do in the retry-link. 
I found this document that explains how to implement this use case: https://www.apollographql.com/docs/link/links/error/#retrying-failed-requests