### PR TITLE
Add new mc-api domains to the CSP headers

### DIFF
--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -69,6 +69,8 @@ const processHeaders = (applicationConfig) => {
       ),
       'connect-src': [
         "'self'",
+        '*.aws.commercetools.com',
+        '*.gcp.commercetools.com',
         'mc-api.commercetools.com', // TODO: deprecated, to be removed when we switch-off the legacy hostnames
         'mc-api.commercetools.co', // TODO: deprecated, to be removed when we switch-off the legacy hostnames
         'app.launchdarkly.com',


### PR DESCRIPTION
#### Summary

This adds the new api hostnames so that for example the local development server can run with the new hostnames.

#### Observed behavior

When you change the hostnames in your merchant center application to the new hostnames (`mc-api.<region_name>.<cloud_provider>.commercetools.com` local development will break because of CSP errors.

#### Expected behavior

New hostnames should be enabled in the CSP headers and the application should load without errors.

#### Technical debt & future

Not sure whether the wildcards in the domain name are the way to go, CSP does not allow any wildcards in the middle of the domain so tricks like `mc-api.*.aws.commercetools.com` will not work. A safer solution is to add each specific region and cloud provider combination to the list. But it will need a new package release for each added endpoint.

#### Visual comparison

No visual comparison.