### PR TITLE
fix(dev authentication): replace trailing slash in mcApiUrl

### DIFF
--- a/packages/mc-dev-authentication/views/login.pug
+++ b/packages/mc-dev-authentication/views/login.pug
@@ -30,7 +30,7 @@ html
       input(
         id="url"
         name="url"
-        value=env.mcApiUrl + "/tokens"
+        value=env.mcApiUrl.replace(/\/$/, '') + "/tokens"
         style="display: none;"
       )
       div


### PR DESCRIPTION
#### Summary

Made a one line change to have the tokens endpoint built in `mc-dev-authentication/views/login.pug` ignore any trailing slashes that are part of the mcApiUrl environment variable.  This should prevent unnecessary authentication failures when this variable has been adjusted for location.

#### Observed behavior
* Adjusting the mcApiUrl environment variable in the dashboard application to a value with a trailing slash to represent a different location for the merchant-center-frontend causes the dev authentication view to build an invalid path for the tokens endpoint with two slashes side by side.

#### Expected behavior
* The tokens endpoint builder ignores any trailing slashes that would prevent a local developer from proceeding through the authentication flow.

#### Technical debt & future

No technical debt is introduced by this minimal change.

cc: @emmenko 