### PR TITLE
fix(app-shell): denormalization of action rights

### DIFF
--- a/packages/application-shell/src/test-utils/test-utils.js
+++ b/packages/application-shell/src/test-utils/test-utils.js
@@ -169,7 +169,8 @@ const denormalizeActionRights = actionRights => {
             name: actionRightKey,
             value: actionRights[actionRightGroup][actionRightKey],
           },
-        ]
+        ],
+        []
       ),
     ],
     []


### PR DESCRIPTION
#### Summary

By not initializing the reducer's accumulator we end up messing up the first value of the accumulated result.