### PR TITLE
Properly report unhandled rejections and ErrorEvents to Sentry

### DIFF
--- a/packages/sentry/src/sentry.spec.ts
+++ b/packages/sentry/src/sentry.spec.ts
@@ -13,8 +13,8 @@ const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 // we can drop this polyfill: https://github.com/jsdom/jsdom/issues/2401
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-type Reason = any;
-type Payload = any;
+type Reason = unknown;
+type Payload = unknown;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 class PromiseRejectionEvent extends Event {

--- a/packages/sentry/src/sentry.spec.ts
+++ b/packages/sentry/src/sentry.spec.ts
@@ -7,6 +7,30 @@ const { testkit, sentryTransport } = sentryTestkit();
 
 const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
+// At the moment, jsdom doesn't support PromiseRejectionEvent type. That leads to
+// ReferenceError in tests. So, we add this ad-hoc polyfill just for tests for now.
+// Once the following issue is fixed (which is unlikely to happen any soon) in jsdom
+// we can drop this polyfill: https://github.com/jsdom/jsdom/issues/2401
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Reason = any;
+type Payload = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+class PromiseRejectionEvent extends Event {
+  reason: Reason;
+  promise: Promise<Payload>;
+
+  constructor(
+    type: string,
+    options: { reason: Reason; promise: Promise<Payload> }
+  ) {
+    super(type);
+    this.promise = options.promise;
+    this.reason = options.reason;
+  }
+}
+
 describe('reportErrorToSentry', () => {
   let error;
 
@@ -94,6 +118,47 @@ describe('reportErrorToSentry', () => {
             `You called "reportErrorToSentry" with a string argument`
           )
         );
+      });
+    });
+  });
+
+  describe('when error is an ErrorEvent', () => {
+    beforeEach(async () => {
+      error = new ErrorEvent('error', { message: 'something went wrong' });
+      reportErrorToSentry(error, undefined, () => true);
+
+      // Wait for the reports to have been sent
+      // eslint-disable-next-line jest/no-standalone-expect
+      await waitForExpect(() => expect(testkit.reports()).toHaveLength(1));
+    });
+
+    it('should send report', () => {
+      const report = testkit.reports()[0];
+      expect(report.error).toMatchObject({
+        message: 'something went wrong',
+      });
+    });
+  });
+
+  describe('when error is an PromiseRejectionEvent', () => {
+    beforeEach(async () => {
+      error = new PromiseRejectionEvent('unhandledrejection', {
+        // That's supposed to be Promise.reject, but jsdom throws in this case
+        promise: Promise.resolve(null),
+        reason: { message: 'something went wrong' },
+      });
+
+      reportErrorToSentry(error, undefined, () => true);
+
+      // Wait for the reports to have been sent
+      // eslint-disable-next-line jest/no-standalone-expect
+      await waitForExpect(() => expect(testkit.reports()).toHaveLength(1));
+    });
+
+    it('should send report', () => {
+      const report = testkit.reports()[0];
+      expect(report.error).toMatchObject({
+        message: '{"message":"something went wrong"}',
       });
     });
   });

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -13,8 +13,15 @@ export const boot = () => {
       // from our code and ignore errors that come from other services
       // https://blog.sentry.io/2017/03/27/tips-for-reducing-javascript-error-noise.html
       whitelistUrls: [window.app.cdnUrl, window.app.frontendHost],
+      // we don't need default Sentry's global handlers, because we  add default ones
+      integrations: [
+        new Sentry.Integrations.GlobalHandlers({
+          onunhandledrejection: false,
+          onerror: false,
+        }),
+      ],
     });
-    Sentry.configureScope((scope) => {
+    Sentry.configureScope(scope => {
       scope.setTag('role', 'frontend');
     });
   }

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -38,7 +38,7 @@ export const boot = () => {
         }),
       ],
     });
-    Sentry.configureScope(scope => {
+    Sentry.configureScope((scope) => {
       scope.setTag('role', 'frontend');
     });
   }


### PR DESCRIPTION
### Context

At the moment we observe following uninformative reports in our Sentry instance:

![Screenshot 2020-03-26 at 10 57 10](https://user-images.githubusercontent.com/1228431/77634141-c74cfe00-6f50-11ea-86b2-448e8120ecb6.png)

That's happening because `PromiseRejectionEvent` and `ErrorEvent` captured by AppShell's global error handlers are passed to `Sentry.captureException` unmodified, whereas the latter expects instance of an `Error`.

 ### Fix

This PR implements wrapping error events into `Error`s inside `reportErrorToSentry` before sending them to `Sentry`. Also default `Sentry`s reporting of unhandled rejections and global errors is disabled, to prevent double-reporting.

### Other fix options

The better option, probably, is to rely on `Sentry`'s default reporting of unhandled rejections and remove our custom global handlers, but that will prevent us from showing error_id to users in MC in case of unhandled rejections. So that's probably a subject for a follow-up discussion.