### PR TITLE
refactor(i18n): expose hook for AsyncLocaleData

### DIFF
--- a/.changeset/polite-camels-tap.md
+++ b/.changeset/polite-camels-tap.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/i18n': minor
+'@commercetools-website/components-playground': minor
+---
+
+Expose a `useAsyncLocaleData` (as a companion of `<AsyncLocaleData>` and additionally a `useAsyncIntlMessages` to load translation files directly.
+The difference between those is that the "async locale data" components additionally load the application-kit and ui-kit messages, as well as the moment locales.

--- a/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { renderApp, waitFor } from '../../test-utils';
+import { renderApp, screen } from '../../test-utils';
 import UserQuery from '../fetch-user/fetch-user.mc.graphql';
 import ProjectsQuery from '../project-switcher/project-switcher.mc.graphql';
 import ProjectSuspended from './project-suspended';
 
 describe('rendering', () => {
   it('when suspension is temporary it should print correct message', async () => {
-    const rendered = renderApp(
+    renderApp(
       <Route
         path="/:projectKey"
         render={() => <ProjectSuspended isTemporary={true} />}
@@ -98,12 +98,9 @@ describe('rendering', () => {
         ],
       }
     );
-    await waitFor(() => {
-      expect(
-        rendered.getByText(
-          /Your Project is temporarily suspended due to maintenance/
-        )
-      ).toBeInTheDocument();
-    });
+    await screen.findByText(
+      /Your Project is temporarily suspended due to maintenance/
+    );
+    await screen.findByText('Search for a project');
   });
 });

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -20,13 +20,19 @@ $ npm install --save @commercetools-frontend/i18n
 - `fr-FR`
 - `zh-CN`
 
-### Usage
+## Usage
 
-> This package should not be used directly to load the application messages, the `application-shell` does that internally.
+> The `<AsyncLocaleData>` component, or the `useAsyncLocaleData` hook, are internally used by the `<ApplicationShell>` and there is no need to use them directly.
+> If you do need to load translation files asynchronously, we expose an additional hook `useAsyncIntlMessages` that you can use for that.
+> The difference between those is that the "async locale data" components additionally load the application-kit and ui-kit messages, as well as the moment locales.
+
+### Using a React component with render props
+
+**With static messages**
 
 ```js
+import { IntlProvider } from 'react-intl';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
-import { ConfigureIntlProvider } from '@commercetools-frontend/application-shell';
 
 const myApplicationMessages = {
   en: {
@@ -34,7 +40,7 @@ const myApplicationMessages = {
   },
 };
 
-const MyApplication = (props) => (
+const Application = (props) => (
   <AsyncLocaleData
     locale={props.user.locale}
     applicationMessages={myApplicationMessages}
@@ -43,20 +49,20 @@ const MyApplication = (props) => (
       if (isLoading) return null;
 
       return (
-        <ConfigureIntlProvider locale={locale} messages={messages}>
+        <IntlProvider locale={locale} messages={messages}>
           ...
-        </ConfigureIntlProvider>
+        </IntlProvider>
       );
     }}
   </AsyncLocaleData>
 );
 ```
 
-### Usage with code splitting
+**With dynamic loaded messages (code splitting)**
 
 ```js
+import { IntlProvider } from 'react-intl';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
-import { ConfigureIntlProvider } from '@commercetools-frontend/application-shell';
 
 const loadMessages = (lang) => {
   let loadAppI18nPromise;
@@ -100,28 +106,51 @@ const Application = (props) => (
       if (isLoading) return null;
 
       return (
-        <ConfigureIntlProvider locale={locale} messages={messages}>
+        <IntlProvider locale={locale} messages={messages}>
           ...
-        </ConfigureIntlProvider>
+        </IntlProvider>
       );
     }}
   </AsyncLocaleData>
 );
 ```
 
-### Generating translation files
+### Using a React hook
+
+Similarly to the `<AsyncLocaleData>`, we also expose a React hook.
+
+```js
+import { IntlProvider } from 'react-intl';
+import { useAsyncLocaleData } from '@commercetools-frontend/i18n';
+
+const Application = (props) => {
+  const { isLoading, locale, messages } = useAsyncLocaleData({
+    locale: props.locale,
+    applicationMessages: loadMessages,
+  });
+
+  if (isLoading) return null;
+  return (
+    <IntlProvider locale={locale} messages={messages}>
+      ...
+    </IntlProvider>
+  );
+};
+```
+
+## Generating translation files
 
 After you have defined the `intl` messages in your React components, you should extract those messages into the source file `core.json`. This file contains a key-value map of the message `id` and the message value.
 
 To extract the messages simply run `mc-scripts extract-intl [options]`.
 
-### Syncing translations with Transifex
+## Syncing translations with Transifex
 
 We use [Transifex](https://www.transifex.com/) as our translation tool. Once we have extracted new messages into the source file `core.json` (see `mc-scripts extract-inl`) and pushed/merged to `master`, the file will be automatically synced with Transifex using the [Transifex GitHub Integration](https://docs.transifex.com/integrations/transifex-github-integration).
 
 Translations that have been **reviewed** in Transifex will be automatically pushed back to GitHub by the Transifex Bot via a Pull Request.
 
-### Shared messages
+## Shared messages
 
 This package exposes some "shared" messages that can be used for different things like buttons, etc. instead of having duplicated messages.
 

--- a/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
@@ -1,11 +1,12 @@
-import type { State, Props, TMessageTranslations } from './async-locale-data';
+import type { TRenderFunctionResult, Props } from './async-locale-data';
+import type { TMessageTranslations } from './use-async-intl-messages';
 
 import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { render, waitFor } from '@testing-library/react';
 import loadI18n from '../load-i18n';
-import AsyncLocaleData from './async-locale-data';
+import { AsyncLocaleData } from './async-locale-data';
 
 jest.mock('@commercetools-frontend/sentry');
 
@@ -33,7 +34,7 @@ const createTestProps = (props: Partial<Props> = {}) => ({
     en: { 'CustomApp.title': 'Custom title en' },
   },
   // eslint-disable-next-line react/display-name
-  children: (state: State) => <ChildComponent {...state} />,
+  children: (result: TRenderFunctionResult) => <ChildComponent {...result} />,
   ...props,
 });
 

--- a/packages/i18n/src/async-locale-data/async-locale-data.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.tsx
@@ -79,7 +79,7 @@ const AsyncLocaleData = (props: Props) => {
     <>
       {props.children({
         isLoading,
-        locale: props.locale,
+        locale: isLoading ? undefined : props.locale,
         messages: error ? undefined : messages,
       })}
     </>

--- a/packages/i18n/src/async-locale-data/index.ts
+++ b/packages/i18n/src/async-locale-data/index.ts
@@ -1,1 +1,2 @@
-export { default } from './async-locale-data';
+export { AsyncLocaleData, useAsyncLocaleData } from './async-locale-data';
+export { default as useAsyncIntlMessages } from './use-async-intl-messages';

--- a/packages/i18n/src/async-locale-data/use-async-intl-messages.ts
+++ b/packages/i18n/src/async-locale-data/use-async-intl-messages.ts
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export type TMessageTranslations = {
+  [key: string]: string;
+};
+export type TMessagesAsync = (locale: string) => Promise<TMessageTranslations>;
+export type TState = {
+  isLoading: boolean;
+  messages?: TMessageTranslations;
+  error?: Error;
+};
+export type THookOptions = {
+  locale?: string;
+  loader: TMessagesAsync;
+};
+
+const initialState: TState = {
+  isLoading: true,
+  messages: undefined,
+  error: undefined,
+};
+
+// Low level hook to load messages for a specific locale. The loading is async
+// because it's assumed that the translation files are dynamically imported (code splitted).
+const useAsyncIntlMessages = ({ locale, loader }: THookOptions): TState => {
+  const [state, setState] = React.useState(initialState);
+
+  React.useEffect(() => {
+    let _isUnmounting = false;
+
+    async function load(_locale: string) {
+      try {
+        if (!_isUnmounting) {
+          const messages = await loader(_locale);
+          setState({ isLoading: false, messages });
+        }
+      } catch (error) {
+        setState({ isLoading: false, error });
+      }
+    }
+
+    if (locale) load(locale);
+
+    return () => {
+      _isUnmounting = true;
+    };
+  }, [locale, loader]);
+
+  return state;
+};
+
+export default useAsyncIntlMessages;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -4,5 +4,9 @@ export type TAsyncLocaleDataProps = Props;
 
 export { default as version } from './version';
 
-export { default as AsyncLocaleData } from './async-locale-data';
+export {
+  AsyncLocaleData,
+  useAsyncLocaleData,
+  useAsyncIntlMessages,
+} from './async-locale-data';
 export { default as sharedMessages } from './shared-messages';

--- a/website-components-playground/src/components/intl-controller.js
+++ b/website-components-playground/src/components/intl-controller.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
-import { AsyncLocaleData } from '@commercetools-frontend/i18n';
+import { useAsyncLocaleData } from '@commercetools-frontend/i18n';
 
 const availableLocales = ['en', 'de', 'es', 'fr-FR', 'zh-CN', 'ja'];
 
@@ -31,18 +31,18 @@ const availableLocaleOptions = availableLocales.map((locale) => ({
 
 const IntlController = (props) => {
   const [activeLocale, setActiveLocale] = React.useState('en');
+  const { locale, messages } = useAsyncLocaleData({
+    locale: activeLocale,
+    applicationMessages: {},
+  });
   return (
-    <AsyncLocaleData locale={activeLocale} applicationMessages={{}}>
-      {({ locale, messages }) => (
-        <IntlProvider locale={locale || activeLocale} messages={messages}>
-          {props.children({
-            locale: locale || activeLocale,
-            setLocale: setActiveLocale,
-            availableLocaleOptions,
-          })}
-        </IntlProvider>
-      )}
-    </AsyncLocaleData>
+    <IntlProvider locale={locale || activeLocale} messages={messages}>
+      {props.children({
+        locale: locale || activeLocale,
+        setLocale: setActiveLocale,
+        availableLocaleOptions,
+      })}
+    </IntlProvider>
   );
 };
 IntlController.displayName = 'IntlController';


### PR DESCRIPTION
- expose a `useAsyncLocaleData` hook. The `<AsyncLocaleData>` component now uses the hook internally.
- expose a `useAsyncIntlMessages` hook, to only load messages with dynamic imports (code splitting).

The second hook is useful for building UI packages (not custom apps) that ship with translations. The translation message should be encapsulated with the package itself and ideally they should be code splitted as well.
The UI package then can use a `IntlProvider` (which will be nested when used within a Custom Application) to load the messages of the package itself.
The `IntlProvider` then merges the messages with the "parent(s)" providers.
