### PR TITLE
refactor(permissions): use Record for dataFences

### DIFF
--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -44,17 +44,11 @@ type TApplicationContextGroupedByResourceType = {
  *   }
  * }
  */
-// NOTE: we currently can't use Mapped Types as the babel transfomer does not
-// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
-// type TApplicationContextDataFenceType = 'store';
-// type TApplicationContextDataFences = {
-//   // E.g. { store: {...} }
-//   [key in TApplicationContextDataFenceType]: TApplicationContextGroupedByResourceType;
-// };
-type TApplicationContextDataFences = {
-  // E.g. { store: {...} }
-  store?: TApplicationContextGroupedByResourceType;
-};
+type TApplicationContextDataFenceType = 'store';
+type TApplicationContextDataFences = Record<
+  TApplicationContextDataFenceType,
+  TApplicationContextGroupedByResourceType
+>;
 type TApplicationContextEnvironment = ApplicationWindow['app'];
 
 const Context = React.createContext({});

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -45,9 +45,11 @@ type TApplicationContextGroupedByResourceType = {
  * }
  */
 type TApplicationContextDataFenceType = 'store';
-type TApplicationContextDataFences = Record<
-  TApplicationContextDataFenceType,
-  TApplicationContextGroupedByResourceType
+type TApplicationContextDataFences = Partial<
+  Record<
+    TApplicationContextDataFenceType,
+    TApplicationContextGroupedByResourceType
+  >
 >;
 type TApplicationContextEnvironment = ApplicationWindow['app'];
 

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.ts
@@ -105,7 +105,7 @@ type NormalizedStoresGroupByResourceType = {
 
 const normalizeAppliedDataFencesForStoresByResourceType = (
   dataFences: Maybe<TStoreDataFence>[]
-): NormalizedGroupedByResourceType => {
+) => {
   const groupedByResourceType = dataFences.reduce<
     NormalizedStoresGroupByResourceType
   >((previousGroupsOfSameType, appliedDataFence) => {
@@ -183,7 +183,7 @@ type NormalizedDataFenceRecord = Record<
 
 export const normalizeAllAppliedDataFences = (
   project: TFetchProjectQuery['project']
-): NormalizedDataFenceRecord | null => {
+) => {
   if (!project) return null;
   const allAppliedDataFences = project.allAppliedDataFences;
   if (!allAppliedDataFences || allAppliedDataFences.length === 0) {

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.ts
@@ -98,23 +98,14 @@ type NormalizedGroupedByResourceType = {
   // E.g. { orders: {...} }
   [key: string]: NormalizedGroupedByPermission | null;
 };
-/**
- * dataFence: {
- *   store: {
- *     orders: {
- *       canManageOrders: { values: ['usa', 'germany'] },
- *       canViewOrders: { values: ['canada'] },
- *     }
- *   }
- * }
- */
 type NormalizedStoresGroupByResourceType = {
+  // E.g [ { group: 'orders', value: 'us', type: 'store', name: 'canManageOrders' } ]
   [key: string]: TStoreDataFence[];
 };
 
 const normalizeAppliedDataFencesForStoresByResourceType = (
   dataFences: Maybe<TStoreDataFence>[]
-) => {
+): NormalizedGroupedByResourceType => {
   const groupedByResourceType = dataFences.reduce<
     NormalizedStoresGroupByResourceType
   >((previousGroupsOfSameType, appliedDataFence) => {
@@ -184,9 +175,15 @@ type NormalizedGroupByType = {
   [key: string]: Maybe<TStoreDataFence>[];
 };
 
+type SupportedDataFenceType = 'store';
+type NormalizedDataFenceRecord = Record<
+  SupportedDataFenceType,
+  NormalizedGroupedByResourceType
+>;
+
 export const normalizeAllAppliedDataFences = (
   project: TFetchProjectQuery['project']
-) => {
+): NormalizedDataFenceRecord | null => {
   if (!project) return null;
   const allAppliedDataFences = project.allAppliedDataFences;
   if (!allAppliedDataFences || allAppliedDataFences.length === 0) {
@@ -212,7 +209,9 @@ export const normalizeAllAppliedDataFences = (
         }
       : {}),
   };
-  return Object.keys(normalizedDataFences).length > 0
-    ? normalizedDataFences
-    : null;
+
+  if (Object.keys(normalizedDataFences).length > 0)
+    return normalizedDataFences as NormalizedDataFenceRecord;
+
+  return null;
 };

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.ts
@@ -176,9 +176,8 @@ type NormalizedGroupByType = {
 };
 
 type SupportedDataFenceType = 'store';
-type NormalizedDataFenceRecord = Record<
-  SupportedDataFenceType,
-  NormalizedGroupedByResourceType
+type NormalizedDataFences = Partial<
+  Record<SupportedDataFenceType, NormalizedGroupedByResourceType>
 >;
 
 export const normalizeAllAppliedDataFences = (
@@ -211,7 +210,7 @@ export const normalizeAllAppliedDataFences = (
   };
 
   if (Object.keys(normalizedDataFences).length > 0)
-    return normalizedDataFences as NormalizedDataFenceRecord;
+    return normalizedDataFences as NormalizedDataFences;
 
   return null;
 };

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -38,7 +38,9 @@ type TDataFenceGroupedByResourceType = {
   [key: string]: TDataFenceGroupedByPermission | null;
 };
 type TDataFenceType = 'store';
-type TDataFences = Record<TDataFenceType, TDataFenceGroupedByResourceType>;
+type TDataFences = Partial<
+  Record<TDataFenceType, TDataFenceGroupedByResourceType>
+>;
 type TDemandedDataFence = {
   group: string;
   name: string;

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -37,16 +37,8 @@ type TDataFenceGroupedByResourceType = {
   // E.g. { orders: {...} }
   [key: string]: TDataFenceGroupedByPermission | null;
 };
-// NOTE: we currently can't use Mapped Types as the babel transfomer does not
-// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
-// type TDataFences = {
-//   // E.g. { store: {...} }
-//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
-// };
-type TDataFences = {
-  // E.g. { store: {...} }
-  store?: TDataFenceGroupedByResourceType;
-};
+type TDataFenceType = 'store';
+type TDataFences = Record<TDataFenceType, TDataFenceGroupedByResourceType>;
 type TDemandedDataFence = {
   group: string;
   name: string;

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -28,16 +28,11 @@ type TDataFenceGroupedByResourceType = {
   // E.g. { orders: {...} }
   [key: string]: TDataFenceGroupedByPermission | null;
 };
-// NOTE: we currently can't use Mapped Types as the babel transfomer does not
-// understand them yet: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/23
-// type TDataFences = {
-//   // E.g. { store: {...} }
-//   [key in TDataFenceType]: TDataFenceGroupedByResourceType;
-// };
-type TDataFences = {
-  // E.g. { store: {...} }
-  store?: TDataFenceGroupedByResourceType;
-};
+
+// Potentially a union type.
+type TDataFenceType = 'store';
+type TDataFences = Record<TDataFenceType, TDataFenceGroupedByResourceType>;
+
 type TDemandedDataFence = {
   group: string;
   name: string;

--- a/packages/permissions/src/utils/has-permissions.ts
+++ b/packages/permissions/src/utils/has-permissions.ts
@@ -31,7 +31,9 @@ type TDataFenceGroupedByResourceType = {
 
 // Potentially a union type.
 type TDataFenceType = 'store';
-type TDataFences = Record<TDataFenceType, TDataFenceGroupedByResourceType>;
+type TDataFences = Partial<
+  Record<TDataFenceType, TDataFenceGroupedByResourceType>
+>;
 
 type TDemandedDataFence = {
   group: string;


### PR DESCRIPTION
## Summary

- refactored `DataFences` to use `Record`

#### Descripton

I read up about `Record` and was curious about its use case. ref https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkt

This seemed a really awesome utility type and I could see that there is application for it.

For dataFences, we know that for each `key` in `DataFences` should represent a type (e.g `store`) and with that type have a specific shape, a group of resource type.

namely the following:
```
{
  [<dataFenceType]: {
    [<resourceType>]: {
      [<permissionName>]: {
        values: string[]
      }
    }
  }
}
```

I doubt that the dataFence model will change (at least for a while). we can use `Record` to solidify this domain constraint within the code.

#### With just `store`

![image](https://user-images.githubusercontent.com/462507/80290255-6f1e3d00-8744-11ea-8bd2-b69fed5ac251.png)

#### Adding values, not supported by the Record

![image](https://user-images.githubusercontent.com/462507/80290286-adb3f780-8744-11ea-9523-49160c95f13e.png)

#### Extending the record, by adding more `dataFence` types to support.
![image](https://user-images.githubusercontent.com/462507/80290275-9c6aeb00-8744-11ea-983e-5023f8b905a9.png)
