### PR TITLE
feat(app-shell): add ability to `skipTokenRetry` with variable

### DIFF
--- a/.changeset/chilled-snakes-thank.md
+++ b/.changeset/chilled-snakes-thank.md
@@ -2,11 +2,12 @@
 "@commercetools-frontend/application-shell": minor	
 ---
 
-feat(app-shell): add ability to `skipTokenRetry` via context.
+feat(app-shell): add ability to `skipTokenRetry` for Apollo queries.
 
-The commercetools Platform token is renewed once whenever it expired. This is an automatic mechanism which retries a failed request responding with `401` once based on the GraphQL target.
+The Merchant Center API Gateway assigns a commercetools platform API token in order to access the commercetools HTTP APIs. The access token eventually expires, causing requests to fail with HTTP `401`.
+A Custom Application comes with a built-in mechanism to automatically retries unauthorized requests by forcing the Merchant Center API Gateway to assign a new valid API token. This retry mechanism is configured for Apollo queries for certain GraphQL APIs.
 
-It is however useful for some requests to disable this mechanism to avoid uncalled-for network requests. We introduced a `skipTokenRetry` property on the GraphQL `context` for this.
+However, it is useful for some requests to disable this mechanism to avoid uncalled-for network requests. This is done by specifying a `skipTokenRetry` property on the Apollo query `context` object.
 
 You can skip the process of token refetching as follows:
 

--- a/.changeset/chilled-snakes-thank.md
+++ b/.changeset/chilled-snakes-thank.md
@@ -1,0 +1,17 @@
+---
+"@commercetools-frontend/application-shell": minor	
+---
+
+feat(app-shell): add ability to `skipTokenRetry` via context.
+
+The commercetools Platform token is renewed once whenever it expired. This is an automatic mechanism which retries a failed request responding with `401` once based on the GraphQL target.
+
+It is however useful for some requests to disable this mechanism to avoid uncalled-for network requests. We introduced a `skipTokenRetry` property on the GraphQL `context` for this.
+
+You can skip the process of token refetching as follows:
+
+```js
+const query = useQuery(MyGraphQLQuery, {
+   context: { skipTokenRetry: true }
+})
+```

