### PR TITLE
fix(app-shell): user settings menu labels for opening and closing menu

### DIFF
--- a/.changeset/slimy-grapes-joke.md
+++ b/.changeset/slimy-grapes-joke.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/application-shell": patch
+"@commercetools-frontend/i18n": patch
+"playground": patch
+---
+
+fix(app-shell): user settings menu labels for opening and closing menu

--- a/cypress/integration/playground/application-shell.js
+++ b/cypress/integration/playground/application-shell.js
@@ -6,8 +6,10 @@ import { URL_BASE, URL_STATE_MACHINES } from '../../support/urls';
 describe('when user is authenticated', () => {
   it('should log out with reason "user"', () => {
     cy.login({ redirectToUri: URL_STATE_MACHINES });
-    cy.findByLabelText('open menu').click();
+
+    cy.findByRole('button', { name: /close user settings menu/i }).click();
     cy.findByText('Logout').click();
+
     const queryParams = encode({
       reason: LOGOUT_REASONS.USER,
     });

--- a/cypress/integration/playground/application-shell.js
+++ b/cypress/integration/playground/application-shell.js
@@ -7,7 +7,7 @@ describe('when user is authenticated', () => {
   it('should log out with reason "user"', () => {
     cy.login({ redirectToUri: URL_STATE_MACHINES });
 
-    cy.findByRole('button', { name: /close user settings menu/i }).click();
+    cy.findByRole('button', { name: /open user settings menu/i }).click();
     cy.findByText('Logout').click();
 
     const queryParams = encode({

--- a/packages/application-shell/src/components/user-settings-menu/messages.ts
+++ b/packages/application-shell/src/components/user-settings-menu/messages.ts
@@ -16,4 +16,14 @@ export default defineMessages({
     description: 'The label for privacy policy option',
     defaultMessage: 'Privacy Policy',
   },
+  openMenuLabel: {
+    id: 'UserSettingsMenu.openMenuLabel',
+    description: 'The label when menu is closed and would be opened by a click',
+    defaultMessage: 'Open User Settings Menu',
+  },
+  closeMenuLabel: {
+    id: 'UserSettingsMenu.closeMenuLabel',
+    description: 'The label when menu is open and would be closed by a click',
+    defaultMessage: 'Close User Settings Menu',
+  },
 });

--- a/packages/application-shell/src/components/user-settings-menu/messages.ts
+++ b/packages/application-shell/src/components/user-settings-menu/messages.ts
@@ -19,11 +19,11 @@ export default defineMessages({
   openMenuLabel: {
     id: 'UserSettingsMenu.openMenuLabel',
     description: 'The label when menu is closed and would be opened by a click',
-    defaultMessage: 'Open User Settings Menu',
+    defaultMessage: 'Open user settings menu',
   },
   closeMenuLabel: {
     id: 'UserSettingsMenu.closeMenuLabel',
     description: 'The label when menu is open and would be closed by a click',
-    defaultMessage: 'Close User Settings Menu',
+    defaultMessage: 'Close user settings menu',
   },
 });

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -55,10 +55,14 @@ describe('rendering', () => {
           },
         ],
       });
-      const dropdownMenu = await rendered.findByLabelText('open menu');
+      const dropdownMenu = await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
       fireEvent.click(dropdownMenu);
       // Menu should be open
-      await rendered.findByLabelText('close menu');
+      await rendered.findByRole('button', {
+        name: /close user settings menu/i,
+      });
 
       const checkLink = linkChecker(rendered);
 
@@ -82,10 +86,14 @@ describe('rendering', () => {
           Promise.all([Promise.resolve(createTestMenuConfig('projects'))]),
       });
       const rendered = renderApp(<UserSettingsMenu {...props} />);
-      const dropdownMenu = await rendered.findByLabelText('open menu');
+      const dropdownMenu = await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
       fireEvent.click(dropdownMenu);
       // Menu should be open
-      await rendered.findByLabelText('close menu');
+      await rendered.findByRole('button', {
+        name: /close user settings menu/i,
+      });
 
       const checkLink = linkChecker(rendered);
 
@@ -109,16 +117,22 @@ describe('rendering', () => {
           Promise.all([Promise.resolve(createTestMenuConfig('projects'))]),
       });
       const rendered = renderApp(<UserSettingsMenu {...props} />);
-      const dropdownMenu = await rendered.findByLabelText('open menu');
+      const dropdownMenu = await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
       fireEvent.click(dropdownMenu);
       // Menu should be open
-      await rendered.findByLabelText('close menu');
+      await rendered.findByRole('button', {
+        name: /close user settings menu/i,
+      });
 
       const link = rendered.queryByText('Projects');
       fireEvent.click(link);
 
       // Menu should be closed
-      await rendered.findByLabelText('open menu');
+      await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
       await waitFor(() => {
         expect(rendered.history.location.pathname).toBe('/account/projects');
       });
@@ -131,16 +145,22 @@ describe('rendering', () => {
           Promise.all([Promise.resolve(createTestMenuConfig('projects'))]),
       });
       const rendered = renderApp(<UserSettingsMenu {...props} />);
-      const dropdownMenu = await rendered.findByLabelText('open menu');
+      const dropdownMenu = await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
       fireEvent.click(dropdownMenu);
       // Menu should be open
-      await rendered.findByLabelText('close menu');
+      await rendered.findByRole('button', {
+        name: /close user settings menu/i,
+      });
 
       const link = rendered.queryByText('Privacy Policy');
       fireEvent.click(link);
 
       // Menu should be closed
-      await rendered.findByLabelText('open menu');
+      await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
     });
   });
   describe('when clicking on the Support link', () => {
@@ -150,16 +170,22 @@ describe('rendering', () => {
           Promise.all([Promise.resolve(createTestMenuConfig('projects'))]),
       });
       const rendered = renderApp(<UserSettingsMenu {...props} />);
-      const dropdownMenu = await rendered.findByLabelText('open menu');
+      const dropdownMenu = await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
       fireEvent.click(dropdownMenu);
       // Menu should be open
-      await rendered.findByLabelText('close menu');
+      await rendered.findByRole('button', {
+        name: /close user settings menu/i,
+      });
 
       const link = rendered.queryByText('Support');
       fireEvent.click(link);
 
       // Menu should be closed
-      await rendered.findByLabelText('open menu');
+      await rendered.findByRole('button', {
+        name: /open user settings menu/i,
+      });
     });
   });
 });

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -7,7 +7,7 @@ import type {
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Downshift from 'downshift';
@@ -233,36 +233,49 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
 };
 UserSettingsMenuBody.displayName = 'UserSettingsMenuBody';
 
