### PR TITLE
fix(app-shell): coercing values for stringified array with double escaped quotes

### DIFF
--- a/.changeset/ninety-dancers-pump.md
+++ b/.changeset/ninety-dancers-pump.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+fix(app-shell): coercing values for stringified array with double escaped quotes

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -46,6 +46,7 @@ import version from '../../version';
 import RedirectToProjectCreate from '../redirect-to-project-create';
 import { selectProjectKeyFromUrl, getPreviousProjectKey } from '../../utils';
 import QuickAccess from '../quick-access';
+import shallowlyCoerceValues from './coerce-values';
 
 type Props<AdditionalEnvironmentProperties extends {}> = {
   /**
@@ -487,38 +488,6 @@ export const RestrictedApplication = <
   );
 };
 RestrictedApplication.displayName = 'RestrictedApplication';
-
-/**
- * NOTE:
- *   This function try-catches around a `JSON.parse` and return
- *   the parsed value whenever possible.
- *
- *   This allows parsing most primitive values.
- *
- *   - `JSON.parse('null')` => `null`
- *   - `JSON.parse('1')` => `1`
- *   - `JSON.parse('["a", "b"]')` => `['a', 'b']`
- */
-const getCoerceEnvironmentValue = (environmentValueAsString: unknown) => {
-  try {
-    return JSON.parse(String(environmentValueAsString));
-  } catch (e) {
-    return environmentValueAsString;
-  }
-};
-
-type ShallowJson = { [key: string]: unknown };
-const shallowlyCoerceValues = (uncoercedEnvironmentValues: ShallowJson) =>
-  Object.keys(uncoercedEnvironmentValues).reduce(
-    (coercedEnvironmentValues, key) => {
-      const uncoercedEnvironmentValue = uncoercedEnvironmentValues[key];
-      return {
-        ...coercedEnvironmentValues,
-        [key]: getCoerceEnvironmentValue(uncoercedEnvironmentValue),
-      };
-    },
-    {}
-  );
 
 const ApplicationShell = <AdditionalEnvironmentProperties extends {}>(
   props: Props<AdditionalEnvironmentProperties>

--- a/packages/application-shell/src/components/application-shell/coerce-values.spec.ts
+++ b/packages/application-shell/src/components/application-shell/coerce-values.spec.ts
@@ -7,18 +7,25 @@ describe('given a JSON with stringified values', () => {
     expect(result).toMatchInlineSnapshot(`
       Object {
         "array": Array [
+          "hello",
+          "world",
+        ],
+        "arrayAsString": Array [
           "1",
           "2",
         ],
-        "arrayWithDoubleEscapedQuotes": Array [
+        "arrayAsStringWithDoubleEscapedQuotes": Array [
           "1",
           "2",
         ],
         "bool": true,
+        "boolAsString": true,
         "empty": "",
-        "emptyArray": Array [],
+        "emptyArrayAsString": Array [],
         "null": null,
+        "nullAsString": null,
         "number": 1,
+        "numberAsString": 1,
         "string": "foo",
       }
     `);

--- a/packages/application-shell/src/components/application-shell/coerce-values.spec.ts
+++ b/packages/application-shell/src/components/application-shell/coerce-values.spec.ts
@@ -1,0 +1,26 @@
+import shallowlyCoerceValues from './coerce-values';
+import coerceValuesJson from './fixtures/coerce-values.json';
+
+describe('given a JSON with stringified values', () => {
+  it('should coerce values into their primitives', () => {
+    const result = shallowlyCoerceValues(coerceValuesJson);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "array": Array [
+          "1",
+          "2",
+        ],
+        "arrayWithDoubleEscapedQuotes": Array [
+          "1",
+          "2",
+        ],
+        "bool": true,
+        "empty": "",
+        "emptyArray": Array [],
+        "null": null,
+        "number": 1,
+        "string": "foo",
+      }
+    `);
+  });
+});

--- a/packages/application-shell/src/components/application-shell/coerce-values.ts
+++ b/packages/application-shell/src/components/application-shell/coerce-values.ts
@@ -1,0 +1,35 @@
+/**
+ * NOTE:
+ *   This function try-catches around a `JSON.parse` and return
+ *   the parsed value whenever possible.
+ *
+ *   This allows parsing most primitive values.
+ *
+ *   - `JSON.parse('null')` => `null`
+ *   - `JSON.parse('1')` => `1`
+ *   - `JSON.parse('["a", "b"]')` => `['a', 'b']`
+ */
+const getCoerceEnvironmentValue = (environmentValueAsString: unknown) => {
+  try {
+    // Strip out escaped quotes. This is mostly important to coerce an array of string
+    // with escaped quotes.
+    return JSON.parse(String(environmentValueAsString).replace(/(\\")/g, '"'));
+  } catch (e) {
+    return environmentValueAsString;
+  }
+};
+
+type ShallowJson = { [key: string]: unknown };
+const shallowlyCoerceValues = (uncoercedEnvironmentValues: ShallowJson) =>
+  Object.keys(uncoercedEnvironmentValues).reduce(
+    (coercedEnvironmentValues, key) => {
+      const uncoercedEnvironmentValue = uncoercedEnvironmentValues[key];
+      return {
+        ...coercedEnvironmentValues,
+        [key]: getCoerceEnvironmentValue(uncoercedEnvironmentValue),
+      };
+    },
+    {}
+  );
+
+export default shallowlyCoerceValues;

--- a/packages/application-shell/src/components/application-shell/fixtures/coerce-values.json
+++ b/packages/application-shell/src/components/application-shell/fixtures/coerce-values.json
@@ -1,10 +1,17 @@
 {
   "empty": "",
-  "bool": "true",
-  "array": "[\"1\", \"2\"]",
-  "arrayWithDoubleEscapedQuotes": "[\\\"1\\\", \\\"2\\\"]",
-  "emptyArray": "[]",
-  "null": "null",
-  "number": "1",
-  "string": "foo"
+  "boolAsString": "true",
+  "arrayAsString": "[\"1\", \"2\"]",
+  "arrayAsStringWithDoubleEscapedQuotes": "[\\\"1\\\", \\\"2\\\"]",
+  "emptyArrayAsString": "[]",
+  "nullAsString": "null",
+  "numberAsString": "1",
+  "string": "foo",
+  "array": [
+    "hello",
+    "world"
+  ],
+  "null": null,
+  "number": 1,
+  "bool": true
 }

--- a/packages/application-shell/src/components/application-shell/fixtures/coerce-values.json
+++ b/packages/application-shell/src/components/application-shell/fixtures/coerce-values.json
@@ -1,0 +1,10 @@
+{
+  "empty": "",
+  "bool": "true",
+  "array": "[\"1\", \"2\"]",
+  "arrayWithDoubleEscapedQuotes": "[\\\"1\\\", \\\"2\\\"]",
+  "emptyArray": "[]",
+  "null": "null",
+  "number": "1",
+  "string": "foo"
+}


### PR DESCRIPTION
Nasty little edge case. I found this issue when passing a stringified array as an env variable, the injected value in the `window.app` has this value (note the double escaped quotes)

```
"foo":"[\\\"bar\\\"]"
```

This somehow causes the coercion to fail. The only solution I was able to find, was to do a `.replace` and remove the escaped character.

The mysteries of JS...