### PR TITLE
chore(permissions): add warnings to propose improvements

### DIFF
--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -110,6 +110,7 @@ module.exports = function getBabePresetConfigForMcApp() {
           regenerator: true,
         },
       ],
+      isEnvProduction && require('babel-plugin-dev-expression'),
       isEnvProduction && [
         // Remove PropTypes from production build
         require('babel-plugin-transform-react-remove-prop-types').default,

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -39,6 +39,7 @@
     "@emotion/babel-preset-css-prop": "10.0.27",
     "babel-plugin-macros": "2.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+    "babel-plugin-dev-expression": "0.2.2",
     "core-js": "3.6.4"
   }
 }

--- a/packages/jest-preset-mc-app/.gitignore
+++ b/packages/jest-preset-mc-app/.gitignore
@@ -1,0 +1,1 @@
+fail-tests-because-there-was-an-unhandled-rejection.lock

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -41,7 +41,8 @@
     "@commercetools-frontend/application-shell-connectors": "15.8.0",
     "lodash": "4.17.15",
     "lodash-es": "4.17.15",
-    "prop-types": "15.7.2"
+    "prop-types": "15.7.2",
+    "tiny-warning": "1.0.3"
   },
   "devDependencies": {
     "react": "16.12.0"

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -83,7 +83,7 @@ const useIsAuthorized = ({
   );
   warning(
     shouldMatchSomePermissions === false,
-    `@commercetools-frontend/permissions: It is recommended not to use 'shouldMatchSomePermissions' but instead use the hook, HoC or comoponent multiple times.`
+    `@commercetools-frontend/permissions: It is recommended not to use 'shouldMatchSomePermissions' but instead use the hook, HoC or component multiple times.`
   );
   warning(
     !impliedPermissions || impliedPermissions.length === 0,

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -1,3 +1,4 @@
+import warning from 'tiny-warning';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import {
@@ -5,6 +6,7 @@ import {
   hasEveryPermissions,
   hasEveryActionRight,
   hasSomeDataFence,
+  getImpliedPermissions,
 } from '../../utils/has-permissions';
 
 // Permissions
@@ -69,6 +71,27 @@ const useIsAuthorized = ({
   selectDataFenceData?: TSelectDataFenceData;
   shouldMatchSomePermissions?: boolean;
 }) => {
+  const impliedPermissions = getImpliedPermissions(demandedPermissions);
+
+  warning(
+    !demandedActionRights || demandedActionRights.length === 1,
+    `@commercetools-frontend/permissions: It is recommended to pass a single demanded action right while using the hook, HoC or component multiple times.`
+  );
+  warning(
+    !demandedPermissions || demandedPermissions.length === 1,
+    `@commercetools-frontend/permissions: It is recommended to pass a single demanded permission while using the hook, HoC or component multiple times.`
+  );
+  warning(
+    shouldMatchSomePermissions === false,
+    `@commercetools-frontend/permissions: It is recommended not to use 'shouldMatchSomePermissions' but instead use the hook, HoC or comoponent multiple times.`
+  );
+  warning(
+    !impliedPermissions || impliedPermissions.length === 0,
+    `@commercetools-frontend/permissions: Demanded permissions contain implied permissions. These are implied: ${impliedPermissions.join(
+      ', '
+    )}.`
+  );
+
   const actualPermissions = useApplicationContext<TPermissions | null>(
     applicationContext => applicationContext.permissions
   );

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -4,8 +4,8 @@ import {
   hasEveryActionRight,
   hasEveryPermissions,
   hasSomePermissions,
-  getInvalidPermissions,
   hasSomeDataFence,
+  getImpliedPermissions,
 } from './has-permissions';
 
 type TPermissionName = string;
@@ -187,26 +187,6 @@ describe('hasEveryActionRight', () => {
   });
 });
 
-describe('getInvalidPermissions', () => {
-  describe('given all permissions are configured (passed as `actualPermissions`)', () => {
-    it('should return no invalid permissions', () => {
-      expect(
-        getInvalidPermissions(['ManageOrders'], { canManageOrders: true })
-      ).toHaveLength(0);
-    });
-  });
-
-  describe('given some permissions are not configured (not passed as `actualPermissions`)', () => {
-    it('should return invalid permissions', () => {
-      expect(
-        getInvalidPermissions(['ManageOrders', 'ViewStars'], {
-          canManageOrders: true,
-        })
-      ).toEqual(expect.arrayContaining(['ViewStars']));
-    });
-  });
-});
-
 describe('hasSomeDataFence', () => {
   describe('user has not datafence permissions', () => {
     it('should return false', () => {
@@ -385,6 +365,38 @@ describe('hasSomeDataFence', () => {
           selectDataFenceData: () => ['store-1', 'store-2'],
         })
       ).toBe(true);
+    });
+  });
+});
+describe('getImpliedPermissions', () => {
+  describe('when demanded permissions contain implied permissions', () => {
+    it('indicate that the demanded permissions contain implied permissions', () => {
+      expect(getImpliedPermissions(['ManageOrders', 'ViewOrders'])).toEqual(
+        expect.arrayContaining(['ViewOrders'])
+      );
+
+      expect(
+        getImpliedPermissions([
+          'ManageOrders',
+          'ManageCustomerGroups',
+          'ViewCustomers',
+          'ViewOrders',
+        ])
+      ).toEqual(expect.arrayContaining(['ViewOrders']));
+    });
+  });
+  describe('when demanded permissions contain no implied permissions', () => {
+    it('indicate that the demanded permissions contain no implied permissions', () => {
+      expect(
+        getImpliedPermissions(['ManageOrders', 'ViewCustomers'])
+      ).toHaveLength(0);
+      expect(
+        getImpliedPermissions([
+          'ManageOrders',
+          'ViewCustomersGroups',
+          'ManageProjectSettings',
+        ])
+      ).toHaveLength(0);
     });
   });
 });

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -1,4 +1,3 @@
-import isNil from 'lodash/isNil';
 import upperFirst from 'lodash/upperFirst';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 
@@ -107,6 +106,22 @@ const doesManagePermissionInferViewPermission = (
   );
 };
 
+// Check if the demanded permissions contain any unnecessary
+// implied permissions.
+// E.g. ViewCustomerGroup is implied by ManageCustomerGroup.
+export const getImpliedPermissions = (
+  permissions: TPermissionName[]
+): TPermissionName[] => {
+  const viewPermissions = permissions.filter(permission =>
+    permission.startsWith('View')
+  );
+  const impliedPermissions = viewPermissions.filter(viewPermission =>
+    permissions.includes(viewPermission.replace('View', 'Manage'))
+  );
+
+  return impliedPermissions;
+};
+
 // Check the user permissions using one of the defined matchers.
 // The shapes of the arguments are:
 // - demandedPermission:
@@ -190,23 +205,6 @@ export const hasSomePermissions = (
   demandedPermissions.some((permission: TPermissionName) =>
     hasPermission(permission, actualPermissions)
   );
-
-// Returns an Array<String> of unconfigured (not passed as `actualPermissions`) permissions.
-// The shapes of the arguments are:
-// - demandedPermissions:
-//     ['ViewProducts', 'ManageOrders']
-// - actualPermissions:
-//     { canViewProducts: true, canManageOrders: false }
-export const getInvalidPermissions = (
-  demandedPermissions: TPermissionName[],
-  actualPermissions: TPermissions | null
-) => {
-  if (!actualPermissions) return demandedPermissions;
-  // All demanded permissions need to be present as an actual permission.
-  return demandedPermissions.filter((demandedPermission: TPermissionName) =>
-    isNil(actualPermissions[toCanCase(demandedPermission)])
-  );
-};
 
 type TGetHasDemandedDataFenceOptions = {
   actualDataFence: TActualDataFence;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6993,6 +6993,11 @@ babel-plugin-apply-mdx-type-prop@^1.5.3:
     "@babel/helper-plugin-utils" "7.8.0"
     "@mdx-js/util" "^1.5.5"
 
+babel-plugin-dev-expression@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.2.tgz#c18de18a06150f9480edd151acbb01d2e65e999b"
+  integrity sha512-y32lfBif+c2FIh5dwGfcc/IfX5aw/Bru7Du7W2n17sJE/GJGAsmIk5DPW/8JOoeKpXW5evJfJOvRq5xkiS6vng==
+
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"


### PR DESCRIPTION
#### Summary

This pull request iterates on observations and discusisons from the previous pull request by adding warnings to guide the user to a more appripriate usage of the permissions package.

#### Description

There are some cases we seem to all agree on that they're dangerous:

1. Multiple demanded permissions: you can and should just use one and compose yourselr
2. `shouldMatchSomePermissions`: leads to unexpected behaviour when used with e.g. action rights and should be avoided
3. Multiple action rights: should also be avoided and multiple usages of the hook (or if used as HoC) should be preferred
4. Implied permissions: This should not happen when using a single demanded permission. Howeever, as we're only logging suggestions here I propsoe to inform the user about uncalled-for usage. So `['ManageOrders', 'ViewOrders']` should just be `['ViewOrders']` (or in future `'ManageOrders`) while `ViewOrders` is implied by `ManageOrders`.

While on this I recommend us using a babel plugin to remove these warnings in production bundles. Also to avoid: if ever using `tiny-invariant` again (remember?) the app to unmount.
