### PR TITLE
PCM-1600: routes to product varitns from quick access

### DIFF
--- a/packages/application-shell/src/components/quick-access/quick-access.tsx
+++ b/packages/application-shell/src/components/quick-access/quick-access.tsx
@@ -286,7 +286,13 @@ const QuickAccess = (props: Props) => {
           keywords: variantKey ? [variantKey] : undefined,
           action: {
             type: actionTypes.go,
-            to: `/${applicationContext.project.key}/products/${productId}/${variantId}`,
+            to: oneLineTrim`
+            /${applicationContext.project.key}
+            /products
+            /${productId}
+            /variants
+            /${variantId}
+          `,
           },
           subCommands: createProductVariantSubCommands({
             intl,
@@ -318,6 +324,7 @@ const QuickAccess = (props: Props) => {
             /${applicationContext.project.key}
             /products
             /${productId}
+            /variants
             /${variantId}
           `,
           },


### PR DESCRIPTION
In which routing to Product Variant Details from the quick access is redirecting to the incorrect page in both instances. Fixed by correcting the string for the route