### PR TITLE
build(eslint): enable react/no-unused-prop-types rule

### DIFF
--- a/.changeset/dry-cars-kiss.md
+++ b/.changeset/dry-cars-kiss.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/eslint-config-mc-app': minor
+---
+
+enable `react/no-unused-prop-types` eslint rule

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -73,6 +73,7 @@ module.exports = {
     'no-underscore-dangle': 0,
     'jest/no-identical-title': 'warn',
     'jest/no-focused-tests': 2,
+    /* eslint-plugin-react */
     'react/jsx-uses-vars': 2,
     'react/wrap-multilines': 0,
     'react/no-deprecated': 'error',
@@ -83,10 +84,11 @@ module.exports = {
         ignoreTranspilerName: true,
       },
     ],
+    'react/jsx-no-target-blank': 0,
+    'react/no-unused-prop-types': 'error',
     'prefer-object-spread/prefer-object-spread': 2,
     'prefer-destructuring': 0,
     'prefer-promise-reject-errors': 'warn',
-    'react/jsx-no-target-blank': 0,
     'lines-between-class-members': 0,
     // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
     'no-unused-expressions': 0,


### PR DESCRIPTION
#### Summary

<!-- short summary of your changes -->

As a developer, I want to be notified when I'm defining a proptype that is not used in my component (similar to when I get notified when there are unused variables). This is very useful during refactoring, where I don't want to manually check whether a proptype is used.

#### Old architecture

Checking unused proptypes is done manually by the developer.

#### New architecture

Checking unused proptypes is done automatically by eslint [`react/no-unused-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) rule.