### PR TITLE
refactor: use TS "import type"

### DIFF
--- a/packages/actions-global/README.md
+++ b/packages/actions-global/README.md
@@ -4,7 +4,7 @@
   <a href="https://www.npmjs.com/package/@commercetools-frontend/actions-global"><img src="https://badgen.net/npm/v/@commercetools-frontend/actions-global" alt="Latest release (latest dist-tag)" /></a> <a href="https://www.npmjs.com/package/@commercetools-frontend/actions-global"><img src="https://badgen.net/npm/v/@commercetools-frontend/actions-global/next" alt="Latest release (next dist-tag)" /></a> <a href="https://bundlephobia.com/result?p=@commercetools-frontend/actions-global"><img src="https://badgen.net/bundlephobia/minzip/@commercetools-frontend/actions-global" alt="Minified + GZipped size" /></a> <a href="https://github.com/commercetools/merchant-center-application-kit/blob/master/LICENSE"><img src="https://badgen.net/github/license/commercetools/merchant-center-application-kit" alt="GitHub license" /></a>
 </p>
 
-Global redux actions for a MC application.
+Global redux actions for a Custom Application.
 
 ## Install
 

--- a/packages/actions-global/src/actions/handle-action-error.spec.ts
+++ b/packages/actions-global/src/actions/handle-action-error.spec.ts
@@ -1,4 +1,5 @@
-import { TStatusCode } from '@commercetools-frontend/constants';
+import type { TStatusCode } from '@commercetools-frontend/constants';
+
 import handleActionError from './handle-action-error';
 
 let dispatch: jest.Mock;

