### PR TITLE
fix(mc-scripts): remove noop service worker middleware from webpack dev server

### DIFF
--- a/packages/mc-scripts/config/webpack-dev-server.config.js
+++ b/packages/mc-scripts/config/webpack-dev-server.config.js
@@ -5,7 +5,6 @@ const {
 } = require('@commercetools-frontend/mc-html-template');
 const devAuthentication = require('@commercetools-frontend/mc-dev-authentication');
 const errorOverlayMiddleware = require('react-dev-utils/errorOverlayMiddleware');
-const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
 
 const sourcePath = process.cwd();
 const localEnv = loadEnv(path.join(sourcePath, 'env.json'));
@@ -99,12 +98,6 @@ module.exports = ({ proxy, allowedHost, contentBase, publicPath }) => ({
     app.set('view engine', devAuthentication.config.viewEngine);
     // This lets us open files from the runtime error overlay.
     app.use(errorOverlayMiddleware());
-    // This service worker file is effectively a 'no-op' that will reset any
-    // previous service worker registered for the same host:port combination.
-    // We do this in development to avoid hitting the production cache if
-    // it used the same host and port.
-    // https://github.com/facebookincubator/create-react-app/issues/2272#issuecomment-302832432
-    app.use(noopServiceWorkerMiddleware());
     app.use('/api/graphql', (request, response) => {
       response.statusCode = 400;
       response.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
I noticed that the webpack dev server was throwing when starting

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:112:11)
    at Object.join (path.js:1040:7)
    at noopServiceWorkerMiddleware
```

The dev server in react-scripts uses the noop service worker middleware in the `after` hook, which we don't use and we can simply remove it.

https://github.com/facebook/create-react-app/blob/2030ee162df0ca8f19efedcf0447e02613e2f53d/packages/react-scripts/config/webpackDevServer.config.js#L126-L136