### PR TITLE
refactor: to not use wait-for-element

### DIFF
--- a/application-templates/starter/src/components/main-view/main-view.spec.js
+++ b/application-templates/starter/src/components/main-view/main-view.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   renderApp,
-  waitForElement,
   fireEvent,
 } from '@commercetools-frontend/application-shell/test-utils';
 import { ApplicationStarter } from '../entry-point';
@@ -9,17 +8,17 @@ import { ApplicationStarter } from '../entry-point';
 describe('main view', () => {
   it('the user can click on the link to "one" and the page should show a text with "View one"', async () => {
     const initialRoute = '/my-project/examples-starter';
-    const { getByText, history } = renderApp(<ApplicationStarter />, {
+    const rendered = renderApp(<ApplicationStarter />, {
       permissions: { canViewProducts: true, canManageProducts: true },
       route: initialRoute,
     });
-    await waitForElement(() => getByText(/Hello, world/i));
+    await rendered.findByText(/Hello, world/i);
 
-    fireEvent.click(getByText(/Page one/i));
+    fireEvent.click(rendered.getByText(/Page one/i));
 
-    await waitForElement(() => getByText(/View one/i));
+    await rendered.findByText(/View one/i);
 
-    expect(history.location).toEqual(
+    expect(rendered.history.location).toEqual(
       expect.objectContaining({
         pathname: `${initialRoute}/one`,
       })

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitForElement } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import {
   ApplicationContextProvider,
   ApplicationContext,
@@ -104,7 +104,7 @@ describe('<ApplicationContext>', () => {
         )}
       />
     );
-    await waitForElement(() => rendered.getByText('Project name: Foo 1'));
+    await rendered.findByText('Project name: Foo 1');
   });
 });
 
@@ -117,7 +117,7 @@ describe('useApplicationContext', () => {
   };
   it('should render project name from context', async () => {
     const rendered = renderAppWithContext(<TestComponent />);
-    await waitForElement(() => rendered.getByText('Project name: Foo 1'));
+    await rendered.findByText('Project name: Foo 1');
   });
 });
 
@@ -135,7 +135,7 @@ describe('withApplicationContext', () => {
   }))(TestComponent);
   it('should render project name from context', async () => {
     const rendered = renderAppWithContext(<AppWithContext />);
-    await waitForElement(() => rendered.getByText('Project name: Foo 1'));
+    await rendered.findByText('Project name: Foo 1');
   });
 });
 

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ReactReduxContext } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import { render, wait, waitForElement } from '@testing-library/react';
+import { render, wait } from '@testing-library/react';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { GtmContext } from '../gtm-booter';
 // eslint-disable-next-line import/named
