### PR TITLE
refactor(express): support backwards compatibility for v1

### DIFF
--- a/packages-backend/express/README.md
+++ b/packages-backend/express/README.md
@@ -51,6 +51,8 @@ app.use((request, response, next) => {
 
 - `inferIssuer` (_boolean_): Determines whether the issuer should be inferred from the custom request HTTP header `x-mc-api-cloud-identifier` which is sent by the Merchant Center API Gateway when forwarding the request. This might be useful in case the server is used in multiple regions.
 
+- `jwks` (_object_): see options of `jwks-rsa`.
+
 ### Usage in Serverless Functions
 
 If your HTTP server runs as a Serverless Function, the Express.js middleware should not be needed. Instead you can use the underlying function that does not require the `next` callback.

--- a/packages-backend/express/src/constants.ts
+++ b/packages-backend/express/src/constants.ts
@@ -13,3 +13,8 @@ export const MC_API_URLS = {
   AWS_FRA: 'https://mc-api.eu-central-1.aws.commercetools.com',
   AWS_OHIO: 'https://mc-api.us-east-2.aws.commercetools.com',
 } as const;
+
+export const MC_API_PROXY_HEADERS = {
+  FORWARD_TO_VERSION: 'x-mc-api-forward-to-version',
+  CLOUD_IDENTIFIER: 'x-mc-api-cloud-identifier',
+} as const;

--- a/packages-backend/express/src/types.ts
+++ b/packages-backend/express/src/types.ts
@@ -2,16 +2,20 @@ import type { ExpressJwtOptions } from 'jwks-rsa';
 
 import { CLOUD_IDENTIFIERS } from './constants';
 
+export type TAudience = string;
+
+export type TIssuer = string;
+
 export type TCloudIdentifier = typeof CLOUD_IDENTIFIERS[keyof typeof CLOUD_IDENTIFIERS];
 
 export type TSessionMiddlewareOptions = {
   // The public-facing URL used to connect to the server / serverless function.
   // The value should only contain the origin URL (protocol, hostname, port),
   // the request path is inferred from the incoming request.
-  audience: string;
+  audience: TAudience;
   // The cloud identifier (see `CLOUD_IDENTIFIERS`) that maps to the MC API URL
   // of the related cloud region or the MC API URL.
-  issuer: TCloudIdentifier | string;
+  issuer: TCloudIdentifier | TIssuer;
   // Determines whether the issuer should be inferred from the custom request
   // HTTP header `x-mc-api-cloud-identifier` which is sent by the MC API when
   // forwarding the request.

--- a/packages-backend/express/src/utils.ts
+++ b/packages-backend/express/src/utils.ts
@@ -1,0 +1,11 @@
+const getFirstOrThrow = (
+  value: string | string[] | undefined,
+  errorMessage: string
+) => {
+  if (!value) {
+    throw new Error(errorMessage);
+  }
+  return Array.isArray(value) ? value[0] : value;
+};
+
+export { getFirstOrThrow };


### PR DESCRIPTION
In order to allow a non-breaking migration to v2, the middleware should handle the legacy hostnames when processing the request, based on a custom header sent by the MC API with the forwarded request.