### PR TITLE
refactor(app-shell): do not report certain errors

### DIFF
--- a/.changeset/cyan-chairs-tan.md
+++ b/.changeset/cyan-chairs-tan.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Ignore certain errors from being reported to Sentry


### PR DESCRIPTION
From time to time we're getting a bunch of `ResizeObserver loop limit exceeded` errors, which apparently is safe to ignore.

https://forum.sentry.io/t/resizeobserver-loop-limit-exceeded/8402/3
https://stackoverflow.com/a/50387233/2663944

PS: I decided to leave this in app-shell instead of the sentry package, as otherwise it felt too opinionated.