### PR TITLE
refactor: update to typescript 3.9

### DIFF
--- a/.changeset/tasty-beers-compete.md
+++ b/.changeset/tasty-beers-compete.md
@@ -1,0 +1,18 @@
+---
+"@commercetools-backend/loggers": patch
+---
+
+refactor: update to typescript 3.9
+
+The re-export of winston from the `@commercetools-backend/loggers` package has been removed. 
+
+Given the `winston` types use an `export = winston` our package cannot re-export using `export * from`. If you relied on this re-export we suggest to install winston yourself and import it regularily.
+
+After running `yarn add winston` you should change the following
+
+```diff
+-import { winston } from '@commercetools-backend/loggers'
++import winston from 'winston'
+```
+
+We might add `winston` as a peer dependency in a future release to ensure that both, ours and your, `winston` versions remain in sync.

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.0.0",
     "stylelint-value-no-unknown-custom-properties": "3.0.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.2",
     "vfile-message": "2.0.4",
     "xhr-mock": "2.5.1"
   },

--- a/packages-backend/loggers/src/index.ts
+++ b/packages-backend/loggers/src/index.ts
@@ -6,6 +6,3 @@ export { default as createApplicationLogger } from './create-application-logger'
 
 // Formatters
 export { default as rewriteFieldsFormatter } from './formatters/rewrite-fields';
-
-// Re-export winston for convenience
-export * as winston from 'winston';

--- a/yarn.lock
+++ b/yarn.lock
@@ -28058,10 +28058,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
#### Summary

This pull request attempts to update to TypeScript 3.9. I had to exclude it earlier today.

![CleanShot 2020-05-18 at 20 53 45](https://user-images.githubusercontent.com/1877073/82249347-e7de7680-9949-11ea-9430-1c9b17fe7974.png)

I haven't found the root of the issue but it seems in external types. Also the release notes do not mention something directly. Only around relating "exports" areas.