### PR TITLE
feat(actions-global): add use-hide-all-page-notifications

### DIFF
--- a/packages/actions-global/src/hooks/index.ts
+++ b/packages/actions-global/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useShowNotification } from './use-show-notification';
 export { default as useShowApiErrorNotification } from './use-show-api-error-notification';
 export { default as useShowUnexpectedErrorNotification } from './use-show-unexpected-error-notification';
+export { default as useHideAllPageNotifications } from './use-hide-all-page-notifications';

--- a/packages/actions-global/src/hooks/use-hide-all-page-notifications.ts
+++ b/packages/actions-global/src/hooks/use-hide-all-page-notifications.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Dispatch } from 'redux';
+import { useDispatch } from 'react-redux';
+import { hideAllPageNotifications } from '../actions';
+
+export default function useHideAllPageNotifications() {
+  const dispatch = useDispatch<
+    Dispatch<ReturnType<typeof hideAllPageNotifications>>
+  >();
+  return React.useCallback(() => {
+    dispatch(hideAllPageNotifications());
+  }, [dispatch]);
+}


### PR DESCRIPTION
#### Summary

This pull request adds a hook to hide all page notifications.