### PR TITLE
Fix mc-dev-authentication's /login link keeping query params

### DIFF
--- a/.changeset/calm-cats-drum.md
+++ b/.changeset/calm-cats-drum.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-dev-authentication': patch
+---
+
+Fix link to `/login` to preserve url query parameters such as `redirectTo`.

--- a/packages/mc-dev-authentication/views/logout.pug
+++ b/packages/mc-dev-authentication/views/logout.pug
@@ -7,4 +7,4 @@ html
     div
       h3 This is the logout page for local development.
       p Be aware that you might still have an active session as the cookie is assigned to a production domain (e.g. commercetools.com) which we can't unset from localhost. This is only a problem on local development and we intend fix this in the future.
-      p You can #[a(href="/login") go to the login page] now.
+      p You can #[a(href="#" onclick="window.location='/login'+window.location.search;") go to the login page] now.


### PR DESCRIPTION
#### Summary

The mc-dev-authentication is a temporary package. However, the fact that the link to `/login` does not preseve the query params is frustration. Especially with current work on the hostname migration where I would like to preserve the `redirectTo`.

This change has been tested locally.