### PR TITLE
fix(app-shell): to read project key from url again when location changes

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -136,7 +136,7 @@ describe('when route does not contain a project key (e.g. /account)', () => {
     });
   });
 });
-describe('when user fist visits "/" with no projectKey defined in localStorage', () => {
+describe('when user first visits "/" with no projectKey defined in localStorage', () => {
   let operations;
   beforeEach(() => {
     operations = mocksForMc.createMockOperations();

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -26,7 +26,6 @@ import {
   ApplicationNavbarMenuMock,
   ApplicationNavbarSubmenuMock,
 } from '../../../../../graphql-test-utils';
-import selectProjectKeyFromUrl from '../../utils/select-project-key-from-url';
 import { createApolloClient } from '../../configure-apollo';
 import { STORAGE_KEYS } from '../../constants';
 import { PROJECT_EXTENSIONS } from '../../feature-toggles';
@@ -34,7 +33,6 @@ import ApplicationShellProvider from '../application-shell-provider';
 import ApplicationShell from './application-shell';
 
 jest.mock('@commercetools-frontend/sentry');
-jest.mock('../../utils/select-project-key-from-url');
 
 const createTestProps = props => ({
   environment: {
@@ -122,7 +120,7 @@ describe('when rendering', () => {
     await rendered.findByText('Application name: my-app');
   });
 });
-describe('when route does not contain a project key', () => {
+describe('when route does not contain a project key (e.g. /account)', () => {
   beforeEach(() => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: mocksForMc.createMockOperations() },
@@ -136,6 +134,25 @@ describe('when route does not contain a project key', () => {
       expect(rendered.history.location.pathname).toBe('/account');
       expect(rendered.queryByTestId('left-navigation')).not.toBeInTheDocument();
     });
+  });
+});
+describe('when user fist visits "/" with no projectKey defined in localStorage', () => {
+  let operations;
+  beforeEach(() => {
+    operations = mocksForMc.createMockOperations();
+    createGraphqlMockServer(xhrMock, {
+      operationsByTarget: { mc: operations },
+    });
+  });
+  it('should not render the NavBar first, then redirect to "/:projectKey" and render the NavBar', async () => {
+    const rendered = renderApp();
+    await wait(() => {
+      // Redirect "/" -> "/:projectKey"
+      expect(rendered.history.location.pathname).toBe(
+        `/${operations.FetchProject.project.key}`
+      );
+    });
+    expect(rendered.queryByTestId('left-navigation')).toBeInTheDocument();
   });
 });
 describe('when user has no default project', () => {
@@ -456,9 +473,6 @@ describe('when switching project', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should render app for new project', async () => {
     const rendered = renderApp(
@@ -643,9 +657,6 @@ describe('when clicking on navbar menu toggle', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should expand and collapse menu', async () => {
     const rendered = renderApp();
@@ -706,9 +717,6 @@ describe('navbar menu links interactions', () => {
       createGraphqlMockServer(xhrMock, {
         operationsByTarget: { mc: operations },
       });
-      selectProjectKeyFromUrl.mockReturnValue(
-        operations.FetchLoggedInUser.me.defaultProjectKey
-      );
     });
     it('should render links with all the correct state attributes', async () => {
       const navbarSubmenuMock = ApplicationNavbarSubmenuMock.build();
@@ -745,9 +753,6 @@ describe('navbar menu links interactions', () => {
       createGraphqlMockServer(xhrMock, {
         operationsByTarget: { mc: mcOperations, proxy: proxyOperations },
       });
-      selectProjectKeyFromUrl.mockReturnValue(
-        mcOperations.FetchLoggedInUser.me.defaultProjectKey
-      );
     });
     it('should render links with all the correct state attributes', async () => {
       const rendered = renderApp(null, {
@@ -787,9 +792,6 @@ describe('navbar menu links interactions', () => {
           settings: settingsOperations,
         },
       });
-      selectProjectKeyFromUrl.mockReturnValue(
-        mcOperations.FetchLoggedInUser.me.defaultProjectKey
-      );
     });
     it('should render links with all the correct state attributes', async () => {
       const rendered = renderApp(null, {
@@ -822,9 +824,6 @@ describe('when navbar menu items are disabled', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should not render disabled menu items', async () => {
     const navbarSubmenuMock = ApplicationNavbarSubmenuMock.build();
@@ -866,9 +865,6 @@ describe('when navbar menu items are hidden', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should not render hidden menu items', async () => {
     const navbarSubmenuMock = ApplicationNavbarSubmenuMock.build({
@@ -912,9 +908,6 @@ describe('when navbar menu items match given permissions', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should render item', async () => {
     const navbarMock = ApplicationNavbarMenuMock.build({
@@ -950,9 +943,6 @@ describe('when navbar menu items do not match given permissions', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should not render item', async () => {
     const navbarMock = ApplicationNavbarMenuMock.build({
@@ -999,9 +989,6 @@ describe('when navbar menu items match given action rights', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should render item', async () => {
     const navbarMock = ApplicationNavbarMenuMock.build({
@@ -1045,9 +1032,6 @@ describe('when navbar menu items do not match given action rights', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should not render item', async () => {
     const navbarMock = ApplicationNavbarMenuMock.build({
@@ -1097,9 +1081,6 @@ describe('when navbar menu items match given data fences', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should render item', async () => {
     const navbarMock = ApplicationNavbarMenuMock.build({
@@ -1151,9 +1132,6 @@ describe('when navbar menu items do not match given data fences', () => {
     createGraphqlMockServer(xhrMock, {
       operationsByTarget: { mc: operations },
     });
-    selectProjectKeyFromUrl.mockReturnValue(
-      operations.FetchLoggedInUser.me.defaultProjectKey
-    );
   });
   it('should not render item', async () => {
     const navbarMock = ApplicationNavbarMenuMock.build({

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -142,6 +142,11 @@ export const RestrictedApplication = <
     'onRegisterErrorListeners'
   >
 ) => {
+  // TODO: using this hook will subscribe the component to route updates.
+  // This is currently useful for detecting a change in the project key
+  // from URL ("/" --> "/:projectKey").
+  // However, every route change will trigger a re-render. This is probably
+  // ok-ish but we might want to look into a more performant solution.
   const location = useLocation();
   return (
     <FetchUser>

--- a/packages/application-shell/src/components/quick-access/index.tsx
+++ b/packages/application-shell/src/components/quick-access/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import * as gtm from '../../utils/gtm';
 import ErrorBoundary from '../error-boundary';
 import trackingEvents from './tracking-events';
@@ -98,12 +97,11 @@ const QuickAccessTrigger = (props: Props) => {
       document.removeEventListener('keydown', keyHandler);
     };
   }, [keyHandler]);
-  const location = useLocation();
 
   if (!isVisible) return null;
 
   return (
-    <ErrorBoundary pathname={location.pathname}>
+    <ErrorBoundary>
       <React.Suspense fallback={<ButlerContainer tabIndex={-1} />}>
         <QuickAccess
           pimIndexerState={pimIndexerState}

--- a/playground/src/components/state-machines-details/state-machines-details.js
+++ b/playground/src/components/state-machines-details/state-machines-details.js
@@ -99,7 +99,7 @@ const StateMachinesDetails = props => {
               />
               <Spacings.Stack scale="xs">
                 <Text.Headline as="h2">
-                  {data.name ? data.name[dataLocale] : 'n/a'}
+                  {(data.name && data.name[dataLocale]) || 'n/a'}
                 </Text.Headline>
                 <Text.Detail>{data.key}</Text.Detail>
               </Spacings.Stack>
@@ -112,9 +112,9 @@ const StateMachinesDetails = props => {
                   <Text.Body>{'Type'}</Text.Body>
                   <Text.Body>{data.type}</Text.Body>
                   <Text.Body>{'Built In'}</Text.Body>
-                  <Text.Body>{data.builtIn ? <CheckBoldIcon /> : ''}</Text.Body>
+                  <span>{data.builtIn ? <CheckBoldIcon /> : ''}</span>
                   <Text.Body>{'Initial'}</Text.Body>
-                  <Text.Body>{data.initial ? <CheckBoldIcon /> : ''}</Text.Body>
+                  <span>{data.initial ? <CheckBoldIcon /> : ''}</span>
                 </Grid>
               </Constraints.Horizontal>
             </Spacings.Stack>


### PR DESCRIPTION
I noticed that on the very first load of the page, where your localStorage is empty, the NavBar does not get rendered.
This is because the appshell does not render it when there is no "projectKey" in the URL.
However, when you open the MC at `/`, we then redirect you to a project `/:projectKey`.
The redirect works, but the part of the appshell where we read `selectProjectKeyFromUrl` does not re-render.

This PR adds a `useLocation` so that changes in the routes always cause a re-render.