### PR TITLE
fix(app-shell): to handle errors without extentions property

### DIFF
--- a/.changeset/cold-points-doubt.md
+++ b/.changeset/cold-points-doubt.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch	
+---
+
+fix(app-shell): to handle errors without extentions property

--- a/packages/application-shell/src/apollo-links/error-link.spec.js
+++ b/packages/application-shell/src/apollo-links/error-link.spec.js
@@ -120,7 +120,7 @@ describe('with unauthenticated error', () => {
           expect(values).toEqual([responses.success]);
         });
       });
-      describe('when unauthorized via status code', () => {
+      describe('when unauthorized via message', () => {
         beforeEach(async () => {
           const debugLink = new ApolloLink((operation, forward) => {
             context = operation.getContext();

--- a/packages/application-shell/src/apollo-links/error-link.spec.js
+++ b/packages/application-shell/src/apollo-links/error-link.spec.js
@@ -68,7 +68,6 @@ describe('with unauthenticated error', () => {
       },
       unauthenticatedWithStatusCode: {
         data: null,
-        statusCode: 401,
         errors: [
           {
             message: 'invalid_token',

--- a/packages/application-shell/src/apollo-links/error-link.ts
+++ b/packages/application-shell/src/apollo-links/error-link.ts
@@ -36,8 +36,12 @@ const errorLink = onError(
       const context = operation.getContext() as TApolloContext;
 
       for (const err of graphQLErrors) {
+        const isNonAuthenticatedViaExtensionCode =
+          err?.extensions?.code === 'UNAUTHENTICATED';
+        const isNonAuthenticatedViaCode = err?.message === 'invalid_token';
+
         if (
-          err?.extensions?.code === 'UNAUTHENTICATED' &&
+          (isNonAuthenticatedViaExtensionCode || isNonAuthenticatedViaCode) &&
           getDoesGraphQLTargetSupportTokenRetry(context) &&
           !getSkipTokenRetry(context)
         ) {

--- a/packages/application-shell/src/apollo-links/error-link.ts
+++ b/packages/application-shell/src/apollo-links/error-link.ts
@@ -38,6 +38,13 @@ const errorLink = onError(
       for (const err of graphQLErrors) {
         const isNonAuthenticatedViaExtensionCode =
           err?.extensions?.code === 'UNAUTHENTICATED';
+        /**
+         * NOTE:
+         *   Not not all GraphQL APIs expose an `extensions` field in
+         *   each error. For those we have to use the `message`
+         *   property until they introduced support for the `extensions`
+         *   field.
+         */
         const isNonAuthenticatedViaCode = err?.message === 'invalid_token';
 
         if (

--- a/packages/application-shell/src/apollo-links/utils.ts
+++ b/packages/application-shell/src/apollo-links/utils.ts
@@ -60,7 +60,11 @@ const isGraphQLError = (
   error: ErrorResponse['graphQLErrors']
 ): error is GraphQLError[] =>
   Array.isArray(error) &&
-  error.some((err) => (err as GraphQLError).extensions !== undefined);
+  error.some(
+    (err) =>
+      (err as GraphQLError).message !== undefined ||
+      (err as GraphQLError).extensions !== undefined
+  );
 
 export {
   getSkipTokenRetry,


### PR DESCRIPTION
#### Summary

This pull request fixes token regeneration for GraphQL APIs which do not have an `extentions` property.

#### Description

Some internal APIs do not expose an `extensions` property but an error which looks e.g. like this

```json
{"statusCode":401,"message":"invalid_token","errors":[{"code":"invalid_token","message":"invalid_token"}],"error":"invalid_token"}
```

As a result I propose that we don't only assume a GraphQL error based on the presence of the `extensions` property but also based on the `message` property which is part of the `GraphQLError` type. Please note that `code` is actually not part of it.