### PR TITLE
 refactor(app-shell): allow to overwrite LD client ID via application config

### DIFF
--- a/.changeset/gentle-brooms-mate.md
+++ b/.changeset/gentle-brooms-mate.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/constants': patch
+---
+
+Allow to overwrite LD client ID via application config.
+
+> This is mostly useful for internal usage on our staging environments.

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -231,7 +231,7 @@ export const RestrictedApplication = <
                   <SetupFlopFlipProvider
                     user={user}
                     projectKey={projectKeyFromUrl}
-                    appEnv={applicationEnvironment.env}
+                    ldClientSideId={applicationEnvironment.ldClientSideId}
                     flags={props.featureFlags}
                     defaultFlags={props.defaultFeatureFlags}
                   >

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -12,7 +12,7 @@ type Props = {
   user?: TFetchLoggedInUserQuery['user'];
   flags?: TFlags;
   defaultFlags?: TFlags;
-  appEnv: string;
+  ldClientSideId?: string;
   children: React.ReactNode;
   shouldDeferAdapterConfiguration?: boolean;
 };
@@ -21,9 +21,6 @@ type Props = {
 // app uses our account of LD. The value is meant to be public, so there
 // is no need to be concerned about security.
 const ldClientSideIdProduction = '5979d95f6040390cd07b5e01';
-// On our staging env we use a different ID, therefore we need to use the
-// one above only for `production` environment.
-const ldClientSideIdStaging = '5979d95f6040390cd07b5e00';
 
 export const SetupFlopFlipProvider = (props: Props) => {
   const allMenuFeatureToggles = useAllMenuFeatureToggles();
@@ -47,10 +44,10 @@ export const SetupFlopFlipProvider = (props: Props) => {
 
   const adapterArgs = React.useMemo(
     () => ({
-      clientSideId:
-        props.appEnv === 'production'
-          ? ldClientSideIdProduction
-          : ldClientSideIdStaging,
+      // Allow to overwrite the client ID, passed via the `additionalEnv` properties
+      // of the application config.
+      // This is monstly useful for internal usage on our staging environments.
+      clientSideId: props.ldClientSideId ?? ldClientSideIdProduction,
       flags,
       user: {
         key: props.user && props.user.id,
@@ -64,7 +61,7 @@ export const SetupFlopFlipProvider = (props: Props) => {
         },
       },
     }),
-    [flags, props.appEnv, props.projectKey, props.user]
+    [flags, props.ldClientSideId, props.projectKey, props.user]
   );
 
   return (

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -46,7 +46,7 @@ export const SetupFlopFlipProvider = (props: Props) => {
     () => ({
       // Allow to overwrite the client ID, passed via the `additionalEnv` properties
       // of the application config.
-      // This is monstly useful for internal usage on our staging environments.
+      // This is mostly useful for internal usage on our staging environments.
       clientSideId: props.ldClientSideId ?? ldClientSideIdProduction,
       flags,
       user: {

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -149,6 +149,7 @@ export interface ApplicationWindow extends Window {
     servedByProxy: boolean;
     // Optional properties. To use them, pass them to the `additionalEnv` object of the application config.
     mcProxyApiUrl?: string;
+    ldClientSideId?: string;
     trackingSentry?: string;
     trackingGtm?: string;
     enableSignUp?: boolean;


### PR DESCRIPTION
PS: this is also to avoid relying on the `window.app.env` value.