### PR TITLE
feat(jest-preset-mc-app): add config for rtl

### DIFF
--- a/.changeset/six-pillows-share.md
+++ b/.changeset/six-pillows-share.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/jest-preset-mc-app": patch
+---
+
+feat(jest-preset-mc-app): add config for rtl

--- a/packages/jest-preset-mc-app/setup-test-framework.js
+++ b/packages/jest-preset-mc-app/setup-test-framework.js
@@ -1,14 +1,21 @@
 require('unfetch/polyfill');
 require('jest-enzyme');
 require('@testing-library/jest-dom/extend-expect');
+require('./polyfills/intl');
+
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const ShallowWrapper = require('enzyme/ShallowWrapper');
+import { configure as configureRtl } from '@testing-library/react';
 const configureEnzymeExtensions = require('@commercetools/enzyme-extensions');
 const commerceToolsEnzymeMatchers = require('@commercetools/jest-enzyme-matchers');
-require('./polyfills/intl');
+const loadConfig = require('./load-config');
+
+const jestConfig = loadConfig();
 
 Enzyme.configure({ adapter: new Adapter(), disableLifecycleMethods: true });
+
+configureRtl(jestConfig.rtlConfig);
 
 expect.extend({
   toBeComponentWithName(received, actual) {


### PR DESCRIPTION
#### Summary

This pull request adds the abilty to configure react-testing-library.

#### Description

The `react-testing-library` allows a custom configuration which it itself uses and exports from `dom-testing-library`.

![CleanShot 2020-06-21 at 23 03 53](https://user-images.githubusercontent.com/1877073/85235229-ab53de00-b413-11ea-87c7-64872a47bbfa.png)

This can be useful to configure timeouts for `findBy*` queries which can run slow on CI among other things

More information on configuration of the library can be found [here](https://testing-library.com/docs/nightwatch-testing-library/intro#configure).
