### PR TITLE
test(app-kit): remove use of `enzyme` in playground and application-templates/starter

### DIFF
--- a/.changeset/dry-onions-tap.md
+++ b/.changeset/dry-onions-tap.md
@@ -1,0 +1,6 @@
+---
+'merchant-center-application-template-starter': patch
+'playground': patch
+---
+
+remove use of `enzyme`

--- a/application-templates/starter/src/components/entry-point/entry-point.spec.js
+++ b/application-templates/starter/src/components/entry-point/entry-point.spec.js
@@ -1,13 +1,42 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { renderAppWithRedux } from '@commercetools-frontend/application-shell/test-utils';
 import { ApplicationStarter } from './entry-point';
 
-describe('rendering', () => {
-  let wrapper;
-  beforeEach(() => {
-    wrapper = shallow(<ApplicationStarter />);
+const render = (options) => {
+  return renderAppWithRedux(<ApplicationStarter />, {
+    permissions: {
+      canViewProducts: true,
+    },
+    ...options,
   });
-  it('should render examples-starter route', () => {
-    expect(wrapper).toRender({ path: '/:projectKey/examples-starter' });
+};
+
+describe('when route matches', () => {
+  it('should render view', async () => {
+    const rendered = render({
+      route: '/my-project/examples-starter',
+    });
+    await rendered.findByText(/Page one/i);
+  });
+});
+
+describe('when route does not match', () => {
+  it('should render catch all', async () => {
+    const rendered = render({
+      route: '/my-project/xyz',
+    });
+    await rendered.findByText(/we could not find what you are looking for/i);
+  });
+});
+
+describe('without permissions', () => {
+  it('should render `PageUnauthorized`', async () => {
+    const rendered = render({
+      route: '/my-project/examples-starter',
+      permissions: {},
+    });
+    await rendered.findByText(
+      /not enough permissions to access this resource/i
+    );
   });
 });

--- a/playground/src/components/entry-point/entry-point.spec.js
+++ b/playground/src/components/entry-point/entry-point.spec.js
@@ -1,13 +1,56 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { MC_API_PROXY_TARGETS } from '@commercetools-frontend/constants';
+import { renderAppWithRedux } from '@commercetools-frontend/application-shell/test-utils';
 import { ApplicationStateMachines } from './entry-point';
 
-describe('rendering', () => {
-  let wrapper;
-  beforeEach(() => {
-    wrapper = shallow(<ApplicationStateMachines />);
+const createStateMachinesListSdkMock = () => ({
+  action: {
+    type: 'SDK',
+    payload: {
+      method: 'GET',
+      service: 'states',
+      options: {
+        perPage: 25,
+        page: 1,
+      },
+      mcApiProxyTarget: MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM,
+    },
+  },
+  response: {
+    count: 25,
+    offset: 0,
+    total: 2,
+    results: [],
+  },
+});
+
+const render = (options) => {
+  return renderAppWithRedux(<ApplicationStateMachines />, {
+    sdkMocks: [createStateMachinesListSdkMock()],
+    permissions: {
+      canViewDeveloperSettings: true,
+      canManageDeveloperSettings: true,
+    },
+    ...options,
   });
-  it('should render state-machines route', () => {
-    expect(wrapper).toRender({ path: '/:projectKey/state-machines' });
+};
+
+describe('when route is /state-machines', () => {
+  let rendered;
+  it('should render state machines', async () => {
+    rendered = render({
+      route: '/project/state-machines',
+    });
+    await rendered.findByText(/State machines/i);
+  });
+});
+
+describe('when route is not /state-machines', () => {
+  let rendered;
+  it('should render catch all', async () => {
+    rendered = render({
+      route: '/project/xyz',
+    });
+    await rendered.findByText(/we could not find what you are looking for/i);
   });
 });


### PR DESCRIPTION
#### Summary

- removes use of `enzyme` in `playground` and `application-templates`
- address one of https://github.com/commercetools/merchant-center-application-kit/issues/1769

#### Description

There is still use of `enzyme` in `SDK.Get`. I split that in a separate step.

EDIT:
I don't think it makes sense yet to update the docs.
