### PR TITLE
fix(config): get JSON schema from website docs URL

### DIFF
--- a/.changeset/three-bikes-attack.md
+++ b/.changeset/three-bikes-attack.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-config': patch
+'@commercetools-website/custom-applications': patch
+---
+
+Get JSON schema from docs website URL

--- a/packages/application-config/README.md
+++ b/packages/application-config/README.md
@@ -44,7 +44,7 @@ In the VSCode settings (either user settings or workspace settings), reference t
       "/.custom-application-config.json",
       "/custom-application-config.json"
     ],
-    "url": "https://unpkg.com/@commercetools-frontend/application-config/schema.json"
+    "url": "https://docs.commercetools.com/custom-applications/schema.json"
   }
 ]
 ```

--- a/packages/application-config/schema.json
+++ b/packages/application-config/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://unpkg.com/@commercetools-frontend/application-config/schema.json",
+  "$id": "https://docs.commercetools.com/custom-applications/schema.json",
   "title": "JSON schema for Custom Application configuration files",
   "type": "object",
   "definitions": {

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,2 @@
 versions.js
+static/schema.json

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "gatsby build --prefix-paths",
     "prebuild": "rm -rf public/custom-applications",
-    "postbuild": "mv public custom-applications && mkdir public && mv custom-applications public/",
+    "postbuild": "./scripts/postbuild.sh",
     "start": "gatsby develop"
   },
   "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "gatsby build --prefix-paths",
-    "prebuild": "rm -rf public/custom-applications",
+    "prebuild": "./scripts/prebuild.sh",
     "postbuild": "./scripts/postbuild.sh",
     "start": "gatsby develop"
   },

--- a/website/scripts/postbuild.sh
+++ b/website/scripts/postbuild.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+mv public custom-applications
+mkdir public
+mv custom-applications public/
+# Copy the custom application config `schema.json` to the website static assets.
+cp ../packages/application-config/schema.json public/custom-applications/static/

--- a/website/scripts/postbuild.sh
+++ b/website/scripts/postbuild.sh
@@ -5,5 +5,3 @@ set -e
 mv public custom-applications
 mkdir public
 mv custom-applications public/
-# Copy the custom application config `schema.json` to the website static assets.
-cp ../packages/application-config/schema.json public/custom-applications/static/

--- a/website/scripts/prebuild.sh
+++ b/website/scripts/prebuild.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf public/custom-applications
+# Copy the custom application config `schema.json` to the website static assets.
+cp ../packages/application-config/schema.json static/

--- a/website/src/content/development/application-config.mdx
+++ b/website/src/content/development/application-config.mdx
@@ -43,7 +43,7 @@ In the example above, you can see all the necessary properties that are required
 
 <Info>
 
-You can also inspect the [JSON schema](https://unpkg.com/@commercetools-frontend/application-config/schema.json) to see all available properties.
+You can also inspect the [JSON schema](https://docs.commercetools.com/custom-applications/schema.json) to see all available properties.
 
 </Info>
 
@@ -149,7 +149,7 @@ To enable JSON schema autocompletion and validation support, add a reference to 
       "/.custom-application-config.json",
       "/custom-application-config.json"
     ],
-    "url": "https://unpkg.com/@commercetools-frontend/application-config/schema.json"
+    "url": "https://docs.commercetools.com/custom-applications/schema.json"
   }
 ]
 ```

--- a/website/src/releases/2020-07/application-config.mdx
+++ b/website/src/releases/2020-07/application-config.mdx
@@ -158,7 +158,7 @@ In the VSCode settings (either user settings or workspace settings), reference t
       "/.custom-application-config.json",
       "/custom-application-config.json"
     ],
-    "url": "https://unpkg.com/@commercetools-frontend/application-config/schema.json"
+    "url": "https://docs.commercetools.com/custom-applications/schema.json"
   }
 ]
 ```


### PR DESCRIPTION
Unfortunately using the unpkg URL doesn't work from VSCode, because the HTTP redirects are not followed.

The HTTP redirects occur because the URL https://unpkg.com/@commercetools-frontend/application-config/schema.json gets resolved by the latest published version.

After some thoughts I think the better option to host the JSON schema is to put it in the docs website.