### PR TITLE
feat(babel-preset-mc-app): add logical assignment operator

### DIFF
--- a/.changeset/chilled-kiwis-pretend.md
+++ b/.changeset/chilled-kiwis-pretend.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/babel-preset-mc-app": minor
+---
+
+feat(babel-preset-mc-app): add logical assignment operator

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -129,6 +129,7 @@ module.exports = function getBabePresetConfigForMcApp() {
         },
       ],
       require('@babel/plugin-proposal-do-expressions').default,
+      require('@babel/plugin-proposal-logical-assignment-operators').default,
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -29,6 +29,7 @@
     "@babel/plugin-proposal-export-default-from": "7.10.4",
     "@babel/plugin-proposal-export-namespace-from": "7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "7.10.4",
+    "@babel/plugin-proposal-logical-assignment-operators": "7.10.4",
     "@babel/plugin-transform-classes": "7.10.4",
     "@babel/plugin-transform-destructuring": "7.10.4",
     "@babel/plugin-transform-react-display-name": "7.10.4",


### PR DESCRIPTION
#### Summary

This pull request suggests to add the logical assignment operator to our babel config.

#### Description

The logical assignment operator [TC39 proporal](https://github.com/tc39/proposal-logical-assignment) can help us when assignment optional values based on a condition. 

A simple use case is:

```js
a ||= b;
obj.a.b ||= c;

a &&= b;
obj.a.b &&= c;
```

More real world would be

```js
const books = [
  {
    isbn: '123',
  },
  {
    title: 'ECMAScript Language Specification',
    isbn: '456',
  },
];

// Add property .title where it’s missing
for (const book of books) {
  book.title ??= '(Untitled)';
}
```

I think in general we have cases internally where we assign values if they're not assigned yet through ternaries. These case could be simplified through this.

1. https://2ality.com/2020/06/logical-assignment-operators.html
2. https://github.com/tc39/proposal-logical-assignment
3. https://babeljs.io/docs/en/next/babel-plugin-proposal-logical-assignment-operators.html