### PR TITLE
fix(sdk/test-utils): serialize `undefined` as `undefined`

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -58,7 +58,8 @@
     "react": "16.12.0",
     "react-redux": "7.2.0",
     "redux": "4.0.5",
-    "redux-thunk": "2.3.0"
+    "redux-thunk": "2.3.0",
+    "uuid": "3.4.0"
   },
   "peerDependencies": {
     "@types/react": "16.x",

--- a/packages/sdk/src/test-utils/test-utils.spec.ts
+++ b/packages/sdk/src/test-utils/test-utils.spec.ts
@@ -102,28 +102,28 @@ describe('createTestMiddleware', () => {
           });
         }).toThrow(
           `Could not find any more mocks for action {
-  \"type\": \"SDK\",
-  \"payload\": {
-    \"uri\": \"/foo\",
-    \"method\": \"POST\",
-    \"payload\": {
-      \"bar\": undefined
+  "type": "SDK",
+  "payload": {
+    "uri": "/foo",
+    "method": "POST",
+    "payload": {
+      "bar": undefined
     }
   }
 } in [
   {
-    \"action\": {
-      \"type\": \"SDK\",
-      \"payload\": {
-        \"uri\": \"/foo\",
-        \"payload\": {
-          \"foo\": undefined
+    "action": {
+      "type": "SDK",
+      "payload": {
+        "uri": "/foo",
+        "payload": {
+          "foo": undefined
         },
-        \"method\": \"POST\"
+        "method": "POST"
       }
     },
-    \"response\": {
-      \"ok\": true
+    "response": {
+      "ok": true
     }
   }
 ]`

--- a/packages/sdk/src/test-utils/test-utils.spec.ts
+++ b/packages/sdk/src/test-utils/test-utils.spec.ts
@@ -70,9 +70,65 @@ describe('createTestMiddleware', () => {
           },
         });
       }).toThrow(/Could not find any more mocks for action/);
-    });
-    it('should not call next', () => {
+
       expect(store.next).not.toHaveBeenCalled();
+    });
+
+    describe('formatting error message', () => {
+      beforeEach(() => {
+        const testMiddleware = createTestMiddleware([
+          {
+            action: sdkActions.post({
+              uri: '/foo',
+              payload: { foo: undefined },
+            }),
+            response: { ok: true },
+          },
+        ]);
+        store = createTestStore(testMiddleware);
+      });
+
+      it('should not hide fields holding value `undefined`', () => {
+        expect(() => {
+          store.dispatch({
+            type: 'SDK',
+            payload: {
+              uri: '/foo',
+              method: 'POST',
+              payload: {
+                bar: undefined,
+              },
+            },
+          });
+        }).toThrow(
+          `Could not find any more mocks for action {
+  \"type\": \"SDK\",
+  \"payload\": {
+    \"uri\": \"/foo\",
+    \"method\": \"POST\",
+    \"payload\": {
+      \"bar\": undefined
+    }
+  }
+} in [
+  {
+    \"action\": {
+      \"type\": \"SDK\",
+      \"payload\": {
+        \"uri\": \"/foo\",
+        \"payload\": {
+          \"foo\": undefined
+        },
+        \"method\": \"POST\"
+      }
+    },
+    \"response\": {
+      \"ok\": true
+    }
+  }
+]`
+        );
+      });
     });
   });
   describe('when mocks match an action', () => {

--- a/packages/sdk/src/test-utils/test-utils.ts
+++ b/packages/sdk/src/test-utils/test-utils.ts
@@ -1,5 +1,6 @@
 import { deepEqual } from 'fast-equals';
 import { Action, Dispatch } from 'redux';
+import uuid from 'uuid';
 import { HttpErrorType } from '@commercetools/sdk-client';
 import { TSdkAction, Json } from '../types';
 
@@ -14,8 +15,14 @@ interface TSdkMockFailure extends TSdkMockBase {
 }
 export type TSdkMock = TSdkMockSuccess | TSdkMockFailure;
 
-const serialize = (data: unknown) =>
-  JSON.stringify(data, (_k, v) => (v === undefined ? null : v), 2);
+const serialize = (data: unknown) => {
+  const undefinedPlaceholder = uuid.v4();
+  const placeholderRegexp = new RegExp(`"${undefinedPlaceholder}"`, 'g');
+  const mapUndefinedValues = (_k: string, v: unknown) =>
+    v === undefined ? undefinedPlaceholder : v;
+  const withPlaceholders = JSON.stringify(data, mapUndefinedValues, 2);
+  return withPlaceholders.replace(placeholderRegexp, 'undefined');
+};
 
 const throwIfNoMocksArePassed = (mocks: TSdkMock[]) => {
   if (!mocks || !Array.isArray(mocks) || mocks.length === 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19463,22 +19463,6 @@ node-object-hash@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-2.0.0.tgz#9971fcdb7d254f05016bd9ccf508352bee11116b"
   integrity sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ==
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-pre-gyp@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
@@ -25557,7 +25541,7 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
#### Summary

Properly print SDK actions containing fields with `undefined` as a value in a test output.  

#### Description

Whenever `testMiddleware` fails to match an action against a list of provided mocks, it pretty-prints both an action and a list. The problem thought, is that in this pretty-printed version `undefined` values will be replaced with `null`, due to the reason that default JSON serializer drops `undefined` fields as being non-deserializable.

This may lead to a following situation. Imaging having the action and the mocks like this (the data shapes are invalid, but simplified for brevity reasons) :

```js
const action = { foo: undefined };
const mocksSdk = [{ action: { foo: null }, response: 'ok'}]; 
```

Running a test with this input will lead to failure to match action against mock (which is right), but the message shown by a failed test will be like:

```
Could not find any more mocks for action {
  "foo": null,
} in [
  {
    "action": {
      "foo": null,
    },
    "response": "ok",
  }
]`
``` 

That is very confusing when one is trying understand which action/mock pair is missing in the mocks list. Instead what test authors really want to see in console is:

```
Could not find any more mocks for action {
  "foo": undefined,
} in [
  {
    "action": {
      "foo": null,
    },
    "response": "ok",
  }
]`
```

As we do not intend to de-serialize JSONs from errors messages, it's possible to apply a small trick, to actually have proper `undefined` values in the test output.
 
Instead of replacing `undefined` with `null` we gonna perform two steps:
1) replace `undefined` with a random UUID value during the serialization
2) replace UUID value in a result string with `undefined`

UUID is used to avoid accidental overrides of field values provided by test authors in their tests.