### PR TITLE
fix(navbar): timing of updating menu open local storage to eliminate navbar state change during window resize

### DIFF
--- a/.changeset/tall-eyes-deliver.md
+++ b/.changeset/tall-eyes-deliver.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+fix(navbar): timing of updating menu open local storage to eliminate navbar state change during window resize

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -221,15 +221,12 @@ const useNavbarStateManager = (props: HookProps) => {
       dispatch({ type: 'unsetActiveItemIndex' });
     }
     dispatch({ type: 'toggleIsMenuOpen' });
-  }, [state.activeItemIndex, state.isMenuOpen]);
-
-  // Synchronize the menu state with local storage.
-  React.useEffect(() => {
+    // Synchronize the menu state with local storage.
     window.localStorage.setItem(
       STORAGE_KEYS.IS_FORCED_MENU_OPEN,
-      String(state.isMenuOpen)
+      String(!state.isMenuOpen)
     );
-  }, [state.isMenuOpen]);
+  }, [state.activeItemIndex, state.isMenuOpen]);
 
   const allApplicationNavbarMenu = (applicationsNavBarMenu || []).concat(
     customAppsMenu


### PR DESCRIPTION
#### Summary

- Moved updating the `STORAGE_KEYS.IS_FORCED_MENU_OPEN` into the `handleToggleMenu` callback from its own `useEffect` hook to avoid the timing issue described below.

#### Description

After collapsing the navbar and expanding it, the `STORAGE_KEYS.IS_FORCED_MENU_OPEN` local storage value was not being updated soon enough. Upon resizing the browser, the navbar would open and close repeatedly in this state.

This issue is causing one of the dashboard widgets not to resize.

https://jira.commercetools.com/browse/PANGOLIN-414

**Before**
![2020-09-30 09 05 26](https://user-images.githubusercontent.com/8136478/94688908-35a5bb00-02fc-11eb-835a-6751ea7bc27d.gif)

**After**
![2020-09-30 09 07 24](https://user-images.githubusercontent.com/8136478/94689093-6f76c180-02fc-11eb-89f7-bbb2a2af03a7.gif)
