### PR TITLE
fix(permissions): to match inferred data fence (view when manage)

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -1142,7 +1142,7 @@ describe('when navbar menu items do not match given data fences', () => {
               value: 'usa',
               type: 'store',
               group: 'orders',
-              name: 'canManageOrders',
+              name: 'canViewOrders',
             },
           ],
         }),
@@ -1162,7 +1162,7 @@ describe('when navbar menu items do not match given data fences', () => {
         {
           type: 'store',
           group: 'orders',
-          name: 'ViewOrders',
+          name: 'ManageOrders',
         },
       ],
     });

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -33,7 +33,7 @@ describe('hasPermission', () => {
       demandedPermission = 'ManageProducts';
       actualPermissions = { canManageProducts: true };
     });
-    it('should return true', () => {
+    it('should indicate the permission the permission matches', () => {
       expect(hasPermission(demandedPermission, actualPermissions)).toBe(true);
     });
   });
@@ -48,7 +48,7 @@ describe('hasPermission', () => {
           canManageProducts: true,
         };
       });
-      it('should return true', () => {
+      it('should indicate the permission the permission matches', () => {
         expect(hasPermission(demandedPermission, actualPermissions)).toBe(true);
       });
     });
@@ -60,7 +60,35 @@ describe('hasPermission', () => {
           canManageProjectSettings: false,
         };
       });
