### PR TITLE
Revert "chore: ignore ts-jest updates (for now)"

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -23,7 +23,6 @@
   "ignoreDeps": [
     "gatsby-plugin-sharp",
     "gatsby-transformer-sharp",
-    "react-intl",
-    "ts-jest"
+    "react-intl"
   ]
 }


### PR DESCRIPTION
Reverts commercetools/merchant-center-application-kit#1345

This does not seem to be the issue with the dep updates.

https://github.com/commercetools/merchant-center-application-kit/pull/1342#issuecomment-587037365