### PR TITLE
refactor: consistent naming for `examples-starter`

### DIFF
--- a/.changeset/serious-maps-sniff.md
+++ b/.changeset/serious-maps-sniff.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-website/custom-applications': patch
+---
+
+consistent naming of `examples-starter`

--- a/website/src/content/deployment/example-deployment-vercel.mdx
+++ b/website/src/content/deployment/example-deployment-vercel.mdx
@@ -34,7 +34,7 @@ To start, we need to update the `custom-application-config.json` file with the p
 ```json title="custom-application-config.json" highlightLines="7"
 {
   "name": "mc-examples-starter",
-  "entryPointUriPath": "example-starter",
+  "entryPointUriPath": "examples-starter",
   "cloudIdentifier": "gcp-eu",
   "env": {
     "production": {

--- a/website/src/content/getting-started/installing-a-starter-application.mdx
+++ b/website/src/content/getting-started/installing-a-starter-application.mdx
@@ -56,7 +56,7 @@ Once you've authenticated, you are redirected to the application `http://localho
 
 # Renaming the application main route path
 
-The starter application defines `example-starter` as the **main application route path** (see `src/components/entry-point`). This is the route that identifies your application and is used by the proxy router. Check out the [Merchant Center architecture](/main-concepts/architecture) to know more about this.
+The starter application defines `examples-starter` as the **main application route path** (see `src/components/entry-point`). This is the route that identifies your application and is used by the proxy router. Check out the [Merchant Center architecture](/main-concepts/architecture) to know more about this.
 
 <Info>
 

--- a/website/src/content/register-applications/configuring-a-custom-application.mdx
+++ b/website/src/content/register-applications/configuring-a-custom-application.mdx
@@ -11,7 +11,7 @@ To register your Custom Application with a Merchant Center project:
 2. Fill in the _required_ fields as follows:
     * **Name**: The Custom Application's display name in the Merchant Center.
     * **Application URL**: The URL that hosts your application (for example `https://my-custom-app.com`). This should be the same as the `env.production.url` in your [application config](/development/application-config) file.
-    * **Application route path**: The main route path that serves your application. For example, in the [project starter example](https://github.com/commercetools/merchant-center-application-kit/tree/master/application-templates/starter) the value is `example-starter`. This should be the same as the `entryPointUriPath` in your [application config](/development/application-config) file.
+    * **Application route path**: The main route path that serves your application. For example, in the [project starter example](https://github.com/commercetools/merchant-center-application-kit/tree/master/application-templates/starter) the value is `examples-starter`. This should be the same as the `entryPointUriPath` in your [application config](/development/application-config) file.
 
 3. In the **Navigation links** section, fill in the fields as follows:
     * **Link labels**: The main navigation link text for your application. This is what most users will see. Click **Show all languages** to provide labels for all languages (`en`, `de`, `es`).


### PR DESCRIPTION
#### Summary

- closes https://github.com/commercetools/merchant-center-application-kit/issues/1710