### PR TITLE
bug(app-shell-connectors): path mcApiUrl on context env

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -7,6 +7,7 @@ import {
   withApplicationContext,
   mapUserToApplicationContextUser,
   mapProjectToApplicationContextProject,
+  mapEnvironmentToApplicationContextEnvironment,
 } from './application-context';
 import { ApplicationWindow } from '@commercetools-frontend/constants';
 
@@ -167,6 +168,24 @@ describe('mapProjectToApplicationContextProject', () => {
       currencies: expect.any(Array),
       languages: expect.any(Array),
       ownerId: expect.any(String),
+    });
+  });
+});
+
+describe('mapEnvironmentToApplicationContextEnvironment', () => {
+  it('should map environment to environment context', () => {
+    expect(
+      mapEnvironmentToApplicationContextEnvironment(createTestEnvironment())
+    ).toEqual({
+      revision: expect.any(String),
+      applicationName: expect.any(String),
+      frontendHost: expect.any(String),
+      mcApiUrl: 'https://mc-api.commercetools.com',
+      location: expect.any(String),
+      env: expect.any(String),
+      cdnUrl: expect.any(String),
+      servedByProxy: expect.any(Boolean),
+      foo: expect.any(String),
     });
   });
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -173,19 +173,44 @@ describe('mapProjectToApplicationContextProject', () => {
 });
 
 describe('mapEnvironmentToApplicationContextEnvironment', () => {
-  it('should map environment to environment context', () => {
-    expect(
-      mapEnvironmentToApplicationContextEnvironment(createTestEnvironment())
-    ).toEqual({
-      revision: expect.any(String),
-      applicationName: expect.any(String),
-      frontendHost: expect.any(String),
-      mcApiUrl: 'https://mc-api.commercetools.com',
-      location: expect.any(String),
-      env: expect.any(String),
-      cdnUrl: expect.any(String),
-      servedByProxy: expect.any(Boolean),
-      foo: expect.any(String),
+  describe('when application is configured to run behind proxy', () => {
+    it('should map environment to environment context', () => {
+      expect(
+        mapEnvironmentToApplicationContextEnvironment(
+          createTestEnvironment({ servedByProxy: true }),
+          {
+            origin: 'https://mc.europe-west1.gcp.commercetools.com',
+          }
+        )
+      ).toEqual({
+        revision: expect.any(String),
+        applicationName: expect.any(String),
+        frontendHost: expect.any(String),
+        mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
+        location: expect.any(String),
+        env: expect.any(String),
+        cdnUrl: expect.any(String),
+        servedByProxy: expect.any(Boolean),
+        foo: expect.any(String),
+      });
+    });
+  });
+
+  describe('when application is not configured to run behind proxy', () => {
+    it('should map environment to environment context', () => {
+      expect(
+        mapEnvironmentToApplicationContextEnvironment(createTestEnvironment())
+      ).toEqual({
+        revision: expect.any(String),
+        applicationName: expect.any(String),
+        frontendHost: expect.any(String),
+        mcApiUrl: 'https://mc-api.commercetools.com',
+        location: expect.any(String),
+        env: expect.any(String),
+        cdnUrl: expect.any(String),
+        servedByProxy: expect.any(Boolean),
+        foo: expect.any(String),
+      });
     });
   });
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -12,6 +12,7 @@ import {
   normalizeAllAppliedPermissions,
   normalizeAllAppliedDataFences,
 } from './normalizers';
+import getMcApiUrl from '../../utils/get-mc-api-url';
 
 type TFetchedUser = TFetchLoggedInUserQuery['user'];
 type TFetchedProject = TFetchProjectQuery['project'];
@@ -76,6 +77,16 @@ export const mapUserToApplicationContextUser = (user?: TFetchedUser) => {
   };
 };
 
+// Adjust certain fields which depend e.g. on the origin
+export const mapEnvironmentToApplicationContextEnvironment = <
+  TApplicationEnvironment extends {}
+>(
+  environment: TApplicationEnvironment
+) => ({
+  mcApiUrl: getMcApiUrl(),
+  ...environment,
+});
+
 // Expose only certain fields as some of them are only meant to
 // be used internally in the AppShell
 export const mapProjectToApplicationContextProject = (
@@ -129,7 +140,7 @@ const createApplicationContext: <AdditionalEnvironmentProperties extends {}>(
   project,
   projectDataLocale
 ) => ({
-  environment,
+  environment: mapEnvironmentToApplicationContextEnvironment(environment),
   user: mapUserToApplicationContextUser(user),
   project: mapProjectToApplicationContextProject(project),
   permissions: normalizeAllAppliedPermissions(project),

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -55,6 +55,7 @@ type TApplicationContextDataFences = {
   // E.g. { store: {...} }
   store?: TApplicationContextGroupedByResourceType;
 };
+type TApplicationContextEnvironment = ApplicationWindow['app'];
 
 const Context = React.createContext({});
 
@@ -79,12 +80,14 @@ export const mapUserToApplicationContextUser = (user?: TFetchedUser) => {
 
 // Adjust certain fields which depend e.g. on the origin
 export const mapEnvironmentToApplicationContextEnvironment = <
-  TApplicationEnvironment extends {}
+  AdditionalEnvironmentProperties extends {}
 >(
-  environment: TApplicationEnvironment
+  environment: AdditionalEnvironmentProperties & TApplicationContextEnvironment,
+  partialWindow: Pick<Window, 'origin'> = window
 ) => ({
-  mcApiUrl: getMcApiUrl(),
   ...environment,
+  // NOTE: The `mcApiUrl` depends on `servedByProxy` and `disableInferringOfMcApiUrlOnProduction`.
+  mcApiUrl: getMcApiUrl(environment, partialWindow),
 });
 
 // Expose only certain fields as some of them are only meant to
@@ -104,7 +107,6 @@ export const mapProjectToApplicationContextProject = (
   };
 };
 
-type TApplicationContextEnvironment = ApplicationWindow['app'];
 export type TApplicationContext<AdditionalEnvironmentProperties extends {}> = {
   environment: AdditionalEnvironmentProperties & TApplicationContextEnvironment;
   user: ReturnType<typeof mapUserToApplicationContextUser>;

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -1,0 +1,46 @@
+import getMcApiUrl from './get-mc-api-url';
+
+describe('getMcApiUrl', () => {
+  describe('when application is configured not to run behind proxy', () => {
+    it('should return the configured `mcApiUrl`', () => {
+      const actualWindow = {
+        app: {
+          mcApiUrl: 'https://mc-api.commercetools.co',
+        },
+      };
+
+      expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+    });
+  });
+
+  describe('when application is configured to run behind proxy', () => {
+    it('should not return the configured `mcApiUrl` but the origin of the window', () => {
+      const actualWindow = {
+        app: {
+          mcApiUrl: 'https://mc-api.commercetools.co',
+          servedByProxy: 'true',
+        },
+        origin: 'https://mc.europe-west1.gcp.commercetools.com',
+      };
+
+      expect(getMcApiUrl(actualWindow)).toEqual(
+        'https://mc-api.europe-west1.gcp.commercetools.com'
+      );
+    });
+
+    describe('when inferring of `mcApiUrl` from origin is disabled', () => {
+      it('should return the configured `mcApiUrl`', () => {
+        const actualWindow = {
+          app: {
+            mcApiUrl: 'https://mc-api.commercetools.co',
+            servedByProxy: 'true',
+            disableInferringOfMcApiUrlOnProduction: 'true',
+          },
+          origin: 'https://mc.europe-west1.gcp.commercetools.com',
+        };
+
+        expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+      });
+    });
+  });
+});

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.spec.js
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.spec.js
@@ -3,43 +3,43 @@ import getMcApiUrl from './get-mc-api-url';
 describe('getMcApiUrl', () => {
   describe('when application is configured not to run behind proxy', () => {
     it('should return the configured `mcApiUrl`', () => {
-      const actualWindow = {
-        app: {
-          mcApiUrl: 'https://mc-api.commercetools.co',
-        },
+      const environment = {
+        mcApiUrl: 'https://mc-api.commercetools.co',
       };
 
-      expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+      expect(getMcApiUrl(environment)).toEqual(environment.mcApiUrl);
     });
   });
 
   describe('when application is configured to run behind proxy', () => {
     it('should not return the configured `mcApiUrl` but the origin of the window', () => {
-      const actualWindow = {
-        app: {
-          mcApiUrl: 'https://mc-api.commercetools.co',
-          servedByProxy: 'true',
-        },
+      const environment = {
+        mcApiUrl: 'https://mc-api.commercetools.co',
+        servedByProxy: true,
+      };
+      const partialWindow = {
         origin: 'https://mc.europe-west1.gcp.commercetools.com',
       };
 
-      expect(getMcApiUrl(actualWindow)).toEqual(
+      expect(getMcApiUrl(environment, partialWindow)).toEqual(
         'https://mc-api.europe-west1.gcp.commercetools.com'
       );
     });
 
     describe('when inferring of `mcApiUrl` from origin is disabled', () => {
       it('should return the configured `mcApiUrl`', () => {
-        const actualWindow = {
-          app: {
-            mcApiUrl: 'https://mc-api.commercetools.co',
-            servedByProxy: 'true',
-            disableInferringOfMcApiUrlOnProduction: 'true',
-          },
+        const environment = {
+          mcApiUrl: 'https://mc-api.commercetools.co',
+          servedByProxy: true,
+          disableInferringOfMcApiUrlOnProduction: true,
+        };
+        const partialWindow = {
           origin: 'https://mc.europe-west1.gcp.commercetools.com',
         };
 
-        expect(getMcApiUrl(actualWindow)).toEqual(actualWindow.app.mcApiUrl);
+        expect(getMcApiUrl(environment, partialWindow)).toEqual(
+          environment.mcApiUrl
+        );
       });
     });
   });

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,12 +1,4 @@
-export interface ApplicationWindow extends Window {
-  app: {
-    disableInferringOfMcApiUrlOnProduction: string | boolean;
-    servedByProxy: string | boolean;
-    mcApiUrl: string;
-  };
-}
-
-declare let window: ApplicationWindow;
+import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 /**
  * NOTE:
@@ -28,27 +20,27 @@ declare let window: ApplicationWindow;
  *    Using the origin ensures that urls always match with the cookie sent. Otherwise,
  *    the application shell will rightfully redirect to the logout page.
  */
-const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
-  const url = new URL(actualWindow.origin);
+
+type TApplicationContextEnvironment = ApplicationWindow['app'];
+type TPartialWindow = Pick<Window, 'origin'>;
+
+const getMcApiUrlFromOrigin = (partialWindow: TPartialWindow) => {
+  const url = new URL(partialWindow.origin);
   const mcApiUrlHost = url.host.replace('mc.', 'mc-api.');
 
   return `${url.protocol}//${mcApiUrlHost}`;
 };
 
-const isEnvironmentConfigurationEnabled = (
-  environmentConfiguration: string | boolean
-) => environmentConfiguration === true || environmentConfiguration === 'true';
-
-export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
-  const isServedByProxy = isEnvironmentConfigurationEnabled(
-    actualWindow.app.servedByProxy
-  );
-  const isInferringOfMcApiUrlOnProductionDisabled = isEnvironmentConfigurationEnabled(
-    actualWindow.app.disableInferringOfMcApiUrlOnProduction
-  );
+export default function getMcApiUrl(
+  environment: TApplicationContextEnvironment,
+  partialWindow: TPartialWindow
+) {
+  const isServedByProxy = environment.servedByProxy;
+  const isInferringOfMcApiUrlOnProductionDisabled =
+    environment.disableInferringOfMcApiUrlOnProduction;
 
   if (isServedByProxy && !isInferringOfMcApiUrlOnProductionDisabled)
-    return getMcApiUrlFromOrigin(actualWindow);
+    return getMcApiUrlFromOrigin(partialWindow);
 
-  return actualWindow.app.mcApiUrl;
+  return environment.mcApiUrl;
 }

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,0 +1,54 @@
+export interface ApplicationWindow extends Window {
+  app: {
+    disableInferringOfMcApiUrlOnProduction: string | boolean;
+    servedByProxy: string | boolean;
+    mcApiUrl: string;
+  };
+}
+
+declare let window: ApplicationWindow;
+
+/**
+ * NOTE:
+ *    Given the Merchant Center or Custom Application runs behind the proxy
+ *    then the `mcApiUrl` should be build using the origin on the window.
+ *
+ *    This allows the Merchant Center (or any Custom Appliction) to automatically
+ *    use an `mcApiUrl` which matches the respective url of the deployment.
+ *
+ *    This is particularily useful with the new and old hostnames for the Merchant Center.
+ *    When using the origin, it will be made sure that the authorization cookie will
+ *    always be sent as the appropriate API url is used.
+ *
+ *    1. MC: mc.commercetools.com with API: mc-api.europe-west1.gcp.commercetools.com
+ *       -> Will not work as urls differ
+ *    2. MC: mc.europe-west1.gcp.commercetools.com with API: mc-api..commercetools.com
+ *       -> Will not work as urls differ
+ *
+ *    Using the origin ensures that urls always match with the cookie sent. Otherwise,
+ *    the application shell will rightfully redirect to the logout page.
+ */
+const getMcApiUrlFromOrigin = (actualWindow: ApplicationWindow) => {
+  const url = new URL(actualWindow.origin);
+  const mcApiUrlHost = url.host.replace('mc.', 'mc-api.');
+
+  return `${url.protocol}//${mcApiUrlHost}`;
+};
+
+const isEnvironmentConfigurationEnabled = (
+  environmentConfiguration: string | boolean
+) => environmentConfiguration === true || environmentConfiguration === 'true';
+
+export default function getMcApiUrl(actualWindow: ApplicationWindow = window) {
+  const isServedByProxy = isEnvironmentConfigurationEnabled(
+    actualWindow.app.servedByProxy
+  );
+  const isInferringOfMcApiUrlOnProductionDisabled = isEnvironmentConfigurationEnabled(
+    actualWindow.app.disableInferringOfMcApiUrlOnProduction
+  );
+
+  if (isServedByProxy && !isInferringOfMcApiUrlOnProductionDisabled)
+    return getMcApiUrlFromOrigin(actualWindow);
+
+  return actualWindow.app.mcApiUrl;
+}

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -39,7 +39,11 @@ export default function getMcApiUrl(
   const isInferringOfMcApiUrlOnProductionDisabled =
     environment.disableInferringOfMcApiUrlOnProduction;
 
-  if (isServedByProxy && !isInferringOfMcApiUrlOnProductionDisabled)
+  if (
+    isServedByProxy &&
+    !isInferringOfMcApiUrlOnProductionDisabled &&
+    partialWindow.origin
+  )
     return getMcApiUrlFromOrigin(partialWindow);
 
   return environment.mcApiUrl;

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/index.ts
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/index.ts
@@ -1,0 +1,1 @@
+export { default } from './get-mc-api-url';

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -151,5 +151,6 @@ export interface ApplicationWindow extends Window {
     enableSignUp?: boolean;
     disabledMenuItems?: string[];
     useFullRedirectsForLinks?: boolean;
+    disableInferringOfMcApiUrlOnProduction?: string;
   };
 }

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -151,6 +151,6 @@ export interface ApplicationWindow extends Window {
     enableSignUp?: boolean;
     disabledMenuItems?: string[];
     useFullRedirectsForLinks?: boolean;
-    disableInferringOfMcApiUrlOnProduction?: string;
+    disableInferringOfMcApiUrlOnProduction?: boolean;
   };
 }


### PR DESCRIPTION
> I closed the previous PR and opened another one cause this affects another package.

#### Summary

Please refer to https://github.com/commercetools/merchant-center-application-kit/pull/1367 for a more detailed reasoning.

#### Description

Instead of exporting the function we patch the environment.

Note, that we can't export the function from the application-shell so we duplicate it again.

A third option is to overwrite/patch the window itself upon read/boot but I don't think that's really nice.
