### PR TITLE
fix(app-shell): user settings menu link width for testing

### DIFF
--- a/.changeset/happy-donuts-jam.md
+++ b/.changeset/happy-donuts-jam.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/application-shell": patch
+"playground": patch
+---
+
+fix(app-shell): user settings menu link width for testing

--- a/cypress/integration/playground/application-shell.js
+++ b/cypress/integration/playground/application-shell.js
@@ -8,7 +8,7 @@ describe('when user is authenticated', () => {
     cy.login({ redirectToUri: URL_STATE_MACHINES });
 
     cy.findByRole('button', { name: /open user settings menu/i }).click();
-    cy.findByText('Logout').click();
+    cy.findByRole('link', { name: /logout/i }).click();
 
     const queryParams = encode({
       reason: LOGOUT_REASONS.USER,

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -126,8 +126,7 @@ const MenuItem = styled.div<MenuItemProps>`
 `;
 
 const getUserSettingsMenuItemLinkStyles = () => css`
-  display: inline-block;
-  width: 100%;
+  display: block;
 `;
 
 const UserSettingsMenuBody = (props: MenuBodyProps) => {

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -125,6 +125,11 @@ const MenuItem = styled.div<MenuItemProps>`
       : ''};
 `;
 
+const getUserSettingsMenuItemLinkStyles = () => css`
+  display: inline-block;
+  width: 100%;
+`;
+
 const UserSettingsMenuBody = (props: MenuBodyProps) => {
   const servedByProxy = useApplicationContext(
     (context) => context.environment.servedByProxy
@@ -168,26 +173,27 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
             </div>
           </Spacings.Inline>
         </Spacings.Inset>
-        {applicationsAppBarMenu &&
-          applicationsAppBarMenu.map((menu) => (
-            <OptionalFeatureToggle
-              key={menu.key}
-              featureToggle={menu.featureToggle}
+        {applicationsAppBarMenu?.map((menu) => (
+          <OptionalFeatureToggle
+            key={menu.key}
+            featureToggle={menu.featureToggle}
+          >
+            <Link
+              css={getUserSettingsMenuItemLinkStyles()}
+              to={`/account/${menu.uriPath}`}
+              onClick={() => props.downshiftProps.toggleMenu()}
             >
-              <Link
-                to={`/account/${menu.uriPath}`}
-                onClick={() => props.downshiftProps.toggleMenu()}
-              >
-                <MenuItem>
-                  <Spacings.Inset scale="s">
-                    {renderLabel(menu, props.language)}
-                  </Spacings.Inset>
-                </MenuItem>
-              </Link>
-            </OptionalFeatureToggle>
-          ))}
+              <MenuItem>
+                <Spacings.Inset scale="s">
+                  {renderLabel(menu, props.language)}
+                </Spacings.Inset>
+              </MenuItem>
+            </Link>
+          </OptionalFeatureToggle>
+        ))}
         <MenuItem hasDivider={true} />
         <a
+          css={getUserSettingsMenuItemLinkStyles()}
           href={`https://commercetools.com/privacy#suppliers`}
           target="_blank"
           rel="noopener noreferrer"
@@ -200,6 +206,7 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
           </MenuItem>
         </a>
         <a
+          css={getUserSettingsMenuItemLinkStyles()}
           href={SUPPORT_PORTAL_URL}
           rel="noopener noreferrer"
           target="_blank"
@@ -216,6 +223,7 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
         </a>
         <MenuItem hasDivider={true} />
         <a
+          css={getUserSettingsMenuItemLinkStyles()}
           // NOTE: we want to redirect to a new page so that the
           // server can remove things like cookie for access token.
           href={`/logout?reason=${LOGOUT_REASONS.USER}`}


### PR DESCRIPTION
#### Summary

This pull request fixes the with of the `<a />` within the user settings menu. 

#### Description

The DOM structure of elements within the user settings is sort of like `div > div > div > a > TextNode` while the parent `div` has an adequate with the `a` within it has a computed height and width of 0.

![CleanShot 2020-06-14 at 15 07 14](https://user-images.githubusercontent.com/1877073/84595335-a6ad8980-ae57-11ea-83d8-3dac8299799b.png)

This is not acessible and also not nicely testable through Cypress. Cypress will not allow the click the element by `findByRole('link', { name: /logout/i })` as the `a` (link) itself has a height and width of 0 and is not clickable as a result. This forces us to use `findByText` which is suboptimal. Any other text on the page with `logout` would break the test if the selector wasn't scoped. Moreover, Cypress is right that the element has a wrong width and height.

The solution is to make the `a` an `inline-block` with `100%` width.

![CleanShot 2020-06-14 at 15 07 01](https://user-images.githubusercontent.com/1877073/84595397-f0966f80-ae57-11ea-8414-c525baf43cd5.png)

