### PR TITLE
chore: add homepage link and directory to each package.json

### DIFF
--- a/packages/actions-global/package.json
+++ b/packages/actions-global/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/actions-global"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/application-components"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/application-shell-connectors/package.json
+++ b/packages/application-shell-connectors/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/application-shell-connectors"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/application-shell"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/assets"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/babel-preset-mc-app"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/browser-history/package.json
+++ b/packages/browser-history/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/browser-history"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/constants"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/create-mc-app/package.json
+++ b/packages/create-mc-app/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/create-mc-app"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/eslint-config-mc-app/package.json
+++ b/packages/eslint-config-mc-app/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/eslint-config-mc-app"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/i18n"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/jest-preset-mc-app"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/jest-stylelint-runner/package.json
+++ b/packages/jest-stylelint-runner/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/jest-stylelint-runner"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/l10n/package.json
+++ b/packages/l10n/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/l10n"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/mc-dev-authentication/package.json
+++ b/packages/mc-dev-authentication/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/mc-dev-authentication"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/mc-html-template/package.json
+++ b/packages/mc-html-template/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/mc-html-template"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/mc-http-server/package.json
+++ b/packages/mc-http-server/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/mc-http-server"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/mc-scripts"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/notifications"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/permissions"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/react-notifications"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/sdk"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/sentry"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",

--- a/packages/url-utils/package.json
+++ b/packages/url-utils/package.json
@@ -5,8 +5,10 @@
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/merchant-center-application-kit.git"
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/url-utils"
   },
+  "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": [
     "javascript",
     "frontend",


### PR DESCRIPTION
The `directory` field is for monorepo use cases (see https://docs.npmjs.com/files/package.json#repository)