### PR TITLE
fix: proper invocation of window.location.replace

### DIFF
--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.tsx
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.tsx
@@ -6,7 +6,7 @@ import { location } from '../../utils/location';
 
 const ForcePageReload = () => {
   React.useEffect(() => {
-    location.reload(/* forcedReload */ true);
+    location.reload();
   }, []);
   return null;
 };

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.tsx
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.tsx
@@ -6,7 +6,7 @@ import { location } from '../../utils/location';
 
 const ForcePageReload = () => {
   React.useEffect(() => {
-    location.reload();
+    location.reload(/* forcedReload */ true);
   }, []);
   return null;
 };

--- a/packages/application-shell/src/utils/location/location.ts
+++ b/packages/application-shell/src/utils/location/location.ts
@@ -21,7 +21,8 @@
  *    mocking system of Jest and no other trickery.
  * */
 const replace = (url: string): void => window.location.replace(url);
-const reload = (...args): void => window.location.reload(...args);
+const reload = (forceReload = false): void =>
+  window.location.reload(forceReload);
 
 const location = {
   replace,

--- a/packages/application-shell/src/utils/location/location.ts
+++ b/packages/application-shell/src/utils/location/location.ts
@@ -21,7 +21,7 @@
  *    mocking system of Jest and no other trickery.
  * */
 const replace = (url: string): void => window.location.replace(url);
-const reload = window.location.reload;
+const reload = (): void => window.location.reload();
 
 const location = {
   replace,

--- a/packages/application-shell/src/utils/location/location.ts
+++ b/packages/application-shell/src/utils/location/location.ts
@@ -21,7 +21,7 @@
  *    mocking system of Jest and no other trickery.
  * */
 const replace = (url: string): void => window.location.replace(url);
-const reload = (): void => window.location.reload();
+const reload = (...args): void => window.location.reload(...args);
 
 const location = {
   replace,


### PR DESCRIPTION
`utils/location/replace` method invokes `window.location.replace` with a wrong `this` value, which lead to an error when navigation between apps:

![Screenshot 2020-03-23 at 14 34 07](https://user-images.githubusercontent.com/1228431/77322236-b5cae280-6d13-11ea-9e8f-42d269c50e58.png)

This PR fixes that.
