### PR TITLE
feat(app-shell): to add label to maintenance page layouts

### DIFF
--- a/.changeset/quick-tools-wash.md
+++ b/.changeset/quick-tools-wash.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/application-components": minor
+"@commercetools-frontend/application-shell": minor
+---
+
+feat(app-shell): to add label to maintenance page layouts

--- a/packages/application-components/src/components/maintenance-page-layout/README.md
+++ b/packages/application-components/src/components/maintenance-page-layout/README.md
@@ -21,10 +21,11 @@ const PageNotFound = () => (
 
 ## Properties
 
-| Props         | Type     | Required | Values | Default | Description                                |
-| ------------- | -------- | :------: | ------ | ------- | ------------------------------------------ |
-| `imgageSrc`   | `string` |    ✅    | -      | -       | Path to the image to display in the layout |
-| `title`       | `node`   |    ✅    | -      | -       | The header content                         |
-| `paragraph1`  | `node`   |    ✅    | -      | -       | The first paragraph content                |
-| `paragraph2`  | `node`   |    -     | -      | -       | The second paragraph content               |
-| `bodyContent` | `node`   |    -     | -      | -       | The body content                           |
+| Props         | Type     | Required | Values | Default | Description                                   |
+| ------------- | -------- | :------: | ------ | ------- | --------------------------------------------- |
+| `imgageSrc`   | `string` |    ✅    | -      | -       | Path to the image to display in the layout    |
+| `title`       | `node`   |    ✅    | -      | -       | The header content                            |
+| `paragraph1`  | `node`   |    ✅    | -      | -       | The first paragraph content                   |
+| `paragraph2`  | `node`   |    -     | -      | -       | The second paragraph content                  |
+| `bodyContent` | `node`   |    -     | -      | -       | The body content                              |
+| `label`       | `string` |    -     | -      | -       | The label for the page set as the image's alt |

--- a/packages/application-components/src/components/maintenance-page-layout/maintenance-page-layout.spec.tsx
+++ b/packages/application-components/src/components/maintenance-page-layout/maintenance-page-layout.spec.tsx
@@ -64,4 +64,15 @@ describe('rendering', () => {
       expect(rendered.getByText('content')).toBeInTheDocument();
     });
   });