--- a/packages/application-shell/src/apollo-links/token-retry-link.spec.js
+++ b/packages/application-shell/src/apollo-links/token-retry-link.spec.js
@@ -81,7 +81,7 @@ describe('tokenRetryLink', () => {
       it('should set `x-force-token`-header on retry', () => {
         expect(context.headers).toEqual(
           expect.objectContaining({
-            'X-Force-Token': true,
+            'X-Force-Token': 'true',
           })
         );
       });
@@ -135,7 +135,7 @@ describe('tokenRetryLink', () => {
         it('should set `x-force-token`-header on retry', () => {
           expect(context.headers).toEqual(
             expect.objectContaining({
-              'X-Force-Token': true,
+              'X-Force-Token': 'true',
             })
           );
         });
@@ -150,9 +150,8 @@ describe('tokenRetryLink', () => {
       describe('when token retry is skipped', () => {
         beforeEach(async () => {
           const headerLink = new ApolloLink((operation, forward) => {
-            operation.variables.skipTokenRetry = true;
-
             operation.setContext({
+              skipTokenRetry: true,
               headers: {
                 'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
               },
@@ -233,7 +232,7 @@ describe('supported GraphQL targets', () => {
   it('should support the `ctp` GraphQL target', () => {
     expect(
       getDoesGraphQLTargetSupportTokenRetry({
-        'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
+        headers: { 'X-Graphql-Target': GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM },
       })
     ).toBe(true);
   });
@@ -241,7 +240,7 @@ describe('supported GraphQL targets', () => {
   it('should support the `administration` GraphQL target', () => {
     expect(
       getDoesGraphQLTargetSupportTokenRetry({
-        'X-Graphql-Target': GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
+        headers: { 'X-Graphql-Target': GRAPHQL_TARGETS.ADMINISTRATION_SERVICE },
       })
     ).toBe(true);
   });
@@ -249,7 +248,7 @@ describe('supported GraphQL targets', () => {
   it('should not support the `dashboard service` GraphQL target', () => {
     expect(
       getDoesGraphQLTargetSupportTokenRetry({
-        'X-Graphql-Target': GRAPHQL_TARGETS.DASHBOARD_SERVICE,
+        headers: { 'X-Graphql-Target': GRAPHQL_TARGETS.DASHBOARD_SERVICE },
       })
     ).toBe(false);
   });
@@ -257,7 +256,7 @@ describe('supported GraphQL targets', () => {
   it('should not support the `settings service` GraphQL target', () => {
     expect(
       getDoesGraphQLTargetSupportTokenRetry({
-        'X-Graphql-Target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
+        headers: { 'X-Graphql-Target': GRAPHQL_TARGETS.SETTINGS_SERVICE },
       })
     ).toBe(true);
   });
@@ -265,7 +264,9 @@ describe('supported GraphQL targets', () => {
   it('should support the `merchant center backend service` GraphQL target', () => {
     expect(
       getDoesGraphQLTargetSupportTokenRetry({
-        'X-Graphql-Target': GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+        headers: {
+          'X-Graphql-Target': GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+        },
       })
     ).toBe(true);
   });

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -5,8 +5,8 @@ import { RetryLink } from 'apollo-link-retry';
 import {
   STATUS_CODES,
   GRAPHQL_TARGETS,
-  MC_API_SUPPORTED_HEADERS,
 } from '@commercetools-frontend/constants';
+import { SUPPORTED_HEADERS } from '../constants';
 
 // This link retries requests to the CTP API that have been rejected
 // because of an invalid/expired oauth token.
@@ -17,17 +17,21 @@ import {
 export const getDoesGraphQLTargetSupportTokenRetry = (
   context: TApolloContext
 ): boolean => {
-  const target = (context.headers?.[MC_API_SUPPORTED_HEADERS.GRAPHQL_TARGET] ||
-    context.headers?.[
-      MC_API_SUPPORTED_HEADERS.GRAPHQL_TARGET.toLowerCase()
-    ]) as TTokenRetryGraphQlTarget;
+  const graphQLTarget = (context.headers?.[
+    SUPPORTED_HEADERS.X_GRAPHQL_TARGET
+  ] || context.headers?.[SUPPORTED_HEADERS.X_GRAPHQL_TARGET.toLowerCase()]) as
+    | TTokenRetryGraphQlTarget
+    | undefined;
 
-  return [
-    GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
-    GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
-    GRAPHQL_TARGETS.SETTINGS_SERVICE,
-    GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
-  ].includes(target);
+  return Boolean(
+    graphQLTarget &&
+      [
+        GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
+        GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
+        GRAPHQL_TARGETS.SETTINGS_SERVICE,
+        GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+      ].includes(graphQLTarget)
+  );
 };
 export const getSkipTokenRetry = (context: TApolloContext): boolean => {
   const skipTokenRetry = Boolean(context.skipTokenRetry);
@@ -39,7 +43,7 @@ const forwardTokenRetryHeader = (
   headers: TApolloContext['headers']
 ): TApolloContext['headers'] => ({
   ...headers,
-  [MC_API_SUPPORTED_HEADERS.TOKEN_RETRY]: 'true',
+  [SUPPORTED_HEADERS.X_TOKEN_RETRY]: 'true',
 });
 
 const tokenRetryLink = new RetryLink({

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -21,8 +21,10 @@ type ApolloContext = {
 export const getDoesGraphQLTargetSupportTokenRetry = (
   context: ApolloContext
 ): boolean => {
-  const target = (context.headers['X-Graphql-Target'] ||
-    context.headers['x-graphql-target']) as TTokenRetryGraphQlTarget;
+  const target = (context.headers[MC_API_SUPPORTED_HEADERS.TOKEN_RETRY] ||
+    context.headers[
+      MC_API_SUPPORTED_HEADERS.TOKEN_RETRY.toLowerCase()
+    ]) as TTokenRetryGraphQlTarget;
 
   return [
     GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -1,4 +1,3 @@
-import type { TTokenRetryGraphQlTarget } from '@commercetools-frontend/constants';
 import type { TApolloContext } from '../utils/apollo-context';
 
 import { RetryLink } from 'apollo-link-retry';
@@ -7,6 +6,12 @@ import {
   GRAPHQL_TARGETS,
 } from '@commercetools-frontend/constants';
 import { SUPPORTED_HEADERS } from '../constants';
+
+type TTokenRetryGraphQlTarget =
+  | typeof GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM
+  | typeof GRAPHQL_TARGETS.SETTINGS_SERVICE
+  | typeof GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND
+  | typeof GRAPHQL_TARGETS.ADMINISTRATION_SERVICE;
 
 // This link retries requests to the CTP API that have been rejected
 // because of an invalid/expired oauth token.

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -1,13 +1,11 @@
+import type { TTokenRetryGraphQlTarget } from '@commercetools-frontend/constants';
+
 import { RetryLink } from 'apollo-link-retry';
 import {
   STATUS_CODES,
   GRAPHQL_TARGETS,
   MC_API_SUPPORTED_HEADERS,
 } from '@commercetools-frontend/constants';
-
-type TokenRetryGraphQlTarget =
-  | typeof GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM
-  | typeof GRAPHQL_TARGETS.ADMINISTRATION_SERVICE;
 
 type ApolloContext = {
   headers: { [key: string]: string };
@@ -24,7 +22,7 @@ export const getDoesGraphQLTargetSupportTokenRetry = (
   context: ApolloContext
 ): boolean => {
   const target = (context.headers['X-Graphql-Target'] ||
-    context.headers['x-graphql-target']) as TokenRetryGraphQlTarget;
+    context.headers['x-graphql-target']) as TTokenRetryGraphQlTarget;
 
   return [
     GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -17,9 +17,9 @@ import {
 export const getDoesGraphQLTargetSupportTokenRetry = (
   context: TApolloContext
 ): boolean => {
-  const target = (context.headers?.[MC_API_SUPPORTED_HEADERS.TOKEN_RETRY] ||
+  const target = (context.headers?.[MC_API_SUPPORTED_HEADERS.GRAPHQL_TARGET] ||
     context.headers?.[
-      MC_API_SUPPORTED_HEADERS.TOKEN_RETRY.toLowerCase()
+      MC_API_SUPPORTED_HEADERS.GRAPHQL_TARGET.toLowerCase()
     ]) as TTokenRetryGraphQlTarget;
 
   return [

--- a/packages/application-shell/src/apollo-links/token-retry-link.ts
+++ b/packages/application-shell/src/apollo-links/token-retry-link.ts
@@ -2,6 +2,7 @@ import { RetryLink } from 'apollo-link-retry';
 import {
   STATUS_CODES,
   GRAPHQL_TARGETS,
+  MC_API_SUPPORTED_HEADERS,
 } from '@commercetools-frontend/constants';
 
 type TokenRetryGraphQlTarget =
@@ -18,8 +19,6 @@ type ApolloContext = {
 // To do so, we resend the request with the header "X-Force-Token: true"
 // so that the MC BE can issue a new token.
 // NOTE: the retry is not meant to work for the MC access token.
-
-const TOKEN_RETRY_HEADER_NAME = 'X-Force-Token';
 
 export const getDoesGraphQLTargetSupportTokenRetry = (
   context: ApolloContext
@@ -44,7 +43,7 @@ const forwardTokenRetryHeader = (
   headers: ApolloContext['headers']
 ): ApolloContext['headers'] => ({
   ...headers,
-  [TOKEN_RETRY_HEADER_NAME]: 'true',
+  [MC_API_SUPPORTED_HEADERS.TOKEN_RETRY]: 'true',
 });
 
 const tokenRetryLink = new RetryLink({

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -529,7 +529,7 @@ describe('when user is not authenticated', () => {
   beforeEach(() => {
     window.localStorage.getItem.mockReturnValue(null);
     mockServer.use(
-      graphql.query('AmILoggedIn', (req, res, ctx) => res(ctx.status(401)))
+      graphql.query('AmILoggedIn', (req, res, ctx) => res.once(ctx.status(401)))
     );
   });
   it('should redirect to /login with reason "unauthorized"', async () => {

--- a/packages/application-shell/src/components/authenticated/am-i-logged-in.tsx
+++ b/packages/application-shell/src/components/authenticated/am-i-logged-in.tsx
@@ -26,6 +26,8 @@ const AmILoggedIn = (props: Props) => {
   >(AmILoggedInQuery, {
     variables: {
       target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+    },
+    context: {
       skipTokenRetry: true,
     },
     // NOTE: With `no-cache` the `useQuery` will not trigger a

--- a/packages/application-shell/src/components/authenticated/am-i-logged-in.tsx
+++ b/packages/application-shell/src/components/authenticated/am-i-logged-in.tsx
@@ -24,7 +24,10 @@ const AmILoggedIn = (props: Props) => {
     TAmILoggedInQuery,
     TAmILoggedInQueryVariables
   >(AmILoggedInQuery, {
-    variables: { target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND },
+    variables: {
+      target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+      skipTokenRetry: true,
+    },
     // NOTE: With `no-cache` the `useQuery` will not trigger a
     // re-render of the `AmILoggedIn` component. Relying on a default
     // fetch policy results in rendering the component without refetching the data

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -7,6 +7,7 @@ export const SUPPORTED_HEADERS = {
   X_GRAPHQL_TARGET: 'X-Graphql-Target',
   X_PROJECT_KEY: 'X-Project-Key',
   X_TEAM_ID: 'X-Team-Id',
+  X_TOKEN_RETRY: 'X-Force-Token',
 } as const;
 
 export const CONTAINERS = {

--- a/packages/application-shell/src/utils/apollo-context.ts
+++ b/packages/application-shell/src/utils/apollo-context.ts
@@ -4,6 +4,8 @@ export type TApolloContext = {
   uri?: string;
   forwardToConfig?: { version: string; uri: string };
   skipGraphQlTargetCheck?: boolean;
+  headers?: { [key: string]: string };
+  skipTokenRetry?: boolean;
 };
 
 type TApolloContextProxyForwardTo = {

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -139,12 +139,6 @@ export type TTokenRetryGraphQlTarget =
   | typeof GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND
   | typeof GRAPHQL_TARGETS.ADMINISTRATION_SERVICE;
 
-export const MC_API_SUPPORTED_HEADERS = {
-  TOKEN_RETRY: 'X-Force-Token',
-  GRAPHQL_TARGET: 'X-Graphql-Target',
-} as const;
-export type TMcApiSupportedHeaders = typeof MC_API_SUPPORTED_HEADERS[keyof typeof MC_API_SUPPORTED_HEADERS];
-
 // Global application environment on window object
 export interface ApplicationWindow extends Window {
   dataLayer: unknown[];

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -133,6 +133,12 @@ export const MC_API_PROXY_TARGETS = {
 } as const;
 export type TMcApiProxyTargets = typeof MC_API_PROXY_TARGETS[keyof typeof MC_API_PROXY_TARGETS];
 
+export type TTokenRetryGraphQlTarget =
+  | typeof GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM
+  | typeof GRAPHQL_TARGETS.SETTINGS_SERVICE
+  | typeof GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND
+  | typeof GRAPHQL_TARGETS.ADMINISTRATION_SERVICE;
+
 export const MC_API_SUPPORTED_HEADERS = {
   TOKEN_RETRY: 'X-Force-Token',
 } as const;

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -133,12 +133,6 @@ export const MC_API_PROXY_TARGETS = {
 } as const;
 export type TMcApiProxyTargets = typeof MC_API_PROXY_TARGETS[keyof typeof MC_API_PROXY_TARGETS];
 
-export type TTokenRetryGraphQlTarget =
-  | typeof GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM
-  | typeof GRAPHQL_TARGETS.SETTINGS_SERVICE
-  | typeof GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND
-  | typeof GRAPHQL_TARGETS.ADMINISTRATION_SERVICE;
-
 // Global application environment on window object
 export interface ApplicationWindow extends Window {
   dataLayer: unknown[];

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -141,6 +141,7 @@ export type TTokenRetryGraphQlTarget =
 
 export const MC_API_SUPPORTED_HEADERS = {
   TOKEN_RETRY: 'X-Force-Token',
+  GRAPHQL_TARGET: 'X-Graphql-Target',
 } as const;
 export type TMcApiSupportedHeaders = typeof MC_API_SUPPORTED_HEADERS[keyof typeof MC_API_SUPPORTED_HEADERS];
 

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -133,6 +133,11 @@ export const MC_API_PROXY_TARGETS = {
 } as const;
 export type TMcApiProxyTargets = typeof MC_API_PROXY_TARGETS[keyof typeof MC_API_PROXY_TARGETS];
 
+export const MC_API_SUPPORTED_HEADERS = {
+  TOKEN_RETRY: 'X-Force-Token',
+} as const;
+export type TMcApiSupportedHeaders = typeof MC_API_SUPPORTED_HEADERS[keyof typeof MC_API_SUPPORTED_HEADERS];
+
 // Global application environment on window object
 export interface ApplicationWindow extends Window {
   dataLayer: unknown[];


### PR DESCRIPTION
#### Summary

This pull request adds the ability to skip the token retry with a query variable.

In a prior PR we added the ability to retry the request while receiving a new token on requests to our MC API. While I think this is still valid I wonder if we can skip this for certain requests.

When a user is not logged in for example we should not have to retry the token refetching. Not that with it it's a problem but we can avoid a round trip.

The idea is to add a variable which instructs the apollo link to skip setting the header.