### PR TITLE
refactor(app-shell): to remove disabledMenuItems support

### DIFF
--- a/.changeset/odd-bobcats-happen.md
+++ b/.changeset/odd-bobcats-happen.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+refactor(app-shell): to remove disabbledMenuItems support

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -812,32 +812,6 @@ describe('navbar menu links interactions', () => {
     });
   });
 });
-describe('when navbar menu items are disabled', () => {
-  it('should not render disabled menu items', async () => {
-    const navbarSubmenuMock = ApplicationNavbarSubmenuMock.build();
-    const navbarMock = ApplicationNavbarMenuMock.build({
-      submenu: [navbarSubmenuMock],
-    });
-    const rendered = renderApp(null, {
-      environment: { disabledMenuItems: [navbarMock.key] },
-      DEV_ONLY__loadNavbarMenuConfig: () => Promise.resolve([navbarMock]),
-    });
-    await rendered.waitForLeftNavigationToBeLoaded();
-    // Get the nav container, to narrow down the search area
-    const container = await rendered.findByLeftNavigation();
-    const navbarRendered = within(container);
-
-    const applicationLocale = 'en';
-    const mainMenuLabel = navbarMock.labelAllLocales.find(
-      (localized) => localized.locale === applicationLocale
-    );
-    await waitFor(() => {
-      expect(
-        navbarRendered.queryByText(mainMenuLabel.value)
-      ).not.toBeInTheDocument();
-    });
-  });
-});
 describe('when navbar menu items are hidden', () => {
   beforeEach(() => {
     mockServer.resetHandlers();

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -281,16 +281,11 @@ const isEveryMenuVisibilitySetToHidden = (
     (nameOfMenuVisibility) =>
       menuVisibilities && menuVisibilities[nameOfMenuVisibility] === true
   );
-const isMenuItemDisabledForEnvironment = (
-  keyOfMenuItem: string,
-  disabledMenuItems?: string[]
-) => disabledMenuItems && disabledMenuItems.includes(keyOfMenuItem);
 
 type RestrictedMenuItemProps = {
   featureToggle?: string;
   namesOfMenuVisibilities?: string[];
   menuVisibilities?: TApplicationContext<{}>['menuVisibilities'];
-  disabledMenuItems?: string[];
   keyOfMenuItem: string;
   permissions: string[];
   actionRights?: TActionRight[];
@@ -310,10 +305,6 @@ const RestrictedMenuItem = (props: RestrictedMenuItemProps) => {
     isEveryMenuVisibilitySetToHidden(
       props.menuVisibilities,
       props.namesOfMenuVisibilities
-    ) ||
-    isMenuItemDisabledForEnvironment(
-      props.keyOfMenuItem,
-      props.disabledMenuItems
     )
   )
     return null;
@@ -389,7 +380,6 @@ type ApplicationMenuProps = {
   handleToggleItem: () => void;
   applicationLocale: string;
   projectKey: string;
-  disabledMenuItems?: string[];
   useFullRedirectsForLinks: boolean;
   onMenuItemClick?: MenuItemLinkProps['onClick'];
 };
@@ -422,7 +412,6 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
         dataFences={props.menu.dataFences}
         menuVisibilities={props.menuVisibilities}
         namesOfMenuVisibilities={namesOfMenuVisibilitiesOfAllSubmenus}
-        disabledMenuItems={props.disabledMenuItems}
       >
         <MenuItem
           hasSubmenu={hasSubmenu}
@@ -484,7 +473,6 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
                         ? [submenu.menuVisibility]
                         : undefined
                     }
-                    disabledMenuItems={props.disabledMenuItems}
                   >
                     <li className={styles['sublist-item']}>
                       <div className={styles.text}>
@@ -557,7 +545,6 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
     environment: props.environment,
     DEV_ONLY__loadNavbarMenuConfig: props.DEV_ONLY__loadNavbarMenuConfig,
   });
-  const disabledMenuItems = props.environment.disabledMenuItems;
   const useFullRedirectsForLinks = Boolean(
     props.environment.useFullRedirectsForLinks
   );
@@ -586,7 +573,6 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
                 menuVisibilities={menuVisibilities}
                 applicationLocale={props.applicationLocale}
                 projectKey={props.projectKey}
-                disabledMenuItems={disabledMenuItems}
                 useFullRedirectsForLinks={useFullRedirectsForLinks}
               />
             );

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -153,7 +153,6 @@ export interface ApplicationWindow extends Window {
     trackingSentry?: string;
     trackingGtm?: string;
     enableSignUp?: boolean;
-    disabledMenuItems?: string[];
     useFullRedirectsForLinks?: boolean;
     disableInferringOfMcApiUrlOnProduction?: boolean;
   };


### PR DESCRIPTION
#### Summary

This pull request removes the not documented `disabledMenuItems` prop.

#### Description

This prop was only used internally and can be removed as handling this will be moved to the infrastructure level.
