### PR TITLE
feat: support forwardTo request config for apollo and sdk

### DIFF
--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
@@ -34,6 +34,7 @@ const useAllMenuFeatureToggles = () => {
     onError: reportErrorToSentry,
     context: {
       uri: `${mcProxyApiUrl || defaultApiUrl}/api/graphql`,
+      skipGraphQlTargetCheck: true,
     },
   });
 

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
@@ -56,6 +56,7 @@ function useApplicationsMenu<Key extends MenuKey>(
     context: {
       // Allow to overwrite the API url from `env.json`
       uri: `${mcProxyApiUrl || defaultApiUrl}/api/graphql`,
+      skipGraphQlTargetCheck: true,
     },
   });
 

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -8,7 +8,11 @@ export { applyDefaultMiddlewares } from './configure-store';
 export { default as InjectReducers } from './components/inject-reducers';
 export { default as RouteCatchAll } from './components/route-catch-all';
 export { default as setupGlobalErrorListener } from './utils/setup-global-error-listener';
-export { selectUserId, selectProjectKeyFromUrl } from './utils';
+export {
+  selectUserId,
+  selectProjectKeyFromUrl,
+  createApolloContextForProxyForwardTo,
+} from './utils';
 export { GtmContext } from './components/gtm-booter';
 export { default as GtmUserLogoutTracker } from './components/gtm-user-logout-tracker';
 export { default as SetupFlopFlipProvider } from './components/setup-flop-flip-provider';

--- a/packages/application-shell/src/utils/apollo-context.ts
+++ b/packages/application-shell/src/utils/apollo-context.ts
@@ -1,0 +1,26 @@
+import getMcApiUrl from './get-mc-api-url';
+
+export type TApolloContext = {
+  uri?: string;
+  headers?: { [key: string]: string };
+  skipGraphQlTargetCheck?: boolean;
+};
+
+type TApolloContextProxyForwardTo = {
+  // The GraphQL endpoint of the external server
+  uri: string;
+};
+
+const createApolloContextForProxyForwardTo = (
+  context: TApolloContextProxyForwardTo
+): TApolloContext => ({
+  // Send the request to the forward-to endpoint.
+  uri: `${getMcApiUrl()}/proxy/forward-to`,
+  headers: {
+    'Accept-version': 'v2',
+    'X-Forward-To': context.uri,
+  },
+  skipGraphQlTargetCheck: true,
+});
+
+export { createApolloContextForProxyForwardTo };

--- a/packages/application-shell/src/utils/index.ts
+++ b/packages/application-shell/src/utils/index.ts
@@ -5,3 +5,4 @@ export { default as selectUserId } from './select-user-id';
 export { default as getCorrelationId } from './get-correlation-id';
 export { default as getPreviousProjectKey } from './get-previous-project-key';
 export { default as getMcApiUrl } from './get-mc-api-url';
+export { createApolloContextForProxyForwardTo } from './apollo-context';

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -6,13 +6,13 @@
 
 Tools for declarative fetching.
 
-## Install
+# Install
 
 ```bash
 $ npm install --save @commercetools-frontend/sdk
 ```
 
-## Declarative Fetching
+# Declarative Fetching
 
 There are two sides to declarative fetching:
 
@@ -35,13 +35,13 @@ The provided middleware takes an object which describes what data should be
 fetched. The middleware transforms that description into a promise and resolves
 the promise. It passes the response back to the callee.
 
