### PR TITLE
fix(babel): keep runtime helpers

### DIFF
--- a/packages/mc-html-template/package.json
+++ b/packages/mc-html-template/package.json
@@ -69,8 +69,7 @@
       [
         "@babel/plugin-transform-runtime",
         {
-          "corejs": 3,
-          "helpers": false
+          "corejs": 3
         }
       ]
     ]

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -119,8 +119,7 @@
       [
         "@babel/plugin-transform-runtime",
         {
-          "corejs": 3,
-          "helpers": false
+          "corejs": 3
         }
       ]
     ]


### PR DESCRIPTION
Given that in #1471 we fixed the runtime helpers config, we should do the same here.