### PR TITLE
refactor(config): to be more strict on deriving the prod env based on the MC_APP_ENV

### DIFF
--- a/.changeset/tough-pears-join.md
+++ b/.changeset/tough-pears-join.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+refactor(application-config): be more strict on deriving the prod env based on the MC_APP_ENV.
+
+TL;DR: in case the `MC_APP_ENV` is defined, we consider that it's a production environment unless it's one of `development` or `test`. This allows to use for example the `staging` value, which from the application perspective is still considered a production environment.

--- a/.github/workflows/publish-cloud-registry.yml
+++ b/.github/workflows/publish-cloud-registry.yml
@@ -3,7 +3,7 @@ name: Publish to Google Cloud Registry
 on:
   push:
     tags:
-      - "@commercetools-frontend/mc-http-server@*"
+      - "*"
 
 jobs:
   mc-http-server:

--- a/packages/application-config/src/utils.ts
+++ b/packages/application-config/src/utils.ts
@@ -32,9 +32,14 @@ const getUniqueValues = (
   additionalValues: string[] = []
 ): string[] => uniq([...initialValues, ...additionalValues]);
 
+const nonProductionEnvironment = ['development', 'test'];
 const getIsProd = (env: NodeJS.ProcessEnv): boolean =>
+  // TL;DR: in case the `MC_APP_ENV` is defined, we consider that it's
+  // a production environment unless it's one of `development` or `test`.
+  // This allows to use for example the `staging` value, which from the
+  // application perspective is still considered a production environment.
   env.MC_APP_ENV
-    ? env.MC_APP_ENV === 'production'
+    ? !nonProductionEnvironment.includes(env.MC_APP_ENV)
     : env.NODE_ENV === 'production';
 
 const getOrThrow = <T>(fn: () => T, errorMessage: string): T => {

--- a/packages/application-config/test/process-config.spec.js
+++ b/packages/application-config/test/process-config.spec.js
@@ -118,6 +118,41 @@ describe('processing a simple config', () => {
       });
     });
   });
+  describe('with MC_APP_ENV=staging and NODE_ENV=production', () => {
+    it('should process the config in production mode', () => {
+      const result = processConfig(
+        createTestOptions({
+          processEnv: {
+            NODE_ENV: 'production',
+            MC_APP_ENV: 'staging',
+          },
+        })
+      );
+      expect(result).toEqual({
+        env: {
+          applicationId: undefined,
+          applicationName: 'avengers-app',
+          cdnUrl: 'https://avengers.app/',
+          env: 'staging',
+          frontendHost: 'avengers.app',
+          location: 'gcp-eu',
+          mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
+          revision: '',
+          servedByProxy: true,
+        },
+        headers: {
+          csp: {
+            'connect-src': [
+              'https://mc-api.europe-west1.gcp.commercetools.com',
+              'https://avengers.app/',
+            ],
+            'script-src': ['https://avengers.app/'],
+            'style-src': ['https://avengers.app/'],
+          },
+        },
+      });
+    });
+  });
 });
 
 describe('processing a full config', () => {
@@ -236,6 +271,50 @@ describe('processing a full config', () => {
       });
     });
   });
+  describe('with MC_APP_ENV=staging and NODE_ENV=production', () => {
+    it('should process the config in production mode', () => {
+      const result = processConfig(
+        createTestOptions({
+          processEnv: {
+            NODE_ENV: 'production',
+            MC_APP_ENV: 'staging',
+          },
+        })
+      );
+      expect(result).toEqual({
+        env: {
+          applicationId: undefined,
+          applicationName: 'avengers-app',
+          cdnUrl: 'https://cdn.avengers.app/',
+          env: 'staging',
+          frontendHost: 'avengers.app',
+          location: 'gcp-eu',
+          mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
+          numberOfMovies: 4,
+          revision: '',
+          servedByProxy: true,
+        },
+        headers: {
+          csp: {
+            'connect-src': [
+              'https://track.avengers.app',
+              'https://mc-api.europe-west1.gcp.commercetools.com',
+              'https://avengers.app/',
+            ],
+            'script-src': [
+              'https://track.avengers.app',
+              'https://avengers.app/',
+              'https://cdn.avengers.app/',
+            ],
+            'style-src': ['https://avengers.app/', 'https://cdn.avengers.app/'],
+          },
+          featurePolicies: {
+            microphone: 'none',
+          },
+        },
+      });
+    });
+  });
 });
 
 describe('processing a config with environment variable placeholders', () => {
@@ -340,6 +419,43 @@ describe('processing a config with environment variable placeholders', () => {
             ],
             'script-src': [],
             'style-src': [],
+          },
+        },
+      });
+    });
+  });
+  describe('with MC_APP_ENV=staging and NODE_ENV=production', () => {
+    it('should process the config in production mode', () => {
+      const result = processConfig(
+        createTestOptions({
+          processEnv: {
+            APP_URL: 'https://avengers.app',
+            CLOUD_IDENTIFIER: 'gcp-eu',
+            NODE_ENV: 'production',
+            MC_APP_ENV: 'staging',
+          },
+        })
+      );
+      expect(result).toEqual({
+        env: {
+          applicationId: undefined,
+          applicationName: 'avengers-app',
+          cdnUrl: 'https://avengers.app/',
+          env: 'staging',
+          frontendHost: 'avengers.app',
+          location: 'gcp-eu',
+          mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
+          revision: '',
+          servedByProxy: true,
+        },
+        headers: {
+          csp: {
+            'connect-src': [
+              'https://mc-api.europe-west1.gcp.commercetools.com',
+              'https://avengers.app/',
+            ],
+            'script-src': ['https://avengers.app/'],
+            'style-src': ['https://avengers.app/'],
           },
         },
       });


### PR DESCRIPTION
TL;DR: in case the `MC_APP_ENV` is defined, we consider that it's a production environment unless it's one of `development` or `test`. This allows to use for example the `staging` value, which from the application perspective is still considered a production environment.