### PR TITLE
chore: empty commit for triggering mc-http-server release

### DIFF
--- a/.changeset/little-badgers-cough.md
+++ b/.changeset/little-badgers-cough.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/mc-http-server": patch
+---
+
+> Re-release of prior failed release without additional changes.
+
+refactor(mc-http-server): to use Node.js v14


### PR DESCRIPTION
#### Summary

The previous release failed. I will have this PR to create a new release with a patch changeset.