### PR TITLE
fix: building type declarations

### DIFF
--- a/packages/actions-global/tsconfig.declarations.json
+++ b/packages/actions-global/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/application-components/tsconfig.declarations.json
+++ b/packages/application-components/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": ["../../@types-extensions/*"]
 }

--- a/packages/application-shell-connectors/tsconfig.declarations.json
+++ b/packages/application-shell-connectors/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": ["../../@types-extensions/*"]
 }

--- a/packages/browser-history/tsconfig.declarations.json
+++ b/packages/browser-history/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/constants/tsconfig.declarations.json
+++ b/packages/constants/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -20,8 +20,8 @@
   },
   "main": "./dist/i18n-index.cjs.js",
   "module": "./dist/i18n-index.es.js",
-  "typings": "./dist/typings/index.d.ts",
-  "types": "./dist/typings/index.d.ts",
+  "typings": "./dist/typings/src/index.d.ts",
+  "types": "./dist/typings/src/index.d.ts",
   "files": [
     "dist",
     "package.json",

--- a/packages/i18n/tsconfig.declarations.json
+++ b/packages/i18n/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": ["../../@types-extensions/locales.d.ts"]
 }

--- a/packages/l10n/package.json
+++ b/packages/l10n/package.json
@@ -20,8 +20,8 @@
   },
   "main": "./dist/l10n-index.cjs.js",
   "module": "./dist/l10n-index.es.js",
-  "typings": "./dist/typings/index.d.ts",
-  "types": "./dist/typings/index.d.ts",
+  "typings": "./dist/typings/src/index.d.ts",
+  "types": "./dist/typings/src/index.d.ts",
   "files": [
     "dist",
     "package.json",

--- a/packages/l10n/tsconfig.declarations.json
+++ b/packages/l10n/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/notifications/tsconfig.declarations.json
+++ b/packages/notifications/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/permissions/tsconfig.declarations.json
+++ b/packages/permissions/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/react-notifications/tsconfig.declarations.json
+++ b/packages/react-notifications/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/sdk/tsconfig.declarations.json
+++ b/packages/sdk/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/sentry/tsconfig.declarations.json
+++ b/packages/sentry/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }

--- a/packages/url-utils/tsconfig.declarations.json
+++ b/packages/url-utils/tsconfig.declarations.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": { "declaration": true, "isolatedModules": false },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": []
 }


### PR DESCRIPTION
I noticed that the type declarations shipped with the packages were including all types from all packages, which is wrong:

<img width="285" alt="image" src="https://user-images.githubusercontent.com/1110551/71619705-f4924600-2bc5-11ea-8935-9f87dad11e08.png">

Instead, only the type declarations of the related package should be built and shipped:

<img width="262" alt="image" src="https://user-images.githubusercontent.com/1110551/71619732-0ecc2400-2bc6-11ea-8ec1-34d0ff8dbbe1.png">

I think this has been "broken" since #1047