### PR TITLE
feat(headers.json): add support for env variable placeholders

### DIFF
--- a/packages/mc-html-template/lib/load-env.js
+++ b/packages/mc-html-template/lib/load-env.js
@@ -1,84 +1,9 @@
 const fs = require('fs');
+const substituteEnvVariablePlaceholders = require('./utils/substitute-env-variable-placeholders');
 
 // Keep a reference to the loaded config so that requiring the module
 // again will result in returning the cached value.
 let loadedEnv;
-
-/**
- * NOTE:
- *  Allows env variable placeholders e.g. `${env:MC_API_URL}`.
- *  Other placeholder types might be supported in the future.
- */
-const variableSyntax = /\${([ ~:a-zA-Z0-9._\'",\-\/\(\)]+?)}/g;
-const envRefSyntax = /^env:/g;
-
-const hasVariablePlaceholder = (valueOfEnvConfig) =>
-  typeof valueOfEnvConfig === 'string' &&
-  // Using `{regex}.test()` might cause false positives if called multiple
-  // times on a global regular expression:
-  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
-  //    As with exec() (or in combination with it), test() called multiple times
-  //    on the same global regular expression instance will advance past the previous match.
-  Boolean(valueOfEnvConfig.match(variableSyntax));
-const isEnvVariablePlaceholder = (valueOfPlaceholder) =>
-  Boolean(valueOfPlaceholder.match(envRefSyntax));
-const substituteEnvVariablePlaceholder = (
-  valueOfPlaceholder,
-  matchedString,
-  valueOfEnvConfig
-) => {
-  const [, requestedEnvVar] = valueOfPlaceholder.split(':');
-  const valueOfEnv = process.env[requestedEnvVar];
-
-  if (!valueOfEnv) {
-    throw new Error(
-      `Missing '${requestedEnvVar}' specified in config as 'env:${requestedEnvVar}'.`
-    );
-  }
-
-  const escapedMatchedString = matchedString.replace(/[${}:]/g, '\\$&');
-  return valueOfEnvConfig.replace(
-    new RegExp(`(${escapedMatchedString})+`, 'g'),
-    valueOfEnv
-  );
-};
-const getValueOfPlaceholder = (valueWithPlaceholder) =>
-  valueWithPlaceholder
-    .replace(variableSyntax, (match, varName) => varName.trim())
-    .replace(/\s/g, '');
-const substitutePlaceholders = (valueOfEnvConfig) => {
-  if (!hasVariablePlaceholder(valueOfEnvConfig)) return valueOfEnvConfig;
-
-  // NOTE: Interseting into the string with placeholders
-  // values one by one.
-  let populatedValueOfEnvConfig = valueOfEnvConfig;
-
-  valueOfEnvConfig.match(variableSyntax).forEach((matchedString) => {
-    const valueOfPlaceholder = getValueOfPlaceholder(matchedString);
-
-    if (isEnvVariablePlaceholder(valueOfPlaceholder)) {
-      populatedValueOfEnvConfig = substituteEnvVariablePlaceholder(
-        valueOfPlaceholder,
-        matchedString,
-        populatedValueOfEnvConfig
-      );
-    }
-  });
-
-  return populatedValueOfEnvConfig;
-};
-const substituteEnvVariablePlaceholders = (config) => {
-  const entriesOfEnvConfig = Object.entries(config);
-
-  const replacedEntriesOfEnvConfig = entriesOfEnvConfig.map(
-    ([envConfigKey, envConfigValue]) => [
-      envConfigKey,
-      substitutePlaceholders(envConfigValue),
-    ]
-  );
-
-  return Object.fromEntries(replacedEntriesOfEnvConfig);
-};
 
 module.exports = (configPath, { disableCache } = { disableCache: false }) => {
   if (loadedEnv && !disableCache) return loadedEnv;

--- a/packages/mc-html-template/lib/utils/substitute-env-variable-placeholders.js
+++ b/packages/mc-html-template/lib/utils/substitute-env-variable-placeholders.js
@@ -1,0 +1,84 @@
+/**
+ * NOTE:
+ *  Allows env variable placeholders e.g. `${env:MC_API_URL}`.
+ *  Other placeholder types might be supported in the future.
+ */
+const variableSyntax = /\${([ ~:a-zA-Z0-9._\'",\-\/\(\)]+?)}/g;
+const envRefSyntax = /^env:/g;
+
+const hasVariablePlaceholder = (valueOfEnvConfig) =>
+  typeof valueOfEnvConfig === 'string' &&
+  // Using `{regex}.test()` might cause false positives if called multiple
+  // times on a global regular expression:
+  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
+  //    As with exec() (or in combination with it), test() called multiple times
+  //    on the same global regular expression instance will advance past the previous match.
+  Boolean(valueOfEnvConfig.match(variableSyntax));
+
+const isEnvVariablePlaceholder = (valueOfPlaceholder) =>
+  Boolean(valueOfPlaceholder.match(envRefSyntax));
+
+const substituteEnvVariablePlaceholder = (
+  valueOfPlaceholder,
+  matchedString,
+  valueOfEnvConfig
+) => {
+  const [, requestedEnvVar] = valueOfPlaceholder.split(':');
+  const valueOfEnv = process.env[requestedEnvVar];
+
+  if (!valueOfEnv) {
+    throw new Error(
+      `Missing '${requestedEnvVar}' specified in config as 'env:${requestedEnvVar}'.`
+    );
+  }
+
+  const escapedMatchedString = matchedString.replace(/[${}:]/g, '\\$&');
+  return valueOfEnvConfig.replace(
+    new RegExp(`(${escapedMatchedString})+`, 'g'),
+    valueOfEnv
+  );
+};
+
+const getValueOfPlaceholder = (valueWithPlaceholder) =>
+  valueWithPlaceholder
+    .replace(variableSyntax, (match, varName) => varName.trim())
+    .replace(/\s/g, '');
+
+const substitutePlaceholders = (valueOfEnvConfig) => {
+  if (!hasVariablePlaceholder(valueOfEnvConfig)) return valueOfEnvConfig;
+
+  // NOTE: Interseting into the string with placeholders
+  // values one by one.
+  let populatedValueOfEnvConfig = valueOfEnvConfig;
+
+  valueOfEnvConfig.match(variableSyntax).forEach((matchedString) => {
+    const valueOfPlaceholder = getValueOfPlaceholder(matchedString);
+
+    if (isEnvVariablePlaceholder(valueOfPlaceholder)) {
+      populatedValueOfEnvConfig = substituteEnvVariablePlaceholder(
+        valueOfPlaceholder,
+        matchedString,
+        populatedValueOfEnvConfig
+      );
+    }
+  });
+
+  return populatedValueOfEnvConfig;
+};
+
+const substituteEnvVariablePlaceholders = (config = {}) => {
+  const entriesOfEnvConfig = Object.entries(config);
+
+  const replacedEntriesOfEnvConfig = entriesOfEnvConfig.map(
+    ([envConfigKey, envConfigValue]) => {
+      const substitutedConfigValue = Array.isArray(envConfigValue)
+        ? envConfigValue.map(substitutePlaceholders)
+        : substitutePlaceholders(envConfigValue);
+      return [envConfigKey, substitutedConfigValue];
+    }
+  );
+
+  return Object.fromEntries(replacedEntriesOfEnvConfig);
+};
+
+module.exports = substituteEnvVariablePlaceholders;

--- a/packages/mc-html-template/lib/utils/substitute-env-variable-placeholders.spec.js
+++ b/packages/mc-html-template/lib/utils/substitute-env-variable-placeholders.spec.js
@@ -1,0 +1,61 @@
+const substituteEnvVariablePlaceholders = require('./substitute-env-variable-placeholders');
+
+describe('providing a config with env variable placeholders', () => {
+  it('should substitute all values', () => {
+    process.env = {
+      TITLE: 'Awesome',
+      APP_URL: 'https://app.com',
+      CDN_REGION: 'eu',
+      CDN_ID: 'cdn-id',
+    };
+    const result = substituteEnvVariablePlaceholders({
+      title: 'The title is ${env:TITLE}',
+      count: 1,
+      isActive: false,
+      urls: [
+        'https://one.com',
+        'https://two.com',
+        '${env:APP_URL}',
+        'https://${env:CDN_REGION}.${env:CDN_ID}.com',
+      ],
+    });
+    expect(result).toEqual({
+      title: 'The title is Awesome',
+      count: 1,
+      isActive: false,
+      urls: [
+        'https://one.com',
+        'https://two.com',
+        'https://app.com',
+        'https://eu.cdn-id.com',
+      ],
+    });
+  });
+});
+
+describe('providing a config without env variable placeholders', () => {
+  it('should return the config as-is', () => {
+    const result = substituteEnvVariablePlaceholders({
+      title: 'The title is Awesome',
+      count: 1,
+      isActive: false,
+      urls: [
+        'https://one.com',
+        'https://two.com',
+        'https://app.com',
+        'https://eu.cdn-id.com',
+      ],
+    });
+    expect(result).toEqual({
+      title: 'The title is Awesome',
+      count: 1,
+      isActive: false,
+      urls: [
+        'https://one.com',
+        'https://two.com',
+        'https://app.com',
+        'https://eu.cdn-id.com',
+      ],
+    });
+  });
+});

--- a/website/src/content/deployment/runtime-configuration.mdx
+++ b/website/src/content/deployment/runtime-configuration.mdx
@@ -65,6 +65,12 @@ An example configuration for local development:
 
 ## Using environment variables
 
+<Info>
+
+This feature is available from version `>= 16.4.0`.
+
+</Info>
+
 Values in an environment configuration JSON file can contain references to environment variables. This can be useful to avoid duplication between various `env.json` files for multiple different environments. References are specified with a special expansion like syntax `${}` while additionally prefixing the environment variable name with `env:`.
 
 For instance, imagine developing a Custom Application that can be used in the commercetools platform Europe region and North America region. We can assign the `${env:MC_API_URL}` reference to the field `mcApiUrl` and pass the actual value using environment variables.
@@ -144,6 +150,12 @@ This example includes two hostnames as one of them is a legacy hostname: `mc-api
 You can find the list of default directives in the `load-headers.js` file in the `@commercetools-frontend/mc-html-template` package.
 
 ## Using environment variables
+
+<Info>
+
+This feature is available from version `>= 16.7.0`.
+
+</Info>
 
 Values in an environment configuration JSON file can contain references to environment variables. This can be useful to avoid duplication between various `headers.json` files for multiple different environments. References are specified with a special expansion like syntax `${}` while additionally prefixing the environment variable name with `env:`.
 

--- a/website/src/content/deployment/runtime-configuration.mdx
+++ b/website/src/content/deployment/runtime-configuration.mdx
@@ -51,7 +51,7 @@ const MyComponent = () => {
 
 An example configuration for local development:
 
-```json
+```json title="env.json"
 {
   "applicationName": "merchant-center-application-template-starter",
   "frontendHost": "localhost:3001",
@@ -69,7 +69,7 @@ Values in an environment configuration JSON file can contain references to envir
 
 For instance, imagine developing a Custom Application that can be used in the commercetools platform Europe region and North America region. We can assign the `${env:MC_API_URL}` reference to the field `mcApiUrl` and pass the actual value using environment variables.
 
-```json
+```json title="env.json"
 {
   "cdnUrl": "https://bucket.com",
   "mcApiUrl": "${env:MC_API_URL}"
@@ -78,17 +78,13 @@ For instance, imagine developing a Custom Application that can be used in the co
 
 The `MC_API_URL` environment variable can be provided in various ways. For example as an inline environment variable when running a script command (`MC_API_URL=https://mc-api.commercetools.com yarn start`), using a [dotenv](https://github.com/motdotla/dotenv) file or by defining the environment variables in your CI service.
 
-<Info>
+You can also pass multiple references to the same value:
 
-You can also pass multiple references to the same value
-
-```json
+```json title="env.json"
 {
   "mcApiUrl": "https://mc-api.${env:CTP_REGION}.${env.CTP_CLOUD_REGION}.commercetools.com"
 }
 ```
-
-</Info>
 
 ## Production environment
 
@@ -125,7 +121,7 @@ Furthermore, the [API Gateway](/main-concepts/api-gateway#hostnames) hostnames *
 
 For example, given that your application is hosted at `my-app.now.sh` and runs on the [Google Cloud Europe region](/main-concepts/api-gateway#cloud-regions), the `headers.json` file must be configured as following:
 
-```json
+```json title="headers.json"
 {
   "csp": {
     "script-src": ["my-app.now.sh"],
@@ -147,6 +143,42 @@ This example includes two hostnames as one of them is a legacy hostname: `mc-api
 
 You can find the list of default directives in the `load-headers.js` file in the `@commercetools-frontend/mc-html-template` package.
 
+## Using environment variables
+
+Values in an environment configuration JSON file can contain references to environment variables. This can be useful to avoid duplication between various `headers.json` files for multiple different environments. References are specified with a special expansion like syntax `${}` while additionally prefixing the environment variable name with `env:`.
+
+For instance, imagine developing a Custom Application that can be used in the commercetools platform Europe region and North America region. We can assign the `${env:APP_HOSTNAME}` reference to the field `csp` object directives and pass the actual value using environment variables.
+
+```json title="headers.json"
+{
+  "csp": {
+    "script-src": ["${env:APP_HOSTNAME}"],
+    "connect-src": [
+      "${env:APP_HOSTNAME}",
+      "${env:MC_API_HOSTNAME}"
+    ],
+    "style-src": ["${env:APP_HOSTNAME}"]
+  }
+}
+```
+
+The `APP_HOSTNAME` environment variable can be provided in various ways. For example as an inline environment variable when running a script command (`APP_HOSTNAME=my-apps.com yarn start`), using a [dotenv](https://github.com/motdotla/dotenv) file or by defining the environment variables in your CI service.
+
+You can also pass multiple references to the same value:
+
+```json title="headers.json"
+{
+  "csp": {
+    "script-src": ["my-apps.com"],
+    "connect-src": [
+      "my-apps.com",
+      "mc-api.${env:CTP_REGION}.${env.CTP_CLOUD_REGION}.commercetools.com"
+    ],
+    "style-src": ["my-apps.com"]
+  }
+}
+```
+
 ## Production environment
 
 It is recommended to have two separate configuration files, one for development and one for production. The `headers.json` **must** be used for development, therefore for production you can have a `headers.prod.json` file.
@@ -161,11 +193,14 @@ This file has been deprecated by the `headers.json`.
 
 To migrate to the new format, wrap the `csp.json` content into a `csp` property in the `headers.json`:
 
-```json highlightLines="2,6"
+```json highlightLines="2,9"
 {
   "csp": {
     "script-src": ["my-apps.com"],
-    "connect-src": ["my-apps.com"],
+    "connect-src": [
+      "${env:APP_HOSTNAME}",
+      "${env:MC_API_HOSTNAME}"
+    ],
     "style-src": ["my-apps.com"]
   }
 }


### PR DESCRIPTION
Same as for the `env.json`, we should also support it for `headers.json`.