### PR TITLE
fix(app-shell): token refetch triggerd by requests from settings service

### DIFF
--- a/packages/application-shell/src/apollo-links/token-retry-link.spec.js
+++ b/packages/application-shell/src/apollo-links/token-retry-link.spec.js
@@ -206,4 +206,12 @@ describe('supported GraphQL targets', () => {
       })
     ).toBe(false);
   });
+
+  it('should not support the `settings service` GraphQL target', () => {
+    expect(
+      getDoesGraphQLTargetSupportTokenRetry({
+        'X-Graphql-Target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
+      })
+    ).toBe(true);
+  });
 });

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -26,6 +26,7 @@ export const getDoesGraphQLTargetSupportTokenRetry = (
   return [
     GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
     GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
+    GRAPHQL_TARGETS.SETTINGS_SERVICE,
   ].includes(target);
 };
 


### PR DESCRIPTION
Ref #1352 

#### Summary

This pull request starts triggering token refetching on requests against the settings service. 

#### Description

The assumption is that the first request in the custom application after x days is made against the settings service. This service then validates the CTP token using token introspection and detects that it is expired. Rejecting the request as unauthorized (rightfully). 