### PR TITLE
docs(website): improve docs around csp and cloud regions

### DIFF
--- a/website/src/content/deployment/runtime-configuration.mdx
+++ b/website/src/content/deployment/runtime-configuration.mdx
@@ -74,7 +74,7 @@ Therefore, it's important that the application is [registered](/register-applica
 
 </Warning>
 
-It is recommended to have two separate configuration files, one for development and one for production. The `env.json` **must** be used for development, therefore for production you can have a `env.prod.json` file.
+It is recommended to have two separate configuration files, one for development and one for production. The `env.json` **must** be used for development, therefore for production you can have an `env.prod.json` file.
 
 # `headers.json`
 
@@ -88,7 +88,7 @@ For development the `headers.json` file is **optional**. If used, the file must 
 
 ## Content Security Policy
 
-The Content Security Policy (CSP) header allows to instruct the browser how to deal with security measures, according to the configured instructions. Most of the times it's enough to whitelist the hostnames that the Custom Application uses, for example if [static assets](/deployment/serving-static-assets) are served by a CDN.
+The Content Security Policy (CSP) header allows to instruct the browser how to deal with security measures, according to the configured instructions. Most of the time it's enough to whitelist the hostnames that the Custom Application uses, for example if [static assets](/deployment/serving-static-assets) are served by a CDN.
 
 <Info>
 
@@ -115,7 +115,7 @@ For example, given that your application is hosted at `my-app.now.sh` and runs o
 
 <Info>
 
