### PR TITLE
feat(app-shell): fetch organization name with owner

### DIFF
--- a/.changeset/cool-geckos-know.md
+++ b/.changeset/cool-geckos-know.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/application-shell-connectors": minor
+"@commercetools-frontend/application-shell": patch
+"@commercetools-frontend/permissions": patch
+---
+
+feat(app-shell): fetch organization name with owner

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -64,7 +64,7 @@ const createTestProject = (custom = {}) => ({
     isActive: false,
     reason: undefined,
   },
-  owner: { id: 'o1' },
+  owner: { id: 'o1', name: 'Organization 1' },
   ...custom,
 });
 const createTestEnvironment = (

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -170,6 +170,7 @@ describe('mapProjectToApplicationContextProject', () => {
       currencies: expect.any(Array),
       languages: expect.any(Array),
       ownerId: expect.any(String),
+      ownerName: expect.any(String),
     });
   });
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -101,6 +101,7 @@ export const mapProjectToApplicationContextProject = (
     currencies: project.currencies,
     languages: project.languages,
     ownerId: project.owner.id,
+    ownerName: project.owner.name,
   };
 };
 

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
@@ -30,7 +30,7 @@ const createTestProject = (
     isActive: false,
     reason: undefined,
   },
-  owner: { id: 'o1' },
+  owner: { id: 'o1', name: 'Organization Name' },
   ...custom,
 });
 

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
@@ -30,7 +30,7 @@ const createTestProject = (
     isActive: false,
     reason: undefined,
   },
-  owner: { id: 'o1', name: 'Organization Name' },
+  owner: { id: 'o1', name: 'Organization 1' },
   ...custom,
 });
 

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -79,7 +79,7 @@ export type TInvitationOrganizationInput = {
   name: Maybe<Scalars['String']>,
 };
 
-/** 
+/**
  * Note: you can not brute-force fetch user information
  * by trying emails. Only information about the membership itself.
  */
@@ -255,7 +255,7 @@ export type TOAuthClientTemplate = {
   oAuthScopes: Array<TPermissionScope>,
 };
 
-/** 
+/**
  * TODO: use `Reference` instead once there is no more usage of the following fields:
  * - name
  * - createdAt
@@ -279,7 +279,7 @@ export type TOrganizationDraftType = {
   ownerId: Scalars['String'],
 };
 
-/** 
+/**
  * Note:
  *   This is not a `Organization` type as in the future MC schema will not support
  * e.g. expanding on team members on its internal schema.
@@ -688,7 +688,7 @@ export type TFetchProjectQuery = (
       & Pick<TStoreDataFence, 'type' | 'name' | 'value' | 'group'>
     )>, owner: (
       { __typename?: 'Organization' }
-      & Pick<TOrganization, 'id'>
+      & Pick<TOrganization, 'id' | 'name'>
     ) }
   )> }
 );

--- a/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
@@ -39,6 +39,7 @@ query FetchProject($projectKey: String!) {
     }
     owner {
       id
+      name
     }
   }
 }

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -1173,7 +1173,8 @@ describe('QuickAccess', () => {
               currencies: ['EUR', 'GBP'],
               languages: ['en'],
               owner: {
-                id: 'project-id-1',
+                id: 'organization-id-1',
+                name: 'Organization Name',
               },
               suspension: { isActive: false },
               expiry: { isActive: false },
@@ -1190,7 +1191,8 @@ describe('QuickAccess', () => {
                     currencies: ['EUR', 'GBP'],
                     languages: ['en'],
                     owner: {
-                      id: 'project-id-1',
+                      id: 'organization-id-1',
+                      name: 'Organization Name',
                     },
                     suspension: { isActive: false },
                     expiry: { isActive: false },
@@ -1203,7 +1205,8 @@ describe('QuickAccess', () => {
                     currencies: ['EUR'],
                     languages: ['de'],
                     owner: {
-                      id: 'project-id-2',
+                      id: 'organization-id-1',
+                      name: 'Organization Name',
                     },
                     suspension: { isActive: false },
                     expiry: { isActive: false },
@@ -1249,7 +1252,8 @@ describe('QuickAccess', () => {
                   currencies: ['EUR', 'GBP'],
                   languages: ['en'],
                   owner: {
-                    id: 'project-id-1',
+                    id: 'organization-id-1',
+                    name: 'Organization Name',
                   },
                   suspension: { isActive: false },
                   expiry: { isActive: false },
@@ -1262,7 +1266,8 @@ describe('QuickAccess', () => {
                   currencies: ['EUR'],
                   languages: ['de'],
                   owner: {
-                    id: 'project-id-2',
+                    id: 'organization-id-1',
+                    name: 'Organization Name',
                   },
                   suspension: { isActive: false },
                   expiry: { isActive: false },

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -159,7 +159,8 @@ describe('ApplicationContext', () => {
           currencies: ['EUR', 'GBP'],
           languages: ['de', 'en-GB', 'en'],
           owner: {
-            id: 'project-id-1',
+            id: 'organization-id-1',
+            name: 'Organization Name',
           },
         })
       );

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -44,7 +44,8 @@ const defaultProject = {
   currencies: ['EUR', 'GBP'],
   languages: ['de', 'en-GB', 'en'],
   owner: {
-    id: 'project-id-1',
+    id: 'organization-id-1',
+    name: 'Organization Name',
   },
   initialized: true,
   expiry: {

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -688,7 +688,7 @@ export type TFetchProjectQuery = (
       & Pick<TStoreDataFence, 'type' | 'name' | 'value' | 'group'>
     )>, owner: (
       { __typename?: 'Organization' }
-      & Pick<TOrganization, 'id'>
+      & Pick<TOrganization, 'id' | 'name'>
     ) }
   )> }
 );

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -47,7 +47,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         countries: ['us'],
         currencies: ['USD'],
         languages: ['en'],
-        owner: { id: 'o1' },
+        owner: { id: 'o1', name: 'Organization 1' },
         initialized: true,
         expiry: {
           isActive: true,

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -51,7 +51,8 @@ const testRender = ({
         currencies: ['EUR', 'GBP'],
         languages: ['de', 'en-GB'],
         owner: {
-          id: 'project-id-1',
+          id: 'organization-id-1',
+          name: 'Organization Name',
         },
         initialized: true,
         expiry: {

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -96,7 +96,8 @@ const render = ({
         currencies: ['EUR', 'GBP'],
         languages: ['de', 'en-GB'],
         owner: {
-          id: 'project-id-1',
+          id: 'organization-id-1',
+          name: 'Organization Name',
         },
         initialized: true,
         expiry: {


### PR DESCRIPTION
#### Summary

This pull request adds fetching the owner's name which is the organization through the project.

#### Description

This will help more easily redirect SSO users to `login/sso/<orgName>` without the application having to fetch data. Overall the addition of owner.name feels small given we already load the id.
