### PR TITLE
fix(jest-preset-mc-app): add mutation-observer-shim

### DIFF
--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -28,6 +28,7 @@
     "@commercetools/enzyme-extensions": "5.0.0",
     "@commercetools/jest-enzyme-matchers": "1.1.2",
     "@testing-library/jest-dom": "5.1.1",
+    "@sheerun/mutationobserver-shim": "0.3.3",
     "babel-jest": "25.1.0",
     "colors": "1.4.0",
     "enzyme-adapter-react-16": "1.15.2",

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -2,11 +2,14 @@ const fs = require('fs');
 const path = require('path');
 const colors = require('colors/safe');
 const pkgDir = require('pkg-dir');
+const MutationObserver = require('@sheerun/mutationobserver-shim');
 
 global.window.app = {
   applicationName: 'my-app',
   mcApiUrl: 'http://localhost:8080',
 };
+
+window.MutationObserver = MutationObserver;
 
 const shouldSilenceWarnings = (...messages) =>
   [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5318,7 +5318,7 @@
     "@sentry/types" "5.12.4"
     tslib "^1.9.3"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
+"@sheerun/mutationobserver-shim@0.3.3", "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
   integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==


### PR DESCRIPTION
#### Summary

This pull request adds the mutation-observer-shim to our jest preset.

#### Description

The preset was removed within dom-testing-library v7. The library itself recommends adding it or using jsdom v16 (which contains it). We offer a preset for jsdom v16 but should patch out regular preset to include the shim so it works with dom-testing-library v7

Note, that dom-testing-library used this shim itself. Adding it on older dom-testing-library versions (overwriting it) on the window should not be an issue.

<img width="902" alt="CleanShot 2020-03-20 at 09 30 39@2x" src="https://user-images.githubusercontent.com/1877073/77147541-c702bd80-6a8d-11ea-8bcd-54d69d656697.png">