--- a/packages/actions-global/src/actions/handle-action-error.ts
+++ b/packages/actions-global/src/actions/handle-action-error.ts
@@ -1,10 +1,13 @@
-import { ThunkDispatch } from 'redux-thunk';
-import {
-  STATUS_CODES,
-  LOGOUT_REASONS,
+import type { ThunkDispatch } from 'redux-thunk';
+import type {
   TAppNotificationApiError,
   TStatusCode,
   ApplicationWindow,
+} from '@commercetools-frontend/constants';
+
+import {
+  STATUS_CODES,
+  LOGOUT_REASONS,
 } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import browserHistory from '@commercetools-frontend/browser-history';

--- a/packages/actions-global/src/actions/show-api-error-notification.ts
+++ b/packages/actions-global/src/actions/show-api-error-notification.ts
@@ -1,5 +1,9 @@
+import type {
+  TApiErrorNotification,
+  TApiErrorNotificationOptions,
+} from '../types';
+
 import { DOMAINS } from '@commercetools-frontend/constants';
-import { TApiErrorNotification, TApiErrorNotificationOptions } from '../types';
 import showNotification from './show-notification';
 
 export default function showApiErrorNotification({

--- a/packages/actions-global/src/actions/show-notification.ts
+++ b/packages/actions-global/src/actions/show-notification.ts
@@ -1,13 +1,12 @@
+import type { TNotificationMetaOptions } from '@commercetools-frontend/notifications';
+import type { TShowNotification } from '../types';
+
 import isNumber from 'lodash/isNumber';
-import {
-  addNotification,
-  TNotificationMetaOptions,
-} from '@commercetools-frontend/notifications';
+import { addNotification } from '@commercetools-frontend/notifications';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
-import { TShowNotification } from '../types';
 
 export default function showNotification<
   Notification extends TShowNotification

--- a/packages/actions-global/src/actions/show-unexpected-error-notification.ts
+++ b/packages/actions-global/src/actions/show-unexpected-error-notification.ts
@@ -1,8 +1,7 @@
-import {
-  DOMAINS,
-  TAppNotificationValuesUnexpectedError,
-} from '@commercetools-frontend/constants';
-import { TUnexpectedErrorNotification } from '../types';
+import type { TAppNotificationValuesUnexpectedError } from '@commercetools-frontend/constants';
+import type { TUnexpectedErrorNotification } from '../types';
+
+import { DOMAINS } from '@commercetools-frontend/constants';
 import showNotification from './show-notification';
 
 export default function showUnexpectedErrorNotification({

--- a/packages/actions-global/src/hooks/use-on-action-error.spec.tsx
+++ b/packages/actions-global/src/hooks/use-on-action-error.spec.tsx
@@ -1,5 +1,6 @@
+import type { Action } from 'redux';
+
 import React from 'react';
-import { Action } from 'redux';
 import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 import useOnActionError from './use-on-action-error';

--- a/packages/actions-global/src/hooks/use-on-action-error.ts
+++ b/packages/actions-global/src/hooks/use-on-action-error.ts
@@ -1,6 +1,8 @@
+import type { ActionError } from '../actions/handle-action-error';
+
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import handleActionError, { ActionError } from '../actions/handle-action-error';
+import handleActionError from '../actions/handle-action-error';
 
 export default function useOnActionError() {
   const dispatch = useDispatch();

--- a/packages/actions-global/src/hooks/use-show-api-error-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-api-error-notification.ts
@@ -1,7 +1,8 @@
+import type { TApiErrorNotificationOptions } from '../types';
+
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { showApiErrorNotification } from '../actions';
-import { TApiErrorNotificationOptions } from '../types';
 
 // Returns a function that dispatches an API error notification.
 // Example:

--- a/packages/actions-global/src/hooks/use-show-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-notification.ts
@@ -1,8 +1,9 @@
+import type { TNotificationMetaOptions } from '@commercetools-frontend/notifications';
+import type { TShowNotification } from '../types';
+
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { TNotificationMetaOptions } from '@commercetools-frontend/notifications';
 import { showNotification } from '../actions';
-import { TShowNotification } from '../types';
 
 // Returns a function that dispatches a notification, pre-configured to
 // a speficic notification.

--- a/packages/actions-global/src/hooks/use-show-unexpected-error-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-unexpected-error-notification.ts
@@ -1,6 +1,7 @@
+import type { TAppNotificationValuesUnexpectedError } from '@commercetools-frontend/constants';
+
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { TAppNotificationValuesUnexpectedError } from '@commercetools-frontend/constants';
 import { showUnexpectedErrorNotification } from '../actions';
 
 // Returns a function that dispatches an unexpected error notification.

--- a/packages/actions-global/src/index.ts
+++ b/packages/actions-global/src/index.ts
@@ -1,5 +1,5 @@
 export { default as version } from './version';
-import { DispatchActionError } from './actions/handle-action-error';
+import type { DispatchActionError } from './actions/handle-action-error';
 
 export type TDispatchActionError = DispatchActionError;
 

--- a/packages/actions-global/src/types.ts
+++ b/packages/actions-global/src/types.ts
@@ -1,5 +1,5 @@
-import { TNotification } from '@commercetools-frontend/notifications';
-import {
+import type { TNotification } from '@commercetools-frontend/notifications';
+import type {
   TAppNotification,
   TAppNotificationDomain,
   TAppNotificationKind,

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -1,5 +1,7 @@
+import type { IntlShape } from 'react-intl';
+
 import React from 'react';
-import { useIntl, IntlShape } from 'react-intl';
+import { useIntl } from 'react-intl';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import Spacings from '@commercetools-uikit/spacings';

--- a/packages/application-components/src/components/dialogs/internals/dialog-header.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-header.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import { CloseIcon } from '@commercetools-uikit/icons';
 import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
 import Text from '@commercetools-uikit/text';
 import Spacings from '@commercetools-uikit/spacings';
-import { css } from '@emotion/core';
 
 type Props = {
   title: string;

--- a/packages/application-components/src/components/maintenance-page-layout/maintenance-page-layout.spec.tsx
+++ b/packages/application-components/src/components/maintenance-page-layout/maintenance-page-layout.spec.tsx
@@ -1,6 +1,8 @@
+import type { Props } from './maintenance-page-layout';
+
 import React from 'react';
 import { renderComponent } from '../../../test-utils';
-import MaintenancePageLayout, { Props } from './maintenance-page-layout';
+import MaintenancePageLayout from './maintenance-page-layout';
 
 const createTestProps = (props: Partial<Props> = {}) => ({
   imageSrc: '/assets/foo.svg',

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -1,3 +1,5 @@
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import {
@@ -9,7 +11,6 @@ import {
   mapProjectToApplicationContextProject,
   mapEnvironmentToApplicationContextEnvironment,
 } from './application-context';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 type AdditionalEnvironmentProps = { foo: string };
 

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import moment from 'moment-timezone';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
-import getDisplayName from '../../utils/get-display-name';
-import {
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+import type {
   TFetchLoggedInUserQuery,
   TFetchProjectQuery,
 } from '../../types/generated/mc';
+
+import React from 'react';
+import moment from 'moment-timezone';
+import getDisplayName from '../../utils/get-display-name';
 import {
   normalizeAllAppliedActionRights,
   normalizeAllAppliedMenuVisibilities,

--- a/packages/application-shell-connectors/src/components/application-context/index.ts
+++ b/packages/application-shell-connectors/src/components/application-context/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ProviderProps,
   TApplicationContext as ApplicationContext,
 } from './application-context';

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
@@ -1,4 +1,5 @@
-import { TFetchProjectQuery } from '../../types/generated/mc';
+import type { TFetchProjectQuery } from '../../types/generated/mc';
+
 import {
   normalizeAllAppliedActionRights,
   normalizeAllAppliedMenuVisibilities,

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Maybe,
   TFetchProjectQuery,
   TStoreDataFence,

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -1,17 +1,13 @@
+import type { RenderResult } from '@testing-library/react';
+import type { MockedProviderProps } from '@apollo/react-testing';
+import type { TImageRegexContext } from './project-extension-image-regex';
+
 import React from 'react';
-import {
-  render,
-  RenderResult,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
-import {
-  MockedProvider as ApolloMockProvider,
-  MockedProviderProps,
-} from '@apollo/react-testing';
+import { render, waitForElementToBeRemoved } from '@testing-library/react';
+import { MockedProvider as ApolloMockProvider } from '@apollo/react-testing';
 import {
   ProjectExtensionProviderForImageRegex,
   GetProjectExtensionImageRegex,
-  TImageRegexContext,
 } from './project-extension-image-regex';
 import FetchProjectExtensionImageRegex from './fetch-project-extension-image-regex.settings.graphql';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
@@ -1,11 +1,12 @@
+import type {
+  TFetchProjectExtensionImageRegexQuery,
+  TImageRegexOptions,
+} from '../../types/generated/settings';
+
 import React from 'react';
 import { useQuery } from 'react-apollo';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import {
-  TFetchProjectExtensionImageRegexQuery,
-  TImageRegexOptions,
-} from '../../types/generated/settings';
 import getDisplayName from '../../utils/get-display-name';
 import FetchProjectExtensionImageRegex from './fetch-project-extension-image-regex.settings.graphql';
 

--- a/packages/application-shell-connectors/src/index.ts
+++ b/packages/application-shell-connectors/src/index.ts
@@ -1,5 +1,5 @@
 export { default as version } from './version';
-import {
+import type {
   TProviderProps as ProviderProps,
   TApplicationContext as ApplicationContext,
 } from './components/application-context';

--- a/packages/application-shell-connectors/src/test-utils/test-utils.ts
+++ b/packages/application-shell-connectors/src/test-utils/test-utils.ts
@@ -1,8 +1,9 @@
-import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import {
+import type {
   Maybe,
   TFetchProjectExtensionImageRegexQuery,
 } from '../types/generated/settings';
+
+import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { FetchProjectExtensionImageRegex } from '../components/project-extension-image-regex/fetch-project-extension-image-regex.settings.graphql';
 
 export const createGraphqlResponseForProjectExtensionImageRegexQuery = (

--- a/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
+++ b/packages/application-shell-connectors/src/utils/get-mc-api-url/get-mc-api-url.ts
@@ -1,4 +1,4 @@
-import { ApplicationWindow } from '@commercetools-frontend/constants';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
 
 /**
  * NOTE:

--- a/packages/application-shell/src/apollo-links/error-link.ts
+++ b/packages/application-shell/src/apollo-links/error-link.ts
@@ -1,6 +1,8 @@
-import { GraphQLError } from 'graphql';
-import { onError, ErrorResponse } from 'apollo-link-error';
-import { ServerError, ServerParseError } from 'apollo-link-http-common';
+import type { GraphQLError } from 'graphql';
+import type { ErrorResponse } from 'apollo-link-error';
+import type { ServerError, ServerParseError } from 'apollo-link-http-common';
+
+import { onError } from 'apollo-link-error';
 import {
   STATUS_CODES,
   LOGOUT_REASONS,

--- a/packages/application-shell/src/apollo-links/header-link.ts
+++ b/packages/application-shell/src/apollo-links/header-link.ts
@@ -1,7 +1,7 @@
+import type { NormalizedCacheObject } from 'apollo-cache-inmemory';
 import type { TApolloContext } from '../utils/apollo-context';
 
 import ApolloClient from 'apollo-client';
-import { NormalizedCacheObject } from 'apollo-cache-inmemory';
 import { ApolloLink } from 'apollo-link';
 import omitEmpty from 'omit-empty-es';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';

--- a/packages/application-shell/src/components/app-bar/app-bar.tsx
+++ b/packages/application-shell/src/components/app-bar/app-bar.tsx
@@ -1,3 +1,6 @@
+import type { TFetchLoggedInUserQuery } from '../../types/generated/mc';
+import type { TApplicationsMenu } from '../../types/generated/proxy';
+
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/core';
@@ -6,8 +9,6 @@ import { customProperties } from '@commercetools-uikit/design-system';
 import LogoSVG from '@commercetools-frontend/assets/images/logo.svg';
 import { CONTAINERS } from '../../constants';
 import { getPreviousProjectKey } from '../../utils';
-import { TFetchLoggedInUserQuery } from '../../types/generated/mc';
-import { TApplicationsMenu } from '../../types/generated/proxy';
 import UserSettingsMenu from '../user-settings-menu';
 import ProjectSwitcher from '../project-switcher';
 import BackToProject from '../back-to-project';

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.tsx
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.tsx
@@ -1,3 +1,7 @@
+import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
+import type { TrackingWhitelist } from '../../utils/gtm';
+
 import './global-style-imports';
 import '../../track-performance';
 import React from 'react';
@@ -5,15 +9,8 @@ import { Router } from 'react-router-dom';
 import { ApolloProvider } from 'react-apollo';
 import { Provider as ReduxProvider } from 'react-redux';
 import history from '@commercetools-frontend/browser-history';
-import {
-  ApplicationContextProvider,
-  TApplicationContext,
-} from '@commercetools-frontend/application-shell-connectors';
-import {
-  AsyncLocaleData,
-  TAsyncLocaleDataProps,
-} from '@commercetools-frontend/i18n';
-import { TrackingWhitelist } from '../../utils/gtm';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
+import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import internalReduxStore from '../../configure-store';
 import apolloClient from '../../configure-apollo';
 import ConfigureIntlProvider from '../configure-intl-provider';

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -1,8 +1,14 @@
-import React, { SyntheticEvent } from 'react';
-import { Dispatch } from 'redux';
+import type { SyntheticEvent } from 'react';
+import type { Dispatch } from 'redux';
+import type { TFlags } from '@flopflip/types';
+import type { ApolloError } from 'apollo-client';
+import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
+import type { TApplicationsMenu } from '../../types/generated/proxy';
+import type { TrackingWhitelist } from '../../utils/gtm';
+
+import React from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
-import { ApolloError } from 'apollo-client';
-import { TFlags } from '@flopflip/types';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
 import {
@@ -14,17 +20,9 @@ import {
   reportErrorToSentry,
   SentryUserTracker,
 } from '@commercetools-frontend/sentry';
-import {
-  ApplicationContextProvider,
-  TApplicationContext,
-} from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';
-import {
-  AsyncLocaleData,
-  TAsyncLocaleDataProps,
-} from '@commercetools-frontend/i18n';
-import { TApplicationsMenu } from '../../types/generated/proxy';
-import { TrackingWhitelist } from '../../utils/gtm';
+import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import internalReduxStore from '../../configure-store';
 import ProjectDataLocale from '../project-data-locale';
 import PortalsContainer from '../portals-container';

--- a/packages/application-shell/src/components/authenticated/am-i-logged-in.tsx
+++ b/packages/application-shell/src/components/authenticated/am-i-logged-in.tsx
@@ -1,11 +1,12 @@
+import type {
+  TAmILoggedInQuery,
+  TAmILoggedInQueryVariables,
+} from '../../types/generated/mc';
+
 import React from 'react';
 import { useQuery } from 'react-apollo';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { STORAGE_KEYS } from '../../constants';
-import {
-  TAmILoggedInQuery,
-  TAmILoggedInQueryVariables,
-} from '../../types/generated/mc';
 import AmILoggedInQuery from './authenticated.mc.graphql';
 
 type RenderFnArgs = { isAuthenticated: boolean };

--- a/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
+++ b/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
@@ -1,3 +1,5 @@
+import type { TProps } from './authenticated';
+
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
@@ -5,7 +7,7 @@ import { GraphQLError } from 'graphql';
 import { renderApp, waitFor } from '../../test-utils';
 import { STORAGE_KEYS } from '../../constants';
 import AmILoggedInQuery from './authenticated.mc.graphql';
-import Authenticated, { TProps } from './authenticated';
+import Authenticated from './authenticated';
 
 const createTestProps = (custom: Partial<TProps> = {}) => ({
   render: jest.fn(() => <div />),

--- a/packages/application-shell/src/components/configure-intl-provider/configure-intl-provider.tsx
+++ b/packages/application-shell/src/components/configure-intl-provider/configure-intl-provider.tsx
@@ -1,5 +1,7 @@
+import type { IntlConfig } from 'react-intl';
+
 import React from 'react';
-import { IntlProvider, IntlConfig } from 'react-intl';
+import { IntlProvider } from 'react-intl';
 
 interface ApplicationWindow extends Window {
   onAppLoaded: () => void;

--- a/packages/application-shell/src/components/error-boundary/error-boundary.tsx
+++ b/packages/application-shell/src/components/error-boundary/error-boundary.tsx
@@ -1,4 +1,6 @@
-import React, { ErrorInfo } from 'react';
+import type { ErrorInfo } from 'react';
+
+import React from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import ErrorApologizer from '../error-apologizer';
 

--- a/packages/application-shell/src/components/fetch-project/fetch-project.tsx
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
-import { ApolloError } from 'apollo-client';
-import { useQuery } from 'react-apollo';
-import {
-  GRAPHQL_TARGETS,
-  TGraphQLTargets,
-} from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import {
+import type { ApolloError } from 'apollo-client';
+import type { TGraphQLTargets } from '@commercetools-frontend/constants';
+import type {
   TFetchProjectQuery,
   TFetchProjectQueryVariables,
 } from '../../types/generated/mc';
+
+import React from 'react';
+import { useQuery } from 'react-apollo';
+import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import ProjectQuery from './fetch-project.mc.graphql';
 
 type RenderFnArgs = {

--- a/packages/application-shell/src/components/fetch-user/fetch-user.tsx
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
-import { ApolloError } from 'apollo-client';
-import { useQuery } from 'react-apollo';
-import {
-  GRAPHQL_TARGETS,
-  TGraphQLTargets,
-} from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import {
+import type { ApolloError } from 'apollo-client';
+import type { TGraphQLTargets } from '@commercetools-frontend/constants';
+import type {
   TFetchLoggedInUserQuery,
   TFetchLoggedInUserQueryVariables,
 } from '../../types/generated/mc';
+
+import React from 'react';
+import { useQuery } from 'react-apollo';
+import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import LoggedInUserQuery from './fetch-user.mc.graphql';
 
 type RenderFnArgs = {

--- a/packages/application-shell/src/components/gtm-booter/gtm-booter.spec.tsx
+++ b/packages/application-shell/src/components/gtm-booter/gtm-booter.spec.tsx
@@ -1,7 +1,9 @@
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+import type { Props } from './gtm-booter';
+
 import React from 'react';
 import { render, waitFor, fireEvent } from '@testing-library/react';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
-import GtmBooter, { Props } from './gtm-booter';
+import GtmBooter from './gtm-booter';
 
 declare let window: ApplicationWindow;
 

--- a/packages/application-shell/src/components/gtm-user-tracker/gtm-user-tracker.tsx
+++ b/packages/application-shell/src/components/gtm-user-tracker/gtm-user-tracker.tsx
@@ -1,5 +1,6 @@
+import type { TFetchLoggedInUserQuery } from '../../types/generated/mc';
+
 import React from 'react';
-import { TFetchLoggedInUserQuery } from '../../types/generated/mc';
 import * as gtm from '../../utils/gtm';
 
 type TFetchedUser = TFetchLoggedInUserQuery['user'];

--- a/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.tsx
+++ b/packages/application-shell/src/components/handle-apollo-errors/handle-apollo-errors.tsx
@@ -1,6 +1,7 @@
+import type { QueryResult } from 'react-apollo';
+
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { QueryResult } from 'react-apollo';
 import { handleActionError } from '@commercetools-frontend/actions-global';
 import getDisplayName from '../../utils/get-display-name';
 

--- a/packages/application-shell/src/components/inject-reducers/inject-reducers.tsx
+++ b/packages/application-shell/src/components/inject-reducers/inject-reducers.tsx
@@ -1,7 +1,8 @@
+import type { ReducersMapObject } from 'redux';
+import type { TEnhancedStore } from '../../configure-store';
+
 import React from 'react';
-import { ReducersMapObject } from 'redux';
 import { useStore } from 'react-redux';
-import { TEnhancedStore } from '../../configure-store';
 
 type Props = {
   id: string;

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -1,11 +1,17 @@
-import React, { MouseEventHandler, SyntheticEvent } from 'react';
+import type { MouseEventHandler, SyntheticEvent } from 'react';
+import type { RouteComponentProps } from 'react-router-dom';
+import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import type {
+  TDataFence,
+  TActionRight,
+  TApplicationsMenu,
+  TLocalizedField,
+  TNavbarMenu,
+} from '../../types/generated/proxy';
+
+import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import {
-  NavLink,
-  matchPath,
-  RouteComponentProps,
-  useLocation,
-} from 'react-router-dom';
+import { NavLink, matchPath, useLocation } from 'react-router-dom';
 import { ToggleFeature } from '@flopflip/react-broadcast';
 import classnames from 'classnames';
 import {
@@ -33,18 +39,8 @@ import {
   NO_VALUE_FALLBACK,
   SUPPORT_PORTAL_URL,
 } from '@commercetools-frontend/constants';
-import {
-  useApplicationContext,
-  TApplicationContext,
-} from '@commercetools-frontend/application-shell-connectors';
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
-import {
-  TDataFence,
-  TActionRight,
-  TApplicationsMenu,
-  TLocalizedField,
-  TNavbarMenu,
-} from '../../types/generated/proxy';
 import { location } from '../../utils/location';
 import { GtmContext } from '../gtm-booter';
 import LoadingPlaceholder from '../loading-placeholder';

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -1,16 +1,20 @@
+import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import type {
+  TApplicationsMenu,
+  TNavbarMenu,
+} from '../../types/generated/proxy';
+import type {
+  TFetchProjectExtensionsNavbarQuery,
+  TFetchProjectExtensionsNavbarQueryVariables,
+} from '../../types/generated/settings';
+
 import React from 'react';
 import isNil from 'lodash/isNil';
 import throttle from 'lodash/throttle';
 import { useQuery } from 'react-apollo';
 import { useFeatureToggle } from '@flopflip/react-broadcast';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { TApplicationsMenu, TNavbarMenu } from '../../types/generated/proxy';
-import {
-  TFetchProjectExtensionsNavbarQuery,
-  TFetchProjectExtensionsNavbarQueryVariables,
-} from '../../types/generated/settings';
 import { PROJECT_EXTENSIONS } from '../../feature-toggles';
 import { STORAGE_KEYS } from '../../constants';
 import useApplicationsMenu from '../../hooks/use-applications-menu';

--- a/packages/application-shell/src/components/project-container/project-container.tsx
+++ b/packages/application-shell/src/components/project-container/project-container.tsx
@@ -1,16 +1,16 @@
+import type { RouteComponentProps } from 'react-router-dom';
+import type { TProviderProps } from '@commercetools-frontend/application-shell-connectors';
+import type { TFetchLoggedInUserQuery } from '../../types/generated/mc';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Route, Switch, Redirect, RouteComponentProps } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import isNil from 'lodash/isNil';
-import {
-  ApplicationContextProvider,
-  TProviderProps,
-} from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import { DOMAINS, LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import { Notifier } from '@commercetools-frontend/react-notifications';
 import { CONTAINERS, STORAGE_KEYS, SUSPENSION_REASONS } from '../../constants';
-import { TFetchLoggedInUserQuery } from '../../types/generated/mc';
 import ApplicationLoader from '../application-loader';
 import LocaleSwitcher from '../locale-switcher';
 import ProjectDataLocale from '../project-data-locale';

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -1,8 +1,14 @@
+import type { OptionProps, ValueContainerProps } from 'react-select';
+import type {
+  TProject,
+  TFetchUserProjectsQuery,
+  TFetchUserProjectsQueryVariables,
+} from '../../types/generated/mc';
+
 import React from 'react';
 import memoize from 'memoize-one';
 import { useQuery } from 'react-apollo';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { OptionProps, ValueContainerProps } from 'react-select';
 import { css } from '@emotion/core';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
@@ -10,11 +16,6 @@ import SelectInput from '@commercetools-uikit/select-input';
 import { ErrorIcon } from '@commercetools-uikit/icons';
 import { customProperties } from '@commercetools-uikit/design-system';
 import { location } from '../../utils/location';
-import {
-  TProject,
-  TFetchUserProjectsQuery,
-  TFetchUserProjectsQueryVariables,
-} from '../../types/generated/mc';
 import ProjectsQuery from './project-switcher.mc.graphql';
 import messages from './messages';
 

--- a/packages/application-shell/src/components/quick-access/butler-command/butler-command.tsx
+++ b/packages/application-shell/src/components/quick-access/butler-command/butler-command.tsx
@@ -1,9 +1,11 @@
-import React, { MouseEventHandler } from 'react';
+import type { MouseEventHandler } from 'react';
+import type { Command } from '../types';
+
+import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { AngleThinRightIcon } from '@commercetools-uikit/icons';
 import { customProperties } from '@commercetools-uikit/design-system';
-import { Command } from '../types';
 
 type Props = {
   command: Command;

--- a/packages/application-shell/src/components/quick-access/butler/butler.tsx
+++ b/packages/application-shell/src/components/quick-access/butler/butler.tsx
@@ -1,10 +1,19 @@
-import React, {
+import type {
   KeyboardEventHandler,
   ChangeEventHandler,
   KeyboardEvent,
   MouseEventHandler,
   MouseEvent,
 } from 'react';
+import type {
+  Command,
+  SearchText,
+  SelectedResult,
+  Stack,
+  HistoryEntry,
+} from '../types';
+
+import React from 'react';
 import Fuse from 'fuse.js';
 import { FormattedMessage, useIntl } from 'react-intl';
 import last from 'lodash/last';
@@ -15,13 +24,6 @@ import { customProperties } from '@commercetools-uikit/design-system';
 import ButlerCommand from '../butler-command';
 import ButlerContainer from '../butler-container';
 import messages from '../messages';
-import {
-  Command,
-  SearchText,
-  SelectedResult,
-  Stack,
-  HistoryEntry,
-} from '../types';
 
 const isSelectAllCombo = (event: KeyboardEvent<HTMLInputElement>) =>
   event.key === 'a' &&

--- a/packages/application-shell/src/components/quick-access/create-commands.ts
+++ b/packages/application-shell/src/components/quick-access/create-commands.ts
@@ -1,15 +1,17 @@
-import { IntlShape } from 'react-intl';
+import type { IntlShape } from 'react-intl';
+import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import type { Command } from './types';
+
 import { oneLineTrim } from 'common-tags';
 import { hasSomePermissions } from '@commercetools-frontend/permissions';
 import {
   LOGOUT_REASONS,
   SUPPORT_PORTAL_URL,
 } from '@commercetools-frontend/constants';
-import { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { permissions } from './constants';
 import messages from './messages';
 import { location } from '../../utils/location';
-import { actionTypes, Command } from './types';
+import { actionTypes } from './types';
 
 function nonNullable<T>(value: T | boolean): value is NonNullable<T> {
   return value !== null && value !== undefined && typeof value !== 'boolean';

--- a/packages/application-shell/src/components/quick-access/history-entries.ts
+++ b/packages/application-shell/src/components/quick-access/history-entries.ts
@@ -1,4 +1,4 @@
-import { HistoryEntry } from './types';
+import type { HistoryEntry } from './types';
 
 const STORAGE_KEY = 'quickAccessHistoryEntries';
 

--- a/packages/application-shell/src/components/quick-access/quick-access.tsx
+++ b/packages/application-shell/src/components/quick-access/quick-access.tsx
@@ -1,3 +1,6 @@
+import type { TQuickAccessQuery } from '../../types/generated/ctp';
+import type { ExecGraphQlQuery, Command, HistoryEntry } from './types';
+
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { useFeatureToggles } from '@flopflip/react-broadcast';
@@ -15,7 +18,6 @@ import {
 } from '@commercetools-frontend/constants';
 import { hasSomePermissions } from '@commercetools-frontend/permissions';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import { TQuickAccessQuery } from '../../types/generated/ctp';
 import { location } from '../../utils/location';
 import Butler from './butler';
 import QuickAccessQuery from './quick-access.ctp.graphql';
@@ -29,7 +31,7 @@ import messages from './messages';
 import { permissions } from './constants';
 import { saveHistoryEntries, loadHistoryEntries } from './history-entries';
 import pimIndexerStates from './pim-indexer-states';
-import { actionTypes, ExecGraphQlQuery, Command, HistoryEntry } from './types';
+import { actionTypes } from './types';
 
 const searchProductIdsAction = (
   searchText: string,

--- a/packages/application-shell/src/components/quick-access/sub-commands.ts
+++ b/packages/application-shell/src/components/quick-access/sub-commands.ts
@@ -1,16 +1,18 @@
-import { IntlShape } from 'react-intl';
-import { oneLineTrim } from 'common-tags';
-import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { hasSomePermissions } from '@commercetools-frontend/permissions';
-import { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import {
+import type { IntlShape } from 'react-intl';
+import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import type {
   TProductVariant,
   TQuickAccessProductQuery,
 } from '../../types/generated/ctp';
+import type { Command, ExecGraphQlQuery } from './types';
+
+import { oneLineTrim } from 'common-tags';
+import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import { hasSomePermissions } from '@commercetools-frontend/permissions';
 import QuickAccessProductQuery from './quick-access-product.ctp.graphql';
 import { permissions } from './constants';
 import messages from './messages';
-import { actionTypes, Command, ExecGraphQlQuery } from './types';
+import { actionTypes } from './types';
 
 type CreateProductVariantSubCommandsOptions = {
   intl: IntlShape;

--- a/packages/application-shell/src/components/quick-access/types.ts
+++ b/packages/application-shell/src/components/quick-access/types.ts
@@ -1,6 +1,6 @@
-import { DocumentNode } from 'graphql';
-import { ApolloQueryResult } from 'apollo-client';
-import { OperationVariables } from '@apollo/react-common';
+import type { DocumentNode } from 'graphql';
+import type { ApolloQueryResult } from 'apollo-client';
+import type { OperationVariables } from '@apollo/react-common';
 
 export const actionTypes = {
   go: 'go',

--- a/packages/application-shell/src/components/quick-access/utils.ts
+++ b/packages/application-shell/src/components/quick-access/utils.ts
@@ -1,5 +1,5 @@
-import { TLocalizedString } from '../../types/generated/ctp';
-import { Command, ExecGraphQlQuery } from './types';
+import type { TLocalizedString } from '../../types/generated/ctp';
+import type { Command, ExecGraphQlQuery } from './types';
 
 export const sanitize = (param: string) =>
   param

--- a/packages/application-shell/src/components/redirector/redirector.tsx
+++ b/packages/application-shell/src/components/redirector/redirector.tsx
@@ -1,7 +1,8 @@
+import type { RouteComponentProps } from 'react-router-dom';
+import type { TEnhancedLocation } from '@commercetools-frontend/browser-history';
+
 import React from 'react';
 import { encode } from 'qss';
-import { RouteComponentProps } from 'react-router-dom';
-import { TEnhancedLocation } from '@commercetools-frontend/browser-history';
 import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import { location } from '../../utils/location';
 

--- a/packages/application-shell/src/components/requests-in-flight-loader/reducer.spec.ts
+++ b/packages/application-shell/src/components/requests-in-flight-loader/reducer.spec.ts
@@ -1,11 +1,12 @@
-import { Action } from 'redux';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
-import reducer from './reducer';
-import {
+import type { Action } from 'redux';
+import type {
   TShowRequestInFlightAction,
   THideRequestInFlightAction,
 } from './types';
+
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
+import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
+import reducer from './reducer';
 
 jest.mock('@commercetools-frontend/sentry');
 

--- a/packages/application-shell/src/components/requests-in-flight-loader/reducer.ts
+++ b/packages/application-shell/src/components/requests-in-flight-loader/reducer.ts
@@ -1,11 +1,12 @@
-import { Action } from 'redux';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
-import {
+import type { Action } from 'redux';
+import type {
   TRequestsInFlightState,
   TShowRequestInFlightAction,
   THideRequestInFlightAction,
 } from './types';
+
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
+import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
 
 const isShowRequestInFlightAction = (
   action: Action

--- a/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.tsx
+++ b/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.tsx
@@ -1,3 +1,5 @@
+import type { TRequestsInFlightState } from './types';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { FormattedMessage } from 'react-intl';
@@ -5,7 +7,6 @@ import { useSelector } from 'react-redux';
 import LoadingSpinner from '@commercetools-uikit/loading-spinner';
 import { REQUESTS_IN_FLIGHT_LOADER_DOM_ID } from './constants';
 import messages from './messages';
-import { TRequestsInFlightState } from './types';
 
 const getPortalContainer = () =>
   process.env.NODE_ENV === 'test'

--- a/packages/application-shell/src/components/requests-in-flight-loader/types.ts
+++ b/packages/application-shell/src/components/requests-in-flight-loader/types.ts
@@ -1,4 +1,4 @@
-import { Action } from 'redux';
+import type { Action } from 'redux';
 import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
 
 export type TRequestsInFlightState = string[];

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -1,8 +1,9 @@
+import type { TFlags } from '@flopflip/types';
+import type { TFetchLoggedInUserQuery } from '../../types/generated/mc';
+
 import React from 'react';
 import ldAdapter from '@flopflip/launchdarkly-adapter';
 import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
-import { TFlags } from '@flopflip/types';
-import { TFetchLoggedInUserQuery } from '../../types/generated/mc';
 import useAllMenuFeatureToggles from '../../hooks/use-all-menu-feature-toggles';
 import { FLAGS } from '../../feature-toggles';
 

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -1,12 +1,16 @@
+import type { ControllerStateAndHelpers, DownshiftProps } from 'downshift';
+import type { TUser } from '../../types/generated/mc';
+import type {
+  TApplicationsMenu,
+  TFetchApplicationsMenuQuery,
+} from '../../types/generated/proxy';
+
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import Downshift, {
-  ControllerStateAndHelpers,
-  DownshiftProps,
-} from 'downshift';
+import Downshift from 'downshift';
 import { ToggleFeature } from '@flopflip/react-broadcast';
 import Avatar from '@commercetools-uikit/avatar';
 import Spacings from '@commercetools-uikit/spacings';
@@ -21,11 +25,6 @@ import {
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import useApplicationsMenu from '../../hooks/use-applications-menu';
-import { TUser } from '../../types/generated/mc';
-import {
-  TApplicationsMenu,
-  TFetchApplicationsMenuQuery,
-} from '../../types/generated/proxy';
 import messages from './messages';
 
 type Props = Pick<

--- a/packages/application-shell/src/components/version-tracker/actions.ts
+++ b/packages/application-shell/src/components/version-tracker/actions.ts
@@ -1,4 +1,6 @@
-import { actions as sdkActions, Json } from '@commercetools-frontend/sdk';
+import type { Json } from '@commercetools-frontend/sdk';
+
+import { actions as sdkActions } from '@commercetools-frontend/sdk';
 import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/application-shell/src/configure-apollo.ts
+++ b/packages/application-shell/src/configure-apollo.ts
@@ -1,3 +1,6 @@
+import type { IdGetterObj } from 'apollo-cache-inmemory';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import ApolloClient from 'apollo-client';
 import { version as apolloVersion } from 'apollo-client/version';
 import { ApolloLink } from 'apollo-link';
@@ -6,9 +9,7 @@ import { createHttpLink } from 'apollo-link-http';
 import {
   InMemoryCache,
   IntrospectionFragmentMatcher,
-  IdGetterObj,
 } from 'apollo-cache-inmemory';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 import createHttpUserAgent from '@commercetools/http-user-agent';
 import { errorLink, headerLink, tokenRetryLink } from './apollo-links';
 import { getMcApiUrl } from './utils';

--- a/packages/application-shell/src/configure-store.ts
+++ b/packages/application-shell/src/configure-store.ts
@@ -1,24 +1,19 @@
-import {
-  createStore,
-  compose,
-  applyMiddleware,
-  combineReducers,
+import type {
   ReducersMapObject,
   Store,
   Middleware,
   StoreEnhancer,
 } from 'redux';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
+import { createStore, compose, applyMiddleware, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
 import {
   middleware as notificationsMiddleware,
   reducer as notificationsReducer,
 } from '@commercetools-frontend/notifications';
 import { createMiddleware as createSdkMiddleware } from '@commercetools-frontend/sdk';
-import {
-  SHOW_LOADING,
-  HIDE_LOADING,
-  ApplicationWindow,
-} from '@commercetools-frontend/constants';
+import { SHOW_LOADING, HIDE_LOADING } from '@commercetools-frontend/constants';
 import hideNotificationsMiddleware from './middleware/hide-notifications';
 import loggerMiddleware from './middleware/logger';
 import { requestsInFlightReducer } from './components/requests-in-flight-loader';

--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
@@ -1,10 +1,11 @@
-import { useQuery } from 'react-apollo';
-import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import {
+import type {
   TFetchAllMenuFeatureTogglesQuery,
   TFetchAllMenuFeatureTogglesQueryVariables,
 } from '../../types/generated/proxy';
+
+import { useQuery } from 'react-apollo';
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { FetchAllMenuFeatureToggles } from './fetch-all-menu-feature-toggles.proxy.graphql';
 
 const defaultApiUrl = window.location.origin;

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
@@ -1,15 +1,17 @@
+import type { TFetchApplicationsMenuQuery } from '../../types/generated/proxy';
+import type {
+  MenuKey,
+  Config,
+  MenuLoaderResult,
+} from './use-applications-menu';
+
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import upperFirst from 'lodash/upperFirst';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { renderApp, waitFor } from '../../test-utils';
-import { TFetchApplicationsMenuQuery } from '../../types/generated/proxy';
 import FetchApplicationsMenu from './fetch-applications-menu.proxy.graphql';
-import useApplicationsMenu, {
-  MenuKey,
-  Config,
-  MenuLoaderResult,
-} from './use-applications-menu';
+import useApplicationsMenu from './use-applications-menu';
 
 jest.mock('@commercetools-frontend/sentry');
 

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
@@ -1,10 +1,12 @@
-import React from 'react';
-import { useLazyQuery, QueryFunctionOptions } from 'react-apollo';
-import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
-import {
+import type { QueryFunctionOptions } from 'react-apollo';
+import type {
   TFetchApplicationsMenuQuery,
   TFetchApplicationsMenuQueryVariables,
 } from '../../types/generated/proxy';
+
+import React from 'react';
+import { useLazyQuery } from 'react-apollo';
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import FetchApplicationsMenu from './fetch-applications-menu.proxy.graphql';
 
 export type MenuKey = 'appBar' | 'navBar';

--- a/packages/application-shell/src/middleware/hide-notifications.ts
+++ b/packages/application-shell/src/middleware/hide-notifications.ts
@@ -1,13 +1,14 @@
-import { Action, Dispatch, MiddlewareAPI } from 'redux';
-import {
-  removeNotification,
-  ADD_NOTIFICATION,
-  TNotificationAction,
-} from '@commercetools-frontend/notifications';
-import {
+import type { Action, Dispatch, MiddlewareAPI } from 'redux';
+import type { TNotificationAction } from '@commercetools-frontend/notifications';
+import type {
   TApiErrorNotification,
   TUnexpectedErrorNotification,
 } from '@commercetools-frontend/actions-global';
+
+import {
+  removeNotification,
+  ADD_NOTIFICATION,
+} from '@commercetools-frontend/notifications';
 import { selectPageNotifications } from '@commercetools-frontend/react-notifications';
 import {
   HIDE_ALL_PAGE_NOTIFICATIONS,

--- a/packages/application-shell/src/middleware/logger.ts
+++ b/packages/application-shell/src/middleware/logger.ts
@@ -1,4 +1,5 @@
-import { Middleware } from 'redux';
+import type { Middleware } from 'redux';
+
 import { createLogger } from 'redux-logger';
 import {
   ADD_NOTIFICATION,

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -4,11 +4,11 @@
 // the `render` method sets up the tests correctly.
 // This is a bit different from our usual tests, as we are testing our testing
 // tools here instead of actual components.
+import React from 'react';
+import PropTypes from 'prop-types';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
-import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { Query } from 'react-apollo';
 import { useSelector } from 'react-redux';
@@ -293,7 +293,7 @@ describe('custom render functions', () => {
     it('should merge the passed wrapper with renderApp internal wrapper', async () => {
       const TestComponent = () => {
         // provided wrapper
-        const value = useContext(Context);
+        const value = React.useContext(Context);
         // own wrapper
         useIntl();
 
@@ -309,7 +309,7 @@ describe('custom render functions', () => {
     it('should merge the passed wrapper with renderAppWithRedux internal wrapper', async () => {
       const TestComponent = () => {
         // provided wrapper
-        const value = useContext(Context);
+        const value = React.useContext(Context);
         // own wrapper
         useSelector(() => undefined);
 

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -1,3 +1,9 @@
+import type { MockedProviderProps } from '@apollo/react-testing';
+import type { TFlags } from '@flopflip/types';
+import type { TProviderProps } from '@commercetools-frontend/application-shell-connectors';
+import type { TMapNotificationToComponentProps } from '@commercetools-frontend/react-notifications';
+import type { TSdkMock } from '@commercetools-frontend/sdk/test-utils';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Router } from 'react-router-dom';
@@ -7,28 +13,17 @@ import * as rtl from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { IntlProvider } from 'react-intl';
 import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
-import { TFlags } from '@flopflip/types';
-import {
-  MockedProvider as ApolloMockProvider,
-  MockedProviderProps,
-} from '@apollo/react-testing';
+import { MockedProvider as ApolloMockProvider } from '@apollo/react-testing';
 import memoryAdapter from '@flopflip/memory-adapter';
 import { Provider as StoreProvider } from 'react-redux';
 import { createEnhancedHistory } from '@commercetools-frontend/browser-history';
-import {
-  ApplicationContextProvider,
-  TProviderProps,
-} from '@commercetools-frontend/application-shell-connectors';
+import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import {
   NotificationsList,
   NotificationProviderForCustomComponent,
-  TMapNotificationToComponentProps,
 } from '@commercetools-frontend/react-notifications';
 import { DOMAINS } from '@commercetools-frontend/constants';
-import {
-  createTestMiddleware as createSdkTestMiddleware,
-  TSdkMock,
-} from '@commercetools-frontend/sdk/test-utils';
+import { createTestMiddleware as createSdkTestMiddleware } from '@commercetools-frontend/sdk/test-utils';
 import { createReduxStore } from '../configure-store';
 import { createApolloClient } from '../configure-apollo';
 

--- a/packages/application-shell/src/track-performance.ts
+++ b/packages/application-shell/src/track-performance.ts
@@ -1,7 +1,9 @@
-import Perfume, {
+import type {
   IPerfumeNavigationTiming,
   IPerfumeDataConsumption,
 } from 'perfume.js';
+
+import Perfume from 'perfume.js';
 import { trackTiming } from './utils/gtm';
 
 const trackPerformance = () => {

--- a/packages/application-shell/src/utils/gtm.ts
+++ b/packages/application-shell/src/utils/gtm.ts
@@ -1,7 +1,8 @@
 /**
  * Google Tag Manager (GTM) Tracking Utilities
  */
-import { ApplicationWindow } from '@commercetools-frontend/constants';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import camelcase from 'lodash/camelCase';
 import logger from './logger';
 

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.ts
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.ts
@@ -1,6 +1,7 @@
+import type { NormalizedCacheObject } from 'apollo-cache-inmemory';
+import type { TFetchUserIdQuery } from '../../types/generated/mc';
+
 import ApolloClient from 'apollo-client';
-import { NormalizedCacheObject } from 'apollo-cache-inmemory';
-import { TFetchUserIdQuery } from '../../types/generated/mc';
 import FetchUserIdQuery from './select-user-id.mc.graphql';
 
 export default function selectUserId({

--- a/packages/browser-history/src/index.ts
+++ b/packages/browser-history/src/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/named
-import { EnhancedLocation } from 'history-query-enhancer';
+import type { EnhancedLocation } from 'history-query-enhancer';
 
 export { default as version } from './version';
 

--- a/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
@@ -1,13 +1,11 @@
+import type { State, Props, TMessageTranslations } from './async-locale-data';
+
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { render, waitFor } from '@testing-library/react';
 import loadI18n from '../load-i18n';
-import AsyncLocaleData, {
-  State,
-  Props,
-  TMessageTranslations,
-} from './async-locale-data';
+import AsyncLocaleData from './async-locale-data';
 
 jest.mock('@commercetools-frontend/sentry');
 

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,4 +1,4 @@
-import { Props } from './async-locale-data/async-locale-data';
+import type { Props } from './async-locale-data/async-locale-data';
 
 export type TAsyncLocaleDataProps = Props;
 

--- a/packages/l10n/src/country-information.ts
+++ b/packages/l10n/src/country-information.ts
@@ -1,7 +1,8 @@
+import type { Countries } from './types';
+
 import * as PropTypes from 'prop-types';
 import { createL10NInjector, createL10NHook } from './create-l10n-injector';
 import { getSupportedLocale, mapLocaleToIntlLocale } from './utils';
-import { Countries } from './types';
 
 type ImportData = {
   default: Countries;

--- a/packages/l10n/src/currency-information.ts
+++ b/packages/l10n/src/currency-information.ts
@@ -1,7 +1,8 @@
+import type { Currencies } from './types';
+
 import * as PropTypes from 'prop-types';
 import { createL10NInjector, createL10NHook } from './create-l10n-injector';
 import { getSupportedLocale, mapLocaleToIntlLocale } from './utils';
-import { Currencies } from './types';
 
 type ImportData = {
   default: Currencies;

--- a/packages/l10n/src/language-information.ts
+++ b/packages/l10n/src/language-information.ts
@@ -1,7 +1,8 @@
+import type { Languages } from './types';
+
 import * as PropTypes from 'prop-types';
 import { createL10NInjector, createL10NHook } from './create-l10n-injector';
 import { getSupportedLocale, mapLocaleToIntlLocale } from './utils';
-import { Languages } from './types';
 
 type ImportData = {
   default: Languages;

--- a/packages/l10n/src/time-zone-information.ts
+++ b/packages/l10n/src/time-zone-information.ts
@@ -1,7 +1,8 @@
+import type { TimeZones } from './types';
+
 import * as PropTypes from 'prop-types';
 import { createL10NInjector, createL10NHook } from './create-l10n-injector';
 import { getSupportedLocale, mapLocaleToIntlLocale } from './utils';
-import { TimeZones } from './types';
 
 type ImportData = {
   default: TimeZones;

--- a/packages/l10n/src/utils.ts
+++ b/packages/l10n/src/utils.ts
@@ -1,4 +1,4 @@
-import { Currencies } from './types';
+import type { Currencies } from './types';
 
 export const mapLocaleToIntlLocale = (locale: string) => {
   if (locale.startsWith('de')) return 'de';

--- a/packages/notifications/src/action-creators.ts
+++ b/packages/notifications/src/action-creators.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   TNotificationMetaOptions,
   TRemoveNotificationAction,
   TNotification,
   TAddNotificationAction,
 } from './types';
+
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from './action-types';
 
 export function addNotification<Payload extends TNotification>(

--- a/packages/notifications/src/middleware.ts
+++ b/packages/notifications/src/middleware.ts
@@ -1,9 +1,10 @@
-import { Action, Dispatch, MiddlewareAPI } from 'redux';
-import {
+import type { Action, Dispatch, MiddlewareAPI } from 'redux';
+import type {
   TNotification,
   TNotificationOnDismiss,
   TNotificationAction,
 } from './types';
+
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from './action-types';
 import { removeNotification } from './action-creators';
 

--- a/packages/notifications/src/notifications.spec.ts
+++ b/packages/notifications/src/notifications.spec.ts
@@ -1,5 +1,6 @@
+import type { TNotificationAction, TNotificationState } from './types';
+
 import { createStore, applyMiddleware } from 'redux';
-import { TNotificationAction, TNotificationState } from './types';
 import { addNotification } from './action-creators';
 import reducer from './reducer';
 import middleware from './middleware';

--- a/packages/notifications/src/reducer.ts
+++ b/packages/notifications/src/reducer.ts
@@ -1,8 +1,9 @@
-import {
+import type {
   TNotification,
   TNotificationAction,
   TNotificationState,
 } from './types';
+
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from './action-types';
 
 export default function notificationsReducer<Payload extends TNotification>(

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -1,4 +1,5 @@
-import { Action } from 'redux';
+import type { Action } from 'redux';
+
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from './action-types';
 
 export type TNotification = {

--- a/packages/react-notifications/src/components/map-notification-to-component/index.ts
+++ b/packages/react-notifications/src/components/map-notification-to-component/index.ts
@@ -1,4 +1,4 @@
-import { Props } from './map-notification-to-component';
+import type { Props } from './map-notification-to-component';
 
 // Re-export type for convenience
 export type TProps = Props;

--- a/packages/react-notifications/src/components/map-notification-to-component/map-notification-to-component.tsx
+++ b/packages/react-notifications/src/components/map-notification-to-component/map-notification-to-component.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import {
+import type {
   TAppNotificationGlobal,
   TAppNotificationPage,
   TAppNotificationSide,
 } from '@commercetools-frontend/constants';
+
+import React from 'react';
 
 export type Props = {
   mapNotificationToComponent: (

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
@@ -1,8 +1,10 @@
+import type { TAppNotificationApiError } from '@commercetools-frontend/constants';
+import type { IntlShape } from 'react-intl';
+
 import React from 'react';
-import { useIntl, IntlShape } from 'react-intl';
+import { useIntl } from 'react-intl';
 import has from 'lodash/has';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { TAppNotificationApiError } from '@commercetools-frontend/constants';
 import messages from './messages';
 
 const regexInvalidOperationRequiredAttribute = /Required attribute '(.*)' cannot be removed/;

--- a/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
-import {
+import type {
   TAppNotification,
   TAppNotificationValuesApiError,
+} from '@commercetools-frontend/constants';
+
+import React from 'react';
+import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_PAGE,
 } from '@commercetools-frontend/constants';

--- a/packages/react-notifications/src/components/notification-kinds/generic/generic.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/generic/generic.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import {
+import type {
   TAppNotification,
   TAppNotificationDomain,
   TAppNotificationKindSide,
 } from '@commercetools-frontend/constants';
+
+import React from 'react';
 import Notification from '../../notification';
 
 type Props = {

--- a/packages/react-notifications/src/components/notification-kinds/unexpected-error/unexpected-error.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/unexpected-error/unexpected-error.tsx
@@ -1,10 +1,13 @@
+import type {
+  TAppNotification,
+  TAppNotificationValuesUnexpectedError,
+} from '@commercetools-frontend/constants';
+
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_PAGE,
-  TAppNotification,
-  TAppNotificationValuesUnexpectedError,
 } from '@commercetools-frontend/constants';
 import Spacings from '@commercetools-uikit/spacings';
 import Notification from '../../notification';

--- a/packages/react-notifications/src/components/notification/notification.spec.tsx
+++ b/packages/react-notifications/src/components/notification/notification.spec.tsx
@@ -1,11 +1,14 @@
+import type { RenderResult } from '@testing-library/react';
+import type { Props } from './notification';
+
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-import { render, RenderResult, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
-import Notification, { Props } from './notification';
+import Notification from './notification';
 
 const TestComponent = () => <div>{'Test'}</div>;
 

--- a/packages/react-notifications/src/components/notification/notification.styles.ts
+++ b/packages/react-notifications/src/components/notification/notification.styles.ts
@@ -1,9 +1,12 @@
+import type {
+  TAppNotificationKind,
+  TAppNotificationDomain,
+} from '@commercetools-frontend/constants';
+
 import { css, keyframes } from '@emotion/core';
 import { customProperties } from '@commercetools-uikit/design-system';
 import {
   NOTIFICATION_DOMAINS,
-  TAppNotificationKind,
-  TAppNotificationDomain,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
 

--- a/packages/react-notifications/src/components/notification/notification.tsx
+++ b/packages/react-notifications/src/components/notification/notification.tsx
@@ -1,3 +1,8 @@
+import type {
+  TAppNotificationKind,
+  TAppNotificationDomain,
+} from '@commercetools-frontend/constants';
+
 import React from 'react';
 import { useIntl } from 'react-intl';
 import {
@@ -10,8 +15,6 @@ import {
 import IconButton from '@commercetools-uikit/icon-button';
 import {
   NOTIFICATION_DOMAINS,
-  TAppNotificationKind,
-  TAppNotificationDomain,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
 import filterDataAttributes from '../../utils/filter-data-attributes';

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.spec.tsx
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.spec.tsx
@@ -1,8 +1,10 @@
+import type { RenderResult } from '@testing-library/react';
+
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { render, RenderResult } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_PAGE,

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.styles.ts
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.styles.ts
@@ -1,9 +1,8 @@
+import type { TAppNotificationDomain } from '@commercetools-frontend/constants';
+
 import { css } from '@emotion/core';
 import { customProperties } from '@commercetools-uikit/design-system';
-import {
-  NOTIFICATION_DOMAINS,
-  TAppNotificationDomain,
-} from '@commercetools-frontend/constants';
+import { NOTIFICATION_DOMAINS } from '@commercetools-frontend/constants';
 
 type StyleProps = {
   domain: TAppNotificationDomain;

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.tsx
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.tsx
@@ -1,3 +1,12 @@
+import type {
+  TAppNotificationDomain,
+  TAppNotificationGlobal,
+  TAppNotificationPage,
+  TAppNotificationSide,
+  TAppNotificationValuesUnexpectedError,
+} from '@commercetools-frontend/constants';
+import type { TAppState } from './types';
+
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -5,11 +14,6 @@ import {
   NOTIFICATION_KINDS_GLOBAL,
   NOTIFICATION_KINDS_PAGE,
   NOTIFICATION_KINDS_SIDE,
-  TAppNotificationDomain,
-  TAppNotificationGlobal,
-  TAppNotificationPage,
-  TAppNotificationSide,
-  TAppNotificationValuesUnexpectedError,
 } from '@commercetools-frontend/constants';
 import { removeNotification } from '@commercetools-frontend/notifications';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
@@ -22,7 +26,6 @@ import {
   selectPageNotifications,
   selectSideNotifications,
 } from './selectors';
-import { TAppState } from './types';
 import { getStyles } from './notifications-list.styles';
 
 type Props = {

--- a/packages/react-notifications/src/components/notifications-list/selectors.ts
+++ b/packages/react-notifications/src/components/notifications-list/selectors.ts
@@ -1,12 +1,13 @@
-import { createSelector } from 'reselect';
-import {
-  NOTIFICATION_DOMAINS,
+import type {
   TAppNotificationGlobal,
   TAppNotificationPage,
   TAppNotificationSide,
   TAppNotificationDomain,
 } from '@commercetools-frontend/constants';
-import { TAppState } from './types';
+import type { TAppState } from './types';
+
+import { createSelector } from 'reselect';
+import { NOTIFICATION_DOMAINS } from '@commercetools-frontend/constants';
 
 // These selectors are okay memoization-wise, but once a single notifications
 // is added or removed the memoization for all domain selectors is reset

--- a/packages/react-notifications/src/components/notifications-list/types.ts
+++ b/packages/react-notifications/src/components/notifications-list/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TAppNotificationGlobal,
   TAppNotificationPage,
   TAppNotificationSide,

--- a/packages/react-notifications/src/components/notifier/notifier.spec.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.spec.tsx
@@ -1,24 +1,17 @@
 /* eslint-disable react/prop-types */
+import type { RenderResult } from '@testing-library/react';
+import type { TAddNotificationAction } from '@commercetools-frontend/notifications';
+import type { TShowNotification } from '@commercetools-frontend/actions-global';
+
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  waitFor,
-  RenderResult,
-} from '@testing-library/react';
-import {
-  TAddNotificationAction,
-  ADD_NOTIFICATION,
-} from '@commercetools-frontend/notifications';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { ADD_NOTIFICATION } from '@commercetools-frontend/notifications';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
-import {
-  useShowNotification,
-  TShowNotification,
-} from '@commercetools-frontend/actions-global';
+import { useShowNotification } from '@commercetools-frontend/actions-global';
 import Notifier from './notifier';
 
 jest.mock('@commercetools-frontend/actions-global');

--- a/packages/react-notifications/src/components/notifier/notifier.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.tsx
@@ -1,10 +1,13 @@
+import type {
+  TAppNotificationDomain,
+  TAppNotificationKind,
+} from '@commercetools-frontend/constants';
+
 import React from 'react';
 import isNumber from 'lodash/isNumber';
 import * as globalActions from '@commercetools-frontend/actions-global';
 import {
   NOTIFICATION_DOMAINS,
-  TAppNotificationDomain,
-  TAppNotificationKind,
   NOTIFICATION_KINDS_SIDE,
 } from '@commercetools-frontend/constants';
 

--- a/packages/react-notifications/src/index.ts
+++ b/packages/react-notifications/src/index.ts
@@ -1,4 +1,4 @@
-import { TProps as MapNotificationToComponentProps } from './components/map-notification-to-component';
+import type { TProps as MapNotificationToComponentProps } from './components/map-notification-to-component';
 
 // Re-export type for convenience
 export type TMapNotificationToComponentProps = MapNotificationToComponentProps;

--- a/packages/sdk/src/actions/actions.ts
+++ b/packages/sdk/src/actions/actions.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TSdkActionPayload,
   TSdkActionPayloadBody,
   TSdkActionPayloadForUri,

--- a/packages/sdk/src/components/sdk-get/sdk-get.spec.tsx
+++ b/packages/sdk/src/components/sdk-get/sdk-get.spec.tsx
@@ -1,9 +1,12 @@
+import type { ShallowWrapper } from 'enzyme';
+import type { Props } from './sdk-get';
+import type { Json } from '../../types';
+
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as sdkActions from '../../actions';
-import { SdkGet, Props } from './sdk-get';
-import { Json } from '../../types';
+import { SdkGet } from './sdk-get';
 
 const createTestProps = (custom: Partial<Props> = {}) => ({
   dispatch: jest.fn(() => Promise.resolve({})),

--- a/packages/sdk/src/components/sdk-get/sdk-get.tsx
+++ b/packages/sdk/src/components/sdk-get/sdk-get.tsx
@@ -1,9 +1,10 @@
+import type { ThunkDispatch } from 'redux-thunk';
+import type { SuccessResult, HttpErrorType } from '@commercetools/sdk-client';
+import type { TSdkAction } from '../../types';
+
 import React from 'react';
 import { connect } from 'react-redux';
-import { ThunkDispatch } from 'redux-thunk';
 import { deepEqual } from 'fast-equals';
-import { SuccessResult, HttpErrorType } from '@commercetools/sdk-client';
-import { TSdkAction } from '../../types';
 
 type TSdkError = Error | HttpErrorType;
 type TActionCreatorArgs = unknown[];

--- a/packages/sdk/src/hooks/use-async-dispatch.ts
+++ b/packages/sdk/src/hooks/use-async-dispatch.ts
@@ -1,6 +1,7 @@
-import { Dispatch } from 'redux';
+import type { Dispatch } from 'redux';
+import type { TSdkAction } from '../types';
+
 import { useDispatch } from 'react-redux';
-import { TSdkAction } from '../types';
 
 // Wraps `dispatch` and cast the return type to a Promise, as the middleware
 // returns a Promise.

--- a/packages/sdk/src/middleware/client.ts
+++ b/packages/sdk/src/middleware/client.ts
@@ -1,13 +1,14 @@
-import {
-  createClient as createSdkClient,
+import type {
   MiddlewareRequest,
   MiddlewareResponse,
   Next,
 } from '@commercetools/sdk-client';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
+import { createClient as createSdkClient } from '@commercetools/sdk-client';
 import { createHttpMiddleware as createSdkHttpMiddleware } from '@commercetools/sdk-middleware-http';
 import { createCorrelationIdMiddleware as createSdkCorrelationIdMiddleware } from '@commercetools/sdk-middleware-correlation-id';
 import createHttpUserAgent from '@commercetools/http-user-agent';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 import { getMcApiUrl } from '../utils';
 import version from '../version';
 

--- a/packages/sdk/src/middleware/middleware.spec.ts
+++ b/packages/sdk/src/middleware/middleware.spec.ts
@@ -1,11 +1,12 @@
+import type { SuccessResult, ClientRequest } from '@commercetools/sdk-client';
+import type { Json, TSdkAction } from '../types';
+
 import { mocked } from 'ts-jest/utils';
 import {
   SHOW_LOADING,
   HIDE_LOADING,
   MC_API_PROXY_TARGETS,
 } from '@commercetools-frontend/constants';
-import { SuccessResult, ClientRequest } from '@commercetools/sdk-client';
-import { Json, TSdkAction } from '../types';
 import * as sdkActions from '../actions';
 import createMiddleware from './middleware';
 import createClient from './client';

--- a/packages/sdk/src/middleware/middleware.ts
+++ b/packages/sdk/src/middleware/middleware.ts
@@ -1,17 +1,18 @@
-import { Action, Dispatch, MiddlewareAPI } from 'redux';
+import type { Action, Dispatch, MiddlewareAPI } from 'redux';
+import type { HttpErrorType } from '@commercetools/sdk-client';
+import type {
+  TSdkAction,
+  TSdkActionPayload,
+  TSdkActionPayloadForUri,
+} from '../types';
+
 import { createRequestBuilder } from '@commercetools/api-request-builder';
-import { HttpErrorType } from '@commercetools/sdk-client';
 import {
   SHOW_LOADING,
   HIDE_LOADING,
   STATUS_CODES,
 } from '@commercetools-frontend/constants';
 import { logRequest } from '../utils';
-import {
-  TSdkAction,
-  TSdkActionPayload,
-  TSdkActionPayloadForUri,
-} from '../types';
 import createClient from './client';
 
 const isSdkActionForUri = (

--- a/packages/sdk/src/test-utils/test-utils.spec.ts
+++ b/packages/sdk/src/test-utils/test-utils.spec.ts
@@ -1,5 +1,6 @@
+import type { TSdkAction, Json } from '../types';
+
 import { getErrorByCode } from '@commercetools/sdk-middleware-http';
-import { TSdkAction, Json } from '../types';
 import * as sdkActions from '../actions';
 import { createTestMiddleware } from './test-utils';
 

--- a/packages/sdk/src/test-utils/test-utils.ts
+++ b/packages/sdk/src/test-utils/test-utils.ts
@@ -1,9 +1,10 @@
+import type { Action, Dispatch } from 'redux';
+import type { HttpErrorType } from '@commercetools/sdk-client';
+import type { TSdkAction, Json } from '../types';
+
 import { deepEqual } from 'fast-equals';
-import { Action, Dispatch } from 'redux';
 // eslint-disable-next-line import/named
 import { v4 as uuid } from 'uuid';
-import { HttpErrorType } from '@commercetools/sdk-client';
-import { TSdkAction, Json } from '../types';
 
 interface TSdkMockBase {
   action: TSdkAction;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,4 +1,4 @@
-import { TMcApiProxyTargets } from '@commercetools-frontend/constants';
+import type { TMcApiProxyTargets } from '@commercetools-frontend/constants';
 
 export type Json = { [key: string]: unknown };
 

--- a/packages/sdk/src/utils/utils.spec.ts
+++ b/packages/sdk/src/utils/utils.spec.ts
@@ -1,5 +1,7 @@
+import type { ApplicationWindow } from './utils';
+
 import { decode } from 'qss';
-import { parseUri, getMcApiUrl, ApplicationWindow } from './utils';
+import { parseUri, getMcApiUrl } from './utils';
 
 type Result = { pathname: string; search: ReturnType<typeof decode> };
 

--- a/packages/sdk/src/utils/utils.ts
+++ b/packages/sdk/src/utils/utils.ts
@@ -1,6 +1,7 @@
+import type { THttpMethod, TSdkAction, Json, TSdkActionPost } from '../types';
+
 import { decode } from 'qss';
 import logger from './logger';
-import { THttpMethod, TSdkAction, Json, TSdkActionPost } from '../types';
 
 type LogRequestParams = {
   method: THttpMethod;

--- a/packages/sentry/src/sentry-user-logout-tracker/sentry-user-logout-tracker.tsx
+++ b/packages/sentry/src/sentry-user-logout-tracker/sentry-user-logout-tracker.tsx
@@ -1,6 +1,7 @@
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import React from 'react';
 import * as Sentry from '@sentry/browser';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 declare let window: ApplicationWindow;
 

--- a/packages/sentry/src/sentry-user-tracker/sentry-user-tracker.spec.tsx
+++ b/packages/sentry/src/sentry-user-tracker/sentry-user-tracker.spec.tsx
@@ -1,7 +1,8 @@
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import * as Sentry from '@sentry/browser';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 import SentryUserTracker from './sentry-user-tracker';
 
 declare let window: ApplicationWindow;

--- a/packages/sentry/src/sentry-user-tracker/sentry-user-tracker.tsx
+++ b/packages/sentry/src/sentry-user-tracker/sentry-user-tracker.tsx
@@ -1,6 +1,7 @@
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import React from 'react';
 import * as Sentry from '@sentry/browser';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 declare let window: ApplicationWindow;
 

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -1,5 +1,6 @@
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
 import * as Sentry from '@sentry/browser';
-import { ApplicationWindow } from '@commercetools-frontend/constants';
 
 declare let window: ApplicationWindow;
 


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-exports

Advantages: clearer separation of imports for types and "normal" JS.