+  describe('with label', () => {
+    beforeEach(() => {
+      props = createTestProps({ label: 'page label' });
+    });
+    it('renders the label as an alt of the image', () => {
+      const rendered = renderComponent(<MaintenancePageLayout {...props} />);
+      expect(
+        rendered.getByRole('img', { name: props.label })
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/application-components/src/components/maintenance-page-layout/maintenance-page-layout.tsx
+++ b/packages/application-components/src/components/maintenance-page-layout/maintenance-page-layout.tsx
@@ -8,6 +8,7 @@ import Spacings from '@commercetools-uikit/spacings';
 export type Props = {
   imageSrc: string;
   title: React.ReactNode;
+  label?: string;
   paragraph1: React.ReactNode;
   paragraph2?: React.ReactNode;
   bodyContent?: React.ReactNode;
@@ -28,7 +29,7 @@ const MaintenancePageLayout = (props: Props) => (
     <Constraints.Horizontal constraint="l">
       <Spacings.Stack scale="m">
         <div>
-          <img src={props.imageSrc} />
+          <img src={props.imageSrc} alt={props.label} />
         </div>
         <Text.Headline as="h2">{props.title}</Text.Headline>
         <Text.Body>{props.paragraph1}</Text.Body>
@@ -50,6 +51,7 @@ const MaintenancePageLayout = (props: Props) => (
 MaintenancePageLayout.displayName = 'MaintenancePageLayout';
 MaintenancePageLayout.propTypes = {
   imageSrc: PropTypes.string.isRequired,
+  label: PropTypes.string,
   title: PropTypes.node.isRequired,
   paragraph1: PropTypes.node.isRequired,
   paragraph2: PropTypes.node,

--- a/packages/application-components/src/components/page-not-found/page-not-found.tsx
+++ b/packages/application-components/src/components/page-not-found/page-not-found.tsx
@@ -1,35 +1,40 @@
 /* eslint-disable react/display-name */
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import PageNotFoundSVG from '@commercetools-frontend/assets/images/desert-fox.svg';
 import { SUPPORT_PORTAL_URL } from '@commercetools-frontend/constants';
 import MaintenancePageLayout from '../maintenance-page-layout';
 import messages from './messages';
 
-const PageNotFound = () => (
-  <MaintenancePageLayout
-    imageSrc={PageNotFoundSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={
-      <FormattedMessage<
-        Record<string, (msg: React.ReactNodeArray) => JSX.Element>
-      >
-        {...messages.paragraph1}
-        values={{
-          a: (msg) => (
-            <a
-              href={SUPPORT_PORTAL_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {msg}
-            </a>
-          ),
-        }}
-      />
-    }
-  />
-);
+const PageNotFound = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={PageNotFoundSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={
+        <FormattedMessage<
+          Record<string, (msg: React.ReactNodeArray) => JSX.Element>
+        >
+          {...messages.paragraph1}
+          values={{
+            a: (msg) => (
+              <a
+                href={SUPPORT_PORTAL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {msg}
+              </a>
+            ),
+          }}
+        />
+      }
+    />
+  );
+};
 PageNotFound.displayName = 'PageNotFound';
 
 export default PageNotFound;

--- a/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
+++ b/packages/application-shell/src/components/application-shell-provider/application-shell-provider.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ReactReduxContext } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+import { IntlProvider, FormattedMessage } from 'react-intl';
 import { render, waitFor } from '@testing-library/react';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { GtmContext } from '../gtm-booter';
@@ -150,9 +150,11 @@ describe('rendering', () => {
       }
     }
     const rendered = render(
-      <ApplicationShellProvider {...createTestProps()}>
-        {() => <Thrower />}
-      </ApplicationShellProvider>
+      <IntlProvider locale="en" messages={{}}>
+        <ApplicationShellProvider {...createTestProps()}>
+          {() => <Thrower />}
+        </ApplicationShellProvider>
+      </IntlProvider>
     );
     await rendered.findByText(/Sorry! An unexpected error occured/i);
     expect(console.error).toHaveBeenCalled();

--- a/packages/application-shell/src/components/error-apologizer/error-apologizer.tsx
+++ b/packages/application-shell/src/components/error-apologizer/error-apologizer.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import UnexpectedErrorSVG from '@commercetools-frontend/assets/images/icecream.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import messages from './messages';
 
-const ErrorApologizer = () => (
-  <MaintenancePageLayout
-    imageSrc={UnexpectedErrorSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={<FormattedMessage {...messages.notifiedTeam} />}
-  />
-);
+const ErrorApologizer = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={UnexpectedErrorSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={<FormattedMessage {...messages.notifiedTeam} />}
+    />
+  );
+};
 
 ErrorApologizer.displayName = 'ErrorApologizer';
 

--- a/packages/application-shell/src/components/failed-authentication/failed-authentication.tsx
+++ b/packages/application-shell/src/components/failed-authentication/failed-authentication.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import FailedAuthenticationSVG from '@commercetools-frontend/assets/images/locked-diamond.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import messages from './messages';
 
-const FailedAuthentication = () => (
-  <MaintenancePageLayout
-    imageSrc={FailedAuthenticationSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={<FormattedMessage {...messages.paragraph1} />}
-  />
-);
+const FailedAuthentication = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={FailedAuthenticationSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={<FormattedMessage {...messages.paragraph1} />}
+    />
+  );
+};
 FailedAuthentication.displayName = 'FailedAuthentication';
 
 export default FailedAuthentication;

--- a/packages/application-shell/src/components/project-expired/project-expired.tsx
+++ b/packages/application-shell/src/components/project-expired/project-expired.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import ProjectExpiredSVG from '@commercetools-frontend/assets/images/hourglass.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import ServicePageProjectSwitcher from '../service-page-project-switcher';
@@ -16,19 +16,24 @@ const EmailLink = (props: Props) => (
 );
 EmailLink.displayName = 'EmailLink';
 
-const ProjectExpired = () => (
-  <MaintenancePageLayout
-    imageSrc={ProjectExpiredSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={
-      <FormattedMessage
-        {...messages.paragraph1}
-        values={{ mailto: <EmailLink email={salesEmail} /> }}
-      />
-    }
-    bodyContent={<ServicePageProjectSwitcher />}
-  />
-);
+const ProjectExpired = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={ProjectExpiredSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={
+        <FormattedMessage
+          {...messages.paragraph1}
+          values={{ mailto: <EmailLink email={salesEmail} /> }}
+        />
+      }
+      bodyContent={<ServicePageProjectSwitcher />}
+    />
+  );
+};
 ProjectExpired.displayName = 'ProjectExpired';
 
 export default ProjectExpired;

--- a/packages/application-shell/src/components/project-not-found/project-not-found.tsx
+++ b/packages/application-shell/src/components/project-not-found/project-not-found.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import FailedAuthorizationSVG from '@commercetools-frontend/assets/images/folder-full-locked.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import ServicePageProjectSwitcher from '../service-page-project-switcher';
 import messages from './messages';
 
-const ProjectNotFound = () => (
-  <MaintenancePageLayout
-    imageSrc={FailedAuthorizationSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={<FormattedMessage {...messages.paragraph1} />}
-    paragraph2={<FormattedMessage {...messages.paragraph2} />}
-    bodyContent={<ServicePageProjectSwitcher />}
-  />
-);
+const ProjectNotFound = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={FailedAuthorizationSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={<FormattedMessage {...messages.paragraph1} />}
+      paragraph2={<FormattedMessage {...messages.paragraph2} />}
+      bodyContent={<ServicePageProjectSwitcher />}
+    />
+  );
+};
 ProjectNotFound.displayName = 'ProjectNotFound';
 
 export default ProjectNotFound;

--- a/packages/application-shell/src/components/project-not-initialized/project-not-initialized.tsx
+++ b/packages/application-shell/src/components/project-not-initialized/project-not-initialized.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import ProjectNotInitializedSVG from '@commercetools-frontend/assets/images/hourglass.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import ServicePageProjectSwitcher from '../service-page-project-switcher';
@@ -16,19 +16,24 @@ const EmailLink = (props: Props) => (
 );
 EmailLink.displayName = 'EmailLink';
 
-const ProjectNotInitialized = () => (
-  <MaintenancePageLayout
-    imageSrc={ProjectNotInitializedSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={
-      <FormattedMessage
-        {...messages.paragraph1}
-        values={{ mailto: <EmailLink email={supportEmail} /> }}
-      />
-    }
-    bodyContent={<ServicePageProjectSwitcher />}
-  />
-);
+const ProjectNotInitialized = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={ProjectNotInitializedSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={
+        <FormattedMessage
+          {...messages.paragraph1}
+          values={{ mailto: <EmailLink email={supportEmail} /> }}
+        />
+      }
+      bodyContent={<ServicePageProjectSwitcher />}
+    />
+  );
+};
 ProjectNotInitialized.displayName = 'ProjectNotInitialized';
 
 export default ProjectNotInitialized;

--- a/packages/application-shell/src/components/project-suspended/project-suspended.tsx
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import ProjectSuspendedSVG from '@commercetools-frontend/assets/images/doors-closed.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import ServicePageProjectSwitcher from '../service-page-project-switcher';
@@ -9,7 +9,9 @@ type Props = {
   isTemporary?: boolean;
 };
 
-const ProjectSuspended = (props: Props) => (
+const ProjectSuspended = (props: Props) => {
+  const intl = useIntl();
+
   <MaintenancePageLayout
     imageSrc={ProjectSuspendedSVG}
     title={(() => {
@@ -22,10 +24,11 @@ const ProjectSuspended = (props: Props) => (
         );
       return <FormattedMessage {...messages.defaultSuspensionMessage} />;
     })()}
+    label={intl.formatMessage(messages.title)}
     paragraph1={<FormattedMessage {...messages.paragraph1} />}
     bodyContent={<ServicePageProjectSwitcher />}
-  />
-);
+  />;
+};
 ProjectSuspended.displayName = 'ProjectSuspended';
 
 export default ProjectSuspended;

--- a/packages/application-shell/src/components/project-suspended/project-suspended.tsx
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.tsx
@@ -21,13 +21,15 @@ const ProjectSuspended = (props: Props) => {
   const intl = useIntl();
   const titleMessage = getTitleMessage(props);
 
-  <MaintenancePageLayout
-    imageSrc={ProjectSuspendedSVG}
-    title={<FormattedMessage {...titleMessage} />}
-    label={intl.formatMessage(titleMessage)}
-    paragraph1={<FormattedMessage {...messages.paragraph1} />}
-    bodyContent={<ServicePageProjectSwitcher />}
-  />;
+  return (
+    <MaintenancePageLayout
+      imageSrc={ProjectSuspendedSVG}
+      title={<FormattedMessage {...titleMessage} />}
+      label={intl.formatMessage(titleMessage)}
+      paragraph1={<FormattedMessage {...messages.paragraph1} />}
+      bodyContent={<ServicePageProjectSwitcher />}
+    />
+  );
 };
 ProjectSuspended.displayName = 'ProjectSuspended';
 

--- a/packages/application-shell/src/components/project-suspended/project-suspended.tsx
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useIntl, FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage, MessageDescriptor } from 'react-intl';
 import ProjectSuspendedSVG from '@commercetools-frontend/assets/images/doors-closed.svg';
 import { MaintenancePageLayout } from '@commercetools-frontend/application-components';
 import ServicePageProjectSwitcher from '../service-page-project-switcher';
@@ -9,22 +9,22 @@ type Props = {
   isTemporary?: boolean;
 };
 
+const getTitleMessage = (props: Props): MessageDescriptor => {
+  /* NOTE: Other suspension reasons are `Payment` and `Other` which are not handled yet */
+  if (props.isTemporary === true)
+    return messages.temporaryMaintenanceSuspensionMessage;
+
+  return messages.defaultSuspensionMessage;
+};
+
 const ProjectSuspended = (props: Props) => {
   const intl = useIntl();
+  const titleMessage = getTitleMessage(props);
 
   <MaintenancePageLayout
     imageSrc={ProjectSuspendedSVG}
-    title={(() => {
-      /* NOTE: Other suspension reasons are `Payment` and `Other` which are not handled yet */
-      if (props.isTemporary === true)
-        return (
-          <FormattedMessage
-            {...messages.temporaryMaintenanceSuspensionMessage}
-          />
-        );
-      return <FormattedMessage {...messages.defaultSuspensionMessage} />;
-    })()}
-    label={intl.formatMessage(messages.title)}
+    title={<FormattedMessage {...titleMessage} />}
+    label={intl.formatMessage(titleMessage)}
     paragraph1={<FormattedMessage {...messages.paragraph1} />}
     bodyContent={<ServicePageProjectSwitcher />}
   />;


### PR DESCRIPTION
#### Summary

This pull request adds a label which is used on the images alt to all maintenance pages.

#### Description

Our maintenance pages mostly have: title, two paragraphs and an image. The image itself however doesn't contain any alt text. It would be good to mostly use the `title` as the alt text on the image. 

This also eases querying for the image with `byRole('img', { name: //i })` under test.

I had multiple solution in mind when working on this:

1. Add a optional string of `label` which goes to the `img` alt. The `img` `alt` needs to be a string and can't be React.Node
2. Just use the `title` and pass it as the `alt`. Slighly less flexible but less noisy for consumers. However, the `title` is an React.Node as it's a FormattedMessage while the `alt` needs a string.
3. Refactor everything to just accept `*IntlMessage` for instance `titleIntlMessage`. This however is a breaking change to the public component.
4. Offer two sets of props: a bit too much work for a little thing like this