### PR TITLE
refactor(appkit): migrate PageUnauthorized component to AppKit

### DIFF
--- a/.changeset/great-otters-clean.md
+++ b/.changeset/great-otters-clean.md
@@ -1,5 +1,0 @@
----
-"@commercetools-frontend/jest-preset-mc-app": patch
----
-
-fix(jest-preset-mc-app): to import with cjs

--- a/.changeset/metal-meals-compete.md
+++ b/.changeset/metal-meals-compete.md
@@ -1,6 +1,6 @@
 ---
-'@commercetools-frontend/application-components': patch
-'@commercetools-local/visual-testing-app': patch
+'@commercetools-frontend/application-components': minor
+'@commercetools-local/visual-testing-app': minor
 ---
 
 refactor(application-components, visual-testing-app): migrate PageUnauthorized component to AppKit

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -34,7 +34,7 @@
     "redux": "4.0.5"
   },
   "devDependencies": {
-    "@commercetools-frontend/jest-preset-mc-app": "16.12.0",
+    "@commercetools-frontend/jest-preset-mc-app": "16.12.1",
     "@commercetools-frontend/mc-scripts": "16.12.0",
     "@testing-library/react": "10.3.0",
     "dotenv-cli": "3.1.0",

--- a/packages/application-components/src/components/page-unauthorized/README.md
+++ b/packages/application-components/src/components/page-unauthorized/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The PageUnauthorized component can be used for informing user they don't have permissions for certain resources in Merchant Center applications.
+The PageUnauthorized component can be used to inform a user that certain permissions are lacking for views of a respective Merchant Center application.
 
 ## Usage
 

--- a/packages/application-components/src/components/page-unauthorized/README.md
+++ b/packages/application-components/src/components/page-unauthorized/README.md
@@ -1,0 +1,20 @@
+# PageUnauthorized
+
+## Description
+
+The PageUnauthorized component can be used for informing user they don't have permissions for certain resources in Merchant Center applications.
+
+## Usage
+
+```js
+import { Switch, Route } from 'react-router-dom';
+import { PageUnauthorized } from '@commercetools-frontend/application-components';
+
+const Routes = () => (
+  <Switch>
+    <Route exact path="/" component={Home} />
+    <Route path="/user" component={User} />
+    <Route path="/unauthorized" component={PageUnauthorized} />
+  </Switch>
+);
+```

--- a/packages/application-components/src/components/page-unauthorized/index.ts
+++ b/packages/application-components/src/components/page-unauthorized/index.ts
@@ -1,0 +1,1 @@
+export { default } from './page-unauthorized';

--- a/packages/application-components/src/components/page-unauthorized/messages.ts
+++ b/packages/application-components/src/components/page-unauthorized/messages.ts
@@ -1,0 +1,18 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  title: {
+    id: 'PageUnauthorized.title',
+    defaultMessage: 'We could not find what you are looking for',
+  },
+  paragraph1: {
+    id: 'PageUnauthorized.paragraph1',
+    defaultMessage:
+      'The Module you are looking for either does not exist for this Project or you are not authorized to view it.',
+  },
+  paragraph2: {
+    id: 'PageUnauthorized.paragraph2',
+    defaultMessage:
+      'Please contact your system administrator or the commercetools <a>Help Desk</a> if you have any further questions.',
+  },
+});

--- a/packages/application-components/src/components/page-unauthorized/page-unauthorized.spec.tsx
+++ b/packages/application-components/src/components/page-unauthorized/page-unauthorized.spec.tsx
@@ -7,4 +7,10 @@ describe('rendering', () => {
     const rendered = renderComponent(<PageUnauthorized />);
     expect(rendered.getByText('Help Desk')).toBeInTheDocument();
   });
