### PR TITLE
fix(permissions): data fences to be overwritten by manage resource permission

### DIFF
--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -282,7 +282,7 @@ describe('action rights', () => {
         expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
       });
     });
-    describe('with applied action right not matching demanded', () => {
+    describe('with applied action right matching demanded', () => {
       it('should indicate being authorized', () => {
         const rendered = render({
           allAppliedPermissions: [
@@ -328,7 +328,7 @@ describe('action rights', () => {
     });
   });
   describe('with applied and none matching demanded view permission', () => {
-    describe('with applied action right matching demanded', () => {
+    describe('with applied action right not matching demanded', () => {
       it('should indicate not being authorized', () => {
         const rendered = render({
           allAppliedPermissions: [{ name: 'canViewProducts', value: false }],

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -375,10 +375,56 @@ describe('action rights', () => {
 describe('data fences', () => {
   describe('when general permission is matched', () => {
     describe('when data fence is matched', () => {
-      it('should indicate as authorized', () => {
+      describe('when not overwritten', () => {
+        it('should indicate as authorized', () => {
+          const rendered = render({
+            shouldMatchSomePermissions: true,
+            allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
+            allAppliedDataFences: [
+              {
+                __typename: 'StoreDataFence',
+                type: 'store',
+                group: 'orders',
+                name: 'canViewOrders',
+                value: 'store-1',
+              },
+            ],
+            demandedPermissions: ['ManageOrders'],
+            demandedDataFences: [
+              {
+                type: 'store',
+                group: 'orders',
+                name: 'ViewOrders',
+              },
+            ],
+            selectDataFenceData: ({ type }) => {
+              switch (type) {
+                case 'store':
+                  return ['store-1'];
+                default:
+                  return null;
+              }
+            },
+          });
+
+          expect(
+            rendered.queryByText('Is authorized: Yes')
+          ).toBeInTheDocument();
+        });
+      });
+    });
+    describe('when overwritten', () => {
+      it('should indicate as not authorized', () => {
         const rendered = render({
           shouldMatchSomePermissions: true,
           allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
+          allAppliedActionRights: [
+            {
+              group: 'products',
+              name: 'canEditPrices',
+              value: false,
+            },
+          ],
           allAppliedDataFences: [
             {
               __typename: 'StoreDataFence',
@@ -389,6 +435,9 @@ describe('data fences', () => {
             },
           ],
           demandedPermissions: ['ManageOrders'],
+          demandedActionRights: [
+            { group: 'products', name: 'PublishProducts' },
+          ],
           demandedDataFences: [
             {
               type: 'store',
@@ -406,7 +455,7 @@ describe('data fences', () => {
           },
         });
 
-        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
       });
     });
     describe('when data fence is not matched', () => {

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
-import { render } from '@testing-library/react';
+import { render as rtlRender } from '@testing-library/react';
 import useIsAuthorized from './use-is-authorized';
 
 type TPermissionName = string;
@@ -62,7 +62,7 @@ const TestComponent = (props: TestProps) => {
   );
 };
 
-const testRender = ({
+const render = ({
   demandedPermissions,
   demandedActionRights,
   demandedDataFences,
@@ -83,7 +83,7 @@ const testRender = ({
   allAppliedDataFences?: TAllAppliedDataFence[];
   shouldMatchSomePermissions?: boolean;
 }) =>
-  render(
+  rtlRender(
     <ApplicationContextProvider
       project={{
         key: 'test-with-big-data',
@@ -130,11 +130,11 @@ const testRender = ({
     </ApplicationContextProvider>
   );
 
-describe('when only one permission matches', () => {
-  describe('General Permissions', () => {
-    describe('when "shouldMatchSomePermissions=true"', () => {
+describe('general permissions', () => {
+  describe('when only some permission should be matched', () => {
+    describe('with one applied permission and one matching demanded permission', () => {
       it('should indicate being authorized', () => {
-        const { queryByText } = testRender({
+        const rendered = render({
           demandedPermissions: ['ManageCustomers', 'ManageOrders'],
           allAppliedPermissions: [
             {
@@ -145,12 +145,30 @@ describe('when only one permission matches', () => {
           shouldMatchSomePermissions: true,
         });
 
-        expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
       });
     });
-    describe('when "shouldMatchSomePermissions=false"', () => {
+    describe('with one applied permission and no matching demanded permission', () => {
+      it('should indicate not being authorized', () => {
+        const rendered = render({
+          demandedPermissions: ['ManageCustomers', 'ManageOrders'],
+          allAppliedPermissions: [
+            {
+              name: 'canManageCustomersGroups',
+              value: true,
+            },
+          ],
+          shouldMatchSomePermissions: true,
+        });
+
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
+      });
+    });
+  });
+  describe('when all permissions should be matched', () => {
+    describe('with one applied permission and one not matching demanded permission', () => {
       it('should indicate being not authorized', () => {
-        const { queryByText } = testRender({
+        const rendered = render({
           allAppliedPermissions: [
             {
               name: 'canManageCustomers',
@@ -161,43 +179,115 @@ describe('when only one permission matches', () => {
           shouldMatchSomePermissions: false,
         });
 
-        expect(queryByText('Is authorized: No')).toBeInTheDocument();
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
       });
     });
-    describe('with actual actionRight different than demanded actionRight', () => {
-      it('should indicate being not authorized', () => {
-        const { queryByText } = testRender({
+    describe('with mulltiple applied permission and all demanded permission matching', () => {
+      it('should indicate being authorized', () => {
+        const rendered = render({
+          allAppliedPermissions: [
+            {
+              name: 'canManageCustomers',
+              value: true,
+            },
+            {
+              name: 'canManageOrders',
+              value: true,
+            },
+          ],
+          demandedPermissions: ['ManageCustomers', 'ManageOrders'],
+          shouldMatchSomePermissions: false,
+        });
+
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
+      });
+    });
+    describe('with applied manage permission', () => {
+      describe('when demanding view permission', () => {
+        it('should indicate being authorized', () => {
+          const rendered = render({
+            allAppliedPermissions: [
+              {
+                name: 'canManageCustomers',
+                value: true,
+              },
+            ],
+            demandedPermissions: ['ViewCustomers'],
+          });
+
+          expect(
+            rendered.queryByText('Is authorized: Yes')
+          ).toBeInTheDocument();
+        });
+      });
+      describe('when demanding manage permission', () => {
+        it('should indicate being authorized', () => {
+          const rendered = render({
+            allAppliedPermissions: [
+              {
+                name: 'canManageCustomers',
+                value: true,
+              },
+            ],
+            demandedPermissions: ['ManageCustomers'],
+          });
+
+          expect(
+            rendered.queryByText('Is authorized: Yes')
+          ).toBeInTheDocument();
+        });
+      });
+    });
+    describe('without applied manage permission', () => {
+      it('should indicate not being authorized', () => {
+        const rendered = render({
           allAppliedPermissions: [
             {
               name: 'canManageCustomers',
               value: true,
             },
           ],
+          demandedPermissions: ['ViewCustomersGroups'],
+        });
+
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
+      });
+    });
+  });
+});
+
+describe('action rights', () => {
+  describe('with applied and matching demanded view permission', () => {
+    describe('without applied action right matching demanded', () => {
+      it('should indicate not being authorized', () => {
+        const rendered = render({
+          allAppliedPermissions: [
+            { name: 'canManageProjectSettings', value: true },
+            { name: 'canViewProducts', value: true },
+          ],
           allAppliedActionRights: [
             {
               group: 'products',
               name: 'canEditPrices',
-              value: true,
+              value: false,
             },
           ],
-          demandedPermissions: ['ManageCustomers'],
+          demandedPermissions: ['ViewProducts'],
           demandedActionRights: [
             { group: 'products', name: 'PublishProducts' },
           ],
-          shouldMatchSomePermissions: false,
+          shouldMatchSomePermissions: true,
         });
 
-        expect(queryByText('Is authorized: No')).toBeInTheDocument();
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
       });
     });
-    describe('with actual actionRight similar to demanded actionRight', () => {
+    describe('with applied action right not matching demanded', () => {
       it('should indicate being authorized', () => {
-        const { queryByText } = testRender({
+        const rendered = render({
           allAppliedPermissions: [
-            {
-              name: 'canManageCustomers',
-              value: true,
-            },
+            { name: 'canManageProjectSettings', value: true },
+            { name: 'canViewProducts', value: true },
           ],
           allAppliedActionRights: [
             {
@@ -206,347 +296,339 @@ describe('when only one permission matches', () => {
               value: true,
             },
           ],
-          demandedPermissions: ['ManageCustomers'],
+          demandedPermissions: ['ViewProducts'],
           demandedActionRights: [{ group: 'products', name: 'EditPrices' }],
+          shouldMatchSomePermissions: true,
+        });
+
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
+      });
+    });
+    describe('with applied action right in another group of demanded', () => {
+      it('should indicate not being authorized', () => {
+        const rendered = render({
+          allAppliedPermissions: [
+            { name: 'canManageProjectSettings', value: true },
+            { name: 'canViewProducts', value: true },
+          ],
+          allAppliedActionRights: [
+            {
+              group: 'orders',
+              name: 'canEditPrices',
+              value: true,
+            },
+          ],
+          demandedPermissions: ['ViewProducts'],
+          demandedActionRights: [{ group: 'products', name: 'EditPrices' }],
+          shouldMatchSomePermissions: true,
+        });
+
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
+      });
+    });
+  });
+  describe('with applied and none matching demanded view permission', () => {
+    describe('with applied action right matching demanded', () => {
+      it('should indicate not being authorized', () => {
+        const rendered = render({
+          allAppliedPermissions: [{ name: 'canViewProducts', value: false }],
+          allAppliedActionRights: [
+            {
+              group: 'products',
+              name: 'canEditPrices',
+              value: true,
+            },
+          ],
+          demandedPermissions: ['ManageProducts'],
+          demandedActionRights: [
+            { group: 'products', name: 'PublishProducts' },
+          ],
+        });
+
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
+      });
+    });
+  });
+  describe('without applied and matching demanded view permission', () => {
+    it('should indicate not being authorized', () => {
+      const rendered = render({
+        allAppliedPermissions: [
+          { name: 'canManageProjectSettings', value: true },
+          // Misses `canViewProducts`
+        ],
+        allAppliedActionRights: [
+          {
+            group: 'products',
+            name: 'canEditPrices',
+            value: true,
+          },
+        ],
+        demandedPermissions: ['ViewProducts'],
+        demandedActionRights: [{ group: 'products', name: 'EditPrices' }],
+      });
+
+      expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('data fences', () => {
+  describe('when general permission is matched', () => {
+    describe('when data fence is matched', () => {
+      it('should indicate as authorized', () => {
+        const rendered = render({
+          shouldMatchSomePermissions: true,
+          allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'orders',
+              name: 'canViewOrders',
+              value: 'store-1',
+            },
+          ],
+          demandedPermissions: ['ManageOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+          ],
+          selectDataFenceData: ({ type }) => {
+            switch (type) {
+              case 'store':
+                return ['store-1'];
+              default:
+                return null;
+            }
+          },
+        });
+
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
+      });
+    });
+    describe('when data fence is not matched', () => {
+      it('should indicate as authorized', () => {
+        const rendered = render({
+          allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'orders',
+              name: 'canViewOrders',
+              value: 'store-1',
+            },
+          ],
+          demandedPermissions: ['ManageOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: ({ type }) => {
+            switch (type) {
+              case 'store':
+                return ['store-1'];
+              default:
+                return null;
+            }
+          },
+        });
+
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
+      });
+    });
+    describe('when actual data fence is from different group', () => {
+      it('should indicate as authorized', () => {
+        const rendered = render({
+          shouldMatchSomePermissions: true,
+          allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'customers',
+              name: 'canViewCustomers',
+              value: 'store-1',
+            },
+          ],
+          demandedPermissions: ['ManageOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: ({ type }) => {
+            switch (type) {
+              case 'store':
+                return ['store-1'];
+              default:
+                return null;
+            }
+          },
+        });
+
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when general permission is not matched', () => {
+    describe('when at least one of the demanded data fence is matched', () => {
+      it('should indicate as authorized', () => {
+        const rendered = render({
           shouldMatchSomePermissions: false,
+          allAppliedPermissions: [
+            { name: 'canViewOrders', value: false },
+            { name: 'canManageOrders', value: false },
+          ],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'orders',
+              name: 'canViewOrders',
+              value: 'store-1',
+            },
+          ],
+          demandedPermissions: ['ViewOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
         });
 
-        expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
       });
     });
-  });
-
-  describe('ActionRights', () => {
-    describe('if can view products', () => {
-      describe('if can not publish products on products group', () => {
-        it('should pass isAuthorized as "false"', () => {
-          const { queryByText } = testRender({
-            allAppliedPermissions: [
-              { name: 'canManageProjectSettings', value: true },
-              { name: 'canViewProducts', value: true },
-            ],
-            allAppliedActionRights: [
-              {
-                group: 'products',
-                name: 'canEditPrices',
-                value: false,
-              },
-            ],
-            demandedPermissions: ['ViewProducts'],
-            demandedActionRights: [
-              { group: 'products', name: 'PublishProducts' },
-            ],
-            shouldMatchSomePermissions: true,
-          });
-
-          expect(queryByText('Is authorized: No')).toBeInTheDocument();
+    describe('when all data fences are matched', () => {
+      it('should indicate as authorized', () => {
+        const rendered = render({
+          shouldMatchSomePermissions: false,
+          allAppliedPermissions: [
+            { name: 'canViewOrders', value: false },
+            { name: 'canManageOrders', value: false },
+          ],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'orders',
+              name: 'canViewOrders',
+              value: 'store-1',
+            },
+          ],
+          demandedPermissions: ['ViewOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+          ],
+          selectDataFenceData: ({ type }) => {
+            switch (type) {
+              case 'store':
+                return ['store-1'];
+              default:
+                return null;
+            }
+          },
         });
-      });
-      describe('if can edit prices on products group', () => {
-        it('should pass isAuthorized as "false"', () => {
-          const { queryByText } = testRender({
-            allAppliedPermissions: [
-              { name: 'canManageProjectSettings', value: true },
-              { name: 'canViewProducts', value: true },
-            ],
-            allAppliedActionRights: [
-              {
-                group: 'products',
-                name: 'canEditPrices',
-                value: true,
-              },
-            ],
-            demandedPermissions: ['ViewProducts'],
-            demandedActionRights: [{ group: 'products', name: 'EditPrices' }],
-            shouldMatchSomePermissions: true,
-          });
 
-          expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
-        });
-      });
-      describe('if can edit prices on orders group', () => {
-        it('should pass isAuthorized as "false"', () => {
-          const { queryByText } = testRender({
-            allAppliedPermissions: [
-              { name: 'canManageProjectSettings', value: true },
-              { name: 'canViewProducts', value: true },
-            ],
-            allAppliedActionRights: [
-              {
-                group: 'orders',
-                name: 'canEditPrices',
-                value: true,
-              },
-            ],
-            demandedPermissions: ['ViewProducts'],
-            demandedActionRights: [{ group: 'products', name: 'EditPrices' }],
-            shouldMatchSomePermissions: true,
-          });
-
-          expect(queryByText('Is authorized: No')).toBeInTheDocument();
-        });
+        expect(rendered.queryByText('Is authorized: Yes')).toBeInTheDocument();
       });
     });
-  });
-
-  describe('DataFences', () => {
-    describe('when general permission is met', () => {
-      describe('when dataFence permission is met', () => {
-        it('should indicate as authorized', () => {
-          const { queryByText } = testRender({
-            shouldMatchSomePermissions: true,
-            allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'orders',
-                name: 'canViewOrders',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ManageOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ViewOrders',
-              },
-            ],
-            selectDataFenceData: ({ type }) => {
-              switch (type) {
-                case 'store':
-                  return ['store-1'];
-                default:
-                  return null;
-              }
+    describe('when data fence permission is not matched', () => {
+      it('should indicate as not authorized', () => {
+        const rendered = render({
+          shouldMatchSomePermissions: true,
+          allAppliedPermissions: [
+            { name: 'canViewOrders', value: false },
+            { name: 'canManageOrders', value: false },
+          ],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'orders',
+              name: 'canViewOrders',
+              value: 'store-1',
             },
-          });
-
-          expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
-        });
-      });
-      describe('when dataFence permission is not met', () => {
-        it('should indicate as authorized', () => {
-          const { queryByText } = testRender({
-            allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'orders',
-                name: 'canViewOrders',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ManageOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ManageOrders',
-              },
-            ],
-            selectDataFenceData: ({ type }) => {
-              switch (type) {
-                case 'store':
-                  return ['store-1'];
-                default:
-                  return null;
-              }
+          ],
+          demandedPermissions: ['ViewOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
             },
-          });
-
-          expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
+          ],
+          selectDataFenceData: ({ type }) => {
+            switch (type) {
+              case 'store':
+                return ['store-1'];
+              default:
+                return null;
+            }
+          },
         });
-      });
-      describe('when actual data fence permission is from different group', () => {
-        it('should indicate as authorized', () => {
-          const { queryByText } = testRender({
-            shouldMatchSomePermissions: true,
-            allAppliedPermissions: [{ name: 'canManageOrders', value: true }],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'customers',
-                name: 'canViewCustomers',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ManageOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ManageOrders',
-              },
-            ],
-            selectDataFenceData: ({ type }) => {
-              switch (type) {
-                case 'store':
-                  return ['store-1'];
-                default:
-                  return null;
-              }
-            },
-          });
 
-          expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
-        });
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
       });
     });
-
-    describe('when general permission is not met', () => {
-      describe('when at least one of the demanded DataFence permissions is met', () => {
-        it('should indicate as authorized', () => {
-          const { queryByText } = testRender({
-            shouldMatchSomePermissions: false,
-            allAppliedPermissions: [
-              { name: 'canViewOrders', value: false },
-              { name: 'canManageOrders', value: false },
-            ],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'orders',
-                name: 'canViewOrders',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ViewOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ViewOrders',
-              },
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ManageOrders',
-              },
-            ],
-            selectDataFenceData: () => ['store-1'],
-          });
-
-          expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
-        });
-      });
-      describe('when all dataFence permission are met', () => {
-        it('should indicate as authorized', () => {
-          const { queryByText } = testRender({
-            shouldMatchSomePermissions: false,
-            allAppliedPermissions: [
-              { name: 'canViewOrders', value: false },
-              { name: 'canManageOrders', value: false },
-            ],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'orders',
-                name: 'canViewOrders',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ViewOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ViewOrders',
-              },
-            ],
-            selectDataFenceData: ({ type }) => {
-              switch (type) {
-                case 'store':
-                  return ['store-1'];
-                default:
-                  return null;
-              }
+    describe('when actual data fence permission is from different group', () => {
+      it('should indicate as not authorized', () => {
+        const rendered = render({
+          shouldMatchSomePermissions: true,
+          allAppliedPermissions: [
+            { name: 'canViewOrders', value: false },
+            { name: 'canManageOrders', value: false },
+          ],
+          allAppliedDataFences: [
+            {
+              __typename: 'StoreDataFence',
+              type: 'store',
+              group: 'customers',
+              name: 'canViewCustomers',
+              value: 'store-1',
             },
-          });
-
-          expect(queryByText('Is authorized: Yes')).toBeInTheDocument();
-        });
-      });
-      describe('when dataFence permission is not met', () => {
-        it('should indicate as not authorized', () => {
-          const { queryByText } = testRender({
-            shouldMatchSomePermissions: true,
-            allAppliedPermissions: [
-              { name: 'canViewOrders', value: false },
-              { name: 'canManageOrders', value: false },
-            ],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'orders',
-                name: 'canViewOrders',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ViewOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ManageOrders',
-              },
-            ],
-            selectDataFenceData: ({ type }) => {
-              switch (type) {
-                case 'store':
-                  return ['store-1'];
-                default:
-                  return null;
-              }
+          ],
+          demandedPermissions: ['ViewOrders'],
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
             },
-          });
-
-          expect(queryByText('Is authorized: No')).toBeInTheDocument();
+          ],
+          selectDataFenceData: ({ type }) => {
+            switch (type) {
+              case 'store':
+                return ['store-1'];
+              default:
+                return null;
+            }
+          },
         });
-      });
-      describe('when actual data fence permission is from different group', () => {
-        it('should indicate as not authorized', () => {
-          const { queryByText } = testRender({
-            shouldMatchSomePermissions: true,
-            allAppliedPermissions: [
-              { name: 'canViewOrders', value: false },
-              { name: 'canManageOrders', value: false },
-            ],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                type: 'store',
-                group: 'customers',
-                name: 'canViewCustomers',
-                value: 'store-1',
-              },
-            ],
-            demandedPermissions: ['ViewOrders'],
-            demandedDataFences: [
-              {
-                type: 'store',
-                group: 'orders',
-                name: 'ManageOrders',
-              },
-            ],
-            selectDataFenceData: ({ type }) => {
-              switch (type) {
-                case 'store':
-                  return ['store-1'];
-                default:
-                  return null;
-              }
-            },
-          });
 
-          expect(queryByText('Is authorized: No')).toBeInTheDocument();
-        });
+        expect(rendered.queryByText('Is authorized: No')).toBeInTheDocument();
       });
     });
   });

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -4,7 +4,7 @@ import {
   hasSomePermissions,
   hasEveryPermissions,
   hasEveryActionRight,
-  hasAppliedDataFence,
+  hasSomeDataFence,
 } from '../../utils/has-permissions';
 
 // Permissions
@@ -91,7 +91,7 @@ const useIsAuthorized = ({
         )
       );
     }
-    hasDemandeDataFences = hasAppliedDataFence({
+    hasDemandeDataFences = hasSomeDataFence({
       actualPermissions,
       demandedDataFences,
       actualDataFences,

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -56,7 +56,6 @@ type TSelectDataFenceData = (
   }
 ) => string[] | null;
 
-// Forward-compatibility with React Hooks 🎉
 const useIsAuthorized = ({
   demandedPermissions,
   demandedActionRights,
@@ -93,6 +92,7 @@ const useIsAuthorized = ({
       );
     }
     hasDemandeDataFences = hasAppliedDataFence({
+      actualPermissions,
       demandedDataFences,
       actualDataFences,
       selectDataFenceData,

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -5,7 +5,7 @@ import {
   hasEveryPermissions,
   hasSomePermissions,
   getInvalidPermissions,
-  hasAppliedDataFence,
+  hasSomeDataFence,
 } from './has-permissions';
 
 type TPermissionName = string;
@@ -207,11 +207,12 @@ describe('getInvalidPermissions', () => {
   });
 });
 
-describe('hasAppliedDataFence', () => {
+describe('hasSomeDataFence', () => {
   describe('user has not datafence permissions', () => {
     it('should return false', () => {
       expect(
-        hasAppliedDataFence({
+        hasSomeDataFence({
+          actualPermissions: null,
           actualDataFences: null,
           demandedDataFences: [
             {
@@ -229,7 +230,8 @@ describe('hasAppliedDataFence', () => {
   describe('no demanded dataFence exists in actual dataFences', () => {
     it('should return "false"', () => {
       expect(
-        hasAppliedDataFence({
+        hasSomeDataFence({
+          actualPermissions: null,
           actualDataFences: {
             store: {
               orders: {
@@ -254,7 +256,8 @@ describe('hasAppliedDataFence', () => {
   describe('some demanded dataFences exist in actual dataFences', () => {
     it('should return "true"', () => {
       expect(
-        hasAppliedDataFence({
+        hasSomeDataFence({
+          actualPermissions: null,
           actualDataFences: {
             store: {
               orders: {
@@ -284,7 +287,8 @@ describe('hasAppliedDataFence', () => {
   describe('all demanded dataFences exist in actual dataFences', () => {
     it('should return "true"', () => {
       expect(
-        hasAppliedDataFence({
+        hasSomeDataFence({
+          actualPermissions: null,
           actualDataFences: {
             store: {
               orders: {
@@ -309,7 +313,8 @@ describe('hasAppliedDataFence', () => {
   describe('no value from demanded dataFence exists in actual DataFence values', () => {
     it('should return "false"', () => {
       expect(
-        hasAppliedDataFence({
+        hasSomeDataFence({
+          actualPermissions: null,
           actualDataFences: {
             store: {
               orders: {
@@ -333,7 +338,8 @@ describe('hasAppliedDataFence', () => {
   });
   describe('some values from demanded dataFence exist in actual DataFence values', () => {
     it('should return "true"', () => {
-      const hasDF = hasAppliedDataFence({
+      const hasDF = hasSomeDataFence({
+        actualPermissions: null,
         actualDataFences: {
           store: {
             customers: {
@@ -358,7 +364,8 @@ describe('hasAppliedDataFence', () => {
   describe('all values from demanded dataFence exist in actual DataFence values', () => {
     it('should return "true"', () => {
       expect(
-        hasAppliedDataFence({
+        hasSomeDataFence({
+          actualPermissions: null,
           actualDataFences: {
             store: {
               orders: {

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -79,18 +79,30 @@ const hasExactPermission = (
   actualPermissions: TPermissions
 ) => actualPermissions[toCanCase(demandedPermission)];
 
+const getIsViewPermission = (demandedPermission: TPermissionName) =>
+  demandedPermission.startsWith('View');
+
 // Check that the user permissions match the required MANAGE permission.
 // The shapes of the arguments are:
 // - demandedPermission:
 //     'ViewProducts'
 // - actualPermissions:
 //     { canViewProducts: true, canManageOrders: false }
-const hasManagePermission = (
+const doesManagePermissionInferViewPermission = (
   demandedPermission: TPermissionName,
   actualPermissions: TPermissions
-) =>
-  demandedPermission.startsWith('View') &&
-  actualPermissions[toCanCase(demandedPermission.replace('View', 'Manage'))];
+) => {
+  const isDemandedPermissionViewPermission = getIsViewPermission(
+    demandedPermission
+  );
+  const isViewPermissionInferredByManagePermission =
+    actualPermissions[toCanCase(demandedPermission.replace('View', 'Manage'))];
+
+  return (
+    isDemandedPermissionViewPermission &&
+    isViewPermissionInferredByManagePermission
+  );
+};
 
 // Check the user permissions using one of the defined matchers.
 // The shapes of the arguments are:
@@ -107,8 +119,11 @@ export const hasPermission = (
 ) =>
   // First checking the existence of the exact permission
   hasExactPermission(demandedPermission, actualPermissions || {}) ||
-  // Then checking if a manage permission is inferred as a view permission
-  hasManagePermission(demandedPermission, actualPermissions || {});
+  // Then checking if a view permission is inferred as a manage permission
+  doesManagePermissionInferViewPermission(
+    demandedPermission,
+    actualPermissions || {}
+  );
 
 // Check the user action rights using one of the defined matchers.
 // The shapes of the arguments are:

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -97,8 +97,9 @@ const doesManagePermissionInferViewPermission = (
   const isDemandedPermissionViewPermission = getIsViewPermission(
     demandedPermission
   );
-  const isViewPermissionInferredByManagePermission =
-    actualPermissions[toCanCase(demandedPermission.replace('View', 'Manage'))];
+  const isViewPermissionInferredByManagePermission = Boolean(
+    actualPermissions[toCanCase(demandedPermission.replace('View', 'Manage'))]
+  );
 
   return (
     isDemandedPermissionViewPermission &&

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -59,6 +59,7 @@ type TActualDataFence = {
 };
 
 type TOptionsForAppliedDataFence = {
+  actualPermissions: TPermissions | null;
   demandedDataFences: TDemandedDataFence[];
   actualDataFences: TDataFences | null;
   selectDataFenceData?: TSelectDataFenceData;
@@ -205,7 +206,7 @@ export const getInvalidPermissions = (
   );
 };
 
-const hasDemandedDataFence = (options: {
+const getHasDemandedDataFence = (options: {
   actualDataFence: TActualDataFence;
   demandedDataFence: TDemandedDataFence;
   selectDataFenceData?: TSelectDataFenceData;
@@ -255,6 +256,13 @@ const getDataFenceByTypeAndGroup = (
   return null;
 };
 
+const getIsPermissionOverwritingDataFence = (
+  actualPermissions: TPermissions | null,
+  actualDataFence: TActualDataFence
+) => {
+  return false;
+};
+
 export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) => {
   // Datafences applied should be combined with an OR, that is why we use
   // `some` and not `every`
@@ -285,16 +293,24 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) => {
       if (!specificActualDataFence) return false;
 
       const [dataFenceName, dataFenceValue] = specificActualDataFence;
-      return hasDemandedDataFence({
-        actualDataFence: {
-          name: dataFenceName,
-          // we do the type casting because at this point we are sure that
-          // specificActualDataFence.dataFenceValue is not null
-          dataFenceValue: dataFenceValue as TActualDataFence['dataFenceValue'],
-        },
+      const actualDataFence = {
+        name: dataFenceName,
+        // we do the type casting because at this point we are sure that
+        // specificActualDataFence.dataFenceValue is not null
+        dataFenceValue: dataFenceValue as TActualDataFence['dataFenceValue'],
+      };
+
+      const isPermissionOverwritingDataFence = getIsPermissionOverwritingDataFence(
+        options.actualPermissions,
+        actualDataFence
+      );
+      const hasDemandedDataFence = getHasDemandedDataFence({
+        actualDataFence,
         demandedDataFence,
         selectDataFenceData: options.selectDataFenceData,
       });
+
+      return !isPermissionOverwritingDataFence && hasDemandedDataFence;
     }
   );
 };

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -239,17 +239,17 @@ const hasDemandedDataFence = (options: {
   );
 };
 
-const getDataFenceByPermissionGroup = (
+const getDataFenceByTypeAndGroup = (
   dataFences: TDataFences | null,
-  storeKey: TDataFenceType,
-  groupKey: string
+  demandedDataFenceType: TDataFenceType,
+  demandedDataFenceGroup: string
 ) => {
   if (!dataFences) return null;
 
-  if (storeKey in dataFences) {
-    const resourceType = dataFences[storeKey];
-    if (resourceType && groupKey in resourceType) {
-      return resourceType[groupKey];
+  if (demandedDataFenceType in dataFences) {
+    const dataFence = dataFences[demandedDataFenceType];
+    if (dataFence && demandedDataFenceGroup in dataFence) {
+      return dataFence[demandedDataFenceGroup];
     }
   }
   return null;
@@ -266,17 +266,17 @@ export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) => {
       // dataFence[type][group] = dataFence.store.group
       // with value = there is a dataFence to apply, overrules `hasDemandedProjectPermissions`
       // without value = there is no dataFence to apply, overruled by `hasDemandedProjectPermissions`
-      const actualDataFenceByPermissionGroup = getDataFenceByPermissionGroup(
+      const actualDataFenceByTypeAndGroup = getDataFenceByTypeAndGroup(
         options.actualDataFences,
         demandedDataFence.type,
         demandedDataFence.group
       );
 
-      if (!actualDataFenceByPermissionGroup) return false;
+      if (!actualDataFenceByTypeAndGroup) return false;
 
       // we try to find if the demanded dataFence is available inside the actual datafences
       const specificActualDataFence = Object.entries(
-        actualDataFenceByPermissionGroup
+        actualDataFenceByTypeAndGroup
       ).find(
         ([dataFenceName, dataFenceValue]) =>
           dataFenceValue && dataFenceName === toCanCase(demandedDataFence.name)

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -263,7 +263,7 @@ const getIsPermissionOverwritingDataFence = (
   return false;
 };
 
-export const hasAppliedDataFence = (options: TOptionsForAppliedDataFence) => {
+export const hasSomeDataFence = (options: TOptionsForAppliedDataFence) => {
   // Datafences applied should be combined with an OR, that is why we use
   // `some` and not `every`
   return options.demandedDataFences.some(

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -269,7 +269,7 @@ const getIsPermissionOverwritingDataFence = (
 
   /**
    * NOTE:
-   *    A data fence relates, exists in relation to a resource access.
+   *    A data fence relates, exists in relation to a general permission.
    *    This relation is constructed by the group of the data fence.
    *
    *    Given the user already has manage access on the data fence's group

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -83,8 +83,6 @@ const hasExactPermission = (
 
 const getIsViewPermission = (demandedPermission: TPermissionName) =>
   demandedPermission.startsWith('View');
-const getIsManagePermission = (demandedPermission: TPermissionName) =>
-  demandedPermission.startsWith('Manage');
 
 // Check that the user permissions match the required MANAGE permission.
 // The shapes of the arguments are:


### PR DESCRIPTION
## Summary

This pull request fixes an issue when a data fence is configured while the corresponding resource access permission should overwrite it.

## Description

This case is best described in ACs

### Status Quo

```
In the permission configuration UI
Given I configure a resource access (e.g. orders) 
And I grant access to manage orders
Then any condition will be overruled by the general permission
```

```
Given I configure a resource access (e.g. orders)
And I grant access to view orders
Then I can add a condition for a specific store to allow managing orders in this store
```
 
In the evaluation of permissions

```
Given I configure a resource access (e.g. orders) 
And I grant access to manage orders
Then the condition will always gain precedence over the general permission
```


### Desired state

```
Given I configure a resource access to manage (e.g. orders)
And I have an existing condition configured too
Then the resource access to manage should take precedence
```

```
Given I configure a resource access to view (e.g. orders)
And I have an existing condition configured to manage a store
Then the condition to manage should take precedence
```

These pairings become particularily obvious with action rights and data fences.

```
Given I configure manage orders
And I configure a action right to not edit prices
And I configure a store to manage orders
```

In this case the data fence has to be disregarded (but is saved) and we fall back to evaluating the resource access and action right.

During this PR I fixed a lot of naming and test structure. Commit by commit review should be possible.