### PR TITLE
refactor(notifications): do not report to Sentry unmapped errors

### DIFF
--- a/.changeset/fifty-onions-suffer.md
+++ b/.changeset/fifty-onions-suffer.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/react-notifications': patch
+---
+
+Do not report to Sentry unmapped API errors

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
@@ -1,11 +1,7 @@
-import { mocked } from 'ts-jest/utils';
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import ApiErrorMessage from './api-error-message';
-
-jest.mock('@commercetools-frontend/sentry');
 
 const renderMessage = (ui: React.ReactElement) =>
   render(<IntlProvider locale="en">{ui}</IntlProvider>);
@@ -57,7 +53,7 @@ describe('render', () => {
     ).toBeInTheDocument();
   });
   it('should show message for unmapped error and report to sentry', async () => {
-    mocked(reportErrorToSentry).mockReset();
+    console.warn = jest.fn();
     const error = {
       code: 'unmapped error message foo 123',
       message: 'message-content',
@@ -68,11 +64,11 @@ describe('render', () => {
       rendered.getByText('message-content (detailed-error-message-content)')
     ).toBeInTheDocument();
     await waitFor(() => {
-      expect(reportErrorToSentry).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledTimes(1);
     });
   });
   it('should show message for unmapped error and not report to sentry for project expired', async () => {
-    mocked(reportErrorToSentry).mockReset();
+    console.warn = jest.fn();
     const error = {
       code: 'invalid_scope',
       message: 'has expired',
@@ -80,7 +76,7 @@ describe('render', () => {
     const rendered = renderMessage(<ApiErrorMessage error={error} />);
     expect(rendered.getByText('has expired')).toBeInTheDocument();
     await waitFor(() => {
-      expect(reportErrorToSentry).not.toHaveBeenCalled();
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
   it('should show message for DuplicateSlug', () => {

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
@@ -4,7 +4,6 @@ import type { IntlShape } from 'react-intl';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import has from 'lodash/has';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import messages from './messages';
 
 const regexInvalidOperationRequiredAttribute = /Required attribute '(.*)' cannot be removed/;
@@ -60,13 +59,13 @@ const FormattedErrorMessage = (props: Props) => {
   React.useEffect(() => {
     if (!messageCode) {
       // This error is not mapped / translated yet,
-      // we log, report it to sentry and show the original error, unless `error.code` is `invalid_scope`
+      // We log a warning and show the original error, unless `error.code` is `invalid_scope`
       // which an error code emitted for expired project(s)
       if (
         props.error.code !== 'invalid_scope' &&
         !props.error.message.includes('has expired')
       ) {
-        reportErrorToSentry(new Error('Unmapped error'), {
+        console.warn(new Error('Unmapped error'), {
           extra: props.error,
         });
       }


### PR DESCRIPTION
We get from time to time a lot of unmapped error reports on Sentry. To avoid spamming Sentry, we just log a warning instead. We also don't seem to "care much" about mapping those errors, so there is not much of a point to keep reporting them.

If I assumed wrong, please feel free to keep things as they are.