### PR TITLE
fix(actions-global): method signature of useOnActionError

### DIFF
--- a/packages/actions-global/package.json
+++ b/packages/actions-global/package.json
@@ -45,7 +45,8 @@
     "@commercetools-frontend/notifications": "16.2.1",
     "@types/lodash": "^4.14.149",
     "lodash": "4.17.15",
-    "lodash-es": "4.17.15"
+    "lodash-es": "4.17.15",
+    "redux-thunk": "2.3.0"
   },
   "devDependencies": {
     "react": "16.12.0",

--- a/packages/actions-global/src/actions/handle-action-error.ts
+++ b/packages/actions-global/src/actions/handle-action-error.ts
@@ -1,4 +1,4 @@
-import { Dispatch } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import {
   STATUS_CODES,
   LOGOUT_REASONS,
@@ -22,7 +22,9 @@ type ApiError = {
 };
 
 export type ActionError = Error | ApiError;
-export type DispatchActionError = Dispatch<
+export type DispatchActionError = ThunkDispatch<
+  null,
+  null,
   | ReturnType<typeof showApiErrorNotification>
   | ReturnType<typeof showUnexpectedErrorNotification>
 >;

--- a/packages/actions-global/src/hooks/use-hide-all-page-notifications.ts
+++ b/packages/actions-global/src/hooks/use-hide-all-page-notifications.ts
@@ -1,13 +1,10 @@
 import React from 'react';
-import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { hideAllPageNotifications } from '../actions';
 
 export default function useHideAllPageNotifications() {
-  const dispatch = useDispatch<
-    Dispatch<ReturnType<typeof hideAllPageNotifications>>
-  >();
-  return React.useCallback(() => {
-    dispatch(hideAllPageNotifications());
-  }, [dispatch]);
+  const dispatch = useDispatch();
+  return React.useCallback(() => dispatch(hideAllPageNotifications()), [
+    dispatch,
+  ]);
 }

--- a/packages/actions-global/src/hooks/use-on-action-error.spec.tsx
+++ b/packages/actions-global/src/hooks/use-on-action-error.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Action } from 'redux';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import useOnActionError from './use-on-action-error';
+
+jest.mock('../actions/handle-action-error', () => (payload: Error) => ({
+  type: 'fake-handle-action-error',
+  payload,
+}));
+
+const renderUseOnActionError = () => {
+  const dispatchedActions: Array<Action> = [];
+  const fakeStore = {
+    dispatch: (action: Action) => dispatchedActions.push(action),
+    getState: () => null,
+    subscribe: () => null,
+  };
+  const { result } = renderHook(() => useOnActionError(), {
+    // eslint-disable-next-line react/display-name
+    wrapper: ({ children }) => (
+      // @ts-ignore: partially implemented Redux Store is OK as a mock
+      <Provider store={fakeStore}>{children}</Provider>
+    ),
+  });
+  return { onActionError: result.current, dispatchedActions };
+};
+
+describe('useOnActionError', () => {
+  it('dispatches `handleActionError` with a given error as an payload', () => {
+    const { onActionError, dispatchedActions } = renderUseOnActionError();
+
+    const error = new Error('oupsy!');
+    onActionError(error);
+
+    expect(dispatchedActions).toMatchObject([
+      { type: 'fake-handle-action-error', payload: error },
+    ]);
+  });
+});

--- a/packages/actions-global/src/hooks/use-on-action-error.ts
+++ b/packages/actions-global/src/hooks/use-on-action-error.ts
@@ -1,13 +1,9 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import handleActionError, {
-  ActionError,
-  DispatchActionError,
-} from '../actions/handle-action-error';
+import handleActionError, { ActionError } from '../actions/handle-action-error';
 
 export default function useOnActionError() {
-  const dispatch = useDispatch<DispatchActionError>();
-
+  const dispatch = useDispatch();
   return React.useCallback(
     (error: ActionError) => dispatch(handleActionError(error)),
     [dispatch]

--- a/packages/actions-global/src/hooks/use-on-action-error.ts
+++ b/packages/actions-global/src/hooks/use-on-action-error.ts
@@ -1,14 +1,11 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import handleActionError, {
-  ActionError,
-  DispatchActionError,
-} from '../actions/handle-action-error';
+import handleActionError, { ActionError } from '../actions/handle-action-error';
 
-export default function useOnActionError(error: ActionError) {
-  const dispatch = useDispatch<DispatchActionError>();
-  return React.useCallback(() => handleActionError(error)(dispatch), [
-    dispatch,
-    error,
-  ]);
+export default function useOnActionError() {
+  const dispatch = useDispatch();
+  return React.useCallback(
+    (error: ActionError) => dispatch(handleActionError(error)),
+    [dispatch]
+  );
 }

--- a/packages/actions-global/src/hooks/use-on-action-error.ts
+++ b/packages/actions-global/src/hooks/use-on-action-error.ts
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import handleActionError, { ActionError } from '../actions/handle-action-error';
+import handleActionError, {
+  ActionError,
+  DispatchActionError,
+} from '../actions/handle-action-error';
 
 export default function useOnActionError() {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<DispatchActionError>();
+
   return React.useCallback(
     (error: ActionError) => dispatch(handleActionError(error)),
     [dispatch]

--- a/packages/actions-global/src/hooks/use-show-api-error-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-api-error-notification.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { showApiErrorNotification } from '../actions';
 import { TApiErrorNotificationOptions } from '../types';
@@ -9,9 +8,7 @@ import { TApiErrorNotificationOptions } from '../types';
 //   const showApiErrorNotification = useShowApiErrorNotification();
 //   showApiErrorNotification({ errors });
 export default function useShowApiErrorNotification() {
-  const dispatch = useDispatch<
-    Dispatch<ReturnType<typeof showApiErrorNotification>>
-  >();
+  const dispatch = useDispatch();
   return React.useCallback(
     (options: TApiErrorNotificationOptions) =>
       dispatch(showApiErrorNotification(options)),

--- a/packages/actions-global/src/hooks/use-show-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-notification.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { TNotificationMetaOptions } from '@commercetools-frontend/notifications';
 import { showNotification } from '../actions';
@@ -17,7 +16,7 @@ export default function useShowNotification<
   Notification extends TShowNotification
   // FIXME: remove the `notificationFragment`, it makes the typing unnecessarily complex
 >(notificationFragment?: Partial<Notification>) {
-  const dispatch = useDispatch<Dispatch<ReturnType<typeof showNotification>>>();
+  const dispatch = useDispatch();
   return React.useCallback(
     (content: Notification, meta?: TNotificationMetaOptions) => {
       const notification = showNotification<Notification>(

--- a/packages/actions-global/src/hooks/use-show-unexpected-error-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-unexpected-error-notification.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { TAppNotificationValuesUnexpectedError } from '@commercetools-frontend/constants';
 import { showUnexpectedErrorNotification } from '../actions';
@@ -9,9 +8,7 @@ import { showUnexpectedErrorNotification } from '../actions';
 //   const showUnexpectedErrorNotification = useShowUnexpectedErrorNotification();
 //   showUnexpectedErrorNotification({ error });
 export default function useShowUnexpectedErrorNotification() {
-  const dispatch = useDispatch<
-    Dispatch<ReturnType<typeof showUnexpectedErrorNotification>>
-  >();
+  const dispatch = useDispatch();
   return React.useCallback(
     (options: TAppNotificationValuesUnexpectedError) =>
       dispatch(showUnexpectedErrorNotification(options)),


### PR DESCRIPTION
`useOnActionError` implementation looks wrong to me. [This doc](https://github.com/commercetools/merchant-center-application-kit/blob/master/website/src/content/development/testing.mdx) supports my feelings that its current API is not what was actually desired. So, here is the fix.

Old (wrong) API:
```js
const error = new Error();
const onActionError = useOnActionError(error);

...

// error happened here
onActionError();
```

New (fixed) API:
```js

const onActionError = useOnActionError();

...

// error happened here
const error = new Error();
onActionError(error);
```