### PR TITLE
refactor(html-template): remove legacy storage buckets from default CSP directives

### DIFF
--- a/.changeset/breezy-shirts-dream.md
+++ b/.changeset/breezy-shirts-dream.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Remove legacy Google Storage Buckets from default CSP directives

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -58,10 +58,6 @@ const processHeaders = (applicationConfig) => {
       'default-src': "'none'",
       'script-src': [
         "'self'",
-        // NOTE: trailing slash is important for partial URLs!
-        'storage.googleapis.com/mc-production-eu/',
-        'storage.googleapis.com/mc-production-us/',
-        'storage.googleapis.com/mc-production-asia/',
         'www.googletagmanager.com/gtm.js',
         'www.google-analytics.com/analytics.js',
       ].concat(
@@ -85,14 +81,7 @@ const processHeaders = (applicationConfig) => {
         isMcDevEnv ? ['ws:', 'localhost:8080', 'webpack-internal:'] : []
       ),
       'img-src': ['*', 'data:'],
-      'style-src': [
-        "'self'",
-        'fonts.googleapis.com',
-        'data:',
-        'storage.googleapis.com/mc-production-eu/',
-        'storage.googleapis.com/mc-production-us/',
-        'storage.googleapis.com/mc-production-asia/',
-      ].concat(
+      'style-src': ["'self'", 'fonts.googleapis.com', 'data:'].concat(
         // TODO: investigate what needs to be done to avoid unsafe-inline styles
         // https://github.com/commercetools/merchant-center-frontend/pull/5223#discussion_r210367636
         ["'unsafe-inline'"]


### PR DESCRIPTION
This is not necessary anymore, as with the new application config, given that we pass the `env.production.cdnUrl`, the storage buckets are automatically assigned to the CSP headers.