### PR TITLE
fix(ci): use the release event type to trigger the google cloud registry workflow

### DIFF
--- a/.github/workflows/publish-cloud-registry.yml
+++ b/.github/workflows/publish-cloud-registry.yml
@@ -1,9 +1,8 @@
 name: Publish to Google Cloud Registry
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [created]
 
 jobs:
   mc-http-server:


### PR DESCRIPTION
I've been trying to find out more info about the proper trigger for the google cloud registry workflow.

I think we've been using the "wrong" trigger `on.push.tags`, because the release bot uses the `createRelease` function (https://github.com/changesets/action/blob/bfeb9e077e6cf393e4c4ef17e2bbc75b308b4364/src/run.ts#L35-L40) to create the release and implicitly the new tag.

So that's (maybe) why the workflow never got triggered.

Anyway, let's see what happens with this one.