### PR TITLE
fix(application-menu): pass `useFullRedirectsForLinks` to ApplicationMenu

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -393,7 +393,7 @@ type ApplicationMenuProps = {
   applicationLocale: string;
   projectKey: string;
   disabledMenuItems?: string[];
-  useFullRedirectsForLinks?: boolean;
+  useFullRedirectsForLinks: boolean;
   onMenuItemClick?: MenuItemLinkProps['onClick'];
 };
 const ApplicationMenu = (props: ApplicationMenuProps) => {
@@ -569,6 +569,10 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
     DEV_ONLY__loadNavbarMenuConfig: props.DEV_ONLY__loadNavbarMenuConfig,
   });
   const disabledMenuItems = props.environment.disabledMenuItems;
+  const useFullRedirectsForLinks = Boolean(
+    props.environment.useFullRedirectsForLinks
+  );
+
   const menuVisibilities = useApplicationContext(
     context => context.menuVisibilities
   );
@@ -595,6 +599,7 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
                 applicationLocale={props.applicationLocale}
                 projectKey={props.projectKey}
                 disabledMenuItems={disabledMenuItems}
+                useFullRedirectsForLinks={useFullRedirectsForLinks}
               />
             );
           })}


### PR DESCRIPTION

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

`ApplicationMenu` expects `useFullRedirectsForLinks` https://github.com/commercetools/merchant-center-application-kit/blob/729b3104e952859521f27fd6f20eafabfca23973/packages/application-shell/src/components/navbar/navbar.tsx#L452 to let the menu items do a full redirect (so that the user gets redirected to the desired app )

But it's not passed https://github.com/commercetools/merchant-center-application-kit/blob/729b3104e952859521f27fd6f20eafabfca23973/packages/application-shell/src/components/navbar/navbar.tsx#L585


it was passed before here
https://github.com/commercetools/merchant-center-application-kit/pull/1069/files#diff-c897db78ece71d0d6d70adc9a40d41e4L776