### PR TITLE
chore(changelog): add 16.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [16.6.1](https://github.com/commercetools/merchant-center-application-kit/compare/v16.6.0...v16.6.1) (2020-04-15)
+
+#### 🐛 Type: Bug
+
+- `application-shell`
+  - [#1433](https://github.com/commercetools/merchant-center-application-kit/pull/1433) fix(app-shell): apply cached menu state synchronously as a layout effect, to avoid flickering ([@adnasa](https://github.com/adnasa))
+  - [#1436](https://github.com/commercetools/merchant-center-application-kit/pull/1436) fix(app-shell/test-utils): to defer adapter initialization without flags ([@tdeekens](https://github.com/tdeekens))
+
+#### 🖥 Type: Website
+
+- [#1432](https://github.com/commercetools/merchant-center-application-kit/pull/1432) chore(website): update to theme 2.4.1-canary.7 ([@emmenko](https://github.com/emmenko))
+
 ## [16.6.0](https://github.com/commercetools/merchant-center-application-kit/compare/v16.5.3...v16.6.0) (2020-04-08)
 
 #### 🐛 Type: Bug


### PR DESCRIPTION
#### Summary

- adds changelog

locally I still get this

is something up with my setup?

```
packages/sentry/src/sentry.spec.ts:39:7 - error TS2322: Type 'new (options: TransportOptions) => Transport' is not assignable to type 'TransportClass<Transport>'.
  Construct signature return types 'Transport' and 'Transport' are incompatible.
    The types of 'sendEvent' are incompatible between these types.
      Type '(event: import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/types/dist/event").Event) => PromiseLike<import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/types/dist/response").Response>' is not assignable to type '(event: import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/browser/node_modules/@sentry/types/dist/event").Event) => PromiseLike<import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/browser/node_modules/@sentry/types/dist/response").Respon...'.
        Types of parameters 'event' and 'event' are incompatible.
          Type 'import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/browser/node_modules/@sentry/types/dist/event").Event' is not assignable to type 'import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/types/dist/event").Event'.
            Types of property 'spans' are incompatible.
              Type 'import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/browser/node_modules/@sentry/types/dist/span").Span[] | undefined' is not assignable to type 'import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/types/dist/span").Span[] | undefined'.
                Type 'import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/browser/node_modules/@sentry/types/dist/span").Span[]' is not assignable to type 'import("/Users/adnasa/workspace/repos/merchant-center-application-kit/node_modules/@sentry/types/dist/span").Span[]'.
                  Type 'Span' is missing the following properties from type 'Span': child, isRootSpan

39       transport: sentryTransport,
```