### PR TITLE
feat(app-shell): export getMcApiUrl

### DIFF
--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -13,6 +13,7 @@ export { GtmContext } from './components/gtm-booter';
 export { default as GtmUserLogoutTracker } from './components/gtm-user-logout-tracker';
 export { default as SetupFlopFlipProvider } from './components/setup-flop-flip-provider';
 export { default as version } from './version';
+export { getMcApiUrl } from './utils';
 
 // Deprecated
 export { default as AsyncChunkLoader } from './components/async-chunk-loader';


### PR DESCRIPTION
#### Summary

Applications are struggling to log users out on new environments. This is due to the fact that in our logout logic we use the `mcApiUrl` from the application context. This `mcApiUrl` is always the mcApiUrl set on the environment which is still the legacy domain.

This leads to a wrong `set-cookie` header.

<img width="875" alt="CleanShot 2020-02-28 at 18 09 12@2x" src="https://user-images.githubusercontent.com/1877073/75570400-5ef52480-5a57-11ea-82ec-c7a4632e090a.png">

As we send the request to the old mc-api hostname from the new mc hostname.

<img width="447" alt="CleanShot 2020-02-28 at 18 11 14@2x" src="https://user-images.githubusercontent.com/1877073/75570414-661c3280-5a57-11ea-83e2-169f2263642e.png">


Our internal code looks like:

```js
const useLogoutUrl = search => {
  const { mcApiUrl } = useApplicationContext(context => ({
    mcApiUrl: context.environment.mcApiUrl,
  }));

  // ...do some stuff
}
```

I see multiple options: 

1. Duplicate logic in the MC and not export it in app-kit
2. Export it in app-kit and use that in the MC

I am fine with either option but wouldn't mind 2. much as I think it's worthwhile exporting it after all.