### PR TITLE
Fix starter to have `apollo-client` as dependency

### DIFF
--- a/.changeset/soft-beans-deliver.md
+++ b/.changeset/soft-beans-deliver.md
@@ -1,0 +1,5 @@
+---
+'merchant-center-application-template-starter': patch
+---
+
+Add apollo-client as dependency as it is peer dependency or react-apollo.

--- a/.changeset/soft-beans-deliver.md
+++ b/.changeset/soft-beans-deliver.md
@@ -2,4 +2,4 @@
 'merchant-center-application-template-starter': patch
 ---
 
-Add apollo-client as dependency as it is peer dependency or react-apollo.
+Add apollo-client as dependency as it is peer dependency of react-apollo.

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -23,6 +23,7 @@
     "@commercetools-uikit/icons": "10.18.4",
     "@commercetools-uikit/spacings": "10.18.4",
     "@commercetools-uikit/text": "10.18.4",
+    "apollo-client": "2.6.8",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-apollo": "3.1.5",


### PR DESCRIPTION
Closes #1494 

#### Summary

This is a peer dependency of react-apollo and causes the starter to not start.