### PR TITLE
fix(app-shell/components): keyboard navigation of user settings menu

### DIFF
--- a/.changeset/clean-snakes-sort.md
+++ b/.changeset/clean-snakes-sort.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Improved keyboard navigation on the user settings menu.

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -159,7 +159,10 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
   return (
     <div
       onKeyDown={(event) => {
-        if (event.key === 'Tab' && !getIsFocusedElementInMenu()) {
+        if (
+          event.key === 'Esc' ||
+          (event.key === 'Tab' && !getIsFocusedElementInMenu())
+        ) {
           props.downshiftProps.closeMenu();
         }
       }}

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -75,9 +75,7 @@ const UserAvatar = (
 UserAvatar.displayName = 'UserAvatar';
 
 function getIsFocusedElementInMenu() {
-  return Boolean(
-    document.activeElement?.attributes['data-user-settings-menu']
-  );
+  return Boolean(document.activeElement?.attributes['data-user-settings-menu']);
 }
 
 const stateReducer: DownshiftProps<{}>['stateReducer'] = (state, changes) => {
@@ -87,7 +85,7 @@ const stateReducer: DownshiftProps<{}>['stateReducer'] = (state, changes) => {
     case Downshift.stateChangeTypes.blurButton:
       return {
         ...changes,
-        isOpen: state.isOpen && getIsFocusedElementInMenu() ?? false,
+        isOpen: (state.isOpen && getIsFocusedElementInMenu()) ?? false,
       };
     default:
       return changes;

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -75,7 +75,9 @@ const UserAvatar = (
 UserAvatar.displayName = 'UserAvatar';
 
 function getIsFocusedElementInMenu() {
-  return Boolean(document.activeElement?.attributes['data-user-settings-menu']);
+  return Boolean(
+    document.activeElement?.getAttribute('data-user-settings-menu')
+  );
 }
 
 const stateReducer: DownshiftProps<{}>['stateReducer'] = (state, changes) => {
@@ -135,7 +137,7 @@ const getUserSettingsMenuItemLinkStyles = () => css`
 
 const UserSettingsMenuBody = (props: MenuBodyProps) => {
   // Focus on a menu item when it's opened through keyboard
-  const menuElementRef = React.useRef(null);
+  const menuElementRef = React.useRef<HTMLElement>(null);
   React.useEffect(() => {
     menuElementRef.current?.focus();
   }, []);

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -76,7 +76,7 @@ UserAvatar.displayName = 'UserAvatar';
 
 function getIsFocusedElementInMenu() {
   return Boolean(
-    document?.activeElement?.attributes['data-user-settings-menu']
+    document.activeElement?.attributes['data-user-settings-menu']
   );
 }
 

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -87,7 +87,7 @@ const stateReducer: DownshiftProps<{}>['stateReducer'] = (state, changes) => {
     case Downshift.stateChangeTypes.blurButton:
       return {
         ...changes,
-        isOpen: state.isOpen && getIsFocusedElementInMenu() ? true : false,
+        isOpen: state.isOpen && getIsFocusedElementInMenu() ?? false,
       };
     default:
       return changes;
@@ -138,11 +138,8 @@ const getUserSettingsMenuItemLinkStyles = () => css`
 const UserSettingsMenuBody = (props: MenuBodyProps) => {
   // Focus on a menu item when it's opened through keyboard
   const menuElementRef = React.useRef(null);
-  const setFocus = () => {
-    menuElementRef.current?.focus();
-  };
   React.useEffect(() => {
-    setFocus();
+    menuElementRef.current?.focus();
   }, []);
 
   const servedByProxy = useApplicationContext(
@@ -223,7 +220,7 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
           rel="noopener noreferrer"
           onClick={() => props.downshiftProps.toggleMenu()}
           data-user-settings-menu
-          ref={applicationsAppBarMenu ? undefined : menuElementRef}
+          ref={!applicationsAppBarMenu ? menuElementRef : undefined}
         >
           <MenuItem>
             <Spacings.Inset scale="s">

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -143,7 +143,7 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
   };
   React.useEffect(() => {
     setFocus();
-  });
+  }, []);
 
   const servedByProxy = useApplicationContext(
     (context) => context.environment.servedByProxy

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -137,7 +137,7 @@ const getUserSettingsMenuItemLinkStyles = () => css`
 
 const UserSettingsMenuBody = (props: MenuBodyProps) => {
   // Focus on a menu item when it's opened through keyboard
-  const menuElementRef = React.useRef<HTMLElement>(null);
+  const menuElementRef = React.useRef<HTMLAnchorElement>(null);
   React.useEffect(() => {
     menuElementRef.current?.focus();
   }, []);


### PR DESCRIPTION
#### Summary

This PR fixes the keyboard navigation on the user settings menu, so that the menu only opens when its toggle button is pressed (with `Enter` or `Space`) and doesn't remain open when the user navigates out of it.

It can also be closed with the `Esc` key.

![Kapture 2020-10-07 at 12 30 01](https://user-images.githubusercontent.com/2941328/95320335-a4a18780-0899-11eb-9afc-c150299e1425.gif)
