### PR TITLE
fix(tracking): infinite loop in getHierarchy

### DIFF
--- a/packages/application-shell/src/utils/gtm.ts
+++ b/packages/application-shell/src/utils/gtm.ts
@@ -146,17 +146,14 @@ export const trackProjectKey = (projectKey?: string) => {
 };
 
 // Sometimes necessary to manually get the hierarchy.
-export const getHierarchy = (node: Node) => {
+export const getHierarchy = (node: Node | null) => {
   const hierarchy = [];
   let parent = node;
 
   while (parent) {
     const dataTrackComponent = getDataAttribute(parent, 'data-track-component');
     if (dataTrackComponent) hierarchy.push(dataTrackComponent);
-
-    if (parent.parentNode) {
-      parent = parent.parentNode;
-    }
+    parent = parent.parentNode;
   }
 
   hierarchy.reverse();


### PR DESCRIPTION
When iterating over the parents until reaching `document`, `parent.parentNode` will evaluate to `null`, and because of the `if` statement, the `parent` variable will never get assigned `null`, which will result in never breaking the `while` loop.