### PR TITLE
refactor(loggers): remove generic type, as it doesn't really work as expected

### DIFF
--- a/packages-backend/loggers/src/formatters/rewrite-fields.ts
+++ b/packages-backend/loggers/src/formatters/rewrite-fields.ts
@@ -5,29 +5,24 @@ import getIn from 'lodash/get';
 import setIn from 'lodash/set';
 import unsetIn from 'lodash/unset';
 
-type TRewriteField<FieldValue> = {
+type TRewriteField = {
   from: string;
   to: string;
-  replaceValue?: (value: FieldValue) => unknown;
+  replaceValue?: (value: unknown) => unknown;
 };
-type TRewriteFieldsFormatterOption<FieldValue> = {
-  fields: TRewriteField<FieldValue>[];
+type TRewriteFieldsFormatterOption = {
+  fields: TRewriteField[];
 };
 
-function rewriteField<FieldValue>(
-  info: TransformableInfo,
-  field: TRewriteField<FieldValue>
-) {
-  const val: FieldValue | undefined = getIn(info, field.from);
+function rewriteField(info: TransformableInfo, field: TRewriteField) {
+  const val = getIn(info, field.from);
   if (val) {
     unsetIn(info, field.from);
     setIn(info, field.to, field.replaceValue ? field.replaceValue(val) : val);
   }
 }
 
-function rewriteFieldsFormatter<FieldValue>(
-  options: TRewriteFieldsFormatterOption<FieldValue>
-) {
+function rewriteFieldsFormatter(options: TRewriteFieldsFormatterOption) {
   return format((info) => {
     options.fields.forEach((field) => {
       rewriteField(info, field);

--- a/packages-backend/loggers/src/loggers.spec.ts
+++ b/packages-backend/loggers/src/loggers.spec.ts
@@ -1,5 +1,3 @@
-import type { Request } from 'express';
-
 import rewriteFieldsFormatter from './formatters/rewrite-fields';
 import createApplicationLogger from './create-application-logger';
 
@@ -10,15 +8,12 @@ describe('application logger', () => {
     const logger = createApplicationLogger({
       json: true,
       formatters: [
-        rewriteFieldsFormatter<Request['headers']>({
+        rewriteFieldsFormatter({
           fields: [
             {
               from: 'meta.req.headers',
               to: 'meta.req.headersJsonString',
               replaceValue: (value) => {
-                const assertHeaders: typeof value = {};
-                // This should not throw any error
-                assertHeaders.accept = 'application/json';
                 return JSON.stringify(value);
               },
             },


### PR DESCRIPTION
The generic type introduced in #1478 does not really work, because you can pass multiple fields with potentially different value types.

So I think we need to keep it `unknown` and the consumer will need to type cast.