-## Usage
+# Usage
 
 The middleware is a thin wrapper around [`sdk-client`](https://commercetools.github.io/nodejs/sdk/api/sdkClient.html). It offers a way to declaratively describe the data requirements.
 
 A Redux action using one of the action creators below needs to be dispatched. It contains the description of what to get/post/delete. The `sdk` middleware then turns the declarative description into imperative API calls on `sdk-client`. The dispatched action resolves with the result of `sdk-client`.
 
-### Action creators
+## Action creators
 
 The action creators can be imported as
 
@@ -49,7 +49,7 @@ The action creators can be imported as
 import { actions as sdkActions } from '@commercetools-frontend/sdk';
 ```
 
-#### Methods
+### Methods
 
 The supported action creators are:
 
@@ -58,7 +58,7 @@ The supported action creators are:
 - `sdkActions.del(config)`: sends a HTTP `DELETE`
 - `sdkActions.head(config)`: sends a HTTP `HEAD`
 
-#### Specifying an endpoint
+### Specifying an endpoint
 
 There are two ways to describe an endpoint:
 
@@ -69,7 +69,7 @@ The `post` action creator additionally requires a `config.payload` object or str
 
 > The `mcApiProxyTarget` values are exposed from the `@commercetools-frontend/constants` package, as `MC_API_PROXY_TARGETS`. The value will be used to build a prefix to the `uri` as `/proxy/<mcApiProxyTarget>/<uri>`.
 
-##### Usage with `uri`
+**Usage with `uri`**
 
 ```js
 {
@@ -85,7 +85,7 @@ This approach must be used when querying something other than the CTP API. In ca
 
 When both, `uri` and `options` (or `service`) are present, the `uri` takes precedence.
 
-##### Usage with `service` and `options`
+**Usage with `service` and `options`**
 
 ```js
 {
@@ -100,7 +100,32 @@ Before using the `sdk-client` the `sdk` middleware combines `service` and `optio
 
 The supported `options` can be found in the `api-request-builder`'s documentation under the [Declarative Usage](https://commercetools.github.io/nodejs/sdk/api/apiRequestBuilder.html#declarative-usage) section.
 
-### Error handling
+## Action creators for external API usage
+
+By default, all requests with the SDK are configured to be sent to the MC API.
+However, Custom Applications using the [Proxy to external API](https://docs.commercetools.com/custom-applications/main-concepts/proxy-to-external-api) need to configure the request a bit differently, and send additional headers.
+
+To make it easier to make requests to the proxy endpoint using the SDK, there is a new action creator wrapper that comes with built-in configuration options.
+
+The exported action creators have a new export `forwardTo`, which is an object containing wrappers around the normal action creators.
+
+```js
+actions.forwardTo.get(options);
+actions.forwardTo.del(options);
+actions.forwardTo.head(options);
+actions.forwardTo.post(options);
+```
+
+The options for the action creators are the same as the **Usage with `uri`**, except that the `uri` value needs to be the URL to the external API (see `X-Forward-To` header).
+
+The `forwardTo` action creators additionally set the following headers:
+
+- `X-Forward-To`
+- `Accept-version`
+
+For more information, check the [Proxy to external API](https://docs.commercetools.com/custom-applications/main-concepts/proxy-to-external-api) documentation.
+
+## Error handling
 
 Failed requests will result in a rejected promise. The `sdk-client`'s error handling applies, so network errors and CTP API errors on the content itself result in a rejected promise.
 
@@ -108,7 +133,7 @@ The `sdk` package does not provide any error handling out of the box. It's the a
 
 The MC has a `handleActionError` function which is what we currently use for error handling. It logs the error to the tracking tool (Sentry) and shows a notification to the client. This should be used whenever a more special error handling is not necessary.
 
-### Example
+## Example
 
 ```js
 import { actions as sdkActions } from '@commercetools-frontend/sdk';

--- a/packages/sdk/src/actions/actions.ts
+++ b/packages/sdk/src/actions/actions.ts
@@ -48,3 +48,60 @@ export function post(
 export function post(payload: TSdkActionPayload & TSdkActionPayloadBody) {
   return { type: 'SDK', payload: { ...payload, method: 'POST' } };
 }
+
+const enhancePayloadForForwardToProxy = (payload: TSdkActionPayloadForUri) => {
+  const headers = payload.headers ?? {};
+  return {
+    uri: '/proxy/forward-to',
+    mcApiProxyTarget: undefined,
+    headers: {
+      ...headers,
+      'Accept-version': 'v2',
+      'X-Forward-To': payload.uri,
+    },
+  };
+};
+export const forwardTo = {
+  get(payload: TSdkActionPayloadForUri): TSdkActionGetForUri {
+    return {
+      type: 'SDK',
+      payload: {
+        ...payload,
+        method: 'GET',
+        ...enhancePayloadForForwardToProxy(payload),
+      },
+    };
+  },
+  del(payload: TSdkActionPayloadForUri): TSdkActionDeleteForUri {
+    return {
+      type: 'SDK',
+      payload: {
+        ...payload,
+        method: 'DELETE',
+        ...enhancePayloadForForwardToProxy(payload),
+      },
+    };
+  },
+  head(payload: TSdkActionPayloadForUri): TSdkActionHeadForUri {
+    return {
+      type: 'SDK',
+      payload: {
+        ...payload,
+        method: 'HEAD',
+        ...enhancePayloadForForwardToProxy(payload),
+      },
+    };
+  },
+  post(
+    payload: TSdkActionPayloadForUri & TSdkActionPayloadBody
+  ): TSdkActionPostForUri {
+    return {
+      type: 'SDK',
+      payload: {
+        ...payload,
+        method: 'POST',
+        ...enhancePayloadForForwardToProxy(payload),
+      },
+    };
+  },
+};

--- a/website/src/content/main-concepts/data-fetching.mdx
+++ b/website/src/content/main-concepts/data-fetching.mdx
@@ -74,40 +74,23 @@ That's it, Apollo will take care of data normalization, caching, etc.
 
 ## Connecting to an external GraphQL API
 
-In case your Custom Application needs to connect to an external GraphQL API, in addition to the commercetools GraphQL APIs, you can't use the default Apollo Client.
+In case your Custom Application needs to connect to an [external GraphQL API](/main-concepts/proxy-to-external-api), in addition to the commercetools GraphQL APIs, the Apollo Client needs to be reconfigured to connect to the `/proxy/forward-to` endpoint with the appropriate headers.
+This can be achieved by using the `context` option of Apollo Client, which allows to pass configuration options to the Apollo Links.
 
-As mentioned in the section above, the `<ApplicationShell>` has the Apollo Client pre-configured, which points to the `/graphql` endpoint of the [Merchant Center API Gateway](/main-concepts/api-gatway). The Apollo Client can only be configured to **one URL**, which means that for your external GraphQL API you need to **create a new client**.
-
-To send requests to your GraphQL API you need to explicitly pass the client to each query or mutation, as otherwise Apollo will fall back to using the default client defined in the React Context, which is the pre-configured one.
+The `@commercetools-frontend/application-shell` package now exposes a `createApolloContextForProxyForwardTo` to construct a predefined context object specific to the `/proxy/forward-to`.
 
 ```jsx
-// custom-apollo-client.js
-import { createHttpLink } from 'apollo-link-http';
-import { ApolloLink } from 'apollo-link';
-import ApolloClient from 'apollo-client';
-
-const httpLink = createHttpLink({
-  uri: 'https://my-custom-app.com/graphql',
-  headers: { accept: 'application/json' },
-  fetch,
-});
-const link = ApolloLink.from([
-  httpLink,
-]);
-const client = new ApolloClient({ link });
-
-export default client;
-
-// hello-world.js
 import React from 'react';
 import { useQuery } from 'react-apollo';
+import { createApolloContextForProxyForwardTo } from '@commercetools-frontend/application-shell';
 import Text from '@commercetools-uikit/text';
-import customClient from './custom-apollo-client';
 import HelloWorldQuery from './hello-world.graphql';
 
 const HelloWorld = () => {
   const { loading, data, error } = useQuery(HelloWorldQuery, {
-    client: customClient,
+    context: createApolloContextForProxyForwardTo({
+      uri: 'https://my-custom-app.com/graphql',
+    }),
   });
 
   if (loading) return 'Loading...';


### PR DESCRIPTION
This PR continues the improvements to work with the endpoint `/proxy/forward-to`.

The idea here is to allow users to keep using apollo graphql and our sdk action creators to make HTTP requests to their external API, without having to provide all the necessary configuration changes.

## Usage for Apollo

We can leverage the `context` option for Apollo queries to change a bit how the request is configured. The app-shell package now exposes an utility function to configure the Apollo context for the `/proxy/forward-to` usage.

```js
import { useQuery } from 'react-apollo';
import { createApolloContextForProxyForwardTo } from '@commercetools-frontend/application-shell';

const Fetcher = () => {
  const { loading, data, error } = useQuery(MyQuery, {
    context: createApolloContextForProxyForwardTo({
      uri: 'https://my-custom-app.com/graphql',
    }),
  });
}; 
```

## Usage for SDK

By default, all requests with the SDK are configured to be sent to the MC API.
To make it easier to make requests to the proxy endpoint using the SDK, there is a new action creator wrapper that comes with built-in configuration options.

The exported action creators have a new export `forwardTo`, which is an object containing wrappers around the normal action creators.

```js
actions.forwardTo.get({ uri: 'https://my-custom-app.com/graphql' });
actions.forwardTo.del(options);
actions.forwardTo.head(options);
actions.forwardTo.post(options);
```

The options for the action creators are the same as the normal **Usage with `uri`** action creators, except that the `uri` value needs to be the URL to the external API.