### PR TITLE
fix(components): explicitly define intl message type, to generate correct prop-types

### DIFF
--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import DialogContainer from '../internals/dialog-container';
 import DialogHeader from '../internals/dialog-header';
 import DialogContent from '../internals/dialog-content';
 import DialogFooter from '../internals/dialog-footer';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   isOpen: boolean;

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import DialogContainer from '../internals/dialog-container';
 import DialogHeader from '../internals/dialog-header';
 import DialogContent from '../internals/dialog-content';
 import DialogFooter from '../internals/dialog-footer';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   isOpen: boolean;

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
-import { useIntl, MessageDescriptor, IntlShape } from 'react-intl';
+import { useIntl, IntlShape } from 'react-intl';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import Spacings from '@commercetools-uikit/spacings';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   labelSecondary: Label;

--- a/packages/application-components/src/components/modal-pages/custom-form-modal-page/custom-form-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/custom-form-modal-page/custom-form-modal-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import ModalPage from '../internals/modal-page';
 import ModalPageHeader from '../internals/modal-page-header';
@@ -11,6 +10,14 @@ import {
   FormDeleteButton,
 } from '../internals/default-form-buttons';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   level?: number;

--- a/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/form-modal-page/form-modal-page.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import CustomFormModalPage from '../custom-form-modal-page';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 
 type Props = {

--- a/packages/application-components/src/components/modal-pages/info-modal-page/info-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/info-modal-page/info-modal-page.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import ModalPage from '../internals/modal-page';
 import ModalPageHeader from '../internals/modal-page-header';
 import { ContentWrapper } from '../internals/modal-page.styles';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   level?: number;

--- a/packages/application-components/src/components/modal-pages/internals/default-form-buttons.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/default-form-buttons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useIntl, MessageDescriptor } from 'react-intl';
+import { useIntl } from 'react-intl';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
 import IconButton from '@commercetools-uikit/icon-button';
@@ -7,6 +7,14 @@ import { BinLinearIcon } from '@commercetools-uikit/icons';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   label: Label;

--- a/packages/application-components/src/components/modal-pages/internals/modal-page-top-bar.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page-top-bar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import { useIntl, MessageDescriptor } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { CloseIcon, AngleLeftIcon } from '@commercetools-uikit/icons';
 import FlatButton from '@commercetools-uikit/flat-button';
 import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
@@ -9,7 +9,7 @@ import Text from '@commercetools-uikit/text';
 import { customProperties } from '@commercetools-uikit/design-system';
 import messages from './messages';
 
-// Component to have a larger the clickable surface
+// Component to have a larger clickable surface
 const LargeIconWrapper = styled.span`
   display: flex;
   align-items: center;
@@ -24,6 +24,14 @@ const LargeIconWrapper = styled.span`
   }
 `;
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   color: 'surface' | 'neutral';

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import Modal from 'react-modal';
 import { ClassNames } from '@emotion/core';
 import { PORTALS_CONTAINER_ID } from '@commercetools-frontend/constants';
@@ -34,6 +33,14 @@ const getDefaultParentSelector = () =>
         `#${PORTALS_CONTAINER_ID}`
       ) as HTMLElement);
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 type Props = {
   level: number;

--- a/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
 import { css } from '@emotion/core';
 import { customProperties } from '@commercetools-uikit/design-system';
 import Spacings from '@commercetools-uikit/spacings';
@@ -13,6 +12,14 @@ import {
   FormDeleteButton,
 } from '../internals/default-form-buttons';
 
+// NOTE: the `MessageDescriptor` type is exposed by `react-intl`.
+// However, we need to explicitly define this otherwise the prop-types babel plugin
+// does not recognize the object shape.
+type MessageDescriptor = {
+  id: string;
+  description?: string | object;
+  defaultMessage?: string;
+};
 type Label = string | MessageDescriptor;
 
 type Props = {


### PR DESCRIPTION
The `MessageDescriptor` type imported from `react-intl` does not get parsed by the prop-types babel plugin because it's not "visible" within the file. For now, we need to explicitly define it.

Before:

<img width="517" alt="image" src="https://user-images.githubusercontent.com/1110551/73550956-cd899700-4445-11ea-89d0-f0696fd21e27.png">


After:

<img width="499" alt="image" src="https://user-images.githubusercontent.com/1110551/73550942-c9f61000-4445-11ea-9f2b-e6d096fdc5ae.png">
