### PR TITLE
fix(workflows): use a personal access token in checkout step, to allow the workflow to trigger a new workflow

### DIFF
--- a/.github/workflows/publish-cloud-registry.yml
+++ b/.github/workflows/publish-cloud-registry.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
+          # other workflows
+          # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+          # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Installing gcloud CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
           # We could set `fetch-depth: 0`, but that would cause the entire history
           # to be cloned. Using 50 seems like a good balance to start with.
           fetch-depth: 50
+          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
+          # other workflows
+          # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+          # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)


### PR DESCRIPTION
This is an attempt to fix the issue with the cloud registry workflow not being triggered when a tag is created through another workflow.

From the information that I could find, it seems that this restriction can be lifted by using a personal access token.

Let's see if this makes a difference or not.