### PR TITLE
refactor(express): support request handler for serverless functions

### DIFF
--- a/packages-backend/express/README.md
+++ b/packages-backend/express/README.md
@@ -16,7 +16,7 @@ $ npm install --save @commercetools-backend/express
 
 ## Session middleware
 
-This middleware should be used to handle the authentication exchange between the server and the `/proxy/forward-to` endpoint of the Merchant Center API Gateway.
+This Express.js middleware should be used to handle the authentication exchange between the server and the `/proxy/forward-to` endpoint of the Merchant Center API Gateway.
 
 > You can read more about the "Proxy to External API" concepts [here](https://docs.commercetools.com/custom-applications/main-concepts/proxy-to-external-api).
 
@@ -26,7 +26,12 @@ const {
   CLOUD_IDENTIFIERS,
 } = require('@commercetools-backend/express');
 
-app.use(createSessionMiddleware({ mcApiUrl: CLOUD_IDENTIFIERS.GCP_EU }));
+app.use(
+  createSessionMiddleware({
+    audience: 'https://my-api-server.com',
+    issuer: CLOUD_IDENTIFIERS.GCP_EU,
+  })
+);
 app.use((request, response, next) => {
   // `request.session` contains the useful information
 });
@@ -34,7 +39,9 @@ app.use((request, response, next) => {
 
 ### Middleware options
 
-- `issuer` (_string_): either a cloud identifier or a valid URL to the Merchant Center API Gateway. The cloud identifier maps to the Merchant Center API URL of the related [cloud region](https://docs.commercetools.com/custom-applications/main-concepts/api-gateway#cloud-regions).
+- `audience` (_string_): The public-facing URL of your API server. The value should only contain the origin URL (protocol, hostname, port), the request path is inferred from the incoming request.
+
+- `issuer` (_string_): Either a cloud identifier or a valid URL to the Merchant Center API Gateway. The cloud identifier maps to the Merchant Center API URL of the related [cloud region](https://docs.commercetools.com/custom-applications/main-concepts/api-gateway#cloud-regions).
 
   - `gcp-au`: `https://mc-api.australia-southeast1.gcp.commercetools.com`
   - `gcp-eu`: `https://mc-api.europe-west1.gcp.commercetools.com`
@@ -42,4 +49,35 @@ app.use((request, response, next) => {
   - `aws-fra`: `https://mc-api.eu-central-1.aws.commercetools.com`
   - `aws-ohio`: `https://mc-api.us-east-2.aws.commercetools.com`
 
-- `inferIssuer` (_boolean_): determines whether the issuer should be inferred from the custom request HTTP header `x-mc-api-cloud-identifier` which is sent by the Merchant Center API Gateway when forwarding the request. This might be useful in case the server is used in multiple regions.
+- `inferIssuer` (_boolean_): Determines whether the issuer should be inferred from the custom request HTTP header `x-mc-api-cloud-identifier` which is sent by the Merchant Center API Gateway when forwarding the request. This might be useful in case the server is used in multiple regions.
+
+### Usage in Serverless Functions
+
+If your HTTP server runs as a Serverless Function, the Express.js middleware should not be needed. Instead you can use the underlying function that does not require the `next` callback.
+
+**Example for Google Cloud Functions**
+
+```js
+const {
+  createSessionAuthVerifier,
+  CLOUD_IDENTIFIERS,
+} = require('@commercetools-backend/express');
+
+const sessionAuthVerifier = createSessionAuthVerifier({
+  audience: 'https://my-api-server.com',
+  issuer: CLOUD_IDENTIFIERS.GCP_EU,
+});
+
+exports.handler = async function (request, response) {
+  try {
+    await sessionAuthVerifier(request, response);
+  } catch (error) {
+    response.status(401).send(JSON.stringify({ message: 'Unauthorized' }));
+    return;
+  }
+
+  // `request.session` contains the useful information
+};
+```
+
+> The same concept applies for serverless functions in other cloud providers.

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -1,0 +1,118 @@
+import type { ServerResponse, IncomingMessage } from 'http';
+import type { TSessionMiddlewareOptions, TSession } from './types';
+
+import { CLOUD_IDENTIFIERS, MC_API_URLS } from './constants';
+import expressJwtMiddleware from 'express-jwt';
+import jwksRsa from 'jwks-rsa';
+
+const decodedTokenKey = 'decoded_token';
+
+const mapCloudIdentifierToUrl = (
+  issuer: TSessionMiddlewareOptions['issuer']
+): string | undefined => {
+  switch (issuer) {
+    case CLOUD_IDENTIFIERS.GCP_AU:
+      return MC_API_URLS.GCP_AU;
+    case CLOUD_IDENTIFIERS.GCP_EU: {
+      return MC_API_URLS.GCP_EU;
+    }
+    case CLOUD_IDENTIFIERS.GCP_US: {
+      return MC_API_URLS.GCP_US;
+    }
+    case CLOUD_IDENTIFIERS.AWS_FRA:
+      return MC_API_URLS.AWS_FRA;
+    case CLOUD_IDENTIFIERS.AWS_OHIO:
+      return MC_API_URLS.AWS_OHIO;
+    default:
+      return undefined;
+  }
+};
+const throwIfIssuerIsNotAValidUrl = (issuer: string) => {
+  try {
+    new URL(issuer);
+  } catch (error) {
+    throw new Error(
+      `Invalid issuer URL "${issuer}". Expected a valid URL to the Merchant Center API Gateway, or a cloud identifier to one of the available cloud regions. See https://docs.commercetools.com/custom-applications/main-concepts/api-gateway#hostnames.`
+    );
+  }
+};
+
+type TDecodedJWT = {
+  sub: string;
+  iss: string;
+  [property: string]: string;
+};
+
+const writeSessionContext = <Request extends IncomingMessage>(
+  request: Request & { decoded_token: TDecodedJWT; session?: TSession }
+) => {
+  const decodedToken = request[decodedTokenKey];
+  const publicClaimForProjectKey = `${decodedToken.iss}/claims/project_key`;
+
+  request.session = {
+    userId: decodedToken.sub,
+    projectKey: decodedToken[publicClaimForProjectKey],
+  };
+
+  delete request.decoded_token;
+};
+
+function createSessionAuthVerifier<
+  Request extends IncomingMessage,
+  Response extends ServerResponse
+>(options: TSessionMiddlewareOptions) {
+  let configuredDefaultIssuer = mapCloudIdentifierToUrl(options.issuer);
+  if (!configuredDefaultIssuer) {
+    throwIfIssuerIsNotAValidUrl(options.issuer);
+    configuredDefaultIssuer = options.issuer;
+  }
+
+  return async (request: Request, response: Response) => {
+    const cloudIdentifierHeader = request.headers['x-mc-api-cloud-identifier'];
+    const issuer =
+      options.inferIssuer &&
+      cloudIdentifierHeader &&
+      !Array.isArray(cloudIdentifierHeader)
+        ? mapCloudIdentifierToUrl(cloudIdentifierHeader) ??
+          configuredDefaultIssuer
+        : configuredDefaultIssuer;
+
+    // @ts-ignore: the node HTTP request does not know about `originalUrl`
+    const requestUrlPath = request.originalUrl ?? request.url;
+    const audience = `${options.audience.replace(/\/?$/, '')}${requestUrlPath}`;
+
+    return new Promise((resolve, reject) => {
+      expressJwtMiddleware({
+        // Dynamically provide a signing key based on the kid in the header
+        // and the singing keys provided by the JWKS endpoint
+        secret: jwksRsa.expressJwtSecret({
+          // Default options
+          cache: true,
+          rateLimit: true,
+          jwksRequestsPerMinute: 5,
+          // Pass custom options
+          ...(options.jwks || {}),
+          // This should be set by the middleware, no matter what.
+          jwksUri: `${issuer}/.well-known/jwks.json`,
+        }),
+        requestProperty: decodedTokenKey,
+        // Validate the audience and the issuer.
+        audience,
+        issuer,
+        algorithms: ['RS256'],
+        // @ts-ignore: the middleware expects an Express.js Request/Response objects
+      })(request, response, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          // @ts-ignore: the Request object does not know about some additional fields
+          // like `decoded_token` and `session`
+          writeSessionContext<Request>(request);
+          resolve();
+        }
+      });
+    });
+  };
+}
+
+export { createSessionAuthVerifier };

--- a/packages-backend/express/src/index.ts
+++ b/packages-backend/express/src/index.ts
@@ -1,2 +1,3 @@
-export * from './constants';
+export { CLOUD_IDENTIFIERS, MC_API_URLS } from './constants';
+export { createSessionAuthVerifier } from './auth';
 export { default as createSessionMiddleware } from './middlewares/session-middleware';

--- a/packages-backend/express/src/middlewares/session-middleware.spec.ts
+++ b/packages-backend/express/src/middlewares/session-middleware.spec.ts
@@ -20,25 +20,18 @@ describe.each`
     });
     it('should verify the token and attach the session info to the request', async () => {
       const sessionMiddleware = createSessionMiddleware({
+        audience: 'http://test-server',
         issuer: cloudIdentifier,
       });
       const fakeRequest = {
         method: 'GET',
-        header: jest.fn((key) => {
-          switch (key) {
-            case 'x-mc-api-cloud-identifier':
-              return cloudIdentifier;
-            default:
-              return undefined;
-          }
-        }),
         headers: {
           authorization: `Bearer ${fixtureJWTToken.createToken({
             issuer,
             audience: 'http://test-server/foo/bar',
           })}`,
+          'x-mc-api-cloud-identifier': cloudIdentifier,
         },
-        hostname: 'http://test-server',
         originalUrl: '/foo/bar',
       };
       const fakeResponse = {};
@@ -59,26 +52,19 @@ describe.each`
     if (!cloudIdentifier.startsWith('http')) {
       it('should infer cloud identifier from custom HTTP header instead of given "mcApiUrl"', async () => {
         const sessionMiddleware = createSessionMiddleware({
+          audience: 'http://test-server',
           issuer: 'https://mc-api.another-ct-test.com', // This value should not matter
           inferIssuer: true,
         });
         const fakeRequest = {
           method: 'GET',
-          header: jest.fn((key) => {
-            switch (key) {
-              case 'x-mc-api-cloud-identifier':
-                return cloudIdentifier;
-              default:
-                return undefined;
-            }
-          }),
           headers: {
             authorization: `Bearer ${fixtureJWTToken.createToken({
               issuer,
               audience: 'http://test-server/foo/bar',
             })}`,
+            'x-mc-api-cloud-identifier': cloudIdentifier,
           },
-          hostname: 'http://test-server',
           originalUrl: '/foo/bar',
         };
         const fakeResponse = {};
@@ -104,6 +90,7 @@ describe('when issuer is not a valid URL', () => {
   it('should throw a validation error', () => {
     expect(() =>
       createSessionMiddleware({
+        audience: 'http://test-server',
         issuer: 'invalid url',
       })
     ).toThrowError('Invalid issuer URL');

--- a/packages-backend/express/src/middlewares/session-middleware.ts
+++ b/packages-backend/express/src/middlewares/session-middleware.ts
@@ -1,106 +1,20 @@
-import type { TSessionMiddlewareOptions } from '../types';
 import type { Request, Response, NextFunction } from 'express';
+import type { TSessionMiddlewareOptions } from '../types';
 
-import { CLOUD_IDENTIFIERS, MC_API_URLS } from '../constants';
-import expressJwtMiddleware from 'express-jwt';
-import jwksRsa from 'jwks-rsa';
-
-const decodedTokenKey = 'decoded_token';
-
-const mapCloudIdentifierToUrl = (
-  issuer: TSessionMiddlewareOptions['issuer']
-): string | undefined => {
-  switch (issuer) {
-    case CLOUD_IDENTIFIERS.GCP_AU:
-      return MC_API_URLS.GCP_AU;
-    case CLOUD_IDENTIFIERS.GCP_EU: {
-      return MC_API_URLS.GCP_EU;
-    }
-    case CLOUD_IDENTIFIERS.GCP_US: {
-      return MC_API_URLS.GCP_US;
-    }
-    case CLOUD_IDENTIFIERS.AWS_FRA:
-      return MC_API_URLS.AWS_FRA;
-    case CLOUD_IDENTIFIERS.AWS_OHIO:
-      return MC_API_URLS.AWS_OHIO;
-    default:
-      return undefined;
-  }
-};
-const throwIfIssuerIsNotAValidUrl = (issuer: string) => {
-  try {
-    new URL(issuer);
-  } catch (error) {
-    throw new Error(
-      `Invalid issuer URL "${issuer}". Expected a valid URL to the Merchant Center API Gateway, or a cloud identifier to one of the available cloud regions. See https://docs.commercetools.com/custom-applications/main-concepts/api-gateway#hostnames.`
-    );
-  }
-};
-
-type TDecodedJWT = {
-  sub: string;
-  iss: string;
-  [property: string]: string;
-};
-
-const writeSessionContext = (
-  request: Request & { decoded_token: TDecodedJWT }
-) => {
-  const decodedToken = request[decodedTokenKey];
-  const publicClaimForProjectKey = `${decodedToken.iss}/claims/project_key`;
-
-  // @ts-ignore
-  request.session = {
-    userId: decodedToken.sub,
-    projectKey: decodedToken[publicClaimForProjectKey],
-  };
-
-  delete request.decoded_token;
-};
+import { createSessionAuthVerifier } from '../auth';
 
 function createSessionMiddleware(options: TSessionMiddlewareOptions) {
-  let configuredDefaultIssuer = mapCloudIdentifierToUrl(options.issuer);
-  if (!configuredDefaultIssuer) {
-    throwIfIssuerIsNotAValidUrl(options.issuer);
-    configuredDefaultIssuer = options.issuer;
-  }
+  const sessionAuthVerifier = createSessionAuthVerifier<Request, Response>(
+    options
+  );
 
-  // Return the middleware
-  return (request: Request, response: Response, next: NextFunction) => {
-    const cloudIdentifierHeader = request.header('x-mc-api-cloud-identifier');
-    const issuer =
-      options.inferIssuer && cloudIdentifierHeader
-        ? mapCloudIdentifierToUrl(cloudIdentifierHeader) ??
-          configuredDefaultIssuer
-        : configuredDefaultIssuer;
-
-    const audience = `${request.hostname}${request.originalUrl}`;
-    return expressJwtMiddleware({
-      // Dynamically provide a signing key based on the kid in the header
-      // and the singing keys provided by the JWKS endpoint
-      secret: jwksRsa.expressJwtSecret({
-        // Default options
-        cache: true,
-        rateLimit: true,
-        jwksRequestsPerMinute: 5,
-        // Pass custom options
-        ...(options.jwks || {}),
-        // This should be set by the middleware, no matter what.
-        jwksUri: `${issuer}/.well-known/jwks.json`,
-      }),
-      requestProperty: decodedTokenKey,
-      // Validate the audience and the issuer.
-      audience,
-      issuer,
-      algorithms: ['RS256'],
-    })(request, response, (error) => {
-      if (error) {
-        return next(error);
-      }
-      // @ts-ignore
-      writeSessionContext(request);
+  return async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      await sessionAuthVerifier(request, response);
       next();
-    });
+    } catch (error) {
+      next(error);
+    }
   };
 }
 

--- a/packages-backend/express/src/types.ts
+++ b/packages-backend/express/src/types.ts
@@ -1,4 +1,3 @@
-import type { Request } from 'express';
 import type { ExpressJwtOptions } from 'jwks-rsa';
 
 import { CLOUD_IDENTIFIERS } from './constants';
@@ -6,6 +5,10 @@ import { CLOUD_IDENTIFIERS } from './constants';
 export type TCloudIdentifier = typeof CLOUD_IDENTIFIERS[keyof typeof CLOUD_IDENTIFIERS];
 
 export type TSessionMiddlewareOptions = {
+  // The public-facing URL used to connect to the server / serverless function.
+  // The value should only contain the origin URL (protocol, hostname, port),
+  // the request path is inferred from the incoming request.
+  audience: string;
   // The cloud identifier (see `CLOUD_IDENTIFIERS`) that maps to the MC API URL
   // of the related cloud region or the MC API URL.
   issuer: TCloudIdentifier | string;
@@ -23,5 +26,3 @@ export type TSession = {
   userId: string;
   projectKey: string;
 };
-
-export type TRequestWithSession = Request & { session: TSession };


### PR DESCRIPTION
To better support the usage in serverless functions, I extracted the core logic into a `createSessionAuthVerifier`, which only requires `req, res` to be passed.

The middleware then is just a wrapper for express.