### PR TITLE
fix(app-shell/test-utils): to defer adapter initialization without flags

### DIFF
--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -350,6 +350,7 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
     ...defaultEnvironment,
     ...environment,
   } as TProviderProps<AdditionalEnvironmentProperties>['environment'];
+  const hasFlags = flags && Object.keys(flags).length > 0;
 
   const ApplicationProviders = (props: TApplicationProvidersProps) => (
     <IntlProvider locale={locale}>
@@ -358,6 +359,7 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
           adapter={adapter}
           defaultFlags={flags}
           adapterArgs={defaultFlopflipAdapterArgs}
+          shouldDeferAdapterConfiguration={!hasFlags}
         >
           <ApplicationContextProvider
             user={mergedUser}


### PR DESCRIPTION
#### Summary

This pull request fixes act warning when testing through the test-utils without flags with recent versions of flopflip.

#### Description

flopflip and its adapters are inherently async. They integrate with LaunchDarkly APIs or poll from local-storage. So that all adapters have the same API even the memory-adapter's configure/reconfigure are async functions.

This comes with some "drawbacks" when testing with them. Given you test a small component without flags while using `getBy*` or `queryBy*` you are likely to get act warnings. These originate from the fact that your test passes, all components (by rtl) are unmounted while flopflip's async configuration is not finished. It then finishes _after_ your test is over yielding an act warning. This realisation took some time for me 😄.

This gives us multiple options:

1. Make flopflip's test-utils public while exposing an `waitUntilConfigured` from the `renderWithAdapter` (the library uses this internally)
   - app-kit could then use `renderWithAdapter` and expose this function on the rendered result
   - Any test should then have to render and `await rendered.waitUntilReady()`
2. Implement a MockConfigureFlopflip to use under test which doesn't behave async in any way
3. Fix any test failing with an act warning to use `findBy*` essentially for it to end up on the next tick and omitting the act warning hopefully in most cases

I personally don't like any of those cases.

1. Is a lot of burden on the consumser which doesn't want to care that app-kit uses flopflip and/or has to await for something rendered to be ready to test
2. Make the actually running code and tests deviate making test fragile. Also `updateFlags` from an adapter might never work
3. Also very strange and not obvious to why that needs to happen. I even like this most cause I start to believe that UI is inherently async at scale and tests need to be as a reuslt

As a compromise to all above I propose to just not initialize the adapter (in our case memory) when we don't pass flags. This serves as decent middle ground. Whenever flags are used it's easier to communicate that this test is now async as it uses feature flags which are async. This also leaves option 1. open as we would just say `await waitUntilFlags()` and it becomes sort of clear.

I hope this all makes sense. It's a small change regarding the process of understanding things above 🐍. I tried it out internally and it seems to resolve most cases and allows us to update flopflip with minimum hassle (hopefully) and somewhat generall makes sense.

Appendix: The last alternative is to not render the ConfigureFlopflip at all. But then any useFeatureFlag will fail while now we just default to disabled flags.
