### PR TITLE
feat(app-shell): to add hideMenuItems property

### DIFF
--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -78,6 +78,7 @@ type Props<AdditionalEnvironmentProperties extends {}> = {
   // Use `trackingEventList` instead.
   trackingEventWhitelist?: TrackingList;
   trackingEventList?: TrackingList;
+  hideMenuItems?: string[];
   applicationMessages: TAsyncLocaleDataProps['applicationMessages'];
   onRegisterErrorListeners: (args: { dispatch: Dispatch }) => void;
   onMenuItemClick?: <TrackFn>(
@@ -378,6 +379,7 @@ export const RestrictedApplication = <
                                         applicationLocale={locale}
                                         projectKey={projectKeyFromUrl}
                                         environment={applicationEnvironment}
+                                        hideMenuItems={props.hideMenuItems}
                                         DEV_ONLY__loadNavbarMenuConfig={
                                           props.DEV_ONLY__loadNavbarMenuConfig
                                         }
@@ -537,6 +539,7 @@ const ApplicationShell = <AdditionalEnvironmentProperties extends {}>(
                     render={props.render}
                     applicationMessages={props.applicationMessages}
                     onMenuItemClick={props.onMenuItemClick}
+                    hideMenuItems={props.hideMenuItems}
                     DEV_ONLY__loadAppbarMenuConfig={
                       props.DEV_ONLY__loadAppbarMenuConfig
                     }

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -281,16 +281,14 @@ const isEveryMenuVisibilitySetToHidden = (
     (nameOfMenuVisibility) =>
       menuVisibilities && menuVisibilities[nameOfMenuVisibility] === true
   );
-const isMenuItemDisabledForEnvironment = (
-  keyOfMenuItem: string,
-  disabledMenuItems?: string[]
-) => disabledMenuItems && disabledMenuItems.includes(keyOfMenuItem);
+const isMenuItemHidden = (keyOfMenuItem: string, hiddenMenuItems?: string[]) =>
+  hiddenMenuItems && hiddenMenuItems.includes(keyOfMenuItem);
 
 type RestrictedMenuItemProps = {
   featureToggle?: string;
   namesOfMenuVisibilities?: string[];
   menuVisibilities?: TApplicationContext<{}>['menuVisibilities'];
-  disabledMenuItems?: string[];
+  hideMenuItems?: string[];
   keyOfMenuItem: string;
   permissions: string[];
   actionRights?: TActionRight[];
@@ -311,10 +309,7 @@ const RestrictedMenuItem = (props: RestrictedMenuItemProps) => {
       props.menuVisibilities,
       props.namesOfMenuVisibilities
     ) ||
-    isMenuItemDisabledForEnvironment(
-      props.keyOfMenuItem,
-      props.disabledMenuItems
-    )
+    isMenuItemHidden(props.keyOfMenuItem, props.hideMenuItems)
   )
     return null;
 
@@ -389,7 +384,7 @@ type ApplicationMenuProps = {
   handleToggleItem: () => void;
   applicationLocale: string;
   projectKey: string;
-  disabledMenuItems?: string[];
+  hideMenuItems?: string[];
   useFullRedirectsForLinks: boolean;
   onMenuItemClick?: MenuItemLinkProps['onClick'];
 };
@@ -422,7 +417,7 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
         dataFences={props.menu.dataFences}
         menuVisibilities={props.menuVisibilities}
         namesOfMenuVisibilities={namesOfMenuVisibilitiesOfAllSubmenus}
-        disabledMenuItems={props.disabledMenuItems}
+        hideMenuItems={props.hideMenuItems}
       >
         <MenuItem
           hasSubmenu={hasSubmenu}
@@ -484,7 +479,7 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
                         ? [submenu.menuVisibility]
                         : undefined
                     }
-                    disabledMenuItems={props.disabledMenuItems}
+                    hideMenuItems={props.hideMenuItems}
                   >
                     <li className={styles['sublist-item']}>
                       <div className={styles.text}>
@@ -538,6 +533,7 @@ type NavbarProps<AdditionalEnvironmentProperties extends {}> = {
   environment: TApplicationContext<
     AdditionalEnvironmentProperties
   >['environment'];
+  hideMenuItems?: string[];
   onMenuItemClick?: MenuItemLinkProps['onClick'];
   DEV_ONLY__loadNavbarMenuConfig?: () => Promise<TApplicationsMenu['navBar']>;
 };
@@ -557,7 +553,8 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
     environment: props.environment,
     DEV_ONLY__loadNavbarMenuConfig: props.DEV_ONLY__loadNavbarMenuConfig,
   });
-  const disabledMenuItems = props.environment.disabledMenuItems;
+  const hideMenuItems =
+    props.hideMenuItems || props.environment.disabledMenuItems;
   const useFullRedirectsForLinks = Boolean(
     props.environment.useFullRedirectsForLinks
   );
@@ -586,7 +583,7 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
                 menuVisibilities={menuVisibilities}
                 applicationLocale={props.applicationLocale}
                 projectKey={props.projectKey}
-                disabledMenuItems={disabledMenuItems}
+                hideMenuItems={hideMenuItems}
                 useFullRedirectsForLinks={useFullRedirectsForLinks}
               />
             );


### PR DESCRIPTION
#### Summary

This pull request proposes to add a `hideMenuItems` prop to the `ApplicationShell`.

#### Description

Each application currently has a non-documented feature which allows hiding menu items based on the `ctx.environment.disabledMenuItems`. We sometimes use this property internally. However, we would like to move this property to be controlled by our APIs instead of the environment to have better control over it.

The result would be to remove the `ctx.environment.disabledMenuItems` and have a non-documented `hideMenuItems` on the Application Shell. We could then feed this prop from our API.

We could also attempt to remove the `ctx.environment.disabledMenuItems` with this if our APIs and applications are already prepared for it. Open for discussions here.
