### PR TITLE
fix(quick access): wrong navigation when using product commands

### DIFF
--- a/.changeset/violet-fireants-hope.md
+++ b/.changeset/violet-fireants-hope.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Fix wrong navigation when using Quick Access Product commands

--- a/packages/application-shell/src/components/quick-access/create-commands.ts
+++ b/packages/application-shell/src/components/quick-access/create-commands.ts
@@ -57,7 +57,7 @@ const createCommands = ({
         keywords: ['Go to Products'],
         action: {
           type: actionTypes.go,
-          to: `/${applicationContext.project.key}/products`,
+          to: `/${applicationContext.project.key}/products/pim-search`,
         },
         subCommands: [
           hasSomePermissions(
@@ -68,7 +68,7 @@ const createCommands = ({
             text: intl.formatMessage(messages.openProductList),
             action: {
               type: actionTypes.go,
-              to: `/${applicationContext.project.key}/products`,
+              to: `/${applicationContext.project.key}/products/pim-search`,
             },
           },
           hasSomePermissions(

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -705,7 +705,7 @@ describe('QuickAccess', () => {
     fireEvent.keyUp(searchInput, { key: 'Enter' });
     await waitFor(() => {
       expect(rendered.history.location.pathname).toBe(
-        '/test-with-big-data/products'
+        '/test-with-big-data/products/pim-search'
       );
     });
     // should close quick access

--- a/packages/application-shell/src/components/quick-access/sub-commands.ts
+++ b/packages/application-shell/src/components/quick-access/sub-commands.ts
@@ -139,7 +139,6 @@ const createProductVariantListSubCommands = async ({
     data.product.masterData.staged &&
     applicationContext.project
   ) {
-    const projectKey = applicationContext.project;
     return data.product.masterData.staged.allVariants.map((variant) => ({
       id: `go/product(${productId})/variant(${variant.id})`,
       text: formatVariantMessage(variant, intl),
@@ -152,7 +151,7 @@ const createProductVariantListSubCommands = async ({
       action: {
         type: actionTypes.go,
         to: oneLineTrim`
-          /${projectKey}
+          /${applicationContext.project.key}
           /products
           /${productId}
           /variants

--- a/packages/application-shell/src/components/quick-access/sub-commands.ts
+++ b/packages/application-shell/src/components/quick-access/sub-commands.ts
@@ -139,6 +139,7 @@ const createProductVariantListSubCommands = async ({
     data.product.masterData.staged &&
     applicationContext.project
   ) {
+    const projectKey = applicationContext.project.key;
     return data.product.masterData.staged.allVariants.map((variant) => ({
       id: `go/product(${productId})/variant(${variant.id})`,
       text: formatVariantMessage(variant, intl),
@@ -151,7 +152,7 @@ const createProductVariantListSubCommands = async ({
       action: {
         type: actionTypes.go,
         to: oneLineTrim`
-          /${applicationContext.project.key}
+          /${projectKey}
           /products
           /${productId}
           /variants


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

Fix wrong navigation when using Quick Access Product commands.

#### Description

<!-- provide some context -->

Fix wrong navigation when using Quick Access Product commands.

- Using `Open Product List` and `Open Products` commands navigate the user to the old product list. Using them now navigate the user to the PIM list instead.
- Using `Open Variant` command navigates the user to a "We could not find this Project" page because of the malformed URL. Using it now navigates the user to the variant details page.