### PR TITLE
feat(playground): implement echo server view/api to demo /proxy/forward-to feature

### DIFF
--- a/packages-backend/express/index.ts
+++ b/packages-backend/express/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './src';

--- a/playground/config/transformer-now.js
+++ b/playground/config/transformer-now.js
@@ -15,8 +15,14 @@ module.exports = ({ env, headers }) => {
     version: 2,
     public: true,
     regions: regions[env.location],
+    env: {
+      // Use the `cdnUrl` vale as it happens to be the exact value that we
+      // need for the audience.
+      PLAYGROUND_API_AUDIENCE: env.cdnUrl,
+    },
     builds: [
       { src: 'public/**', use: '@now/static' },
+      { src: 'api/*.ts', use: '@now/node' },
       { src: 'routes/fallback.js', use: '@now/node' },
     ],
     routes: [
@@ -26,6 +32,7 @@ module.exports = ({ env, headers }) => {
         headers: headersStaticFiles,
       },
       { src: '/(login|logout)', dest: '/routes/fallback.js' },
+      { src: '/api/(.*)', dest: '/api/$1.ts' },
       {
         src: '/(.*)',
         // eslint-disable-next-line

--- a/playground/env.json
+++ b/playground/env.json
@@ -5,5 +5,6 @@
   "location": "gcp-eu",
   "env": "development",
   "cdnUrl": "http://localhost:3001",
-  "servedByProxy": false
+  "servedByProxy": false,
+  "echoServerApiUrl": "https://state-machines-gcp-eu.commercetools-playground.now.sh/api/echo"
 }

--- a/playground/menu.json
+++ b/playground/menu.json
@@ -2,9 +2,10 @@
   "key": "state-machines",
   "uriPath": "state-machines",
   "icon": "RocketIcon",
-  "permissions": ["ViewDeveloperSettings"],
+  "permissions": [
+    "ViewDeveloperSettings"
+  ],
   "featureToggle": null,
-  "submenu": [],
   "labelAllLocales": [
     {
       "locale": "en",
@@ -17,6 +18,28 @@
     {
       "locale": "es",
       "value": "State Machines"
+    }
+  ],
+  "submenu": [
+    {
+      "key": "state-machines-echo-server",
+      "uriPath": "state-machines/echo-server",
+      "permissions": [],
+      "featureToggle": null,
+      "labelAllLocales": [
+        {
+          "locale": "en",
+          "value": "Echo Server"
+        },
+        {
+          "locale": "de",
+          "value": "Echo Server"
+        },
+        {
+          "locale": "es",
+          "value": "Echo Server"
+        }
+      ]
     }
   ]
 }

--- a/playground/now-deployments/state-machines-gcp-eu/api/echo.ts
+++ b/playground/now-deployments/state-machines-gcp-eu/api/echo.ts
@@ -1,0 +1,37 @@
+// NOTE: this file is duplicated in both gcp-eu/us deployment folders
+/* eslint-disable import/no-unresolved */
+// @ts-ignore
+import { NowRequest, NowResponse } from '@now/node';
+import {
+  createSessionAuthVerifier,
+  CLOUD_IDENTIFIERS,
+} from '@commercetools-backend/express';
+
+const sessionAuthVerifier = createSessionAuthVerifier({
+  audience: process.env.PLAYGROUND_API_AUDIENCE,
+  issuer: CLOUD_IDENTIFIERS.GCP_EU,
+  inferIssuer: true,
+});
+
+export default async (request: NowRequest, response: NowResponse) => {
+  const { url, headers, body } = request;
+  try {
+    await sessionAuthVerifier(request, response);
+  } catch (error) {
+    response.status(401).json({
+      message: 'Missing or invalid authorization token',
+      url,
+      headers,
+      body,
+    });
+    return;
+  }
+  response.status(200).json({
+    message: `Echoing request: ${request.url}`,
+    url,
+    headers,
+    body,
+    // @ts-ignore
+    session: request.session,
+  });
+};

--- a/playground/now-deployments/state-machines-gcp-eu/package.json
+++ b/playground/now-deployments/state-machines-gcp-eu/package.json
@@ -2,5 +2,9 @@
   "name": "state-machines-gcp-eu",
   "scripts": {
     "deploy": "npx now --prod --scope=commercetools-playground --local-config=production-gcp-eu.now.json --confirm --no-clipboard"
+  },
+  "dependencies": {
+    "@commercetools-backend/express": "canary",
+    "@now/node": "^1.5.1"
   }
 }

--- a/playground/now-deployments/state-machines-gcp-us/api/echo.ts
+++ b/playground/now-deployments/state-machines-gcp-us/api/echo.ts
@@ -1,0 +1,37 @@
+// NOTE: this file is duplicated in both gcp-eu/us deployment folders
+/* eslint-disable import/no-unresolved */
+// @ts-ignore
+import { NowRequest, NowResponse } from '@now/node';
+import {
+  createSessionAuthVerifier,
+  CLOUD_IDENTIFIERS,
+} from '@commercetools-backend/express';
+
+const sessionAuthVerifier = createSessionAuthVerifier({
+  audience: process.env.PLAYGROUND_API_AUDIENCE,
+  issuer: CLOUD_IDENTIFIERS.GCP_EU,
+  inferIssuer: true,
+});
+
+export default async (request: NowRequest, response: NowResponse) => {
+  const { url, headers, body } = request;
+  try {
+    await sessionAuthVerifier(request, response);
+  } catch (error) {
+    response.status(401).json({
+      message: 'Missing or invalid authorization token',
+      url,
+      headers,
+      body,
+    });
+    return;
+  }
+  response.status(200).json({
+    message: `Echoing request: ${request.url}`,
+    url,
+    headers,
+    body,
+    // @ts-ignore
+    session: request.session,
+  });
+};

--- a/playground/now-deployments/state-machines-gcp-us/package.json
+++ b/playground/now-deployments/state-machines-gcp-us/package.json
@@ -2,5 +2,9 @@
   "name": "state-machines-gcp-us",
   "scripts": {
     "deploy": "npx now --prod --scope=commercetools-playground --local-config=production-gcp-us.now.json --confirm --no-clipboard"
+  },
+  "dependencies": {
+    "@commercetools-backend/express": "canary",
+    "@now/node": "^1.5.1"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -12,6 +12,7 @@
     "i18n:build": "mc-scripts extract-intl --output-path=$(pwd)/src/i18n/data 'src/**/!(*.spec).js' --build-translations"
   },
   "dependencies": {
+    "@commercetools-docs/ui-kit": "2.5.0",
     "@commercetools-frontend/actions-global": "16.6.0",
     "@commercetools-frontend/application-components": "16.6.0",
     "@commercetools-frontend/application-shell": "16.6.1",
@@ -25,6 +26,7 @@
     "@commercetools-frontend/sdk": "16.6.0",
     "@commercetools-uikit/constraints": "10.18.4",
     "@commercetools-uikit/flat-button": "10.18.4",
+    "@commercetools-uikit/primary-button": "10.18.4",
     "@commercetools-uikit/grid": "10.18.4",
     "@commercetools-uikit/icons": "10.18.4",
     "@commercetools-uikit/loading-spinner": "10.18.4",

--- a/playground/src/components/echo-server/echo-server.js
+++ b/playground/src/components/echo-server/echo-server.js
@@ -8,8 +8,23 @@ import Text from '@commercetools-uikit/text';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import { CodeBlock } from '@commercetools-docs/ui-kit';
 
+const initialState = {
+  isLoading: false,
+  result: null,
+};
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'loading':
+      return { isLoading: true, result: null };
+    case 'complete':
+      return { isLoading: false, result: action.payload };
+    default:
+      return state;
+  }
+};
+
 const EchoServer = () => {
-  const [result, setResult] = React.useState();
+  const [state, dispatchState] = React.useReducer(reducer, initialState);
   const dispatch = useAsyncDispatch();
   const dispatchError = useOnActionError();
   const echoServerApiUrl = useApplicationContext(
@@ -26,11 +41,13 @@ const EchoServer = () => {
             },
           })
         );