+  it('should render the title', () => {
+    const rendered = renderComponent(<PageUnauthorized />);
+    expect(
+      rendered.getByText('We could not find what you are looking for')
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/application-components/src/components/page-unauthorized/page-unauthorized.spec.tsx
+++ b/packages/application-components/src/components/page-unauthorized/page-unauthorized.spec.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { renderComponent } from '../../test-utils';
+import PageUnauthorized from './page-unauthorized';
+
+describe('rendering', () => {
+  it('should render help desk link', () => {
+    const rendered = renderComponent(<PageUnauthorized />);
+    expect(rendered.getByText('Help Desk')).toBeInTheDocument();
+  });
+});

--- a/packages/application-components/src/components/page-unauthorized/page-unauthorized.tsx
+++ b/packages/application-components/src/components/page-unauthorized/page-unauthorized.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import FailedAuthorizationSVG from '@commercetools-frontend/assets/images/folder-full-locked.svg';
 import MaintenancePageLayout from '../maintenance-page-layout';
 import { SUPPORT_PORTAL_URL } from '@commercetools-frontend/constants';
@@ -12,21 +12,26 @@ const getSupportUrlLink = (msg: string) => (
   </a>
 );
 
-export const PageUnauthorized = () => (
-  <MaintenancePageLayout
-    imageSrc={FailedAuthorizationSVG}
-    title={<FormattedMessage {...messages.title} />}
-    paragraph1={<FormattedMessage {...messages.paragraph1} />}
-    paragraph2={
-      <FormattedMessage
-        {...messages.paragraph2}
-        values={{
-          a: getSupportUrlLink,
-        }}
-      />
-    }
-  />
-);
+export const PageUnauthorized = () => {
+  const intl = useIntl();
+
+  return (
+    <MaintenancePageLayout
+      imageSrc={FailedAuthorizationSVG}
+      title={<FormattedMessage {...messages.title} />}
+      label={intl.formatMessage(messages.title)}
+      paragraph1={<FormattedMessage {...messages.paragraph1} />}
+      paragraph2={
+        <FormattedMessage
+          {...messages.paragraph2}
+          values={{
+            a: getSupportUrlLink,
+          }}
+        />
+      }
+    />
+  );
+};
 
 PageUnauthorized.displayName = 'PageUnauthorized';
 

--- a/packages/application-components/src/components/page-unauthorized/page-unauthorized.tsx
+++ b/packages/application-components/src/components/page-unauthorized/page-unauthorized.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import FailedAuthorizationSVG from '@commercetools-frontend/assets/images/folder-full-locked.svg';
+import MaintenancePageLayout from '../maintenance-page-layout';
+import { SUPPORT_PORTAL_URL } from '@commercetools-frontend/constants';
+import messages from './messages';
+
+// eslint-disable-next-line react/display-name
+const getSupportUrlLink = (msg: string) => (
+  <a href={SUPPORT_PORTAL_URL} target="_blank" rel="noopener noreferrer">
+    {msg}
+  </a>
+);
+
+export const PageUnauthorized = () => (
+  <MaintenancePageLayout
+    imageSrc={FailedAuthorizationSVG}
+    title={<FormattedMessage {...messages.title} />}
+    paragraph1={<FormattedMessage {...messages.paragraph1} />}
+    paragraph2={
+      <FormattedMessage
+        {...messages.paragraph2}
+        values={{
+          a: getSupportUrlLink,
+        }}
+      />
+    }
+  />
+);
+
+PageUnauthorized.displayName = 'PageUnauthorized';
+
+export default PageUnauthorized;

--- a/packages/application-components/src/index.ts
+++ b/packages/application-components/src/index.ts
@@ -3,6 +3,7 @@ export { default as version } from './version';
 // Maintenance pages
 export { default as MaintenancePageLayout } from './components/maintenance-page-layout';
 export { default as PageNotFound } from './components/page-not-found';
+export { default as PageUnauthorized } from './components/page-unauthorized';
 
 // Dialogs
 export { default as InfoDialog } from './components/dialogs/info-dialog';

--- a/packages/jest-preset-mc-app/CHANGELOG.md
+++ b/packages/jest-preset-mc-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @commercetools-frontend/jest-preset-mc-app
 
+## 16.12.1
+
+### Patch Changes
+
+- [`f1946cc`](https://github.com/commercetools/merchant-center-application-kit/commit/f1946cc841906820235c8cb1bab0c2a92ae7601a) [#1593](https://github.com/commercetools/merchant-center-application-kit/pull/1593) Thanks [@tdeekens](https://github.com/tdeekens)! - fix(jest-preset-mc-app): to import with cjs
+
 ## 16.12.0
 
 ### Patch Changes

--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-frontend/jest-preset-mc-app",
-  "version": "16.12.0",
+  "version": "16.12.1",
   "description": "Jest preset used by a MC application",
   "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
   "repository": {

--- a/visual-testing-app/src/components/page-unauthorized/page-unauthorized.visualroute.tsx
+++ b/visual-testing-app/src/components/page-unauthorized/page-unauthorized.visualroute.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { PageUnauthorized } from '@commercetools-frontend/application-components';
+import { Suite, Spec } from '../../test-utils';
+
+export const routePath = '/page-unauthorized';
+
+export const Component = () => (
+  <Suite>
+    <Spec label="PageUnauthorized" size="l" contentAlignment="center">
+      <PageUnauthorized />
+    </Spec>
+  </Suite>
+);

--- a/visual-testing-app/src/components/page-unauthorized/page-unauthorized.visualspec.ts
+++ b/visual-testing-app/src/components/page-unauthorized/page-unauthorized.visualspec.ts
@@ -1,0 +1,13 @@
+import { percySnapshot } from '@percy/puppeteer';
+import { HOST } from '../../constants';
+
+describe('PageUnauthorized', () => {
+  beforeAll(async () => {
+    await page.goto(`${HOST}/page-unauthorized`);
+  });
+
+  it('Default', async () => {
+    await expect(page).toMatch('PageUnauthorized');
+    await percySnapshot(page, 'PageUnauthorized');
+  });
+});


### PR DESCRIPTION
#### Summary

This PR migrates the PageUnauthorized component from Merchant Center to Application Kit. It can be used for informing user they don't have permissions for certain resources in Merchant Center applications