-const UserSettingsMenu = (props: Props) => (
-  <div data-test="user-settings-menu">
-    <Downshift stateReducer={stateReducer}>
-      {(downshiftProps) => (
-        <div>
-          <button
-            role="user-menu-toggle"
-            css={css`
-              cursor: pointer;
-              border: none;
-              padding: 0;
-              display: flex;
-              background: transparent;
-            `}
-            {...downshiftProps.getToggleButtonProps()}
-          >
-            <UserAvatar
-              firstName={props.firstName}
-              lastName={props.lastName}
-              gravatarHash={props.gravatarHash}
-            />
-          </button>
-          {downshiftProps.isOpen && (
-            <UserSettingsMenuBody {...props} downshiftProps={downshiftProps} />
-          )}
-        </div>
-      )}
-    </Downshift>
-  </div>
-);
+const UserSettingsMenu = (props: Props) => {
+  const intl = useIntl();
+
+  return (
+    <div data-test="user-settings-menu">
+      <Downshift stateReducer={stateReducer}>
+        {(downshiftProps) => (
+          <div>
+            <button
+              role="user-menu-toggle"
+              css={css`
+                cursor: pointer;
+                border: none;
+                padding: 0;
+                display: flex;
+                background: transparent;
+              `}
+              {...downshiftProps.getToggleButtonProps({
+                'aria-label': intl.formatMessage(
+                  downshiftProps.isOpen
+                    ? messages.closeMenuLabel
+                    : messages.openMenuLabel
+                ),
+              })}
+            >
+              <UserAvatar
+                firstName={props.firstName}
+                lastName={props.lastName}
+                gravatarHash={props.gravatarHash}
+              />
+            </button>
+            {downshiftProps.isOpen && (
+              <UserSettingsMenuBody
+                {...props}
+                downshiftProps={downshiftProps}
+              />
+            )}
+          </div>
+        )}
+      </Downshift>
+    </div>
+  );
+};
 UserSettingsMenu.displayName = 'UserSettingsMenu';
 
 export default UserSettingsMenu;

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -131,7 +131,9 @@
   "QuickAccess.showProductVariantPrices": "Show Prices",
   "QuickAccess.useProject": "Switch to project \"{projectName}\"",
   "TopNavigation.labelLoading": "Processing...",
+  "UserSettingsMenu.closeMenuLabel": "Close User Settings Menu",
   "UserSettingsMenu.logout": "Logout",
+  "UserSettingsMenu.openMenuLabel": "Open User Settings Menu",
   "UserSettingsMenu.privacyPolicy": "Privacy Policy",
   "UserSettingsMenu.support": "Support"
 }

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -131,9 +131,9 @@
   "QuickAccess.showProductVariantPrices": "Show Prices",
   "QuickAccess.useProject": "Switch to project \"{projectName}\"",
   "TopNavigation.labelLoading": "Processing...",
-  "UserSettingsMenu.closeMenuLabel": "Close User Settings Menu",
+  "UserSettingsMenu.closeMenuLabel": "Close user settings menu",
   "UserSettingsMenu.logout": "Logout",
-  "UserSettingsMenu.openMenuLabel": "Open User Settings Menu",
+  "UserSettingsMenu.openMenuLabel": "Open user settings menu",
   "UserSettingsMenu.privacyPolicy": "Privacy Policy",
   "UserSettingsMenu.support": "Support"
 }


### PR DESCRIPTION
#### Summary

This pull request fixes the user settings menu labels to be translated and custom named.

#### Description

Downshift's default naming of the `aria-label` is `open menu` and `close menu`. The library recommends to pass an own tranlation of this label

![CleanShot 2020-06-14 at 16 17 15](https://user-images.githubusercontent.com/1877073/84596062-bc24b280-ae5b-11ea-9eb5-87c37723ec3c.png)

This then allows us to use better selectors and also one which would not break with a second Downshift dropdown on the page.

![CleanShot 2020-06-14 at 16 12 50](https://user-images.githubusercontent.com/1877073/84596071-d1014600-ae5b-11ea-9867-15e649965434.png)

Note, that updating the tests and using the new labels prooves that this works.
