### PR TITLE
fix(app-shell): apply cached menu state synchronously as a layout effect, to avoid flickering

### DIFF
--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -50,6 +50,7 @@ import { GtmContext } from '../gtm-booter';
 import LoadingPlaceholder from '../loading-placeholder';
 import styles from './navbar.mod.css';
 import messages from './messages';
+import useInitialForcedMenuState from './use-initial-forced-menu-state';
 import useNavbarStateManager from './use-navbar-state-manager';
 import nonNullable from './non-nullable';
 
@@ -644,6 +645,7 @@ export default NavBar;
 
 export const LoadingNavBar = () => {
   const ref = React.useRef<HTMLDivElement>(null);
+  useInitialForcedMenuState();
   return (
     <NavBarLayout ref={ref}>
       <MenuGroup id="main" level={1}>

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -50,7 +50,7 @@ import { GtmContext } from '../gtm-booter';
 import LoadingPlaceholder from '../loading-placeholder';
 import styles from './navbar.mod.css';
 import messages from './messages';
-import useInitialForcedMenuState from './use-initial-forced-menu-state';
+import useLoadingMenuLayoutEffect from './use-loading-menu-layout-effect';
 import useNavbarStateManager from './use-navbar-state-manager';
 import nonNullable from './non-nullable';
 
@@ -645,7 +645,7 @@ export default NavBar;
 
 export const LoadingNavBar = () => {
   const ref = React.useRef<HTMLDivElement>(null);
-  useInitialForcedMenuState();
+  useLoadingMenuLayoutEffect();
   return (
     <NavBarLayout ref={ref}>
       <MenuGroup id="main" level={1}>

--- a/packages/application-shell/src/components/navbar/use-initial-forced-menu-state.ts
+++ b/packages/application-shell/src/components/navbar/use-initial-forced-menu-state.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+import isNil from 'lodash/isNil';
+import { STORAGE_KEYS } from '../../constants';
+
+const useInitialForcedMenuState = () => {
+  const cachedIsForcedMenuOpen = window.localStorage.getItem(
+    STORAGE_KEYS.IS_FORCED_MENU_OPEN
+  );
+  const isForcedMenuOpen = isNil(cachedIsForcedMenuOpen)
+    ? null
+    : (JSON.parse(cachedIsForcedMenuOpen) as boolean);
+  React.useLayoutEffect(() => {
+    if (isForcedMenuOpen) document.body.classList.add('body__menu-open');
+    if (!isForcedMenuOpen) document.body.classList.remove('body__menu-open');
+  }, [isForcedMenuOpen]);
+};
+
+export default useInitialForcedMenuState;

--- a/packages/application-shell/src/components/navbar/use-loading-menu-layout-effect.ts
+++ b/packages/application-shell/src/components/navbar/use-loading-menu-layout-effect.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import isNil from 'lodash/isNil';
 import { STORAGE_KEYS } from '../../constants';
 
-const useInitialForcedMenuState = () => {
+const useLoadingMenuLayoutEffect = () => {
   const cachedIsForcedMenuOpen = window.localStorage.getItem(
     STORAGE_KEYS.IS_FORCED_MENU_OPEN
   );
@@ -15,4 +15,4 @@ const useInitialForcedMenuState = () => {
   }, [isForcedMenuOpen]);
 };
 
-export default useInitialForcedMenuState;
+export default useLoadingMenuLayoutEffect;

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -34,18 +34,29 @@ type Action =
   | { type: 'setIsMenuOpenAndMakeExpanderVisible'; payload: boolean }
   | { type: 'reset' };
 
+type CachedIsMenuOpenState = string | null;
+
+const initialState = {
+  isExpanderVisible: true,
+  isMenuOpen: false,
+};
+
 const cachedIsForcedMenuOpen = window.localStorage.getItem(
   STORAGE_KEYS.IS_FORCED_MENU_OPEN
 );
 
-const getShouldInitiallyOpen = (): boolean => {
-  if (!isNil(cachedIsForcedMenuOpen)) {
-    return JSON.parse(cachedIsForcedMenuOpen);
+const getShouldInitiallyOpen = (
+  cachedIsMenuOpen: CachedIsMenuOpenState
+): boolean => {
+  if (!isNil(cachedIsMenuOpen)) {
+    return JSON.parse(cachedIsMenuOpen);
   }
   return false;
 };
 
-const shouldBeInitiallyOpen: boolean = getShouldInitiallyOpen();
+const shouldBeInitiallyOpen: boolean = getShouldInitiallyOpen(
+  cachedIsForcedMenuOpen
+);
 
 // GIVEN user has `STORAGE_KEYS.IS_FORCED_MENU_OPEN=true`
 // THEN update the DOM immediately and not defer that to the reducer
@@ -53,10 +64,11 @@ const shouldBeInitiallyOpen: boolean = getShouldInitiallyOpen();
 if (shouldBeInitiallyOpen) {
   document.body.classList.add('body__menu-open');
 }
-const initialState = {
-  isExpanderVisible: true,
-  isMenuOpen: shouldBeInitiallyOpen,
-};
+
+const getInitialState = (cachedIsMenuOpen: CachedIsMenuOpenState): State => ({
+  ...initialState,
+  isMenuOpen: getShouldInitiallyOpen(cachedIsMenuOpen),
+});
 
 const reducer = (state = initialState, action: Action): State => {
   switch (action.type) {
@@ -144,7 +156,7 @@ const useNavbarStateManager = (props: HookProps) => {
 
   const [state, dispatch] = React.useReducer<
     (prevState: State, action: Action) => State
-  >(reducer, initialState);
+  >(reducer, getInitialState(cachedIsForcedMenuOpen));
 
   const checkSize = React.useCallback(
     throttle(() => {

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -34,10 +34,33 @@ type Action =
   | { type: 'setIsMenuOpenAndMakeExpanderVisible'; payload: boolean }
   | { type: 'reset' };
 
+const cachedIsForcedMenuOpen = window.localStorage.getItem(
+  STORAGE_KEYS.IS_FORCED_MENU_OPEN
+);
+
+const getShouldInitiallyOpen = (): boolean => {
+  if (!isNil(cachedIsForcedMenuOpen)) {
+    return (
+      typeof cachedIsForcedMenuOpen === 'string' &&
+      cachedIsForcedMenuOpen === 'true'
+    );
+  }
+  return false;
+};
+
+const shouldBeInitiallyOpen: boolean = getShouldInitiallyOpen();
+
+// GIVEN user has `STORAGE_KEYS.IS_FORCED_MENU_OPEN=true`
+// THEN update the DOM immediately and not defer that to the reducer
+// this is done to avoid the flickering experience of the menu once the user loads the application
+if (shouldBeInitiallyOpen) {
+  document.body.classList.add('body__menu-open');
+}
 const initialState = {
   isExpanderVisible: true,
-  isMenuOpen: false,
+  isMenuOpen: shouldBeInitiallyOpen,
 };
+
 const reducer = (state = initialState, action: Action): State => {
   switch (action.type) {
     case 'setActiveItemIndex':
@@ -117,9 +140,6 @@ const useNavbarStateManager = (props: HookProps) => {
           })
           .filter(nonNullable)
       : [];
-  const cachedIsForcedMenuOpen = window.localStorage.getItem(
-    STORAGE_KEYS.IS_FORCED_MENU_OPEN
-  );
   const isForcedMenuOpen =
     typeof cachedIsForcedMenuOpen === 'string'
       ? cachedIsForcedMenuOpen === 'true'

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -40,10 +40,7 @@ const cachedIsForcedMenuOpen = window.localStorage.getItem(
 
 const getShouldInitiallyOpen = (): boolean => {
   if (!isNil(cachedIsForcedMenuOpen)) {
-    return (
-      typeof cachedIsForcedMenuOpen === 'string' &&
-      cachedIsForcedMenuOpen === 'true'
-    );
+    return JSON.parse(cachedIsForcedMenuOpen);
   }
   return false;
 };


### PR DESCRIPTION
#### Summary

- update the DOM immediately when `STORAGE_KEYS.IS_FORCED_MENU_OPEN=true`

#### Description

We have `use-navbar-state-manager` to determine the state of the menu as the user loads the application. An issue within the state manager, is that we wait for the reducer to execute actions to determine the state.

This defers the experience of having the menu open _immediately_ when the user loads the application

For example
![flickering menu](https://user-images.githubusercontent.com/462507/78885629-3a7c6700-7a5d-11ea-9a75-6dd927ad2266.gif)

**Proposed solution**

Update the dom immediately, before the reducer executes action.
![no-flicket](https://user-images.githubusercontent.com/462507/78885805-7e6f6c00-7a5d-11ea-90e5-6a0fab747eac.gif)

trade off, [this code](https://github.com/commercetools/merchant-center-application-kit/blob/adnasa-use-navbar-state-manage-flick-thousand-cuts/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts#L178-L188) will no longer execute. I however decided to keep it, since I'm unsure about what other cases could arise that would need this execution.

---

I created this as a Draft PR, because I'm open to other approaches of updating the DOM immediate and not defer it to the reducer execution.
I added @FreddieK to UAT this.
