### PR TITLE
refactor(app-shell): sdk and apollo to fallback to build `mcApiUrl` from origin

### DIFF
--- a/packages/application-shell/src/configure-apollo.ts
+++ b/packages/application-shell/src/configure-apollo.ts
@@ -11,6 +11,7 @@ import {
 import { ApplicationWindow } from '@commercetools-frontend/constants';
 import createHttpUserAgent from '@commercetools/http-user-agent';
 import { errorLink, headerLink, tokenRetryLink } from './apollo-links';
+import { getMcApiUrl } from './utils';
 import { isLoggerEnabled } from './utils/logger';
 import version from './version';
 
@@ -30,7 +31,7 @@ const userAgent = createHttpUserAgent({
 });
 
 const httpLink = createHttpLink({
-  uri: `${window.app.mcApiUrl}/graphql`,
+  uri: `${getMcApiUrl()}/graphql`,
   headers: {
     accept: 'application/json',
     'x-user-agent': userAgent,

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -8,7 +8,7 @@ export { applyDefaultMiddlewares } from './configure-store';
 export { default as InjectReducers } from './components/inject-reducers';
 export { default as RouteCatchAll } from './components/route-catch-all';
 export { default as setupGlobalErrorListener } from './utils/setup-global-error-listener';
-export { selectUserId, selectProjectKeyFromUrl, getMcApiUrl } from './utils';
+export { selectUserId, selectProjectKeyFromUrl } from './utils';
 export { GtmContext } from './components/gtm-booter';
 export { default as GtmUserLogoutTracker } from './components/gtm-user-logout-tracker';
 export { default as SetupFlopFlipProvider } from './components/setup-flop-flip-provider';

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -8,7 +8,7 @@ export { applyDefaultMiddlewares } from './configure-store';
 export { default as InjectReducers } from './components/inject-reducers';
 export { default as RouteCatchAll } from './components/route-catch-all';
 export { default as setupGlobalErrorListener } from './utils/setup-global-error-listener';
-export { selectUserId, selectProjectKeyFromUrl } from './utils';
+export { selectUserId, selectProjectKeyFromUrl, getMcApiUrl } from './utils';
 export { GtmContext } from './components/gtm-booter';
 export { default as GtmUserLogoutTracker } from './components/gtm-user-logout-tracker';
 export { default as SetupFlopFlipProvider } from './components/setup-flop-flip-provider';

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -1,0 +1,9 @@
+import getMcApiUrl from './get-mc-api-url';
+
+describe('getMcApiUrl', () => {
+  let mcApiUrl;
+
+  beforeEach(() => {
+    mcApiUrl = getMcApiUrl();
+  });
+});

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -1,9 +1,15 @@
 import getMcApiUrl from './get-mc-api-url';
 
 describe('getMcApiUrl', () => {
-  let mcApiUrl;
+  describe('when `mcApiurl` is defined on application environment', () => {
+    it('should return the configured `mcApiUrl`', () => {
+      const applicationEnvironment = {
+        mcApiUrl: 'mc.commercetools.co',
+      };
 
-  beforeEach(() => {
-    mcApiUrl = getMcApiUrl();
+      expect(getMcApiUrl(applicationEnvironment)).toEqual(
+        applicationEnvironment.mcApiUrl
+      );
+    });
   });
 });

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -2,47 +2,30 @@ import getMcApiUrl from './get-mc-api-url';
 
 describe('getMcApiUrl', () => {
   describe('when application is configured not to run behind proxy', () => {
-    describe('when `mcApiurl` is defined on application environment', () => {
-      it('should return the configured `mcApiUrl`', () => {
-        const applicationEnvironment = {
+    it('should return the configured `mcApiUrl`', () => {
+      const actualWindow = {
+        app: {
           mcApiUrl: 'mc.commercetools.co',
-        };
+        },
+      };
 
-        expect(getMcApiUrl(applicationEnvironment)).toEqual(
-          applicationEnvironment.mcApiUrl
-        );
-      });
+      expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
     });
   });
 
   describe('when application is configured to run behind proxy', () => {
-    beforeEach(() => {
-      global.window.origin = 'https://mc.europe-west1.gcp.commercetools.com';
-    });
-
-    describe('when `mcApiurl` is defined on application environment', () => {
-      it('should not return the configured `mcApiUrl` but the origin of the window', () => {
-        const applicationEnvironment = {
+    it('should not return the configured `mcApiUrl` but the origin of the window', () => {
+      const actualWindow = {
+        app: {
           mcApiUrl: 'mc.commercetools.co',
           servedByProxy: 'true',
-        };
+        },
+        origin: 'https://mc.europe-west1.gcp.commercetools.com',
+      };
 
-        expect(getMcApiUrl(applicationEnvironment)).toEqual(
-          applicationEnvironment.mcApiUrl
-        );
-      });
-    });
-
-    describe('when `mcApiurl` is not defined on application environment', () => {
-      it('should not return an api url based on the origin of the window', () => {
-        const applicationEnvironment = {
-          servedByProxy: 'true',
-        };
-
-        expect(getMcApiUrl(applicationEnvironment)).toEqual(
-          'https://mc-api.europe-west1.gcp.commercetools.com'
-        );
-      });
+      expect(getMcApiUrl(actualWindow)).toEqual(
+        'https://mc-api.europe-west1.gcp.commercetools.com'
+      );
     });
   });
 });

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -24,7 +24,7 @@ describe('getMcApiUrl', () => {
       it('should not return the configured `mcApiUrl` but the origin of the window', () => {
         const applicationEnvironment = {
           mcApiUrl: 'mc.commercetools.co',
-          servedByProxy: true,
+          servedByProxy: 'true',
         };
 
         expect(getMcApiUrl(applicationEnvironment)).toEqual(
@@ -36,7 +36,7 @@ describe('getMcApiUrl', () => {
     describe('when `mcApiurl` is not defined on application environment', () => {
       it('should not return an api url based on the origin of the window', () => {
         const applicationEnvironment = {
-          servedByProxy: true,
+          servedByProxy: 'true',
         };
 
         expect(getMcApiUrl(applicationEnvironment)).toEqual(

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -17,7 +17,7 @@ describe('getMcApiUrl', () => {
 
   describe('when application is configured to run behind proxy', () => {
     beforeEach(() => {
-      global.window.origin = 'mc-api.europe-west1.gcp.commercetools.com';
+      global.window.origin = 'https://mc.europe-west1.gcp.commercetools.com';
     });
 
     describe('when `mcApiurl` is defined on application environment', () => {
@@ -34,12 +34,14 @@ describe('getMcApiUrl', () => {
     });
 
     describe('when `mcApiurl` is not defined on application environment', () => {
-      it('should not return the origin of the window', () => {
+      it('should not return an api url based on the origin of the window', () => {
         const applicationEnvironment = {
           servedByProxy: true,
         };
 
-        expect(getMcApiUrl(applicationEnvironment)).toEqual(window.origin);
+        expect(getMcApiUrl(applicationEnvironment)).toEqual(
+          'https://mc-api.europe-west1.gcp.commercetools.com'
+        );
       });
     });
   });

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -1,15 +1,46 @@
 import getMcApiUrl from './get-mc-api-url';
 
 describe('getMcApiUrl', () => {
-  describe('when `mcApiurl` is defined on application environment', () => {
-    it('should return the configured `mcApiUrl`', () => {
-      const applicationEnvironment = {
-        mcApiUrl: 'mc.commercetools.co',
-      };
+  describe('when application is configured not to run behind proxy', () => {
+    describe('when `mcApiurl` is defined on application environment', () => {
+      it('should return the configured `mcApiUrl`', () => {
+        const applicationEnvironment = {
+          mcApiUrl: 'mc.commercetools.co',
+        };
 
-      expect(getMcApiUrl(applicationEnvironment)).toEqual(
-        applicationEnvironment.mcApiUrl
-      );
+        expect(getMcApiUrl(applicationEnvironment)).toEqual(
+          applicationEnvironment.mcApiUrl
+        );
+      });
+    });
+  });
+
+  describe('when application is configured to run behind proxy', () => {
+    beforeEach(() => {
+      global.window.origin = 'mc-api.europe-west1.gcp.commercetools.com';
+    });
+
+    describe('when `mcApiurl` is defined on application environment', () => {
+      it('should not return the configured `mcApiUrl` but the origin of the window', () => {
+        const applicationEnvironment = {
+          mcApiUrl: 'mc.commercetools.co',
+          servedByProxy: true,
+        };
+
+        expect(getMcApiUrl(applicationEnvironment)).toEqual(
+          applicationEnvironment.mcApiUrl
+        );
+      });
+    });
+
+    describe('when `mcApiurl` is not defined on application environment', () => {
+      it('should not return the origin of the window', () => {
+        const applicationEnvironment = {
+          servedByProxy: true,
+        };
+
+        expect(getMcApiUrl(applicationEnvironment)).toEqual(window.origin);
+      });
     });
   });
 });

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -10,7 +10,7 @@ const getMcApiUrlFromOrigin = () => {
 };
 
 export default function getMcApiUrl(appEnv = window.app) {
-  const isServedByProxy = appEnv.servedByProxy;
+  const isServedByProxy = JSON.parse(appEnv.servedByProxy);
   const mcApiUrl = appEnv.mcApiUrl;
 
   if (isServedByProxy && !mcApiUrl) return getMcApiUrlFromOrigin();

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -3,5 +3,10 @@ import { ApplicationWindow } from '@commercetools-frontend/constants';
 declare let window: ApplicationWindow;
 
 export default function getMcApiUrl(appEnv = window.app) {
+  const isServedByProxy = appEnv.servedByProxy;
+  const mcApiUrl = appEnv.mcApiUrl;
+
+  if (isServedByProxy && !mcApiUrl) return window.origin;
+
   return appEnv.mcApiUrl;
 }

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -2,6 +2,6 @@ import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 declare let window: ApplicationWindow;
 
-export default function getMcApiUrl() {
-  return window.app.mcApiUrl;
+export default function getMcApiUrl(appEnv = window.app) {
+  return appEnv.mcApiUrl;
 }

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,6 +1,6 @@
 export interface ApplicationWindow extends Window {
   app: {
-    servedByProxy?: string;
+    servedByProxy: string | boolean;
     mcApiUrl: string;
   };
 }
@@ -24,7 +24,7 @@ declare let window: ApplicationWindow;
  *    2. MC: mc.europe-west1.gcp.commercetools.com with API: mc-api..commercetools.com
  *       -> Will not work as urls differ
  *
- *    Using the origin ensures that urls always match the the cookie is sent. Otherwise,
+ *    Using the origin ensures that urls always match with the cookie sent. Otherwise,
  *    the application shell will rightfully redirect to the logout page.
  */
 const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,0 +1,7 @@
+import { ApplicationWindow } from '@commercetools-frontend/constants';
+
+declare let window: ApplicationWindow;
+
+export default function getMcApiUrl() {
+  return window.app.mcApiUrl;
+}

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -2,11 +2,18 @@ import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 declare let window: ApplicationWindow;
 
+const getMcApiUrlFromOrigin = () => {
+  const url = new URL(window.origin);
+  const mcApiUrlHost = url.host.replace('mc.', 'mc-api.');
+
+  return `${url.protocol}//${mcApiUrlHost}`;
+};
+
 export default function getMcApiUrl(appEnv = window.app) {
   const isServedByProxy = appEnv.servedByProxy;
   const mcApiUrl = appEnv.mcApiUrl;
 
-  if (isServedByProxy && !mcApiUrl) return window.origin;
+  if (isServedByProxy && !mcApiUrl) return getMcApiUrlFromOrigin();
 
   return appEnv.mcApiUrl;
 }

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,19 +1,45 @@
-import { ApplicationWindow } from '@commercetools-frontend/constants';
+export interface ApplicationWindow extends Window {
+  app: {
+    servedByProxy?: string;
+    mcApiUrl: string;
+  };
+}
 
 declare let window: ApplicationWindow;
 
-const getMcApiUrlFromOrigin = () => {
-  const url = new URL(window.origin);
+/**
+ * NOTE:
+ *    Given the Merchant Center or Custom Application runs behind the proxy
+ *    then the `mcApiUrl` should be build using the origin on the window.
+ *
+ *    This allows the Merchant Center (or any Custom Appliction) to automatically
+ *    use an `mcApiUrl` which matches the respective url of the deployment.
+ *
+ *    This is particularily useful with the new and old hostnames for the Merchant Center.
+ *    When using the origin, it will be made sure that the authorization cookie will
+ *    always be sent as the appropriate API url is used.
+ *
+ *    1. MC: mc.commercetools.com with API: mc-api.europe-west1.gcp.commercetools.com
+ *       -> Will not work as urls differ
+ *    2. MC: mc.europe-west1.gcp.commercetools.com with API: mc-api..commercetools.com
+ *       -> Will not work as urls differ
+ *
+ *    Using the origin ensures that urls always match the the cookie is sent. Otherwise,
+ *    the application shell will rightfully redirect to the logout page.
+ */
+const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
+  const url = new URL(actualWindow.origin);
   const mcApiUrlHost = url.host.replace('mc.', 'mc-api.');
 
   return `${url.protocol}//${mcApiUrlHost}`;
 };
 
-export default function getMcApiUrl(appEnv = window.app) {
-  const isServedByProxy = JSON.parse(appEnv.servedByProxy);
-  const mcApiUrl = appEnv.mcApiUrl;
+export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
+  const isServedByProxy =
+    actualWindow.app.servedByProxy &&
+    JSON.parse(actualWindow.app.servedByProxy);
 
-  if (isServedByProxy && !mcApiUrl) return getMcApiUrlFromOrigin();
+  if (isServedByProxy) return getMcApiUrlFromOrigin(actualWindow);
 
-  return appEnv.mcApiUrl;
+  return actualWindow.app.mcApiUrl;
 }

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,6 +1,6 @@
 export interface ApplicationWindow extends Window {
   app: {
-    servedByProxy: string | boolean;
+    servedByProxy: string | boolean;
     mcApiUrl: string;
   };
 }
@@ -36,8 +36,8 @@ const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
 
 export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
   const isServedByProxy =
-    actualWindow.app.servedByProxy &&
-    JSON.parse(actualWindow.app.servedByProxy);
+    actualWindow.app.servedByProxy === true ||
+    actualWindow.app.servedByProxy === 'true';
 
   if (isServedByProxy) return getMcApiUrlFromOrigin(actualWindow);
 

--- a/packages/application-shell/src/utils/get-mc-api-url/index.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/index.ts
@@ -1,0 +1,1 @@
+export { default } from './get-mc-api-url';

--- a/packages/application-shell/src/utils/index.ts
+++ b/packages/application-shell/src/utils/index.ts
@@ -4,3 +4,4 @@ export { default as selectProjectKeyFromUrl } from './select-project-key-from-ur
 export { default as selectUserId } from './select-user-id';
 export { default as getCorrelationId } from './get-correlation-id';
 export { default as getPreviousProjectKey } from './get-previous-project-key';
+export { default as getMcApiUrl } from './get-mc-api-url';

--- a/packages/sdk/src/middleware/client.ts
+++ b/packages/sdk/src/middleware/client.ts
@@ -8,6 +8,7 @@ import { createHttpMiddleware as createSdkHttpMiddleware } from '@commercetools/
 import { createCorrelationIdMiddleware as createSdkCorrelationIdMiddleware } from '@commercetools/sdk-middleware-correlation-id';
 import createHttpUserAgent from '@commercetools/http-user-agent';
 import { ApplicationWindow } from '@commercetools-frontend/constants';
+import { getMcApiUrl } from '@commercetools-frontend/application-shell';
 import version from '../version';
 
 declare let window: ApplicationWindow;
@@ -37,7 +38,7 @@ const customUserAgentMiddleware = (next: Next): Next => (
 // NOTE we should not use these directly but rather have them passed in from
 // the application
 const httpMiddleware = createSdkHttpMiddleware({
-  host: window.app.mcApiUrl,
+  host: getMcApiUrl(),
   includeResponseHeaders: true,
   credentialsMode: 'include',
   fetch,

--- a/packages/sdk/src/middleware/client.ts
+++ b/packages/sdk/src/middleware/client.ts
@@ -8,7 +8,7 @@ import { createHttpMiddleware as createSdkHttpMiddleware } from '@commercetools/
 import { createCorrelationIdMiddleware as createSdkCorrelationIdMiddleware } from '@commercetools/sdk-middleware-correlation-id';
 import createHttpUserAgent from '@commercetools/http-user-agent';
 import { ApplicationWindow } from '@commercetools-frontend/constants';
-import { getMcApiUrl } from '@commercetools-frontend/application-shell';
+import { getMcApiUrl } from '../utils';
 import version from '../version';
 
 declare let window: ApplicationWindow;

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -1,1 +1,1 @@
-export { parseUri, logRequest } from './utils';
+export { parseUri, logRequest, getMcApiUrl } from './utils';

--- a/packages/sdk/src/utils/utils.spec.ts
+++ b/packages/sdk/src/utils/utils.spec.ts
@@ -1,5 +1,5 @@
 import { decode } from 'qss';
-import { parseUri } from './utils';
+import { parseUri, getMcApiUrl, ApplicationWindow } from './utils';
 
 type Result = { pathname: string; search: ReturnType<typeof decode> };
 
@@ -28,6 +28,38 @@ describe('parseUri', () => {
         foo: true,
         bar: 5,
       });
+    });
+  });
+});
+
+describe('getMcApiUrl', () => {
+  describe('when application is configured not to run behind proxy', () => {
+    it('should return the configured `mcApiUrl`', () => {
+      const actualWindow = {
+        app: {
+          mcApiUrl: 'mc.commercetools.co',
+        },
+      };
+
+      expect(getMcApiUrl(actualWindow as ApplicationWindow)).toEqual(
+        actualWindow.app.mcApiUrl
+      );
+    });
+  });
+
+  describe('when application is configured to run behind proxy', () => {
+    it('should not return the configured `mcApiUrl` but the origin of the window', () => {
+      const actualWindow = {
+        app: {
+          mcApiUrl: 'mc.commercetools.co',
+          servedByProxy: 'true',
+        },
+        origin: 'https://mc.europe-west1.gcp.commercetools.com',
+      };
+
+      expect(getMcApiUrl(actualWindow as ApplicationWindow)).toEqual(
+        'https://mc-api.europe-west1.gcp.commercetools.com'
+      );
     });
   });
 });

--- a/packages/sdk/src/utils/utils.ts
+++ b/packages/sdk/src/utils/utils.ts
@@ -52,7 +52,7 @@ export const logRequest = ({
 
 export interface ApplicationWindow extends Window {
   app: {
-    servedByProxy?: string;
+    servedByProxy: string | boolean;
     mcApiUrl: string;
   };
 }
@@ -88,8 +88,8 @@ const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
 
 export function getMcApiUrl(actualWindow: ApplicationWindow = window) {
   const isServedByProxy =
-    actualWindow.app.servedByProxy &&
-    JSON.parse(actualWindow.app.servedByProxy);
+    actualWindow.app.servedByProxy === true ||
+    actualWindow.app.servedByProxy === 'true';
 
   if (isServedByProxy) return getMcApiUrlFromOrigin(actualWindow);
 

--- a/packages/sdk/src/utils/utils.ts
+++ b/packages/sdk/src/utils/utils.ts
@@ -49,3 +49,49 @@ export const logRequest = ({
   if (error) logger.log('%cerror', `color: red; font-weight: bold;`, error);
   logger.groupEnd();
 };
+
+export interface ApplicationWindow extends Window {
+  app: {
+    servedByProxy?: string;
+    mcApiUrl: string;
+  };
+}
+
+declare let window: ApplicationWindow;
+
+/**
+ * NOTE:
+ *    Given the Merchant Center or Custom Application runs behind the proxy
+ *    then the `mcApiUrl` should be build using the origin on the window.
+ *
+ *    This allows the Merchant Center (or any Custom Appliction) to automatically
+ *    use an `mcApiUrl` which matches the respective url of the deployment.
+ *
+ *    This is particularily useful with the new and old hostnames for the Merchant Center.
+ *    When using the origin, it will be made sure that the authorization cookie will
+ *    always be sent as the appropriate API url is used.
+ *
+ *    1. MC: mc.commercetools.com with API: mc-api.europe-west1.gcp.commercetools.com
+ *       -> Will not work as urls differ
+ *    2. MC: mc.europe-west1.gcp.commercetools.com with API: mc-api..commercetools.com
+ *       -> Will not work as urls differ
+ *
+ *    Using the origin ensures that urls always match the the cookie is sent. Otherwise,
+ *    the application shell will rightfully redirect to the logout page.
+ */
+const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
+  const url = new URL(actualWindow.origin);
+  const mcApiUrlHost = url.host.replace('mc.', 'mc-api.');
+
+  return `${url.protocol}//${mcApiUrlHost}`;
+};
+
+export function getMcApiUrl(actualWindow: ApplicationWindow = window) {
+  const isServedByProxy =
+    actualWindow.app.servedByProxy &&
+    JSON.parse(actualWindow.app.servedByProxy);
+
+  if (isServedByProxy) return getMcApiUrlFromOrigin(actualWindow);
+
+  return actualWindow.app.mcApiUrl;
+}


### PR DESCRIPTION
#### Summary

This pull request suggests to change building the `mcApiUrl` from the window's origin if no `mcApiUrl` is defined and the app runs behind the proxy.

#### Description

Eventually the MC needs to be able to run on multiple hostnames (at least for some time). In GCP EU that means `https://mc-api.europe-west1.gcp.commercetools.com` and `https://mc-api.commercetools.com`.

This brings some challengens. Mainly around the cookie (yes cookie based auth ain't the best). 

```txt
Given you login on `mc.commercetools.com`
And your our app talks to `https://mc-api.europe-west1.gcp.commercetools.com` will log you out again
```

```txt
Given you login on `mc.europe-west1.gcp.commercetools.com`
And your our app talks to `https://mc-api.commercetools.com` will log you out again
```

This is rooted in the fact that the cookie is not valid for the different mc api domain and hence will not be sent. The MC API itself then logs out the user.

This is however unintended. As we don't want to configure two MC API urls on the env and switch between them I propose to

- Build the `mcApiUrl` from the `window.origin` only _and only if_ the app is `servedByProxy` and no `mcApiUrl` is defined

This allows us to

1. Keep Custom Applications be able to specify an `mcApiUrl` which is entirely different from what the "window runs on"
2. Keep us interally be able to overwrite the `mcApiUrl` and be backwards compatible as no change happens if the `mcApiUrl` is not removed