@@ -39,7 +39,7 @@ describe('rendering', () => {
     hasCachedAuthenticationState.mockReturnValue(true);
   });
   it('should access environment from application context', async () => {
-    const { getByText } = render(
+    const rendered = render(
       <ApplicationShellProvider {...createTestProps()}>
         {() => (
           <ApplicationContext
@@ -48,7 +48,7 @@ describe('rendering', () => {
         )}
       </ApplicationShellProvider>
     );
-    await waitForElement(() => getByText('eu'));
+    await rendered.findByText('eu');
   });
   it('should access redux store from context', () => {
     let hasStore = false;
@@ -118,7 +118,7 @@ describe('rendering', () => {
     hasCachedAuthenticationState.mockReturnValue(false);
     __setIsAuthenticated(false);
     getBrowserLocale.mockReturnValue('de');
-    const { getByText } = render(
+    const rendered = render(
       <ApplicationShellProvider {...createTestProps()}>
         {({ isAuthenticated }) =>
           isAuthenticated ? null : (
@@ -127,17 +127,17 @@ describe('rendering', () => {
         }
       </ApplicationShellProvider>
     );
-    await waitForElement(() => getByText('Titel'));
+    await rendered.findByText('Titel');
   });
   it('when authenticated, it should render children', async () => {
-    const { getByText } = render(
+    const rendered = render(
       <ApplicationShellProvider {...createTestProps()}>
         {({ isAuthenticated }) =>
           isAuthenticated ? <div>{'Hello'}</div> : null
         }
       </ApplicationShellProvider>
     );
-    await waitForElement(() => getByText('Hello'));
+    await rendered.findByText('Hello');
   });
   it('when something in the children throws, it should render the error apologiser page', async () => {
     console.error = jest.fn();
@@ -149,14 +149,12 @@ describe('rendering', () => {
         return null;
       }
     }
-    const { getByText } = render(
+    const rendered = render(
       <ApplicationShellProvider {...createTestProps()}>
         {() => <Thrower />}
       </ApplicationShellProvider>
     );
-    await waitForElement(() =>
-      getByText(/Sorry! An unexpected error occured/i)
-    );
+    await rendered.findByText(/Sorry! An unexpected error occured/i);
     expect(console.error).toHaveBeenCalled();
   });
 });

--- a/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { renderApp, waitForElement } from '../../test-utils';
+import { renderApp } from '../../test-utils';
 import ProjectQuery from './fetch-project.mc.graphql';
 import FetchProject from './fetch-project';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
@@ -90,7 +90,7 @@ const createGraphqlResponseForProjectQuery = custom => ({
 
 describe('rendering', () => {
   it('should fetch project and pass data to children function', async () => {
-    const { getByText } = renderProject({
+    const rendered = renderProject({
       mocks: [
         {
           request: {
@@ -106,10 +106,10 @@ describe('rendering', () => {
         },
       ],
     });
-    await waitForElement(() => getByText(/Test 1/i));
+    await rendered.findByText(/Test 1/i);
   });
   it('should render loading state', async () => {
-    const { getByText } = renderProject({
+    const rendered = renderProject({
       mocks: [
         {
           request: {
@@ -128,10 +128,10 @@ describe('rendering', () => {
         },
       ],
     });
-    await waitForElement(() => getByText(/Loading/i));
+    await rendered.findByText(/Loading/i);
   });
   it('should render error state', async () => {
-    const { getByText } = renderProject({
+    const rendered = renderProject({
       mocks: [
         {
           request: {
@@ -145,7 +145,7 @@ describe('rendering', () => {
         },
       ],
     });
-    await waitForElement(() => getByText(/Error: Oops/i));
+    await rendered.findByText(/Error: Oops/i);
     expect(reportErrorToSentry).toHaveBeenCalled();
   });
 });

--- a/packages/application-shell/src/components/fetch-user/fetch-user.spec.js
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { renderApp, waitForElement } from '../../test-utils';
+import { renderApp } from '../../test-utils';
 import LoggedInUserQuery from './fetch-user.mc.graphql';
 import FetchUser from './fetch-user';
 
@@ -56,7 +56,7 @@ const createGraphqlResponseForUserQuery = custom => ({
 
 describe('rendering', () => {
   it('should fetch user and pass data to children function', async () => {
-    const { getByText } = renderUser({
+    const rendered = renderUser({
       addTypename: true,
       mocks: [
         {
@@ -72,10 +72,10 @@ describe('rendering', () => {
         },
       ],
     });
-    await waitForElement(() => getByText(/John/i));
+    await rendered.findByText(/John/i);
   });
   it('should render loading state', async () => {
-    const { getByText } = renderUser({
+    const rendered = renderUser({
       addTypename: true,
       mocks: [
         {
@@ -94,10 +94,10 @@ describe('rendering', () => {
         },
       ],
     });
-    await waitForElement(() => getByText(/Loading/i));
+    await rendered.findByText(/Loading/i);
   });
   it('should render error state', async () => {
-    const { getByText } = renderUser({
+    const rendered = renderUser({
       addTypename: true,
       mocks: [
         {
@@ -111,6 +111,6 @@ describe('rendering', () => {
         },
       ],
     });
-    await waitForElement(() => getByText(/Error: Oops/i));
+    await rendered.findByText(/Error: Oops/i);
   });
 });

--- a/packages/application-shell/src/components/inject-reducers/inject-reducers.spec.js
+++ b/packages/application-shell/src/components/inject-reducers/inject-reducers.spec.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-  renderAppWithRedux,
-  waitForElement,
-  fireEvent,
-} from '../../test-utils';
+import { renderAppWithRedux, fireEvent } from '../../test-utils';
 import InjectReducers from './inject-reducers';
 
 const Counter = props => (
@@ -41,16 +37,16 @@ const reducers = { counter: counterReducer };
 
 describe('injecting reducers', () => {
   it('should inject reducers and render count from connected store', async () => {
-    const { getByText, getByTestId } = renderAppWithRedux(
+    const rendered = renderAppWithRedux(
       <InjectReducers id="test" reducers={reducers}>
         <ConnectedCounter />
       </InjectReducers>
     );
 
-    await waitForElement(() => getByText(/The count is 0/i));
+    await rendered.findByText(/The count is 0/i);
 
-    fireEvent.click(getByTestId('increment'));
+    fireEvent.click(rendered.getByTestId('increment'));
 
-    await waitForElement(() => getByText(/The count is 1/i));
+    await rendered.findByText(/The count is 1/i);
   });
 });

--- a/packages/application-shell/src/components/project-data-locale/project-data-locale.spec.js
+++ b/packages/application-shell/src/components/project-data-locale/project-data-locale.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitForElement } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { STORAGE_KEYS } from '../../constants';
 import ProjectDataLocale from './project-data-locale';
 import { wait } from '@apollo/react-testing';
@@ -20,7 +20,7 @@ describe('rendering', () => {
             {({ locale }) => <span>{`Locale: ${locale}`}</span>}
           </ProjectDataLocale>
         );
-        await waitForElement(() => rendered.getByText('Locale: de'));
+        await rendered.findByText('Locale: de');
       });
     });
     describe('when cached locale is not in the list of project locales', () => {
@@ -31,7 +31,7 @@ describe('rendering', () => {
             {({ locale }) => <span>{`Locale: ${locale}`}</span>}
           </ProjectDataLocale>
         );
-        await waitForElement(() => rendered.getByText('Locale: en'));
+        await rendered.findByText('Locale: en');
         await wait(() => {
           expect(window.localStorage.setItem).toHaveBeenCalledWith(
             STORAGE_KEYS.SELECTED_DATA_LOCALE,
@@ -49,7 +49,7 @@ describe('rendering', () => {
           {({ locale }) => <span>{`Locale: ${locale}`}</span>}
         </ProjectDataLocale>
       );
-      await waitForElement(() => rendered.getByText('Locale: en'));
+      await rendered.findByText('Locale: en');
       await wait(() => {
         expect(window.localStorage.setItem).toHaveBeenCalledWith(
           STORAGE_KEYS.SELECTED_DATA_LOCALE,

--- a/packages/application-shell/src/components/project-switcher/project-switcher.spec.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.spec.tsx
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { renderApp, fireEvent, waitForElement, wait } from '../../test-utils';
+import { renderApp, fireEvent, wait } from '../../test-utils';
 import { createGraphqlResponseForProjectsQuery } from './project-switcher-test-utils';
 import ProjectSwitcher from './project-switcher';
 
@@ -29,7 +29,7 @@ describe('rendering', () => {
   });
   it('should search and select a project', async () => {
     const rendered = render();
-    await waitForElement(() => rendered.getByLabelText('Project switcher'));
+    await rendered.findByLabelText('Project switcher');
     const input = rendered.getByLabelText('Project switcher');
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'key-1' } });
@@ -41,20 +41,18 @@ describe('rendering', () => {
   });
   it('should see no results message when search does not match any project', async () => {
     const rendered = render();
-    await waitForElement(() => rendered.getByLabelText('Project switcher'));
+    await rendered.findByLabelText('Project switcher');
     const input = rendered.getByLabelText('Project switcher');
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'not existing' } });
 
-    await waitForElement(() =>
-      rendered.getByText(
-        /Sorry, but there are no projects that match your search/i
-      )
+    await rendered.findByText(
+      /Sorry, but there are no projects that match your search/i
     );
   });
   it('should prevent clicking on a suspended project', async () => {
     const rendered = render();
-    await waitForElement(() => rendered.getByLabelText('Project switcher'));
+    await rendered.findByLabelText('Project switcher');
     const input = rendered.getByLabelText('Project switcher');
     fireEvent.focus(input);
     fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -66,7 +64,7 @@ describe('rendering', () => {
   });
   it('should prevent clicking on an expired project', async () => {
     const rendered = render();
-    await waitForElement(() => rendered.getByLabelText('Project switcher'));
+    await rendered.findByLabelText('Project switcher');
     const input = rendered.getByLabelText('Project switcher');
     fireEvent.focus(input);
     fireEvent.keyDown(input, { key: 'ArrowDown' });

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderApp, wait, waitForElement } from '../../test-utils';
+import { renderApp, wait } from '../../test-utils';
 import RouteCatchAll from './route-catch-all';
 
 describe('rendering', () => {
@@ -23,9 +23,7 @@ describe('rendering', () => {
           servedByProxy: false,
         },
       });
-      await waitForElement(() =>
-        rendered.getByText('We could not find what you are looking for')
-      );
+      await rendered.findByText('We could not find what you are looking for');
     });
   });
 });

--- a/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
+++ b/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { renderApp, wait, waitForElement } from '../../test-utils';
+import { renderApp, wait } from '../../test-utils';
 import { createGraphqlResponseForProjectsQuery } from '../project-switcher/project-switcher-test-utils';
 import ServicePageProjectSwitcher from './service-page-project-switcher';
 
@@ -51,8 +51,10 @@ describe('rendering', () => {
           mocks: mockedRequest,
         }
       );
-      await waitForElement(() =>
-        rendered.container.querySelector('[name="project-switcher"]')
+      await wait(() =>
+        expect(
+          rendered.container.querySelector('[name="project-switcher"]')
+        ).toBeInTheDocument()
       );
     });
   });

--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.spec.js
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { renderApp, waitForElement, wait } from '../../test-utils';
+import { renderApp, wait } from '../../test-utils';
 import FetchAllMenuFeatureToggles from './fetch-all-menu-feature-toggles.proxy.graphql';
 import useAllMenuFeatureToggles from './use-all-menu-feature-toggles';
 
@@ -70,12 +70,10 @@ describe('when served by proxy', () => {
         mocks: [mockRequests.withoutError],
       });
 
-      await waitForElement(() => rendered.getByText('Loading'));
-      await waitForElement(() => [
-        rendered.getByText(/Number of toggles: 2/i),
-        rendered.getByText(/Toggle: flagA is disabled/i),
-        rendered.getByText(/Toggle: flagB is disabled/i),
-      ]);
+      await rendered.findByText('Loading');
+      await rendered.findByText(/Number of toggles: 2/i);
+      await rendered.findByText(/Toggle: flagA is disabled/i);
+      await rendered.findByText(/Toggle: flagB is disabled/i);
     });
   });
 
@@ -88,8 +86,8 @@ describe('when served by proxy', () => {
         mocks: [mockRequests.withError],
       });
 
-      await waitForElement(() => rendered.getByText('Loading'));
-      await waitForElement(() => rendered.getByText(/Number of toggles: 0/i));
+      await rendered.findByText('Loading');
+      await rendered.findByText(/Number of toggles: 0/i);
 
       await wait(() => {
         expect(reportErrorToSentry).toHaveBeenCalled();
@@ -104,6 +102,6 @@ describe('when not served proxy', () => {
 
     expect(rendered.queryByText('Loading')).not.toBeInTheDocument();
 
-    await waitForElement(() => rendered.getByText(/Number of toggles: 0/i));
+    await rendered.findByText(/Number of toggles: 0/i);
   });
 });

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitForElement } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import branchOnPermissions from './branch-on-permissions';
 
@@ -88,8 +88,8 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
 describe('rendering', () => {
   describe('when permissions match', () => {
     it('should render component', async () => {
-      const { getByText } = renderWithPermissions(['ViewProducts']);
-      await waitForElement(() => getByText('Authorized'));
+      const rendered = renderWithPermissions(['ViewProducts']);
+      await rendered.findByText('Authorized');
     });
   });
 });

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.spec.tsx
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.spec.tsx
@@ -2,7 +2,7 @@ import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { render, waitForElement, RenderResult } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_PAGE,
@@ -52,7 +52,7 @@ describe('rendering', () => {
       );
     });
     it('should render the <CustomComponent> notification component', async () => {
-      await waitForElement(() => rendered.getByText('Custom component'));
+      await rendered.findByText('Custom component');
     });
   });
   describe('for domain: page', () => {
@@ -72,7 +72,7 @@ describe('rendering', () => {
         );
       });
       it('should render the GenericNotification notification component', async () => {
-        await waitForElement(() => rendered.getByText('Something went wrong'));
+        await rendered.findByText('Something went wrong');
       });
     });
     describe('for kind: api-error', () => {
@@ -98,10 +98,8 @@ describe('rendering', () => {
         );
       });
       it('should render the ApiErrorNotification notification component', async () => {
-        await waitForElement(() =>
-          rendered.getByText(
-            /we were unable to save your changes as someone else made changes to this same resource while you were editing/
-          )
+        await rendered.findByText(
+          /we were unable to save your changes as someone else made changes to this same resource while you were editing/
         );
       });
     });
@@ -122,8 +120,8 @@ describe('rendering', () => {
         );
       });
       it('should render the UnexpectedErrorNotification notification component', async () => {
-        await waitForElement(() =>
-          rendered.getByText(/Sorry, but there seems to be something wrong/)
+        await rendered.findByText(
+          /Sorry, but there seems to be something wrong/
         );
       });
     });
@@ -145,7 +143,7 @@ describe('rendering', () => {
         );
       });
       it('should render the GenericNotification notification component', async () => {
-        await waitForElement(() => rendered.getByText('Something went wrong'));
+        await rendered.findByText('Something went wrong');
       });
     });
     describe('for kind: unexpected-error', () => {
@@ -164,8 +162,8 @@ describe('rendering', () => {
         );
       });
       it('should render the UnexpectedErrorNotification notification component', async () => {
-        await waitForElement(() =>
-          rendered.getByText(/Sorry, but there seems to be something wrong/)
+        await rendered.findByText(
+          /Sorry, but there seems to be something wrong/
         );
       });
     });
@@ -187,7 +185,7 @@ describe('rendering', () => {
         );
       });
       it('should render the GenericNotification notification component', async () => {
-        await waitForElement(() => rendered.getByText('Something went wrong'));
+        await rendered.findByText('Something went wrong');
       });
     });
   });

--- a/packages/react-notifications/src/components/notifier/notifier.spec.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.spec.tsx
@@ -1,13 +1,7 @@
 /* eslint-disable react/prop-types */
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  waitForElement,
-  wait,
-  RenderResult,
-} from '@testing-library/react';
+import { render, fireEvent, wait, RenderResult } from '@testing-library/react';
 import {
   TAddNotificationAction,
   ADD_NOTIFICATION,
@@ -72,7 +66,7 @@ describe('rendering', () => {
         />
       </TestController>
     );
-    await waitForElement(() => rendered.getByText('Open'));
+    await rendered.findByText('Open');
     fireEvent.click(rendered.getByText('Open'));
 
     await wait(() => {
@@ -90,7 +84,7 @@ describe('rendering', () => {
     fireEvent.click(rendered.getByText('Increase counter'));
     fireEvent.click(rendered.getByText('Increase counter'));
     fireEvent.click(rendered.getByText('Increase counter'));
-    await waitForElement(() => rendered.getByText('Count: 3'));
+    await rendered.findByText('Count: 3');
 
     fireEvent.click(rendered.getByText('Close'));
     await wait(() => {

--- a/playground/src/components/state-machines-list/state-machines-list.spec.js
+++ b/playground/src/components/state-machines-list/state-machines-list.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 import {
   renderAppWithRedux,
-  waitForElement,
   wait,
   fireEvent,
 } from '@commercetools-frontend/application-shell/test-utils';
@@ -105,12 +104,10 @@ describe('list view', () => {
         canManageDeveloperSettings: true,
       },
     });
-    await waitForElement(() => rendered.getByText(/State machines/i));
-    await waitForElement(() =>
-      rendered.getByText(/There are 2 objects in the cache/i)
-    );
-    await waitForElement(() => rendered.getByText('sm-1'));
-    await waitForElement(() => rendered.getByText('sm-2'));
+    await rendered.findByText(/State machines/i);
+    await rendered.findByText(/There are 2 objects in the cache/i);
+    await rendered.findByText('sm-1');
+    await rendered.findByText('sm-2');
   });
   it('the user can click on the state machines to get to the details page', async () => {
     rendered = renderApp({
@@ -123,16 +120,14 @@ describe('list view', () => {
         canManageDeveloperSettings: true,
       },
     });
-    await waitForElement(() =>
-      rendered.getByText(/There are 2 objects in the cache/i)
-    );
+    await rendered.findByText(/There are 2 objects in the cache/i);
     fireEvent.click(rendered.getByText('sm-1'));
     await wait(() => {
       expect(rendered.history.location.pathname).toBe(
         '/my-project/state-machines/sm1'
       );
     });
-    await waitForElement(() => rendered.getByText(/sm-1/i));
+    await rendered.findByText(/sm-1/i);
   });
 });
 
@@ -151,7 +146,7 @@ describe('details view', () => {
           canManageDeveloperSettings: true,
         },
       });
-      await waitForElement(() => rendered.getByText(/sm-1/i));
+      await rendered.findByText(/sm-1/i);
     });
     it('should retrigger request if id changes', async () => {
       rendered = renderApp({
@@ -165,10 +160,10 @@ describe('details view', () => {
           canManageDeveloperSettings: true,
         },
       });
-      await waitForElement(() => rendered.getByText(/sm-1/i));
+      await rendered.findByText(/sm-1/i);
 
       rendered.history.push('/my-project/state-machines/sm2');
-      await waitForElement(() => rendered.getByText(/sm-2/i));
+      await rendered.findByText(/sm-2/i);
     });
   });
   describe('when request returns an error', () => {
@@ -184,8 +179,8 @@ describe('details view', () => {
           canManageDeveloperSettings: true,
         },
       });
-      await waitForElement(() =>
-        rendered.getByText(/^Sorry, but there seems to be something wrong/i)
+      await rendered.findByText(
+        /^Sorry, but there seems to be something wrong/i
       );
     });
   });


### PR DESCRIPTION
#### Summary

This uses the new findBy API. The other dep update PR is blocked by this. I just want to extract this out of a dependency update where possible.