### PR TITLE
refactor: to use waitFor and waitForElementToBeRemoved

### DIFF
--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
-import { renderComponent, wait, fireEvent } from '../../../test-utils';
+import { renderComponent, fireEvent } from '../../../test-utils';
 import ConfirmationDialog from './confirmation-dialog';
 
 type DialogControllerProps = {
@@ -27,7 +27,7 @@ describe('rendering', () => {
   it('should open the modal and close it by clicking on the close button', async () => {
     const onCancel = jest.fn();
     const onConfirm = jest.fn();
-    const { queryByText, getByLabelText } = renderComponent(
+    const rendered = renderComponent(
       <DialogController>
         {({ isOpen, setIsOpen }) => (
           <ConfirmationDialog
@@ -42,28 +42,24 @@ describe('rendering', () => {
         )}
       </DialogController>
     );
-    expect(queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
+    expect(rendered.queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
 
-    fireEvent.click(getByLabelText(/Open Confirmation Dialog/i));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/i)).toBeInTheDocument();
-    });
-    expect(queryByText(/Hello/i)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Open Confirmation Dialog/i));
+    await rendered.findByText(/Lorem ipsus/i);
+    expect(rendered.queryByText(/Hello/i)).toBeInTheDocument();
 
-    fireEvent.click(getByLabelText('Cancel'));
+    fireEvent.click(rendered.getByLabelText('Cancel'));
     expect(onCancel).toHaveBeenCalled();
-    fireEvent.click(getByLabelText('Confirm'));
+    fireEvent.click(rendered.getByLabelText('Confirm'));
     expect(onConfirm).toHaveBeenCalled();
 
-    fireEvent.click(getByLabelText(/Close dialog/i));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
-    });
+    fireEvent.click(rendered.getByLabelText(/Close dialog/i));
+    expect(rendered.queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
   });
   it('should not be able to close the modal when onClose is not provided', async () => {
     const onCancel = jest.fn();
     const onConfirm = jest.fn();
-    const { queryByText, getByLabelText } = renderComponent(
+    const rendered = renderComponent(
       <DialogController>
         {({ isOpen }) => (
           <ConfirmationDialog
@@ -77,16 +73,12 @@ describe('rendering', () => {
         )}
       </DialogController>
     );
-    expect(queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
+    expect(rendered.queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
 
-    fireEvent.click(getByLabelText(/Open Confirmation Dialog/i));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/i)).toBeInTheDocument();
-    });
-    expect(queryByText(/Hello/i)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Open Confirmation Dialog/i));
+    await rendered.findByText(/Lorem ipsus/i);
+    expect(rendered.queryByText(/Hello/i)).toBeInTheDocument();
 
-    await wait(() => {
-      expect(queryByText(/Close dialog/i)).not.toBeInTheDocument();
-    });
+    expect(rendered.queryByText(/Close dialog/i)).not.toBeInTheDocument();
   });
 });

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
-import { renderComponent, wait, fireEvent } from '../../../test-utils';
+import { renderComponent, fireEvent } from '../../../test-utils';
 import FormDialog from './form-dialog';
 
 type DialogControllerProps = {
@@ -27,7 +27,7 @@ describe('rendering', () => {
   it('should open the modal and close it by clicking on the close button', async () => {
     const onCancel = jest.fn();
     const onConfirm = jest.fn();
-    const { queryByText, getByLabelText } = renderComponent(
+    const rendered = renderComponent(
       <DialogController>
         {({ isOpen, setIsOpen }) => (
           <FormDialog
@@ -42,28 +42,24 @@ describe('rendering', () => {
         )}
       </DialogController>
     );
-    expect(queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
+    expect(rendered.queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
 
-    fireEvent.click(getByLabelText(/Open Form Dialog/i));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/i)).toBeInTheDocument();
-    });
-    expect(queryByText(/Hello/i)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Open Form Dialog/i));
+    await rendered.findByText(/Lorem ipsus/i);
+    expect(rendered.queryByText(/Hello/i)).toBeInTheDocument();
 
-    fireEvent.click(getByLabelText('Cancel'));
+    fireEvent.click(rendered.getByLabelText('Cancel'));
     expect(onCancel).toHaveBeenCalled();
-    fireEvent.click(getByLabelText('Save'));
+    fireEvent.click(rendered.getByLabelText('Save'));
     expect(onConfirm).toHaveBeenCalled();
 
-    fireEvent.click(getByLabelText(/Close dialog/i));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
-    });
+    fireEvent.click(rendered.getByLabelText(/Close dialog/i));
+    expect(rendered.queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
   });
   it('should not be able to close the modal when onClose is not provided', async () => {
     const onCancel = jest.fn();
     const onConfirm = jest.fn();
-    const { queryByText, getByLabelText } = renderComponent(
+    const rendered = renderComponent(
       <DialogController>
         {({ isOpen }) => (
           <FormDialog
@@ -77,16 +73,12 @@ describe('rendering', () => {
         )}
       </DialogController>
     );
-    expect(queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
+    expect(rendered.queryByText(/Lorem ipsus/i)).not.toBeInTheDocument();
 
-    fireEvent.click(getByLabelText(/Open Form Dialog/i));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/i)).toBeInTheDocument();
-    });
-    expect(queryByText(/Hello/i)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Open Form Dialog/i));
+    await rendered.findByText(/Lorem ipsus/i);
+    expect(rendered.queryByText(/Hello/i)).toBeInTheDocument();
 
-    await wait(() => {
-      expect(queryByText(/Close dialog/i)).not.toBeInTheDocument();
-    });
+    expect(rendered.queryByText(/Close dialog/i)).not.toBeInTheDocument();
   });
 });

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
-import { renderComponent, wait, fireEvent } from '../../../test-utils';
+import { renderComponent, fireEvent } from '../../../test-utils';
 import InfoDialog from './info-dialog';
 
 type DialogControllerProps = {
@@ -25,7 +25,7 @@ DialogController.displayName = 'DialogController';
 
 describe('rendering', () => {
   it('should open the modal and close it by clicking on the close button', async () => {
-    const { queryByText, getByLabelText } = renderComponent(
+    const rendered = renderComponent(
       <DialogController>
         {({ isOpen, setIsOpen }) => (
           <InfoDialog
@@ -38,17 +38,13 @@ describe('rendering', () => {
         )}
       </DialogController>
     );
-    expect(queryByText(/Lorem ipsus/)).not.toBeInTheDocument();
+    expect(rendered.queryByText(/Lorem ipsus/)).not.toBeInTheDocument();
 
-    fireEvent.click(getByLabelText(/Open Info Dialog/));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/)).toBeInTheDocument();
-    });
-    expect(queryByText(/Hello/)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Open Info Dialog/));
+    await rendered.findByText(/Lorem ipsus/);
+    expect(rendered.queryByText(/Hello/)).toBeInTheDocument();
 
-    fireEvent.click(getByLabelText(/Close dialog/));
-    await wait(() => {
-      expect(queryByText(/Lorem ipsus/)).not.toBeInTheDocument();
-    });
+    fireEvent.click(rendered.getByLabelText(/Close dialog/));
+    expect(rendered.queryByText(/Lorem ipsus/)).not.toBeInTheDocument();
   });
 });

