### PR TITLE
Update Application Shell link in the docs

### DIFF
--- a/website/src/content/getting-started/tooling.mdx
+++ b/website/src/content/getting-started/tooling.mdx
@@ -50,7 +50,7 @@ Some of those packages should not need to be used directly, others are necessary
 
 - [`@commercetools-frontend/application-shell`](https://www.npmjs.com/package/@commercetools-frontend/application-shell)
 
-  This package is **the main library** used to run a Merchant Center application. See [Application Shell](/main-concepts/application-shell) for more information.
+  This package is **the main library** used to run a Merchant Center application. See [Application Shell](/components/application-shell) for more information.
 
 - [`@commercetools-frontend/application-shell-connectors`](https://www.npmjs.com/package/@commercetools-frontend/application-shell-connectors)
 


### PR DESCRIPTION
#### Summary
On the Custom Application [Tooling](https://docs.commercetools.com/custom-applications/getting-started/tooling) docs page 
**Application Shell link** currently points to the [wrong link](https://docs.commercetools.com/custom-applications/main-concepts/application-shell), but It should point to [correct link](https://docs.commercetools.com/custom-applications/components/application-shell).
