### PR TITLE
feat(components/modal-pages): allow use of iconLeft on secondaryButton

### DIFF
--- a/.changeset/mighty-ears-develop.md
+++ b/.changeset/mighty-ears-develop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+Allow iconLeft use on secondaryButton of modal-pages application component

--- a/packages/application-components/src/components/modal-pages/internals/default-form-buttons.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/default-form-buttons.tsx
@@ -20,6 +20,7 @@ type Props = {
   label: Label;
   onClick: (event: React.SyntheticEvent) => void;
   isDisabled: boolean;
+  iconLeft?: React.ReactNode;
   dataAttributes: { [key: string]: string };
   children?: never;
 };
@@ -57,10 +58,11 @@ FormPrimaryButton.defaultProps = primaryDefaultProps;
 
 const secondaryDefaultProps: Pick<
   Props,
-  'label' | 'isDisabled' | 'dataAttributes'
+  'label' | 'isDisabled' | 'iconLeft' | 'dataAttributes'
 > = {
   label: sharedMessages.cancel,
   isDisabled: false,
+  iconLeft: undefined,
   dataAttributes: {},
 };
 
@@ -72,6 +74,7 @@ const FormSecondaryButton = (props: Props) => {
       label={label}
       onClick={props.onClick}
       isDisabled={props.isDisabled}
+      iconLeft={props.iconLeft}
       {...filterDataAttributes(props.dataAttributes)}
     />
   );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

In discount application's rule builder quick selection context we use the secondary button of modal pages to trigger 'revert changes'. Based on the decision by the ui-team, revert changes button should have the corresponding revert icon. These changes allow the use of an icon with the secondary button of the modal pages.


