### PR TITLE
fix(mc-scripts/extract-intl): fix console warning

### DIFF
--- a/.changeset/gold-olives-tie.md
+++ b/.changeset/gold-olives-tie.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix console warning. Replaced `console.warning` with `console.warn`

--- a/packages/mc-scripts/src/extract-intl.js
+++ b/packages/mc-scripts/src/extract-intl.js
@@ -30,7 +30,7 @@ const flags = mri(process.argv.slice(2), {
 });
 const commands = flags._;
 
-console.warning(`
+console.warn(`
 This command has been deprecated. To extract React Intl message please refer to the "@formatjs/cli" message extraction.
 https://formatjs.io/docs/getting-started/message-extraction
 


### PR DESCRIPTION
#### Summary

- `mc-scripts/extract-intl` => fix the wrong usage of console warning. Replaced `console.warning` with `console.warn`