### PR TITLE
refactor: to suggest using new url schemes and change docs and cors

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 GITHUB_AUTH= # for lerna changelog
 AUTH_TOKEN= # for github labels
-MC_API_URL=https://mc-api.commercetools.com/graphql
+MC_API_URL=https://mc-api.europe-west1.gcp.commercetools.com/graphql
 MC_PROXY_URL=https://mc.commercetools.com/api/graphql
 MC_ACCESS_TOKEN= # for schema introspection
 CTP_PROJECT_KEY=mc-e2e-app-kit-01 # one of your CTP projects where you have access to

--- a/application-templates/starter/env.json
+++ b/application-templates/starter/env.json
@@ -1,7 +1,7 @@
 {
   "applicationName": "merchant-center-application-template-starter",
   "frontendHost": "localhost:3001",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "development",
   "cdnUrl": "http://localhost:3001",

--- a/packages/application-shell-connectors/src/components/application-context/README.md
+++ b/packages/application-shell-connectors/src/components/application-context/README.md
@@ -43,7 +43,7 @@ The following are common fields defined in `env.json`. However, each application
 
 - `applicationName`: the name of the application (usually the same as in the `package.json`)
 - `frontendHost`: the host where the Merchant Center application is running (e.g. `mc.commercetools.com`)
-- `mcApiUrl`: the API URL of the Merchant Center (`https://mc-api.commercetools.com` for projects in `EU` and `https://mc-api.commercetools.co` for projects in `US`)
+- `mcApiUrl`: the API URL of the Merchant Center (`https://mc-api.europe-west1.gcp.commercetools.com` for projects in `EU` and `https://mc-api.us-central1.gcp.commercetools.com` for projects in `US`)
 - `location`: the location where the Merchant Center is running, usually `eu` or `us`
 - `env`: the environment where the Merchant Center is running, usually `production` or `staging`
 - `cdnUrl`: the URL where the static assets are stored

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -71,7 +71,7 @@ const createTestEnvironment = (
   revision: '1',
   applicationName: 'my-app',
   frontendHost: 'localhost:3001',
-  mcApiUrl: 'https://mc-api.commercetools.com',
+  mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
   location: 'eu',
   env: 'development',
   cdnUrl: 'http://localhost:3001',

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
@@ -23,7 +23,7 @@ const createTestProps = props => ({
   environment: {
     applicationName: 'my-app',
     frontendHost: 'localhost:3001',
-    mcApiUrl: 'https://mc-api.commercetools.com',
+    mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
     location: 'eu',
     env: 'development',
     cdnUrl: 'http://localhost:3001',

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -38,7 +38,7 @@ const createTestProps = props => ({
   environment: {
     applicationName: 'my-app',
     frontendHost: 'localhost:3001',
-    mcApiUrl: 'https://mc-api.commercetools.com',
+    mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
     location: 'eu',
     env: 'development',
     cdnUrl: 'http://localhost:3001',

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -234,7 +234,7 @@ describe('ApplicationContext', () => {
       expect(environment).toEqual(
         expect.objectContaining({
           frontendHost: 'localhost:3001',
-          mcApiUrl: 'https://mc-api.commercetools.com',
+          mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
           location: 'eu',
           env: 'production',
           cdnUrl: 'http://localhost:3001',

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -94,7 +94,7 @@ const defaultUser = {
 const defaultEnvironment = {
   applicationName: 'my-app',
   frontendHost: 'localhost:3001',
-  mcApiUrl: 'https://mc-api.commercetools.com',
+  mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
   location: 'eu',
   env: 'production',
   cdnUrl: 'http://localhost:3001',

--- a/packages/mc-html-template/lib/load-headers.js
+++ b/packages/mc-html-template/lib/load-headers.js
@@ -83,6 +83,8 @@ module.exports = (env, options) => {
       ),
       'connect-src': [
         "'self'",
+        'mc-api.europe-west1.gcp.commercetools.com',
+        'mc-api.us-central1.gcp.commercetools.com',
         'mc-api.commercetools.com',
         'mc-api.commercetools.co',
         'app.launchdarkly.com',

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -73,7 +73,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         revision: '1',
         applicationName: 'my-app',
         frontendHost: 'localhost:3001',
-        mcApiUrl: 'https://mc-api.commercetools.com',
+        mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
         location: 'eu',
         env: 'development',
         cdnUrl: 'http://localhost:3001',

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -71,7 +71,7 @@ const testRender = ({
         revision: '1',
         applicationName: 'my-app',
         frontendHost: 'localhost:3001',
-        mcApiUrl: 'https://mc-api.commercetools.com',
+        mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
         location: 'eu',
         env: 'production',
         cdnUrl: 'http://localhost:3001',

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -116,7 +116,7 @@ const render = ({
         revision: '1',
         applicationName: 'my-app',
         frontendHost: 'localhost:3001',
-        mcApiUrl: 'https://mc-api.commercetools.com',
+        mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
         location: 'eu',
         env: 'production',
         cdnUrl: 'http://localhost:3001',

--- a/playground/README.md
+++ b/playground/README.md
@@ -42,7 +42,7 @@ A project for developing a Merchant Center Application usually consists of the f
 - `env.json` contains runtime configuration available as a global state `window.app`. The object has to be passed to the `<ApplicationShell>` as `environment` prop. The object can contain any configuration specific to the application, plus the following **required** fields:
   - `applicationName`: the name of the application (usually the same as in`package.json`)
   - `frontendHost`: the host where the Merchant Center application is running (e.g. `mc.commercetools.com`)
-  - `mcApiUrl`: the API URL of the Merchant Center (`https://mc-api.commercetools.com` for projects in `EU` and `https://mc-api.commercetools.co` for projects in `US`)
+  - `mcApiUrl`: the API URL of the Merchant Center (`https://mc-api.europe-west1.gcp.commercetools.com` for projects in `EU` and `https://mc-api.us-central1.gcp.commercetools.com` for projects in `US`)
   - `location`: the location where the Merchant Center is running, usually `eu` or `us`
   - `env`: the environment where the Merchant Center is running, usually `production` or `staging`
   - `cdnUrl`: the URL where the static assets are stored
@@ -74,8 +74,8 @@ The Merchant Center runs on 2 different _data centers_: one in `EU` and one in `
 
 The **Merchant Center API** is available at the following domains:
 
-- for `EU`: `https://mc-api.commercetools.com`
-- for `US`: `https://mc-api.commercetools.co`
+- for `EU`: `https://mc-api.europe-west1.gcp.commercetools.com`
+- for `US`: `https://mc-api.us-central1.gcp.commercetools.com`
 
 The Merchant Center API mostly works as an **API Gateway** and exposes several entry points, like:
 

--- a/playground/env.json
+++ b/playground/env.json
@@ -1,7 +1,7 @@
 {
   "applicationName": "playground",
   "frontendHost": "localhost:3001",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "development",
   "cdnUrl": "http://localhost:3001",

--- a/playground/production-eu.env.json
+++ b/playground/production-eu.env.json
@@ -1,7 +1,7 @@
 {
   "applicationName": "playground-eu",
   "frontendHost": "mc.commercetools.com",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "production",
   "cdnUrl": "https://mc-app-state-machines-production-eu.now.sh",

--- a/playground/production-us.env.json
+++ b/playground/production-us.env.json
@@ -1,7 +1,7 @@
 {
   "applicationName": "playground-us",
   "frontendHost": "mc.commercetools.co",
-  "mcApiUrl": "https://mc-api.commercetools.co",
+  "mcApiUrl": "https://mc-api.us-central1.gcp.commercetools.com",
   "location": "us",
   "env": "production",
   "cdnUrl": "https://mc-app-state-machines-production-us.now.sh",

--- a/schemas/ctp.json
+++ b/schemas/ctp.json
@@ -58592,7 +58592,7 @@
   },
   "extensions": {
     "graphql-config": {
-      "source": "https://mc-api.commercetools.com/graphql",
+      "source": "https://mc-api.europe-west1.gcp.commercetools.com/graphql",
       "timestamp": "Fri Jan 24 2020 11:39:35 GMT+0100 (Central European Standard Time)"
     }
   }

--- a/schemas/mc.json
+++ b/schemas/mc.json
@@ -6117,7 +6117,7 @@
   },
   "extensions": {
     "graphql-config": {
-      "source": "https://mc-api.commercetools.com/graphql",
+      "source": "https://mc-api.europe-west1.gcp.commercetools.com/graphql",
       "timestamp": "Fri Jan 24 2020 11:37:47 GMT+0100 (Central European Standard Time)"
     }
   }

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -12704,7 +12704,7 @@
   },
   "extensions": {
     "graphql-config": {
-      "source": "https://mc-api.commercetools.com/graphql",
+      "source": "https://mc-api.europe-west1.gcp.commercetools.com/graphql",
       "timestamp": "Tue Dec 31 2019 16:44:28 GMT+0100 (Central European Standard Time)"
     }
   }

--- a/website/src/content/deployment/example-deployment-aws-s3-cloudfront.mdx
+++ b/website/src/content/deployment/example-deployment-aws-s3-cloudfront.mdx
@@ -347,7 +347,7 @@ First, you need to create an `env.prod.json` file with the following JSON:
 {
   "applicationName": "my-app",
   "frontendHost": "mc.commercetools.co",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "production",
   "cdnUrl": "https://[cloudfront-domain]",

--- a/website/src/content/deployment/example-deployment-firebase.mdx
+++ b/website/src/content/deployment/example-deployment-firebase.mdx
@@ -127,7 +127,7 @@ First, you need to create an `env.prod.json` file with the following JSON:
 {
   "applicationName": "my-app",
   "frontendHost": "mc.commercetools.co",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "production",
   "cdnUrl": "https://[projectID].firebaseapp.com",

--- a/website/src/content/deployment/example-deployment-now-v1.mdx
+++ b/website/src/content/deployment/example-deployment-now-v1.mdx
@@ -53,7 +53,7 @@ Next, we need to create an `env.prod.json` file with the following JSON:
 {
   "applicationName": "my-app",
   "frontendHost": "mc-examples-starter.now.sh",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "production",
   "cdnUrl": "http://mc-examples-starter.now.sh",

--- a/website/src/content/deployment/runtime-configuration.mdx
+++ b/website/src/content/deployment/runtime-configuration.mdx
@@ -45,7 +45,7 @@ An example configuration for local development:
 {
   "applicationName": "merchant-center-application-template-starter",
   "frontendHost": "localhost:3001",
-  "mcApiUrl": "https://mc-api.commercetools.com",
+  "mcApiUrl": "https://mc-api.europe-west1.gcp.commercetools.com",
   "location": "eu",
   "env": "development",
   "cdnUrl": "http://localhost:3001",

--- a/website/src/content/main-concepts/api-gateway.mdx
+++ b/website/src/content/main-concepts/api-gateway.mdx
@@ -14,5 +14,5 @@ All Merchant Center applications should send requests through the API Gateway, w
 
 Official domains:
 
-- `https://mc-api.commercetools.com` for projects in **Europe** running on Google Cloud Platform
-- `https://mc-api.commercetools.co` for projects in the **United States** running on Google Cloud Platform
+- `https://mc-api.europe-west1.gcp.commercetools.com` for projects in **Europe** running on Google Cloud Platform
+- `https://mc-api.us-central1.gcp.commercetools.com` for projects in the **United States** running on Google Cloud Platform

--- a/website/src/content/main-concepts/authentication.mdx
+++ b/website/src/content/main-concepts/authentication.mdx
@@ -35,7 +35,7 @@ fetch(`https://api.commercetools.com/${projectKey}/orders`, {
 });
 
 // Proxied request to the commercetools platform HTTP API
-fetch(`https://mc-api.commercetools.com/proxy/ctp/${projectKey}/orders`, {
+fetch(`https://mc-api.europe-west1.gcp.commercetools.com/proxy/ctp/${projectKey}/orders`, {
   method: 'GET',
   headers: { Accept: 'application/json' },
   credentials: 'include', // <-- this will send along the cookie "mcAccessToken"

--- a/website/src/content/main-concepts/proxy-endpoints.mdx
+++ b/website/src/content/main-concepts/proxy-endpoints.mdx
@@ -24,7 +24,7 @@ For example, to make requests to the [commercetools platform HTTP API](https://d
 
 ```js
 // Proxied request to the commercetools platform HTTP API
-fetch(`https://mc-api.commercetools.com/proxy/ctp/${projectKey}/orders`);
+fetch(`https://mc-api.europe-west1.gcp.commercetools.com/proxy/ctp/${projectKey}/orders`);
 
 // Underlying request to the commercetools platform HTTP API
 fetch(`https://api.commercetools.com/${projectKey}/orders`);

--- a/website/src/content/main-concepts/proxy-to-external-api.mdx
+++ b/website/src/content/main-concepts/proxy-to-external-api.mdx
@@ -20,7 +20,7 @@ Requests to your backend server should be configured as following:
 - define the original request URL to your backend server as an HTTP header `X-Forward-To`.
 
 ```js
-fetch(`https://mc-api.commercetools.com/proxy/forward-to`, {
+fetch(`https://mc-api.europe-west1.gcp.commercetools.com/proxy/forward-to`, {
   method: 'GET',
   headers: {
     Accept: 'application/json',
@@ -56,7 +56,7 @@ const jwksRsa = require('jwks-rsa');
 const app = express();
 
 // The issuer refers to the Merchant Center API Gateway URL.
-const issuer = 'https://mc-api.commercetools.com';
+const issuer = 'https://mc-api.europe-west1.gcp.commercetools.com';
 // The audience refers to the forwarded target URL (same value as in `X-Forward-To` header)
 const audience = 'https://my-custom-app.com/foo/bar';
 


### PR DESCRIPTION
#### Summary

This pull request changes the occurance of the urls suggested to be used in app-kit to match the new url schema.

#### Description

Of course the old urls will continue to work. However, I think it makes sense to

1. Suggest from the start to use the new urls
2. Amend them to our CORS rules (while eventually removing the old) to allow us to migrate local development environments

As a side note, all MC services already use the new hostnames internally.

Lastly, I suggest not to change the hostname of the MC frontend just yet. We should do that only _after_ the SSO users have migrated all their callback urls and added the new urls in to avoid non matching expectations.