--- a/packages/application-shell/src/components/application-loader/application-loader.spec.js
+++ b/packages/application-shell/src/components/application-loader/application-loader.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import ApplicationLoader from './application-loader';
 
 describe('rendering', () => {
@@ -16,15 +16,10 @@ describe('rendering', () => {
     beforeEach(() => {
       rendered = render(<ApplicationLoader />);
     });
-    it('should render the commercetools logo', async () => {
-      await wait(
-        () => {
-          expect(
-            rendered.queryByAltText('commercetools logo')
-          ).not.toBeInTheDocument();
-        },
-        { timeout: 1000 }
-      );
+    it('should not render the commercetools logo', async () => {
+      expect(
+        rendered.queryByAltText('commercetools logo')
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ReactReduxContext } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import { render, wait } from '@testing-library/react';
+import { render, wait as waitFor } from '@testing-library/react';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { GtmContext } from '../gtm-booter';
 // eslint-disable-next-line import/named
@@ -110,7 +110,7 @@ describe('rendering', () => {
         }}
       </ApplicationShellProvider>
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(isAuth).toBe(false);
     });
   });

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { encode } from 'qss';
 import xhrMock from 'xhr-mock';
-import { render, wait, fireEvent, within } from '@testing-library/react';
+import {
+  render,
+  wait as waitFor,
+  fireEvent,
+  within,
+} from '@testing-library/react';
 import { AuthenticationError, ApolloError } from 'apollo-server-errors';
 import { useDispatch } from 'react-redux';
 import { createMemoryHistory } from 'history';
@@ -130,7 +135,7 @@ describe('when route does not contain a project key (e.g. /account)', () => {
     const rendered = renderApp();
     await rendered.findByText('OK');
     rendered.history.push('/account');
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe('/account');
       expect(rendered.queryByTestId('left-navigation')).not.toBeInTheDocument();
     });
@@ -146,7 +151,7 @@ describe('when user first visits "/" with no projectKey defined in localStorage'
   });
   it('should not render the NavBar first, then redirect to "/:projectKey" and render the NavBar', async () => {
     const rendered = renderApp();
-    await wait(() => {
+    await waitFor(() => {
       // Redirect "/" -> "/:projectKey"
       expect(rendered.history.location.pathname).toBe(
         `/${operations.FetchProject.project.key}`
@@ -176,7 +181,7 @@ describe('when user has no default project', () => {
         servedByProxy: 'true',
       },
     });
-    await wait(() => {
+    await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith(
         '/account/projects/new'
       );
@@ -218,7 +223,7 @@ describe('when loading user fails with an unauthorized graphql error', () => {
     const queryParams = encode({
       reason: LOGOUT_REASONS.UNAUTHORIZED,
     });
-    await wait(() => {
+    await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith(
         expect.stringContaining(`/logout?${queryParams}`)
       );
@@ -243,7 +248,7 @@ describe('when loading user fails with a "was not found." graphql error message'
     const queryParams = encode({
       reason: LOGOUT_REASONS.DELETED,
     });
-    await wait(() => {
+    await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith(
         expect.stringContaining(`/logout?${queryParams}`)
       );
@@ -385,7 +390,7 @@ describe('when project is about to expire (>14 days left)', () => {
   });
   it('should not render global warning message', async () => {
     const rendered = renderApp();
-    await wait(() => {
+    await waitFor(() => {
       expect(
         rendered.queryByText(/^Your project trial period will expire (.*)$/)
       ).not.toBeInTheDocument();
@@ -484,7 +489,7 @@ describe('when switching project', () => {
     fireEvent.focus(input);
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     rendered.getByText(nextProject.name).click();
-    await wait(() => {
+    await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith(
         `/${nextProject.key}`
       );
@@ -512,7 +517,7 @@ describe('when user is not authenticated', () => {
       reason: LOGOUT_REASONS.UNAUTHORIZED,
       redirectTo: `${window.location.origin}/foo`,
     });
-    await wait(() => {
+    await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith(
         `${window.location.origin}/login?${queryParams}`
       );
@@ -560,7 +565,7 @@ describe('when project has only one language', () => {
   });
   it('should not render locale switcher', async () => {
     const rendered = renderApp();
-    await wait(() => {
+    await waitFor(() => {
       expect(
         rendered.container.querySelector('[name="locale-switcher"]')
       ).not.toBeInTheDocument();
@@ -584,7 +589,7 @@ describe('when user has no projects', () => {
   });
   it('should not render project switcher', async () => {
     const rendered = renderApp();
-    await wait(() => {
+    await waitFor(() => {
       expect(
         rendered.container.querySelector('[name="project-switcher"]')
       ).not.toBeInTheDocument();
@@ -645,7 +650,7 @@ describe('when dispatching a loading notification', () => {
     await rendered.findByText('Processing...');
     const hideBtn = await rendered.findByText('Hide loading');
     fireEvent.click(hideBtn);
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.queryByText('Processing...')).not.toBeInTheDocument();
     });
   });
@@ -662,14 +667,14 @@ describe('when clicking on navbar menu toggle', () => {
     const rendered = renderApp();
     const button = await rendered.findByTestId('menu-expander');
     fireEvent.click(button);
-    await wait(() => {
+    await waitFor(() => {
       expect(window.localStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.IS_FORCED_MENU_OPEN,
         'false'
       );
     });
     fireEvent.click(button);
-    await wait(() => {
+    await waitFor(() => {
       expect(window.localStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.IS_FORCED_MENU_OPEN,
         'true'
@@ -697,7 +702,7 @@ describe('navbar menu links interactions', () => {
     const submenuContainer = rendered.container.querySelector(`#${groupId}`);
     expect(submenuContainer).toHaveAttribute('aria-expanded', 'false');
     fireEvent.click(menuTitle);
-    await wait(() => {
+    await waitFor(() => {
       expect(submenuContainer).toHaveAttribute('aria-expanded', 'true');
     });
     const menuGroupContainer = within(rendered.getByTestId(groupId));
@@ -706,7 +711,7 @@ describe('navbar menu links interactions', () => {
     expect(menuLink).not.toHaveAttribute('aria-current');
     // Go to the link to check if the link becomes active
     fireEvent.click(menuLink);
-    await wait(() => {
+    await waitFor(() => {
       expect(menuLink).toHaveAttribute('aria-current', 'page');
     });
   }
@@ -845,7 +850,7 @@ describe('when navbar menu items are disabled', () => {
     const mainMenuLabel = navbarMock.labelAllLocales.find(
       localized => localized.locale === applicationLocale
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(
         navbarRendered.queryByText(mainMenuLabel.value)
       ).not.toBeInTheDocument();
@@ -888,7 +893,7 @@ describe('when navbar menu items are hidden', () => {
     const mainMenuLabel = navbarMock.labelAllLocales.find(
       localized => localized.locale === applicationLocale
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(
         navbarRendered.queryByText(mainMenuLabel.value)
       ).not.toBeInTheDocument();
@@ -962,7 +967,7 @@ describe('when navbar menu items do not match given permissions', () => {
     const mainMenuLabel = navbarMock.labelAllLocales.find(
       localized => localized.locale === applicationLocale
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(
         navbarRendered.queryByText(mainMenuLabel.value)
       ).not.toBeInTheDocument();
@@ -1052,7 +1057,7 @@ describe('when navbar menu items do not match given action rights', () => {
     const mainMenuLabel = navbarMock.labelAllLocales.find(
       localized => localized.locale === applicationLocale
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(
         navbarRendered.queryByText(mainMenuLabel.value)
       ).not.toBeInTheDocument();
@@ -1158,7 +1163,7 @@ describe('when navbar menu items do not match given data fences', () => {
     const mainMenuLabel = navbarMock.labelAllLocales.find(
       localized => localized.locale === applicationLocale
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(
         navbarRendered.queryByText(mainMenuLabel.value)
       ).not.toBeInTheDocument();

--- a/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
+++ b/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
@@ -2,7 +2,7 @@ import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { GraphQLError } from 'graphql';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import { STORAGE_KEYS } from '../../constants';
 import AmILoggedInQuery from './authenticated.mc.graphql';
 import Authenticated, { TProps } from './authenticated';
@@ -24,7 +24,7 @@ describe('rendering', () => {
       mocked(window.localStorage.getItem).mockReturnValue('true');
       const props = createTestProps();
       renderApp(<Authenticated {...props} />);
-      await wait(() => {
+      await waitFor(() => {
         expect(props.render).toHaveBeenCalledWith({ isAuthenticated: true });
       });
     });
@@ -49,7 +49,7 @@ describe('rendering', () => {
             },
           ],
         });
-        await wait(() => {
+        await waitFor(() => {
           expect(props.render).toHaveBeenCalledWith({ isAuthenticated: true });
         });
         expect(mocked(window.localStorage.setItem)).toHaveBeenCalledWith(
@@ -79,7 +79,7 @@ describe('rendering', () => {
             },
           ],
         });
-        await wait(() => {
+        await waitFor(() => {
           expect(props.render).toHaveBeenCalledWith({ isAuthenticated: false });
         });
         expect(mocked(window.localStorage.setItem)).not.toHaveBeenCalled();
@@ -107,7 +107,7 @@ describe('rendering', () => {
             },
           ],
         });
-        await wait(
+        await waitFor(
           () => {
             expect(props.render).not.toHaveBeenCalled();
           },

--- a/packages/application-shell/src/components/back-to-project/back-to-project.spec.tsx
+++ b/packages/application-shell/src/components/back-to-project/back-to-project.spec.tsx
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { renderApp, fireEvent, wait } from '../../test-utils';
+import { renderApp, fireEvent, wait as waitFor } from '../../test-utils';
 import BackToProject from './back-to-project';
 
 beforeEach(() => {
@@ -11,7 +11,7 @@ describe('with `projectKey`', () => {
   it('should redirect to the project with the key', async () => {
     const rendered = renderApp(<BackToProject projectKey="test-project-key" />);
     fireEvent.click(rendered.getByText('Back to project'));
-    await wait(() => {
+    await waitFor(() => {
       expect(mocked(window.location.replace)).toHaveBeenCalledWith(
         '/test-project-key'
       );
@@ -22,7 +22,7 @@ describe('without `projectKey`', () => {
   it('should redirect to the root', async () => {
     const rendered = renderApp(<BackToProject />);
     fireEvent.click(rendered.getByText('Back to project'));
-    await wait(() => {
+    await waitFor(() => {
       expect(mocked(window.location.replace)).toHaveBeenCalledWith('/');
     });
   });

--- a/packages/application-shell/src/components/gtm-application-tracker/gtm-application-tracker.spec.js
+++ b/packages/application-shell/src/components/gtm-application-tracker/gtm-application-tracker.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render, wait as waitFor } from '@testing-library/react';
 import GtmApplicationTracker from './gtm-application-tracker';
 
 describe('rendering', () => {
@@ -12,7 +12,7 @@ describe('rendering', () => {
         projectKey="project-key"
       />
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(window.dataLayer).toEqual(
         expect.arrayContaining([
           { applicationName: 'playground' },

--- a/packages/application-shell/src/components/gtm-booter/gtm-booter.spec.tsx
+++ b/packages/application-shell/src/components/gtm-booter/gtm-booter.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, wait, fireEvent } from '@testing-library/react';
+import { render, wait as waitFor, fireEvent } from '@testing-library/react';
 import { ApplicationWindow } from '@commercetools-frontend/constants';
 import GtmBooter, { Props } from './gtm-booter';
 
@@ -28,7 +28,7 @@ describe('rendering', () => {
       </GtmBooter>
     );
     fireEvent.click(rendered.getByText('Click me'));
-    await wait(() => {
+    await waitFor(() => {
       expect(window.dataLayer).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/packages/application-shell/src/components/gtm-user-logout-tracker/gtm-user-logout-tracker.spec.js
+++ b/packages/application-shell/src/components/gtm-user-logout-tracker/gtm-user-logout-tracker.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render, wait as waitFor } from '@testing-library/react';
 import GtmUserLogoutTracker from './gtm-user-logout-tracker';
 
 describe('rendering', () => {
@@ -7,7 +7,7 @@ describe('rendering', () => {
     window.app = { trackingGtm: '111' };
     window.dataLayer = [];
     render(<GtmUserLogoutTracker />);
-    await wait(() => {
+    await waitFor(() => {
       expect(window.dataLayer).toEqual(
         expect.arrayContaining([{ userId: undefined }])
       );

--- a/packages/application-shell/src/components/gtm-user-tracker/gtm-user-tracker.spec.js
+++ b/packages/application-shell/src/components/gtm-user-tracker/gtm-user-tracker.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render, wait as waitFor } from '@testing-library/react';
 import GtmUserTracker from './gtm-user-tracker';
 
 describe('rendering', () => {
@@ -7,7 +7,7 @@ describe('rendering', () => {
     window.app = { trackingGtm: '111' };
     window.dataLayer = [];
     render(<GtmUserTracker user={{ id: 'user-id' }} />);
-    await wait(() => {
+    await waitFor(() => {
       expect(window.dataLayer).toEqual(
         expect.arrayContaining([{ userId: 'user-id' }])
       );

--- a/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { renderApp } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import UserQuery from '../fetch-user/fetch-user.mc.graphql';
 import ProjectsQuery from '../project-switcher/project-switcher.mc.graphql';
 import ProjectSuspended from './project-suspended';
@@ -98,8 +98,12 @@ describe('rendering', () => {
         ],
       }
     );
-    await rendered.findByText(
-      /Your Project is temporarily suspended due to maintenance/
-    );
+    await waitFor(() => {
+      expect(
+        rendered.queryByText(
+          /Your Project is temporarily suspended due to maintenance/
+        )
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp } from '../../test-utils';
 import UserQuery from '../fetch-user/fetch-user.mc.graphql';
 import ProjectsQuery from '../project-switcher/project-switcher.mc.graphql';
 import ProjectSuspended from './project-suspended';
 
 describe('rendering', () => {
   it('when suspension is temporary it should print correct message', async () => {
-    const { queryByText } = renderApp(
+    const rendered = renderApp(
       <Route
         path="/:projectKey"
         render={() => <ProjectSuspended isTemporary={true} />}
@@ -98,10 +98,8 @@ describe('rendering', () => {
         ],
       }
     );
-    await wait(() =>
-      expect(
-        queryByText(/Your Project is temporarily suspended due to maintenance/)
-      ).toBeInTheDocument()
+    await rendered.findByText(
+      /Your Project is temporarily suspended due to maintenance/
     );
   });
 });

--- a/packages/application-shell/src/components/project-switcher/project-switcher.spec.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.spec.tsx
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { renderApp, fireEvent, wait } from '../../test-utils';
+import { renderApp, fireEvent, wait as waitFor } from '../../test-utils';
 import { createGraphqlResponseForProjectsQuery } from './project-switcher-test-utils';
 import ProjectSwitcher from './project-switcher';
 
@@ -35,7 +35,7 @@ describe('rendering', () => {
     fireEvent.change(input, { target: { value: 'key-1' } });
     fireEvent.keyDown(input, { key: 'Enter', keyCode: 13, which: 13 });
 
-    await wait(() => {
+    await waitFor(() => {
       expect(mocked(window.location.replace)).toHaveBeenCalledWith('/key-1');
     });
   });
@@ -58,7 +58,7 @@ describe('rendering', () => {
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     fireEvent.click(rendered.getByText(/Suspended/i));
 
-    await wait(() =>
+    await waitFor(() =>
       expect(mocked(window.location.replace)).not.toHaveBeenCalled()
     );
   });
@@ -70,7 +70,7 @@ describe('rendering', () => {
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     fireEvent.click(rendered.getByText(/Expired/i));
 
-    await wait(() =>
+    await waitFor(() =>
       expect(mocked(window.location.replace)).not.toHaveBeenCalled()
     );
   });

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -3,7 +3,12 @@ import {
   GRAPHQL_TARGETS,
   MC_API_PROXY_TARGETS,
 } from '@commercetools-frontend/constants';
-import { renderAppWithRedux, fireEvent, wait } from '../../test-utils';
+import {
+  renderAppWithRedux,
+  fireEvent,
+  wait as waitFor,
+  waitForElementToBeRemoved,
+} from '../../test-utils';
 import * as gtm from '../../utils/gtm';
 import QuickAccessQuery from './quick-access.ctp.graphql';
 import QuickAccessProductQuery from './quick-access-product.ctp.graphql';
@@ -219,7 +224,7 @@ describe('QuickAccess', () => {
 
     // open quick-access
     fireEvent.keyDown(document.body.firstChild, { key: 'f' });
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.queryByTestId('quick-access')).toBeNull();
     });
   });
@@ -315,10 +320,7 @@ describe('QuickAccess', () => {
       // when input is cleared again
       fireEvent.change(searchInput, { target: { value: '' } });
 
-      await wait(() => {
-        // the no results text should be removed
-        expect(rendered.queryByText(noResultsText)).not.toBeInTheDocument();
-      });
+      expect(rendered.queryByText(noResultsText)).not.toBeInTheDocument();
     });
   });
   describe('when there is an error', () => {
@@ -376,10 +378,7 @@ describe('QuickAccess', () => {
       // when input is cleared again
       fireEvent.change(searchInput, { target: { value: '' } });
 
-      await wait(() => {
-        // the offline warning should be removed
-        expect(rendered.queryByText(offlineText)).not.toBeInTheDocument();
-      });
+      expect(rendered.queryByText(offlineText)).not.toBeInTheDocument();
     });
   });
 
@@ -405,13 +404,13 @@ describe('QuickAccess', () => {
     await rendered.findByText('Open Dashboard');
     fireEvent.keyUp(searchInput, { key: 'Enter' });
 
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
         '/test-with-big-data/dashboard'
       );
-      // should close quick access
-      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
+    // should close quick access
+    expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
   });
 
   it('should open (reload to) dashboard when chosing the "Open Dashboard" command when using full redirects for links', async () => {
@@ -437,13 +436,13 @@ describe('QuickAccess', () => {
     await rendered.findByText('Open Dashboard');
     fireEvent.keyUp(searchInput, { key: 'Enter' });
 
-    await wait(() => {
+    await waitFor(() => {
       expect(global.location.replace).toHaveBeenCalledWith(
         '/test-with-big-data/dashboard'
       );
-      // should close quick access
-      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
+    // should close quick access
+    expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
   });
 
   describe('on MacOS', () => {
@@ -477,14 +476,14 @@ describe('QuickAccess', () => {
       fireEvent.keyDown(searchInput, { key: 'Enter', metaKey: true });
       fireEvent.keyUp(searchInput, { key: 'Enter', metaKey: true });
 
-      await wait(() => {
+      await waitFor(() => {
         expect(global.open).toHaveBeenCalledWith(
           '/test-with-big-data/dashboard',
           '_blank'
         );
-        // should close quick access
-        expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
       });
+      // should close quick access
+      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
 
     it('should open dashboard in new tab when chosing the "Open Dashboard" command by cmd+click', async () => {
@@ -514,14 +513,14 @@ describe('QuickAccess', () => {
         }
       );
 
-      await wait(() => {
+      await waitFor(() => {
         expect(global.open).toHaveBeenCalledWith(
           '/test-with-big-data/dashboard',
           '_blank'
         );
-        // should close quick access
-        expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
       });
+      // should close quick access
+      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
   });
 
@@ -555,14 +554,14 @@ describe('QuickAccess', () => {
       fireEvent.keyDown(searchInput, { key: 'Enter', ctrlKey: true });
       fireEvent.keyUp(searchInput, { key: 'Enter', ctrlKey: true });
 
-      await wait(() => {
+      await waitFor(() => {
         expect(global.open).toHaveBeenCalledWith(
           '/test-with-big-data/dashboard',
           '_blank'
         );
-        // should close quick access
-        expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
       });
+      // should close quick access
+      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
 
     it('should open dashboard in new tab when chosing the "Open Dashboard" command by ctrl+click', async () => {
@@ -592,14 +591,14 @@ describe('QuickAccess', () => {
         }
       );
 
-      await wait(() => {
+      await waitFor(() => {
         expect(global.open).toHaveBeenCalledWith(
           '/test-with-big-data/dashboard',
           '_blank'
         );
-        // should close quick access
-        expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
       });
+      // should close quick access
+      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
   });
 
@@ -625,13 +624,13 @@ describe('QuickAccess', () => {
     await rendered.findByText('Open Dashboard');
     fireEvent.click(rendered.getByTestId('quick-access-result(go/dashboard)'));
 
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
         '/test-with-big-data/dashboard'
       );
-      // should close quick access
-      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
+    // should close quick access
+    expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
   });
 
   it('should cycle through the history', async () => {
@@ -660,12 +659,13 @@ describe('QuickAccess', () => {
     fireEvent.change(searchInput, { target: { value: 'Open dshbrd' } });
     await rendered.findByText('Open Dashboard');
     fireEvent.keyUp(searchInput, { key: 'Enter' });
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
         '/test-with-big-data/dashboard'
       );
-      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
+    // should close quick access
+    expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
 
     // open quick-access
     fireEvent.keyDown(document.body, { key: 'f' });
@@ -677,12 +677,13 @@ describe('QuickAccess', () => {
     fireEvent.change(searchInput, { target: { value: 'Open prdcts' } });
     await rendered.findByText('Open Products');
     fireEvent.keyUp(searchInput, { key: 'Enter' });
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
         '/test-with-big-data/products'
       );
-      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
+    // should close quick access
+    expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
 
     // open quick-access
     fireEvent.keyDown(document.body, { key: 'f' });
@@ -1040,13 +1041,13 @@ describe('QuickAccess', () => {
     // Click the selected result
     fireEvent.click(openOrdersResult);
 
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
         '/test-with-big-data/orders'
       );
-      // should close quick access
-      expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
     });
+    // should close quick access
+    expect(rendered.queryByTestId('quick-access')).not.toBeInTheDocument();
   });
 
   it('should not show project-based commands when used outside of the project context', async () => {
@@ -1098,13 +1099,8 @@ describe('QuickAccess', () => {
       fireEvent.change(searchInput, { target: { value: searchText } });
       await rendered.findAllByText(/^Open/);
 
-      await wait(
-        () => {
-          // results should not contain "Open Orders"
-          expect(rendered.queryByText('Open Orders')).toBeNull();
-        },
-        { timeout: 1000 }
-      );
+      // results should not contain "Open Orders"
+      expect(rendered.queryByText('Open Orders')).not.toBeInTheDocument();
     });
 
     it('should find "Open Orders" when user has the view orders permission', async () => {

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.spec.tsx
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.spec.tsx
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import RedirectToProjectCreate from './redirect-to-project-create';
 
 beforeEach(() => {
@@ -14,7 +14,7 @@ describe('given `servedByProxy`', () => {
         servedByProxy: true,
       },
     });
-    await wait(() => {
+    await waitFor(() => {
       expect(mocked(window.location.replace)).toHaveBeenCalledWith(
         '/account/projects/new'
       );
@@ -25,7 +25,7 @@ describe('given `servedByProxy`', () => {
 describe('given not `servedByProxy`', () => {
   it('should not redirect to `projects/new`', async () => {
     renderApp(<RedirectToProjectCreate />);
-    await wait(() => {
+    await waitFor(() => {
       expect(mocked(window.location.replace)).not.toHaveBeenCalled();
     });
   });

--- a/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.spec.tsx
+++ b/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderAppWithRedux, wait } from '../../test-utils';
+import { renderAppWithRedux } from '../../test-utils';
 import RequestsInFlightLoader from './requests-in-flight-loader';
 
 describe('rendering', () => {
@@ -8,12 +8,7 @@ describe('rendering', () => {
       const rendered = renderAppWithRedux(<RequestsInFlightLoader />, {
         storeState: { requestsInFlight: [] },
       });
-      await wait(
-        () => {
-          expect(rendered.queryByText(/^Processing/)).not.toBeInTheDocument();
-        },
-        { timeout: 1000 }
-      );
+      expect(rendered.queryByText(/^Processing/)).not.toBeInTheDocument();
     });
   });
   describe('when there are requests in flight', () => {

--- a/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.spec.tsx
+++ b/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderAppWithRedux } from '../../test-utils';
+import { renderAppWithRedux, wait as waitFor } from '../../test-utils';
 import RequestsInFlightLoader from './requests-in-flight-loader';
 
 describe('rendering', () => {
@@ -8,7 +8,9 @@ describe('rendering', () => {
       const rendered = renderAppWithRedux(<RequestsInFlightLoader />, {
         storeState: { requestsInFlight: [] },
       });
-      expect(rendered.queryByText(/^Processing/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(rendered.queryByText(/^Processing/)).not.toBeInTheDocument();
+      });
     });
   });
   describe('when there are requests in flight', () => {

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import RouteCatchAll from './route-catch-all';
 
 describe('rendering', () => {
@@ -11,7 +11,7 @@ describe('rendering', () => {
           servedByProxy: true,
         },
       });
-      await wait(() => {
+      await waitFor(() => {
         expect(window.location.reload).toHaveBeenCalledWith(true);
       });
     });

--- a/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
+++ b/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import { createGraphqlResponseForProjectsQuery } from '../project-switcher/project-switcher-test-utils';
 import ServicePageProjectSwitcher from './service-page-project-switcher';
 
@@ -19,7 +19,7 @@ describe('rendering', () => {
           },
         }
       );
-      await wait(() => {
+      await waitFor(() => {
         expect(
           rendered.container.querySelector('[name="project-switcher"]')
         ).not.toBeInTheDocument();
@@ -51,7 +51,7 @@ describe('rendering', () => {
           mocks: mockedRequest,
         }
       );
-      await wait(() =>
+      await waitFor(() =>
         expect(
           rendered.container.querySelector('[name="project-switcher"]')
         ).toBeInTheDocument()

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -4,7 +4,7 @@ import {
   LOGOUT_REASONS,
   SUPPORT_PORTAL_URL,
 } from '@commercetools-frontend/constants';
-import { renderApp, fireEvent, wait } from '../../test-utils';
+import { renderApp, fireEvent, wait as waitFor } from '../../test-utils';
 import FetchApplicationsMenu from '../../hooks/use-applications-menu/fetch-applications-menu.proxy.graphql';
 import UserSettingsMenu from './user-settings-menu';
 
@@ -119,7 +119,7 @@ describe('rendering', () => {
 
       // Menu should be closed
       await rendered.findByLabelText('open menu');
-      await wait(() => {
+      await waitFor(() => {
         expect(rendered.history.location.pathname).toBe('/account/projects');
       });
     });

--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.spec.js
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import FetchAllMenuFeatureToggles from './fetch-all-menu-feature-toggles.proxy.graphql';
 import useAllMenuFeatureToggles from './use-all-menu-feature-toggles';
 
@@ -89,7 +89,7 @@ describe('when served by proxy', () => {
       await rendered.findByText('Loading');
       await rendered.findByText(/Number of toggles: 0/i);
 
-      await wait(() => {
+      await waitFor(() => {
         expect(reportErrorToSentry).toHaveBeenCalled();
       });
     });

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
@@ -2,7 +2,7 @@ import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import upperFirst from 'lodash/upperFirst';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { renderApp, wait } from '../../test-utils';
+import { renderApp, wait as waitFor } from '../../test-utils';
 import { TFetchApplicationsMenuQuery } from '../../types/generated/proxy';
 import FetchApplicationsMenu from './fetch-applications-menu.proxy.graphql';
 import useApplicationsMenu, {
@@ -131,7 +131,7 @@ describe('fetching the menu query', () => {
         }
       );
       await rendered.findByText('loading');
-      await wait(() => {
+      await waitFor(() => {
         expect(reportErrorToSentry).toHaveBeenCalled();
       });
     });
@@ -153,10 +153,8 @@ describe('loading the menu for local development', () => {
       />
     );
     await rendered.findByText('loading');
-    await wait(() => {
-      expect(rendered.queryByText(/Key: orders/i)).toBeInTheDocument();
-      expect(rendered.queryByText(/Key: products/i)).toBeInTheDocument();
-      expect(rendered.queryByText(/Key: customers/i)).toBeInTheDocument();
-    });
+    await rendered.findByText(/Key: orders/i);
+    await rendered.findByText(/Key: products/i);
+    await rendered.findByText(/Key: customers/i);
   });
 });

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -21,7 +21,7 @@ import {
   renderApp,
   renderAppWithRedux,
   experimentalRenderAppWithRedux,
-  wait,
+  wait as waitFor,
 } from './test-utils';
 
 describe('Intl', () => {
@@ -274,7 +274,7 @@ describe('router', () => {
   });
   it('should return a history object', async () => {
     const rendered = renderApp(<TestComponent />, { route: '/foo' });
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe('/foo');
     });
   });

--- a/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { render, wait } from '@testing-library/react';
+import { render, wait as waitFor } from '@testing-library/react';
 import loadI18n from '../load-i18n';
 import AsyncLocaleData, {
   State,
@@ -51,7 +51,7 @@ describe('rendering', () => {
     });
     it('should report the error to sentry', async () => {
       const { container } = render(<AsyncLocaleData {...props} />);
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toHaveTextContent('Nothing');
         expect(reportErrorToSentry).toHaveBeenCalledWith(error, {});
       });
@@ -68,7 +68,7 @@ describe('rendering', () => {
     });
     it('should render children with state', async () => {
       const { container } = render(<AsyncLocaleData {...props} />);
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toHaveTextContent('Locale: en-US');
         expect(container).toHaveTextContent('Messages: Custom title en');
       });
@@ -91,7 +91,7 @@ describe('rendering', () => {
     });
     it('should render children with state', async () => {
       const { container } = render(<AsyncLocaleData {...props} />);
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toHaveTextContent('Locale: en-CA');
         expect(container).toHaveTextContent('Messages: New title en');
       });
@@ -107,7 +107,7 @@ describe('rendering', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { locale, ...withoutLocale } = props;
       const { container } = render(<AsyncLocaleData {...withoutLocale} />);
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toHaveTextContent('Nothing');
       });
     });

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render, wait as waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import ApiErrorMessage from './api-error-message';
@@ -67,7 +67,7 @@ describe('render', () => {
     expect(
       rendered.queryByText('message-content (detailed-error-message-content)')
     ).toBeInTheDocument();
-    await wait(() => {
+    await waitFor(() => {
       expect(reportErrorToSentry).toHaveBeenCalledTimes(1);
     });
   });
@@ -79,7 +79,7 @@ describe('render', () => {
     };
     const rendered = renderMessage(<ApiErrorMessage error={error} />);
     expect(rendered.queryByText('has expired')).toBeInTheDocument();
-    await wait(() => {
+    await waitFor(() => {
       expect(reportErrorToSentry).not.toHaveBeenCalled();
     });
   });

--- a/packages/react-notifications/src/components/notifier/notifier.spec.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.spec.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable react/prop-types */
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { render, fireEvent, wait, RenderResult } from '@testing-library/react';
+import {
+  render,
+  fireEvent,
+  wait as waitFor,
+  RenderResult,
+} from '@testing-library/react';
 import {
   TAddNotificationAction,
   ADD_NOTIFICATION,
@@ -69,7 +74,7 @@ describe('rendering', () => {
     await rendered.findByText('Open');
     fireEvent.click(rendered.getByText('Open'));
 
-    await wait(() => {
+    await waitFor(() => {
       expect(showNotification).toHaveBeenCalledWith(
         expect.objectContaining({
           domain: NOTIFICATION_DOMAINS.SIDE,
@@ -87,7 +92,7 @@ describe('rendering', () => {
     await rendered.findByText('Count: 3');
 
     fireEvent.click(rendered.getByText('Close'));
-    await wait(() => {
+    await waitFor(() => {
       expect(showNotification).toHaveBeenCalledTimes(1);
       expect(dismiss).toHaveBeenCalled();
     });

--- a/playground/src/components/state-machines-list/state-machines-list.spec.js
+++ b/playground/src/components/state-machines-list/state-machines-list.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 import {
   renderAppWithRedux,
-  wait,
+  wait as waitFor,
   fireEvent,
 } from '@commercetools-frontend/application-shell/test-utils';
 import { applyUiKitMocks } from '../../mocks';
@@ -122,7 +122,7 @@ describe('list view', () => {
     });
     await rendered.findByText(/There are 2 objects in the cache/i);
     fireEvent.click(rendered.getByText('sm-1'));
-    await wait(() => {
+    await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
         '/my-project/state-machines/sm1'
       );


### PR DESCRIPTION
#### Summary

The path to react-testing-library/{react,dom} on the latest versions is quite a bit of effort.

In this pull request I tackle:

1. wait to be waitFor
2. waitForElementToBeRemoved where possible
3. Clean up some tests which are just... confusing

In the process I renamed imports from wait to waitFor. This is trick to get the dependency update PR in the end to be lean by just renaming the import again.