### PR TITLE
refactor(release): publish canary using changeset snapshot feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,9 @@ jobs:
       # Publish canary releases only if the packages weren't published already
       - name: Publishing canary releases to npm registry
         if: steps.changesets.outputs.published != 'true'
-        # TODO: this command will be replaced by the changesets snapshots feature
-        run: yarn lerna publish 0.0.0-canary-${{ github.sha }} --exact --dist-tag canary --yes --no-push --force-publish "*"
+        run: |
+          git checkout master
+          yarn changeset version --snapshot canary
+          yarn changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new shapshot feature got released recently. I tried that in a personal project and it works.