-      it('should return false', () => {
+      it('should indicate that the permission does not match', () => {
+        expect(hasPermission(demandedPermission, actualPermissions)).toBe(
+          false
+        );
+      });
+    });
+  });
+  describe('when a manage permission is demanded', () => {
+    beforeEach(() => {
+      demandedPermission = 'ManageProducts';
+    });
+    describe('when the user has the manage permission for same resource', () => {
+      beforeEach(() => {
+        actualPermissions = {
+          canManageProducts: true,
+        };
+      });
+      it('should indicate the permission the permission matches', () => {
+        expect(hasPermission(demandedPermission, actualPermissions)).toBe(true);
+      });
+    });
+    describe('when the user has view permission for the same resource', () => {
+      beforeEach(() => {
+        actualPermissions = {
+          canViewProducts: false,
+          canManageProjectSettings: false,
+        };
+      });
+      it('should indicate that the permission does not match', () => {
         expect(hasPermission(demandedPermission, actualPermissions)).toBe(
           false
         );
@@ -70,7 +98,7 @@ describe('hasPermission', () => {
 });
 
 describe('hasEveryPermission', () => {
-  it('should return true if every demanded permission match', () => {
+  it('should indicate the permission the permission matches if every demanded permission match', () => {
     expect(
       hasEveryPermissions(['ViewProducts', 'ManageOrders'], {
         canViewProducts: true,
@@ -78,7 +106,7 @@ describe('hasEveryPermission', () => {
       })
     ).toBe(true);
   });
-  it('should return false if at least one demanded permission does not match', () => {
+  it('should indicate that the permission does not match if at least one demanded permission does not match', () => {
     expect(
       hasEveryPermissions(['ViewProducts', 'ManageOrders'], {
         canViewProducts: true,
@@ -89,7 +117,7 @@ describe('hasEveryPermission', () => {
 });
 
 describe('hasSomePermissions', () => {
-  it('should return true if at least one demanded permission matches', () => {
+  it('should indicate the permission the permission matches if at least one demanded permission matches', () => {
     expect(
       hasSomePermissions(['ViewProducts', 'ManageOrders'], {
         canViewProducts: true,
@@ -97,7 +125,7 @@ describe('hasSomePermissions', () => {
       })
     ).toBe(true);
   });
-  it('should return false if none of the demanded permissions match', () => {
+  it('should indicate that the permission does not match if none of the demanded permissions match', () => {
     expect(
       hasSomePermissions(['ViewCustomers'], {
         canViewProducts: true,
@@ -116,7 +144,7 @@ describe('hasActionRight', () => {
       demandedActionRight = { group: 'products', name: 'EditPrices' };
       actualActionRights = { products: { canEditPrices: true } };
     });
-    it('should return true', () => {
+    it('should indicate the permission the permission matches', () => {
       expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
         true
       );
@@ -128,7 +156,7 @@ describe('hasActionRight', () => {
         demandedActionRight = { group: 'products', name: 'PublishProducts' };
         actualActionRights = { products: { canEditPrices: true } };
       });
-      it('should return false', () => {
+      it('should indicate that the permission does not match', () => {
         expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
           false
         );
@@ -139,7 +167,7 @@ describe('hasActionRight', () => {
         demandedActionRight = { group: 'orders', name: 'EditPrices' };
         actualActionRights = { products: { canEditPrices: true } };
       });
-      it('should return false', () => {
+      it('should indicate that the permission does not match', () => {
         expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
           false
         );
@@ -149,7 +177,7 @@ describe('hasActionRight', () => {
 });
 
 describe('hasEveryActionRight', () => {
-  it('should return true if every demanded action rights match', () => {
+  it('should indicate the permission the permission matches if every demanded action rights match', () => {
     expect(
       hasEveryActionRight(
         [
@@ -167,7 +195,7 @@ describe('hasEveryActionRight', () => {
       )
     ).toBe(true);
   });
-  it('should return false if at least one demanded action rights do not match', () => {
+  it('should indicate that the permission does not match if at least one demanded action rights do not match', () => {
     expect(
       hasEveryActionRight(
         [
@@ -188,8 +216,8 @@ describe('hasEveryActionRight', () => {
 });
 
 describe('hasSomeDataFence', () => {
-  describe('user has not datafence permissions', () => {
-    it('should return false', () => {
+  describe('user has not data fence permissions', () => {
+    it('should indicate that the permission does not match', () => {
       expect(
         hasSomeDataFence({
           actualPermissions: null,
@@ -207,8 +235,8 @@ describe('hasSomeDataFence', () => {
     });
   });
 
-  describe('no demanded dataFence exists in actual dataFences', () => {
-    it('should return "false"', () => {
+  describe('no demanded data fence exists in actual data fences', () => {
+    it('should indicate that the data fence does not match', () => {
       expect(
         hasSomeDataFence({
           actualPermissions: null,
@@ -233,8 +261,8 @@ describe('hasSomeDataFence', () => {
       ).toBe(false);
     });
   });
-  describe('some demanded dataFences exist in actual dataFences', () => {
-    it('should return "true"', () => {
+  describe('some demanded data fences exist in actual data fences', () => {
+    it('should indicate that the data fence matches', () => {
       expect(
         hasSomeDataFence({
           actualPermissions: null,
@@ -264,8 +292,8 @@ describe('hasSomeDataFence', () => {
       ).toBe(true);
     });
   });
-  describe('all demanded dataFences exist in actual dataFences', () => {
-    it('should return "true"', () => {
+  describe('all demanded data fences exist in actual data fences', () => {
+    it('should indicate that the data fence matches', () => {
       expect(
         hasSomeDataFence({
           actualPermissions: null,
@@ -290,8 +318,8 @@ describe('hasSomeDataFence', () => {
       ).toBe(true);
     });
   });
-  describe('no value from demanded dataFence exists in actual DataFence values', () => {
-    it('should return "false"', () => {
+  describe('no value from demanded data fence exists in actual data fence values', () => {
+    it('should indicate that the data fence does not match', () => {
       expect(
         hasSomeDataFence({
           actualPermissions: null,
@@ -316,8 +344,8 @@ describe('hasSomeDataFence', () => {
       ).toBe(false);
     });
   });
-  describe('some values from demanded dataFence exist in actual DataFence values', () => {
-    it('should return "true"', () => {
+  describe('some values from demanded data fence exist in actual data fence values', () => {
+    it('should indicate that the data fence matches', () => {
       const hasDF = hasSomeDataFence({
         actualPermissions: null,
         actualDataFences: {
@@ -341,8 +369,8 @@ describe('hasSomeDataFence', () => {
       expect(hasDF).toBe(true);
     });
   });
-  describe('all values from demanded dataFence exist in actual DataFence values', () => {
-    it('should return "true"', () => {
+  describe('all values from demanded data fence exist in actual data fence values', () => {
+    it('should indicate that the data fence matches', () => {
       expect(
         hasSomeDataFence({
           actualPermissions: null,

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -344,6 +344,32 @@ describe('hasSomeDataFence', () => {
       ).toBe(true);
     });
   });
+  describe('manage data fences permission requested while only view is applied', () => {
+    it('should indicate that the data fence does not match', () => {
+      expect(
+        hasSomeDataFence({
+          actualPermissions: null,
+          actualDataFences: {
+            store: {
+              orders: {
+                canViewOrders: {
+                  values: ['store-1'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ManageOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
+        })
+      ).toBe(false);
+    });
+  });
   describe('no value from demanded data fence exists in actual data fence values', () => {
     it('should indicate that the data fence does not match', () => {
       expect(

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -33,7 +33,7 @@ describe('hasPermission', () => {
       demandedPermission = 'ManageProducts';
       actualPermissions = { canManageProducts: true };
     });
-    it('should indicate the permission the permission matches', () => {
+    it('should indicate the permission matches', () => {
       expect(hasPermission(demandedPermission, actualPermissions)).toBe(true);
     });
   });
@@ -48,7 +48,7 @@ describe('hasPermission', () => {
           canManageProducts: true,
         };
       });
-      it('should indicate the permission the permission matches', () => {
+      it('should indicate the permission matches', () => {
         expect(hasPermission(demandedPermission, actualPermissions)).toBe(true);
       });
     });
@@ -77,7 +77,7 @@ describe('hasPermission', () => {
           canManageProducts: true,
         };
       });
-      it('should indicate the permission the permission matches', () => {
+      it('should indicate the permission matches', () => {
         expect(hasPermission(demandedPermission, actualPermissions)).toBe(true);
       });
     });
@@ -98,7 +98,7 @@ describe('hasPermission', () => {
 });
 
 describe('hasEveryPermission', () => {
-  it('should indicate the permission the permission matches if every demanded permission match', () => {
+  it('should indicate the permission matches if every demanded permission matches', () => {
     expect(
       hasEveryPermissions(['ViewProducts', 'ManageOrders'], {
         canViewProducts: true,
@@ -117,7 +117,7 @@ describe('hasEveryPermission', () => {
 });
 
 describe('hasSomePermissions', () => {
-  it('should indicate the permission the permission matches if at least one demanded permission matches', () => {
+  it('should indicate the permission matches if at least one demanded permission matches', () => {
     expect(
       hasSomePermissions(['ViewProducts', 'ManageOrders'], {
         canViewProducts: true,
@@ -125,7 +125,7 @@ describe('hasSomePermissions', () => {
       })
     ).toBe(true);
   });
-  it('should indicate that the permission does not match if none of the demanded permissions match', () => {
+  it('should indicate that the permission does not match if none of the demanded permissions matches', () => {
     expect(
       hasSomePermissions(['ViewCustomers'], {
         canViewProducts: true,
@@ -144,7 +144,7 @@ describe('hasActionRight', () => {
       demandedActionRight = { group: 'products', name: 'EditPrices' };
       actualActionRights = { products: { canEditPrices: true } };
     });
-    it('should indicate the permission the permission matches', () => {
+    it('should indicate the permission matches', () => {
       expect(hasActionRight(demandedActionRight, actualActionRights)).toBe(
         true
       );
@@ -177,7 +177,7 @@ describe('hasActionRight', () => {
 });
 
 describe('hasEveryActionRight', () => {
-  it('should indicate the permission the permission matches if every demanded action rights match', () => {
+  it('should indicate the permission matches if every demanded action rights matches', () => {
     expect(
       hasEveryActionRight(
         [

--- a/packages/permissions/src/utils/has-permissions.spec.tsx
+++ b/packages/permissions/src/utils/has-permissions.spec.tsx
@@ -216,7 +216,7 @@ describe('hasEveryActionRight', () => {
 });
 
 describe('hasSomeDataFence', () => {
-  describe('user has not data fence permissions', () => {
+  describe('user has no data fence permissions', () => {
     it('should indicate that the permission does not match', () => {
       expect(
         hasSomeDataFence({
@@ -301,6 +301,32 @@ describe('hasSomeDataFence', () => {
             store: {
               orders: {
                 canViewOrders: {
+                  values: ['store-1'],
+                },
+              },
+            },
+          },
+          demandedDataFences: [
+            {
+              type: 'store',
+              group: 'orders',
+              name: 'ViewOrders',
+            },
+          ],
+          selectDataFenceData: () => ['store-1'],
+        })
+      ).toBe(true);
+    });
+  });
+  describe('inferred data fences permission exist in actual data fences', () => {
+    it('should indicate that the data fence matches', () => {
+      expect(
+        hasSomeDataFence({
+          actualPermissions: null,
+          actualDataFences: {
+            store: {
+              orders: {
+                canManageOrders: {
                   values: ['store-1'],
                 },
               },

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -66,7 +66,11 @@ type TOptionsForAppliedDataFence = {
 
 // Build the permission key from the definition to match it to the format coming
 // from the API.
+const getIsViewPermission = (demandedPermission: TPermissionName) =>
+  demandedPermission.startsWith('View');
 const toCanCase = (permissionName: TPermissionName) => `can${permissionName}`;
+const toManageCase = (permissionName: TPermissionName) =>
+  permissionName.replace('View', 'Manage');
 
 // Check that the user permissions match EXACTLY the required permission.
 // The shapes of the arguments are:
@@ -79,8 +83,10 @@ const hasExactPermission = (
   actualPermissions: TPermissions
 ) => actualPermissions[toCanCase(demandedPermission)];
 
-const getIsViewPermission = (demandedPermission: TPermissionName) =>
-  demandedPermission.startsWith('View');
+const getInferredManagePermission = (
+  demandedPermission: TPermissionName,
+  actualPermissions: TPermissions
+) => actualPermissions[toCanCase(toManageCase(demandedPermission))];
 
 // Check that the user permissions match the required MANAGE permission.
 // The shapes of the arguments are:
@@ -96,7 +102,7 @@ const doesManagePermissionInferViewPermission = (
     demandedPermission
   );
   const isViewPermissionInferredByManagePermission = Boolean(
-    actualPermissions[toCanCase(demandedPermission.replace('View', 'Manage'))]
+    getInferredManagePermission(demandedPermission, actualPermissions)
   );
 
   return (
@@ -115,7 +121,7 @@ export const getImpliedPermissions = (
     permission.startsWith('View')
   );
   const impliedPermissions = viewPermissions.filter(viewPermission =>
-    permissions.includes(viewPermission.replace('View', 'Manage'))
+    permissions.includes(toManageCase(viewPermission))
   );
 
   return impliedPermissions;
@@ -313,10 +319,17 @@ export const hasSomeDataFence = (options: TOptionsForAppliedDataFence) => {
       // we try to find if the demanded dataFence is available inside the actual datafences
       const specificActualDataFence = Object.entries(
         actualDataFenceByTypeAndGroup
-      ).find(
-        ([dataFenceName, dataFenceValue]) =>
-          dataFenceValue && dataFenceName === toCanCase(demandedDataFence.name)
-      );
+      ).find(([dataFenceName, dataFenceValue]) => {
+        // Either the manage permission matches or the
+        // a demanded view permission is implied by a manage permission.
+        const doesDataFenceMatchByName =
+          dataFenceName === toCanCase(demandedDataFence.name) ||
+          dataFenceName === toCanCase(toManageCase(demandedDataFence.name));
+
+        const doesDataFenceHaveValue = Boolean(dataFenceValue);
+
+        return doesDataFenceMatchByName && doesDataFenceHaveValue;
+      });
 
       if (!specificActualDataFence) return false;
 

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -64,11 +64,10 @@ type TOptionsForAppliedDataFence = {
   selectDataFenceData?: TSelectDataFenceData;
 };
 
-// Build the permission key from the definition to match it to the format coming
-// from the API.
+// Build the permission key from the definition to match it to the format coming from the API.
+const toCanCase = (permissionName: TPermissionName) => `can${permissionName}`;
 const getIsViewPermission = (demandedPermission: TPermissionName) =>
   demandedPermission.startsWith('View');
-const toCanCase = (permissionName: TPermissionName) => `can${permissionName}`;
 const toManageCase = (permissionName: TPermissionName) =>
   permissionName.replace('View', 'Manage');
 


### PR DESCRIPTION
#### Summary

This pull request fixes data fencing matching the inferred permission: view should be inferred by manage as with general permissions.

#### Description

I went commit by commit and review should also be possible as such.
