### PR TITLE
chore(actions): skip workflow if CHANGELOG file changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,11 @@ on:
   push:
     branches:
     - master
+    paths-ignore:
+    - 'CHANGELOG.md'
   pull_request:
+    paths-ignore:
+    - 'CHANGELOG.md'
 
 jobs:
   build_lint_and_test:


### PR DESCRIPTION
This might help when we prepare a release changelog, as we don't need to run the workflow for those PRs.

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-ignoring-paths