-        setResult(result);
+        dispatchState({ type: 'complete', payload: result });
       } catch (error) {
+        dispatchState({ type: 'complete' });
         dispatchError(error);
       }
     }
+    dispatchState({ type: 'loading' });
     ping();
   });
   return (
@@ -52,11 +69,15 @@ const EchoServer = () => {
         <Constraints.Horizontal constraint="xl">
           <Spacings.Stack>
             <Spacings.Inline>
-              <PrimaryButton label="Send request" onClick={handleSendRequest} />
+              <PrimaryButton
+                label={state.isLoading ? 'Sending...' : 'Send request'}
+                onClick={handleSendRequest}
+                isDisabled={state.isLoading}
+              />
             </Spacings.Inline>
-            {result && (
+            {state.result && (
               <CodeBlock
-                content={JSON.stringify(result, null, 2)}
+                content={JSON.stringify(state.result, null, 2)}
                 language="json"
               />
             )}

--- a/playground/src/components/echo-server/echo-server.js
+++ b/playground/src/components/echo-server/echo-server.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import { useAsyncDispatch, actions } from '@commercetools-frontend/sdk';
+import { useOnActionError } from '@commercetools-frontend/actions-global';
+import Spacings from '@commercetools-uikit/spacings';
+import Constraints from '@commercetools-uikit/constraints';
+import Text from '@commercetools-uikit/text';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import { CodeBlock } from '@commercetools-docs/ui-kit';
+
+const EchoServer = () => {
+  const [result, setResult] = React.useState();
+  const dispatch = useAsyncDispatch();
+  const dispatchError = useOnActionError();
+  const echoServerApiUrl = useApplicationContext(
+    (context) => context.environment.echoServerApiUrl
+  );
+  const handleSendRequest = React.useCallback(() => {
+    async function ping() {
+      try {
+        const result = await dispatch(
+          actions.forwardTo.post({
+            uri: echoServerApiUrl,
+            payload: {
+              say: 'Hello',
+            },
+          })
+        );
+        setResult(result);
+      } catch (error) {
+        dispatchError(error);
+      }
+    }
+    ping();
+  });
+  return (
+    <Spacings.Inset>
+      <Spacings.Stack>
+        <Text.Headline as="h1">{'Echo Server'}</Text.Headline>
+        <Spacings.Stack>
+          <Text.Body>
+            {
+              'This page demonstrate how to connect a Custom Application to an external API, using the "/proxy/forward-to" endpoint.'
+            }
+          </Text.Body>
+          <Text.Body>
+            {
+              'For demo purposes, the external API used by this page is a simple echo server, which just returns some information about the request sent.'
+            }
+          </Text.Body>
+        </Spacings.Stack>
+        <Constraints.Horizontal constraint="xl">
+          <Spacings.Stack>
+            <Spacings.Inline>
+              <PrimaryButton label="Send request" onClick={handleSendRequest} />
+            </Spacings.Inline>
+            {result && (
+              <CodeBlock
+                content={JSON.stringify(result, null, 2)}
+                language="json"
+              />
+            )}
+          </Spacings.Stack>
+        </Constraints.Horizontal>
+      </Spacings.Stack>
+    </Spacings.Inset>
+  );
+};
+
+export default EchoServer;

--- a/playground/src/components/echo-server/index.js
+++ b/playground/src/components/echo-server/index.js
@@ -1,0 +1,1 @@
+export { default } from './echo-server';

--- a/playground/src/routes.js
+++ b/playground/src/routes.js
@@ -7,6 +7,7 @@ import { InjectReducers } from '@commercetools-frontend/application-shell';
 import { useIsAuthorized } from '@commercetools-frontend/permissions';
 import StateMachinesList from './components/state-machines-list';
 import StateMachinesDetails from './components/state-machines-details';
+import EchoServer from './components/echo-server';
 import reducers from './reducers';
 import { PERMISSIONS } from './constants';
 
@@ -25,6 +26,9 @@ const ApplicationRoutes = (props) => {
   return (
     <InjectReducers id="state-machines" reducers={reducers}>
       <Switch>
+        <Route path={`${props.match.path}/echo-server`}>
+          <EchoServer />
+        </Route>
         <Route
           path={`${props.match.path}/:id`}
           render={(routerProps) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,6 +1177,20 @@
   resolved "https://registry.yarnpkg.com/@commercetools-docs/gatsby-transformer-code-examples/-/gatsby-transformer-code-examples-2.5.1-canary.2.tgz#36332c154b9234315d15fe97921abc141086d386"
   integrity sha512-4ZA99qvys2fIw1XtHgOxqd2zudyVMY8opNRMOnNcy1YMf203RcSPMOLjjBlm3y6wjX3gj7gtxCArfZWYMObjdw==
 
+"@commercetools-docs/ui-kit@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-docs/ui-kit/-/ui-kit-2.5.0.tgz#63991972928afaab015efb82ffd31519cbd459e5"
+  integrity sha512-GWXG+6cBMBuGn4huPwyh5ikoMRVZi5Ameby1nnJwz61vivH2jnHgfEPsmOPvIZzvQA0XyO/WEsQpvYPNDHs3CA==
+  dependencies:
+    "@commercetools-uikit/tooltip" "10.18.4"
+    lodash.escape "4.0.1"
+    lodash.throttle "4.1.1"
+    parse-numeric-range "0.0.2"
+    parse5 "5.1.1"
+    prism-react-renderer "1.0.2"
+    prop-types "15.7.2"
+    tiny-invariant "1.1.0"
+
 "@commercetools-docs/ui-kit@2.5.1-canary.2", "@commercetools-docs/ui-kit@2.5.1-canary.2+6379138":
   version "2.5.1-canary.2"
   resolved "https://registry.yarnpkg.com/@commercetools-docs/ui-kit/-/ui-kit-2.5.1-canary.2.tgz#d6eb524154e677c20fea7f151268e7ae0c967781"


### PR DESCRIPTION
Adds an echo server to the playground app (deployed on ZEIT). The serverless function uses the new "middleware" to authenticate the request.
The playground app then has a new page to demo the connection.

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/1110551/80137931-5414c700-85a4-11ea-8a09-ed2e63bd9fdb.png">
