### PR TITLE
fix(csp): use wildcard for sentry.io for matching subdomains

### DIFF
--- a/.changeset/beige-beers-join.md
+++ b/.changeset/beige-beers-join.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Fix default CSP `connect-src` directive to match all attempts to load from any subdomain of `sentry.io`

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -75,7 +75,8 @@ const processHeaders = (applicationConfig) => {
         'clientstream.launchdarkly.com',
         'events.launchdarkly.com',
         'app.getsentry.com',
-        'sentry.io',
+        // Match all attempts to load from any subdomain of `sentry.io`
+        '*.sentry.io',
         'www.google-analytics.com',
       ].concat(
         isMcDevEnv ? ['ws:', 'localhost:8080', 'webpack-internal:'] : []


### PR DESCRIPTION
<img width="739" alt="image" src="https://user-images.githubusercontent.com/1110551/94925795-15265e00-04c0-11eb-8fd5-bc99227933f2.png">
