### PR TITLE
chore: update copyright date to 2020 in LICENSE files

### DIFF
--- a/.changeset/polite-taxis-shop.md
+++ b/.changeset/polite-taxis-shop.md
@@ -1,0 +1,25 @@
+---
+'@commercetools-frontend/actions-global': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/assets': patch
+'@commercetools-frontend/babel-preset-mc-app': patch
+'@commercetools-frontend/browser-history': patch
+'@commercetools-frontend/constants': patch
+'@commercetools-frontend/create-mc-app': patch
+'@commercetools-frontend/eslint-config-mc-app': patch
+'@commercetools-frontend/i18n': patch
+'@commercetools-frontend/jest-preset-mc-app': patch
+'@commercetools-frontend/l10n': patch
+'@commercetools-frontend/mc-html-template': patch
+'@commercetools-frontend/mc-http-server': patch
+'@commercetools-frontend/mc-scripts': patch
+'@commercetools-frontend/notifications': patch
+'@commercetools-frontend/permissions': patch
+'@commercetools-frontend/react-notifications': patch
+'@commercetools-frontend/sdk': patch
+'@commercetools-frontend/sentry': patch
+'@commercetools-frontend/url-utils': patch
+---
+
+Update copyright date to 2020 in LICENSE files

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/actions-global/LICENSE
+++ b/packages/actions-global/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/application-shell-connectors/LICENSE
+++ b/packages/application-shell-connectors/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/application-shell/LICENSE
+++ b/packages/application-shell/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/assets/LICENSE
+++ b/packages/assets/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/babel-preset-mc-app/LICENSE
+++ b/packages/babel-preset-mc-app/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/browser-history/LICENSE
+++ b/packages/browser-history/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/constants/LICENSE
+++ b/packages/constants/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/create-mc-app/LICENSE
+++ b/packages/create-mc-app/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/eslint-config-mc-app/LICENSE
+++ b/packages/eslint-config-mc-app/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/i18n/LICENSE
+++ b/packages/i18n/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/jest-preset-mc-app/LICENSE
+++ b/packages/jest-preset-mc-app/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/l10n/LICENSE
+++ b/packages/l10n/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mc-html-template/LICENSE
+++ b/packages/mc-html-template/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mc-http-server/LICENSE
+++ b/packages/mc-http-server/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mc-scripts/LICENSE
+++ b/packages/mc-scripts/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/notifications/LICENSE
+++ b/packages/notifications/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/permissions/LICENSE
+++ b/packages/permissions/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/react-notifications/LICENSE
+++ b/packages/react-notifications/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/sentry/LICENSE
+++ b/packages/sentry/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/url-utils/LICENSE
+++ b/packages/url-utils/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 commercetools GmbH
+Copyright (c) 2020 commercetools GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Just a small chance to trigger a release and test the workflow triggers for the http-server when using the personal access token (https://github.com/commercetools/merchant-center-application-kit/commit/e1fb17138b53ecf96e863ae6a8f56d048d5ce85e)