-This example includes two hostnames as one of them is a deprecated hostname: `mc.commercetools.com`. For more information read about [Deprecated hostnames](/main-concepts/api-gateway#deprecated-hostnames).
+This example includes two hostnames as one of them is a deprecated hostname: `mc-api.commercetools.com`. For more information read about [Deprecated hostnames](/main-concepts/api-gateway#deprecated-hostnames).
 
 </Info>
 

--- a/website/src/content/deployment/runtime-configuration.mdx
+++ b/website/src/content/deployment/runtime-configuration.mdx
@@ -6,38 +6,48 @@ Merchant Center applications require a runtime configuration to work. This is us
 
 # `env.json`
 
-The configuration is defined in a file named `env.json`. The following fields are **required** but you can provide additional fields specific to your application:
+The configuration is defined in a file named `env.json`.
 
-- `applicationName`: the name of the application (usually the same as in `package.json`)
-- `frontendHost`: the host where the Merchant Center Custom Application is running (for example `mc.commercetools.com`)
-- `mcApiUrl`: the API URL for the [Merchant Center API Gateway](/main-concepts/api-gateway)
-- `location`: the location where the Merchant Center Custom Application is running. This can be something like:
-  - `eu` for projects in **Europe**
-  - `us` for projects in the **United States**
-- `env`: the environment where the Merchant Center Custom Application is running, usually `production` or `development`
-- `cdnUrl`: the URL where the static assets are stored (see [Serving Static Assets](/deployment/serving-static-assets))
-- `servedByProxy`: a flag to indicate if the application is running behind the Merchant Center proxy or not. This is either:
-  - `true` for **production**
-  - `false` for **local development**
+<Info>
 
-The `env.json` object will eventually be injected into `window.app`, when the `index.html.template` gets compiled into `index.html`.
-The `window.app` object is then passed to the `<ApplicationShell>` component as an `environment` prop and will be available in the application context:
+For development the `env.json` file must be in the root path of the project as it's automatically loaded by the Webpack dev server.
 
-```jsx
-import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+</Info>
 
-const MyComponent = () => (
-  <ApplicationContext
-    render={({ environment }) => <div>{environment.applicationName}</div>}
+The following fields are **required** but you can provide additional fields specific to your application:
+
+- `applicationName`: the name of the application (usually the same as in `package.json`).
+- `frontendHost`: the host where the Merchant Center Custom Application is running. See [Merchant Center hostnames](/main-concepts/api-gateway#hostnames).
+- `mcApiUrl`: the API URL for the [Merchant Center API Gateway](/main-concepts/api-gateway).
+- `location`: the location where the Merchant Center Custom Application is running. This value is used for logging and error reporting. Usually values refer to the cloud region where the Custom Application is running, for example `gcp-eu`, `gcp-us`, `aws-ohio`, etc.
+- `env`: the environment value where the Merchant Center Custom Application is running, usually `production` or `development`.
+- `cdnUrl`: the URL where the static assets are stored (see [Serving Static Assets](/deployment/serving-static-assets)).
+- `servedByProxy`: a flag to indicate if the application is running behind the Merchant Center proxy router or not. This is either `true` for **production** and `false` for **local development**.
+
+When the `index.html.template` gets compiled into `index.html`, the `env.json` is injected into a global variable `window.app`.
+This value should be used in the `<EntryPoint>` component when rendering the `<ApplicationShell>`.
+
+```jsx highlightLines="3"
+const EntryPoint = () => (
+  <ApplicationShell
+    environment={window.app}
+    // other props
   />
 );
 ```
 
-<Info>
+The environment object is parsed and passed into a React Context, making it available to the entire application. To access it, use the `@commercetools-frontend/application-shell-connectors` package.
 
-For `development` the `env.json` file must be in the root path of the project as it's automatically loaded by the webpack dev server.
+```jsx
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 
-</Info>
+const MyComponent = () => {
+  const applicationName = useApplicationContext(
+    context => context.environment.applicationName
+  );
+  return (<div>{`Welcome to the application ${applicationName}!`}</div>);
+};
+```
 
 An example configuration for local development:
 
@@ -53,17 +63,79 @@ An example configuration for local development:
 }
 ```
 
-# `csp.json`
+
+## Production environment
 
 <Warning>
 
-This file has been deprecated by the `headers.json` mentioned below.
+When the application is deployed on a production environment, the application will fail to make requests to the [API Gateway](/main-concepts/api-gateway). This is due to the fact that the domain, where the application is hosted, is not whitelisted by the CORS rules of the API Gateway.
+
+Therefore, it's important that the application is [registered](/register-applications/configuring-a-custom-application), runs behind the proxy router, and that the `servedByProxy` option in the `env.json` is set to `true`.
+
+</Warning>
+
+It is recommended to have two separate configuration files, one for development and one for production. The `env.json` **must** be used for development, therefore for production you can have a `env.prod.json` file.
+
+# `headers.json`
+
+This configuration file allows to configure HTTP headers. The most important one is the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) header.
+
+<Info>
+
+For development the `headers.json` file is **optional**. If used, the file must be in the root path of the project as it's automatically loaded by the Webpack dev server.
+
+</Info>
+
+## Content Security Policy
+
+The Content Security Policy (CSP) header allows to instruct the browser how to deal with security measures, according to the configured instructions. Most of the times it's enough to whitelist the hostnames that the Custom Application uses, for example if [static assets](/deployment/serving-static-assets) are served by a CDN.
+
+<Info>
+
+Since Custom Applications are hosted on any domain of your choice, it's **imperative** that any hostname used by the application is whitelisted in the CSP configuration.
+Furthermore, the [API Gateway](/main-concepts/api-gateway#hostnames) hostnames **must** also be listed in the CSP configuration.
+
+</Info>
+
+For example, given that your application is hosted at `my-app.now.sh` and runs on the [Google Cloud Europe region](/main-concepts/api-gateway#cloud-regions), the `headers.json` file must be configured as following:
+
+```json
+{
+  "csp": {
+    "script-src": ["my-app.now.sh"],
+    "connect-src": [
+      "my-app.now.sh",
+      "mc-api.europe-west1.gcp.commercetools.com",
+      "mc-api.commercetools.com"
+    ],
+    "style-src": ["my-app.now.sh"]
+  }
+}
+```
+
+<Info>
+
+This example includes two hostnames as one of them is a deprecated hostname: `mc.commercetools.com`. For more information read about [Deprecated hostnames](/main-concepts/api-gateway#deprecated-hostnames).
+
+</Info>
+
+You can find the list of default directives in the `load-headers.js` file in the `@commercetools-frontend/mc-html-template` package.
+
+## Production environment
+
+It is recommended to have two separate configuration files, one for development and one for production. The `headers.json` **must** be used for development, therefore for production you can have a `headers.prod.json` file.
+
+# `csp.json` (deprecated)
+
+<Warning>
+
+This file has been deprecated by the `headers.json`.
 
 </Warning>
 
 To migrate to the new format, wrap the `csp.json` content into a `csp` property in the `headers.json`:
 
-```json
+```json highlightLines="2,6"
 {
   "csp": {
     "script-src": ["my-apps.com"],
@@ -75,29 +147,9 @@ To migrate to the new format, wrap the `csp.json` content into a `csp` property 
 
 Additionally, use the `--headers` over the `--csp` CLI option to point to the new `headers.json`.
 
-# `headers.json`
-
-When you deploy your application to a server and domain of your choice, the application will fail to make requests to the [API Gateway](/main-concepts/api-gateway) as the custom domain is not whitelisted. This is why the application can only be accessed through the [proxy router](/main-concepts/api-gateway). Setting the `servedByProxy` in the `env.json` is also important.
-
-However, there are additional security measures that prevent requests or scripts to be executed, based on the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). You can enhance the policy by whitelisting the domains where the application is hosted.
-To do so, you can specify a `headers.json` file where you configure headers such as the CSP directives. This is important as for example [static assets](/deployment/serving-static-assets) may be served by a CDN that is not whitelisted.
-
-For `production`, we recommended defining at a minimum the following directives, where `my-apps.com` is the domain hosting the Custom Application:
-
-```json
-{
-  "csp": {
-    "script-src": ["my-apps.com"],
-    "connect-src": ["my-apps.com"],
-    "style-src": ["my-apps.com"]
-  }
-}
+```console highlightLines="2" noPromptLines="2-4"
+NODE_ENV=production mc-http-server \
+  --headers=$(pwd)/headers.json \
+  --config=$(pwd)/env.json \
+  --use-local-assets
 ```
-
-You can find the list of default directives in the `load-headers.js` file in the `@commercetools-frontend/mc-html-template` package.
-
-<Info>
-
-For `development` this configuration is **optional**. If you use it, the `headers.json` file must be in the root path of the project and is automatically loaded by the webpack dev server.
-
-</Info>

--- a/website/src/content/deployment/runtime-configuration.mdx
+++ b/website/src/content/deployment/runtime-configuration.mdx
@@ -115,7 +115,7 @@ For example, given that your application is hosted at `my-app.now.sh` and runs o
 
 <Info>
 
-This example includes two hostnames as one of them is a deprecated hostname: `mc-api.commercetools.com`. For more information read about [Deprecated hostnames](/main-concepts/api-gateway#deprecated-hostnames).
+This example includes two hostnames as one of them is a legacy hostname: `mc-api.commercetools.com`. For more information read about [Legacy hostnames](/main-concepts/api-gateway#legacy-hostnames).
 
 </Info>
 

--- a/website/src/content/main-concepts/api-gateway.mdx
+++ b/website/src/content/main-concepts/api-gateway.mdx
@@ -12,7 +12,7 @@ To solve these issues, the Merchant Center provides an **API Gateway**, which pr
 
 <Info>
 
-For security reasons, it is recommended that Custom Applications use the API Gateway to access the commercetools APIs. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
+It is recommended that Custom Applications use the API Gateway to access the commercetools APIs, for security reasons. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
 
 </Info>
 
@@ -32,39 +32,30 @@ In case you need advice in which region your project should be located, please c
 
 The Merchant Center and the Merchant Center API Gateway are available at the same cloud regions where the commercetools platform runs.
 
-<Info>
+All hostnames are subdomains of `commercetools.com` and follow a specific naming format, including the cloud provider, the cloud region, and the Merchant Center service name.
 
-The Merchant Center runs on the `mc` subdomain, whereas the API Gateway runs on the `mc-api` subdomain.
+```
+https://{mcService}.{region}.{cloudProvider}.commercetools.com
+```
 
-</Info>
+- `mcService`: for the Merchant Center front-end the value is `mc`, for the Merchant Center API Gateway the value is `mc-api`.
+- `region`: the region of the cloud provider, see table below.
+- `cloudProvider`: the cloud provider (`gcp`, `aws`, etc.).
 
-| Cloud region | Hostname |
+| Cloud region | Merchant Center API Gateway hostname |
 | --- | --- |
 | North America (Google Cloud, Iowa) | `mc-api.us-central1.gcp.commercetools.com` |
 | North America (AWS, Ohio) | `mc-api.us-east-2.aws.commercetools.com` |
 | Europe (Google Cloud, Belgium) | `mc-api.europe-west1.gcp.commercetools.com` |
 | Europe (AWS, Frankfurt) | `mc-api.eu-central-1.aws.commercetools.com` |
 
-## Deprecated hostnames
+### Legacy hostnames
 
-Hostnames for each cloud region follow a specific naming format and therefore any hostname that does not comply to that is considered as deprecated.
-
-Current deprecated hostnames are:
-
-- `mc.commercetools.com`: Europe (Google Cloud).
-- `mc.commercetools.co`: North America (Google Cloud).
-- `mc-api.commercetools.com`: Europe (Google Cloud).
-- `mc-api.commercetools.co`: North America (Google Cloud).
-
-The equivalent new hostnames are respectively:
-
-- `mc.europe-west1.gcp.commercetools.com`: Europe (Google Cloud).
-- `mc.us-central1.gcp.commercetools.com`: North America (Google Cloud).
-- `mc-api.europe-west1.gcp.commercetools.com`: Europe (Google Cloud).
-- `mc-api.us-central1.gcp.commercetools.com`: North America (Google Cloud).
+Any hostname that does not follow the new naming format is considered a **legacy hostname**.
 
 <Warning>
 
-For the time being, we recommend that Custom Applications accommodate for both hostnames, as users can access one or the other. This is important for things like the [`headers.json` configuration](/deployment/runtime-configuration#headersjson).
+Legacy hostname will still be available for the time being, but it is **highly recommended** to swtich to the new hostnames as soon as possible.
+We also recommend that Custom Applications accommodate for both hostnames, as users can access one or the other. This is important for things like the [`headers.json` configuration](/deployment/runtime-configuration#headersjson).
 
 </Warning>

--- a/website/src/content/main-concepts/api-gateway.mdx
+++ b/website/src/content/main-concepts/api-gateway.mdx
@@ -12,7 +12,7 @@ To solve these issues, the Merchant Center provides an **API Gateway**, which pr
 
 <Info>
 
-It is recommended that Custom Applications use the API Gateway to access the commercetools APIs, for security reasons. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
+For security reasons, it is recommended that Custom Applications use the API Gateway to access the commercetools APIs. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
 
 </Info>
 

--- a/website/src/content/main-concepts/api-gateway.mdx
+++ b/website/src/content/main-concepts/api-gateway.mdx
@@ -10,9 +10,61 @@ To solve these issues, the Merchant Center provides an **API Gateway**, which pr
 
 ![HTTP API](/images/mc-http-api.png)
 
-All Merchant Center applications should send requests through the API Gateway, which is available at the same domain of the Merchant Center but with the `mc` subdomain being `mc-api`.
+<Info>
 
-Official domains:
+It is recommended that Custom Applications use the API Gateway to access the commercetools APIs, for security reasons. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
 
-- `https://mc-api.commercetools.com` for projects in **Europe** running on Google Cloud Platform
-- `https://mc-api.commercetools.co` for projects in the **United States** running on Google Cloud Platform
+</Info>
+
+# Cloud regions
+
+The commercetools platform is available in [multiple cloud regions](https://docs.commercetools.com/http-api.html#regions).
+These regions are completely isolated from each other and no data is transferred between them.
+
+<Info>
+
+Platform accounts created for one region are not valid for the other regions. A [signup](https://docs.commercetools.com/getting-started) is required for each region individually.
+In case you need advice in which region your project should be located, please contact [commercetools support](https://support.commercetools.com).
+
+</Info>
+
+## Hostnames
+
+The Merchant Center and the Merchant Center API Gateway are available at the same cloud regions where the commercetools platform runs.
+
+<Info>
+
+The Merchant Center runs on the `mc` subdomain, whereas the API Gateway runs on the `mc-api` subdomain.
+
+</Info>
+
+| Cloud region | Hostname |
+| --- | --- |
+| North America (Google Cloud, Iowa) | `mc-api.us-central1.gcp.commercetools.com` |
+| North America (AWS, Ohio) | `mc-api.us-east-2.aws.commercetools.com` |
+| Europe (Google Cloud, Belgium) | `mc-api.europe-west1.gcp.commercetools.com` |
+| Europe (AWS, Frankfurt) | `mc-api.eu-central-1.aws.commercetools.com` |
+
+## Deprecated hostnames
+
+Hostnames for each cloud region follow a specific naming format and therefore any hostname that does not comply to that is considered as deprecated.
+
+Current deprecated hostnames are:
+
+- `mc.commercetools.com`: Europe (Google Cloud).
+- `mc.commercetools.co`: North America (Google Cloud).
+- `mc-api.commercetools.com`: Europe (Google Cloud).
+- `mc-api.commercetools.co`: North America (Google Cloud).
+
+The equivalent new hostnames are respectively:
+
+- `mc.europe-west1.gcp.commercetools.com`: Europe (Google Cloud).
+- `mc.us-central1.gcp.commercetools.com`: North America (Google Cloud).
+- `mc-api.europe-west1.gcp.commercetools.com`: Europe (Google Cloud).
+- `mc-api.us-central1.gcp.commercetools.com`: North America (Google Cloud).
+
+<Warning>
+
+For the time being, we recommend that Custom Applications accommodate for both hostnames, as users can access one or the other. This is important for things like the [`headers.json` configuration](/deployment/runtime-configuration#headersjson).
+
+</Warning>

--- a/website/src/content/main-concepts/api-gateway.mdx
+++ b/website/src/content/main-concepts/api-gateway.mdx
@@ -8,11 +8,13 @@ However, for security reasons, client-side applications **cannot be trusted** wi
 
 To solve these issues, the Merchant Center provides an **API Gateway**, which proxies requests to underlying APIs. Requests made through the proxy will be authenticated with the correct authentication mechanism specific to the targeted API. This way, a client-side application only needs to [authenticate](#authentication) to the Merchant Center API Gateway without needing to store credentials for the targeted APIs.
 
+# Architecture overview
+
 ![HTTP API](/images/mc-http-api.png)
 
 <Info>
 
-It is recommended that Custom Applications use the API Gateway to access the commercetools APIs, for security reasons. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
+For security reasons, it is recommended that Custom Applications use the API Gateway to access the commercetools APIs. See [Proxy Endpoints](/main-concepts/proxy-endpoints).
 
 </Info>
 


### PR DESCRIPTION
Closes #1343 

This PR aims to clarify how to configure the CSP directives, especially around the new hostnames.