### PR TITLE
fix(jest-preset): to not throw on createFactory

### DIFF
--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -15,9 +15,10 @@ const shouldSilenceWarnings = (...messages) =>
   ].some(msgRegex => messages.some(msg => msgRegex.test(msg)));
 
 const shouldNotThrowWarnings = (...messages) =>
-  [/.*@commercetools-frontend\/permissions.*/].some(msgRegex =>
-    messages.some(msg => msgRegex.test(msg))
-  );
+  [
+    /.*@commercetools-frontend\/permissions.*/,
+    /.*Warning: React.createFactory() is deprecated.*/,
+  ].some(msgRegex => messages.some(msg => msgRegex.test(msg)));
 
 // setup file
 const logOrThrow = (log, method, messages) => {


### PR DESCRIPTION
#### Summary

Library code uses createFactory which in turn will trigger throwing in our tests. Either we don't adopt the latest React version of we log the error instead of throwing it. When it is actually removed we truely need to make sure no library code uses it.