### PR TITLE
chore: add skipping of mc api url inferring process

### DIFF
--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -34,7 +34,7 @@ describe('getMcApiUrl', () => {
           app: {
             mcApiUrl: 'https://mc-api.commercetools.co',
             servedByProxy: 'true',
-            skipInferringOfApiUrlOnProduction: 'true',
+            disableInferringOfMcApiUrlOnProduction: 'true',
           },
           origin: 'https://mc.europe-west1.gcp.commercetools.com',
         };

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -5,7 +5,7 @@ describe('getMcApiUrl', () => {
     it('should return the configured `mcApiUrl`', () => {
       const actualWindow = {
         app: {
-          mcApiUrl: 'mc.commercetools.co',
+          mcApiUrl: 'https://mc-api.commercetools.co',
         },
       };
 
@@ -17,7 +17,7 @@ describe('getMcApiUrl', () => {
     it('should not return the configured `mcApiUrl` but the origin of the window', () => {
       const actualWindow = {
         app: {
-          mcApiUrl: 'mc.commercetools.co',
+          mcApiUrl: 'https://mc-api.commercetools.co',
           servedByProxy: 'true',
         },
         origin: 'https://mc.europe-west1.gcp.commercetools.com',
@@ -26,6 +26,21 @@ describe('getMcApiUrl', () => {
       expect(getMcApiUrl(actualWindow)).toEqual(
         'https://mc-api.europe-west1.gcp.commercetools.com'
       );
+    });
+
+    describe('when inferring of `mcApiUrl` from origin is disabled', () => {
+      it('should return the configured `mcApiUrl`', () => {
+        const actualWindow = {
+          app: {
+            mcApiUrl: 'https://mc-api.commercetools.co',
+            servedByProxy: 'true',
+            skipInferringOfApiUrlOnProduction: 'true',
+          },
+          origin: 'https://mc.europe-west1.gcp.commercetools.com',
+        };
+
+        expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+      });
     });
   });
 });

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,6 +1,6 @@
 export interface ApplicationWindow extends Window {
   app: {
-    skipInferringOfApiUrlOnProduction: string | boolean;
+    disableInferringOfMcApiUrlOnProduction: string | boolean;
     servedByProxy: string | boolean;
     mcApiUrl: string;
   };
@@ -43,11 +43,11 @@ export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
   const isServedByProxy = isEnvironmentConfigurationEnabled(
     actualWindow.app.servedByProxy
   );
-  const isSkipInferringOfApiUrlOnProductionEnabled = isEnvironmentConfigurationEnabled(
-    actualWindow.app.skipInferringOfApiUrlOnProduction
+  const isInferringOfMcApiUrlOnProductionDisabled = isEnvironmentConfigurationEnabled(
+    actualWindow.app.disableInferringOfMcApiUrlOnProduction
   );
 
-  if (isServedByProxy && !isSkipInferringOfApiUrlOnProductionEnabled)
+  if (isServedByProxy && !isInferringOfMcApiUrlOnProductionDisabled)
     return getMcApiUrlFromOrigin(actualWindow);
 
   return actualWindow.app.mcApiUrl;

--- a/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,5 +1,6 @@
 export interface ApplicationWindow extends Window {
   app: {
+    skipInferringOfApiUrlOnProduction: string | boolean;
     servedByProxy: string | boolean;
     mcApiUrl: string;
   };
@@ -34,12 +35,20 @@ const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
   return `${url.protocol}//${mcApiUrlHost}`;
 };
 
-export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
-  const isServedByProxy =
-    actualWindow.app.servedByProxy === true ||
-    actualWindow.app.servedByProxy === 'true';
+const isEnvironmentConfigurationEnabled = (
+  environmentConfiguration: string | boolean
+) => environmentConfiguration === true || environmentConfiguration === 'true';
 
-  if (isServedByProxy) return getMcApiUrlFromOrigin(actualWindow);
+export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
+  const isServedByProxy = isEnvironmentConfigurationEnabled(
+    actualWindow.app.servedByProxy
+  );
+  const isSkipInferringOfApiUrlOnProductionEnabled = isEnvironmentConfigurationEnabled(
+    actualWindow.app.skipInferringOfApiUrlOnProduction
+  );
+
+  if (isServedByProxy && !isSkipInferringOfApiUrlOnProductionEnabled)
+    return getMcApiUrlFromOrigin(actualWindow);
 
   return actualWindow.app.mcApiUrl;
 }

--- a/packages/sdk/src/utils/utils.spec.ts
+++ b/packages/sdk/src/utils/utils.spec.ts
@@ -37,7 +37,7 @@ describe('getMcApiUrl', () => {
     it('should return the configured `mcApiUrl`', () => {
       const actualWindow = {
         app: {
-          mcApiUrl: 'mc.commercetools.co',
+          mcApiUrl: 'https://mc-api.commercetools.co',
         },
       };
 
@@ -51,7 +51,7 @@ describe('getMcApiUrl', () => {
     it('should not return the configured `mcApiUrl` but the origin of the window', () => {
       const actualWindow = {
         app: {
-          mcApiUrl: 'mc.commercetools.co',
+          mcApiUrl: 'https://mc-api.commercetools.co',
           servedByProxy: 'true',
         },
         origin: 'https://mc.europe-west1.gcp.commercetools.com',
@@ -60,6 +60,21 @@ describe('getMcApiUrl', () => {
       expect(getMcApiUrl(actualWindow as ApplicationWindow)).toEqual(
         'https://mc-api.europe-west1.gcp.commercetools.com'
       );
+    });
+
+    describe('when inferring of `mcApiUrl` from origin is disabled', () => {
+      it('should return the configured `mcApiUrl`', () => {
+        const actualWindow = {
+          app: {
+            mcApiUrl: 'https://mc-api.commercetools.co',
+            servedByProxy: 'true',
+            skipInferringOfApiUrlOnProduction: 'true',
+          },
+          origin: 'https://mc.europe-west1.gcp.commercetools.com',
+        };
+
+        expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+      });
     });
   });
 });

--- a/packages/sdk/src/utils/utils.spec.ts
+++ b/packages/sdk/src/utils/utils.spec.ts
@@ -68,12 +68,14 @@ describe('getMcApiUrl', () => {
           app: {
             mcApiUrl: 'https://mc-api.commercetools.co',
             servedByProxy: 'true',
-            skipInferringOfApiUrlOnProduction: 'true',
+            disableInferringOfMcApiUrlOnProduction: 'true',
           },
           origin: 'https://mc.europe-west1.gcp.commercetools.com',
         };
 
-        expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+        expect(getMcApiUrl(actualWindow as ApplicationWindow)).toEqual(
+          actualWindow.app.mcApiUrl
+        );
       });
     });
   });

--- a/packages/sdk/src/utils/utils.ts
+++ b/packages/sdk/src/utils/utils.ts
@@ -52,6 +52,7 @@ export const logRequest = ({
 
 export interface ApplicationWindow extends Window {
   app: {
+    skipInferringOfApiUrlOnProduction: string | boolean;
     servedByProxy: string | boolean;
     mcApiUrl: string;
   };
@@ -86,12 +87,20 @@ const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
   return `${url.protocol}//${mcApiUrlHost}`;
 };
 
-export function getMcApiUrl(actualWindow: ApplicationWindow = window) {
-  const isServedByProxy =
-    actualWindow.app.servedByProxy === true ||
-    actualWindow.app.servedByProxy === 'true';
+const isEnvironmentConfigurationEnabled = (
+  environmentConfiguration: string | boolean
+) => environmentConfiguration === true || environmentConfiguration === 'true';
 
-  if (isServedByProxy) return getMcApiUrlFromOrigin(actualWindow);
+export function getMcApiUrl(actualWindow: ApplicationWindow = window) {
+  const isServedByProxy = isEnvironmentConfigurationEnabled(
+    actualWindow.app.servedByProxy
+  );
+  const isSkipInferringOfApiUrlOnProductionEnabled = isEnvironmentConfigurationEnabled(
+    actualWindow.app.skipInferringOfApiUrlOnProduction
+  );
+
+  if (isServedByProxy && !isSkipInferringOfApiUrlOnProductionEnabled)
+    return getMcApiUrlFromOrigin(actualWindow);
 
   return actualWindow.app.mcApiUrl;
 }

--- a/packages/sdk/src/utils/utils.ts
+++ b/packages/sdk/src/utils/utils.ts
@@ -52,7 +52,7 @@ export const logRequest = ({
 
 export interface ApplicationWindow extends Window {
   app: {
-    skipInferringOfApiUrlOnProduction: string | boolean;
+    disableInferringOfMcApiUrlOnProduction: string | boolean;
     servedByProxy: string | boolean;
     mcApiUrl: string;
   };
@@ -95,11 +95,11 @@ export function getMcApiUrl(actualWindow: ApplicationWindow = window) {
   const isServedByProxy = isEnvironmentConfigurationEnabled(
     actualWindow.app.servedByProxy
   );
-  const isSkipInferringOfApiUrlOnProductionEnabled = isEnvironmentConfigurationEnabled(
-    actualWindow.app.skipInferringOfApiUrlOnProduction
+  const isInferringOfMcApiUrlOnProductionDisabled = isEnvironmentConfigurationEnabled(
+    actualWindow.app.disableInferringOfMcApiUrlOnProduction
   );
 
-  if (isServedByProxy && !isSkipInferringOfApiUrlOnProductionEnabled)
+  if (isServedByProxy && !isInferringOfMcApiUrlOnProductionDisabled)
     return getMcApiUrlFromOrigin(actualWindow);
 
   return actualWindow.app.mcApiUrl;


### PR DESCRIPTION
#### Summary

Internally sometimes we run the MC on another origin than the underlying mc-api url requires (e.g. branch deployments). In this case we set this property `skipInferringOfApiUrlOnProduction`.