### PR TITLE
docs(installing-starter): add `account` endpoint

### DIFF
--- a/.changeset/nervous-beers-exercise.md
+++ b/.changeset/nervous-beers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-website/custom-applications': patch
+---
+
+add `account` to entry-point not used by external custom application

--- a/website/src/content/getting-started/installing-a-starter-application.mdx
+++ b/website/src/content/getting-started/installing-a-starter-application.mdx
@@ -66,13 +66,14 @@ Be sure to choose a value that does not conflict with one of the official route 
 
 The official main route path values are (_the list can be extended at any time_):
 
+- `account`
 - `authentication`
-- `dashboard`
-- `products`
 - `categories`
-- `orders`
 - `customers`
+- `dashboard`
 - `discounts`
+- `orders`
+- `products`
 - `settings`
 
 You should choose a value that fits with the purpose of the application you are developing. For example, if your application manages state machines, you can choose to name the route `state-machines`.


### PR DESCRIPTION
#### Summary

- add `account` to endpoints that can not be used by an external `custom-application`
