### PR TITLE
fix(babel): allow changing jsx runtime in babel

### DIFF
--- a/.changeset/plenty-hotels-suffer.md
+++ b/.changeset/plenty-hotels-suffer.md
@@ -9,7 +9,7 @@ feat: adds the ability to opt into the new `automatic` JSX runtime
 
 Recent React versions support a new JSX runtime. Read more about it [here](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). 
 
-You may opt into the new runtime in `automatic` mode by setting the `ENABLE_NEW_JSX_TRANSFORM` environment variable. Please note you need at least React v17 or v16.14 in your application. 
+You may opt into the new runtime in `automatic` mode by setting the `ENABLE_NEW_JSX_TRANSFORM` environment variable to `true`. Please note you need at least React v17 or v16.14 in your application. 
 Opting into the new JSX transform automatically also changes the Babel, Jest and ESLint configurations. As a conssequence ESLint will warn whenever it discovers React being in scope by importing it as `import React from 'react`'. You have to remove those imports using the respective codemod by running `npx react-codemod update-react-imports`.
 
 Lastly, all code of the Merchant Center Application Kit will continue to be bundled in `classic` mode to support older versions of React.

--- a/.changeset/plenty-hotels-suffer.md
+++ b/.changeset/plenty-hotels-suffer.md
@@ -1,0 +1,15 @@
+---
+"@commercetools-frontend/babel-preset-mc-app": minor
+"@commercetools-frontend/eslint-config-mc-app": minor
+"@commercetools-frontend/jest-preset-mc-app": minor
+"@commercetools-frontend/mc-scripts": minor
+---
+
+feat: adds the ability to opt into the new `automatic` JSX runtime
+
+Recent React versions support a new JSX runtime. Read more about it [here](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). 
+
+You may opt into the new runtime in `automatic` mode by setting the `ENABLE_NEW_JSX_TRANSFORM` environment variable. Please note you need at least React v17 or v16.14 in your application. 
+Opting into the new JSX transform automatically also changes the Babel, Jest and ESLint configurations. As a conssequence ESLint will warn whenever it discovers React being in scope by importing it as `import React from 'react`'. You have to remove those imports using the respective codemod by running `npx react-codemod update-react-imports`.
+
+Lastly, all code of the Merchant Center Application Kit will continue to be bundled in `classic` mode to support older versions of React.

--- a/.changeset/plenty-hotels-suffer.md
+++ b/.changeset/plenty-hotels-suffer.md
@@ -10,6 +10,6 @@ feat: adds the ability to opt into the new `automatic` JSX runtime
 Recent React versions support a new JSX runtime. Read more about it [here](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). 
 
 You may opt into the new runtime in `automatic` mode by setting the `ENABLE_NEW_JSX_TRANSFORM` environment variable to `true`. Please note you need at least React v17 or v16.14 in your application. 
-Opting into the new JSX transform automatically also changes the Babel, Jest and ESLint configurations. As a conssequence ESLint will warn whenever it discovers React being in scope by importing it as `import React from 'react`'. You have to remove those imports using the respective codemod by running `npx react-codemod update-react-imports`.
+Opting into the new JSX transform automatically also changes the Babel, Jest and ESLint configurations. As a consequence ESLint will warn whenever it discovers React being in scope by importing it as `import React from 'react`'. You have to remove those imports using the respective codemod by running `npx react-codemod update-react-imports`.
 
 Lastly, all code of the Merchant Center Application Kit will continue to be bundled in `classic` mode to support older versions of React.

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable global-require */
-module.exports = function getBabePresetConfigForMcApp(api, opts) {
+module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
   // This is similar to how `env` works in Babel:
   // https://babeljs.io/docs/usage/babelrc/#env-option
   // We are not using `env` because it’s ignored in versions > babel-core@6.10.4:

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -9,6 +9,7 @@ module.exports = function getBabePresetConfigForMcApp() {
   const env = process.env.BABEL_ENV || process.env.NODE_ENV;
   const isEnvDevelopment = env === 'development';
   const isEnvProduction = env === 'production';
+  const jsxRuntime = process.env.JSX_RUNTIME || 'classic';
   const isEnvTest = env === 'test';
   const isRollup = process.env.BUILD_ROLLUP === true;
 
@@ -60,6 +61,9 @@ module.exports = function getBabePresetConfigForMcApp() {
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
           useBuiltIns: true,
+          // Allows changing the JSX runtime.
+          // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
+          runtime: jsxRuntime,
         },
       ],
       [

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable global-require */
-module.exports = function getBabePresetConfigForMcApp() {
+module.exports = function getBabePresetConfigForMcApp(api, opts) {
   // This is similar to how `env` works in Babel:
   // https://babeljs.io/docs/usage/babelrc/#env-option
   // We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
@@ -9,7 +9,6 @@ module.exports = function getBabePresetConfigForMcApp() {
   const env = process.env.BABEL_ENV || process.env.NODE_ENV;
   const isEnvDevelopment = env === 'development';
   const isEnvProduction = env === 'production';
-  const jsxRuntime = process.env.JSX_RUNTIME || 'classic';
   const isEnvTest = env === 'test';
   const isRollup = process.env.BUILD_ROLLUP === true;
 
@@ -60,10 +59,8 @@ module.exports = function getBabePresetConfigForMcApp() {
           development: isEnvDevelopment || isEnvTest,
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
-          ...(jsxRuntime !== 'automatic' ? { useBuiltIns: true } : {}),
-          // Allows changing the JSX runtime.
-          // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
-          runtime: jsxRuntime,
+          ...(opts.runtime !== 'automatic' ? { useBuiltIns: true } : {}),
+          runtime: opts.runtime || 'classic',
         },
       ],
       [

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -60,7 +60,7 @@ module.exports = function getBabePresetConfigForMcApp() {
           development: isEnvDevelopment || isEnvTest,
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
-          useBuiltIns: true,
+          ...(jsxRuntime !== 'automatic' ? { useBuiltIns: true } : {}),
           // Allows changing the JSX runtime.
           // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
           runtime: jsxRuntime,

--- a/packages/eslint-config-mc-app/has-jsx-runtime.js
+++ b/packages/eslint-config-mc-app/has-jsx-runtime.js
@@ -1,0 +1,14 @@
+function hasJsxRuntime() {
+  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+    return false;
+  }
+
+  try {
+    require.resolve('react/jsx-runtime');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = hasJsxRuntime;

--- a/packages/eslint-config-mc-app/has-jsx-runtime.js
+++ b/packages/eslint-config-mc-app/has-jsx-runtime.js
@@ -1,5 +1,5 @@
 function hasJsxRuntime() {
-  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+  if (process.env.ENABLE_NEW_JSX_TRANSFORM !== 'true') {
     return false;
   }
 

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -1,3 +1,5 @@
+const hasJsxRuntime = require('./has-jsx-runtime');
+
 module.exports = {
   parser: 'babel-eslint',
   parserOptions: {
@@ -94,6 +96,10 @@ module.exports = {
     'lines-between-class-members': 0,
     // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
     'no-unused-expressions': 0,
+    ...(hasJsxRuntime() && {
+      'react/jsx-uses-react': 'off',
+      'react/react-in-jsx-scope': 'off',
+    }),
   },
   overrides: [
     {

--- a/packages/jest-preset-mc-app/has-jsx-runtime.js
+++ b/packages/jest-preset-mc-app/has-jsx-runtime.js
@@ -1,0 +1,14 @@
+function hasJsxRuntime() {
+  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+    return false;
+  }
+
+  try {
+    require.resolve('react/jsx-runtime');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = hasJsxRuntime;

--- a/packages/jest-preset-mc-app/has-jsx-runtime.js
+++ b/packages/jest-preset-mc-app/has-jsx-runtime.js
@@ -1,5 +1,5 @@
 function hasJsxRuntime() {
-  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+  if (process.env.ENABLE_NEW_JSX_TRANSFORM !== 'true') {
     return false;
   }
 

--- a/packages/jest-preset-mc-app/transform-babel-jest.js
+++ b/packages/jest-preset-mc-app/transform-babel-jest.js
@@ -1,7 +1,10 @@
 const getBabePresetConfigForMcApp = require('@commercetools-frontend/babel-preset-mc-app');
 const getJestBabelPreset = require('babel-preset-jest');
+const hasJsxRuntime = require('./has-jsx-runtime');
 
-const mcAppBabelConfig = getBabePresetConfigForMcApp();
+const mcAppBabelConfig = getBabePresetConfigForMcApp(null, {
+  runtime: hasJsxRuntime(),
+});
 
 const jestBabelConfig = {
   ...mcAppBabelConfig,

--- a/packages/jest-preset-mc-app/transform-babel-jest.js
+++ b/packages/jest-preset-mc-app/transform-babel-jest.js
@@ -1,5 +1,6 @@
 const getBabePresetConfigForMcApp = require('@commercetools-frontend/babel-preset-mc-app');
 const getJestBabelPreset = require('babel-preset-jest');
+const babelJest = require('babel-jest');
 const hasJsxRuntime = require('./has-jsx-runtime');
 
 const mcAppBabelConfig = getBabePresetConfigForMcApp(null, {
@@ -11,4 +12,6 @@ const jestBabelConfig = {
   plugins: [...mcAppBabelConfig.plugins, ...getJestBabelPreset().plugins],
 };
 
-module.exports = require('babel-jest').createTransformer(jestBabelConfig);
+const transformer = babelJest.createTransformer(jestBabelConfig);
+
+module.exports = transformer;

--- a/packages/jest-preset-mc-app/transform-babel-jest.js
+++ b/packages/jest-preset-mc-app/transform-babel-jest.js
@@ -4,7 +4,7 @@ const babelJest = require('babel-jest');
 const hasJsxRuntime = require('./has-jsx-runtime');
 
 const mcAppBabelConfig = getBabePresetConfigForMcApp(null, {
-  runtime: hasJsxRuntime(),
+  runtime: hasJsxRuntime() ? 'automatic' : 'classic',
 });
 
 const jestBabelConfig = {

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.js
@@ -12,6 +12,7 @@ const postcssCustomMediaQueries = require('postcss-custom-media');
 const postcssColorModFunction = require('postcss-color-mod-function');
 const { browserslist } = require('../../package.json');
 const vendorsToTranspile = require('./vendors-to-transpile');
+const hasJsxRuntime = require('./has-jsx-runtime');
 
 const defaultToggleFlags = {
   // Allow to disable index.html generation in case it's not necessary (e.g. for Storybook)
@@ -168,6 +169,9 @@ module.exports = ({
               babelrc: false,
               presets: [
                 require.resolve('@commercetools-frontend/babel-preset-mc-app'),
+                {
+                  runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                },
               ],
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -259,7 +259,7 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
                     '@commercetools-frontend/babel-preset-mc-app'
                   ),
                   {
-                    runtime: hasJsxRuntime ? 'automatic' : 'classic',
+                    runtime: hasJsxRuntime() ? 'automatic' : 'classic',
                   },
                 ],
                 // This is a feature of `babel-loader` for webpack (not Babel itself).

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -22,6 +22,7 @@ const postcssColorModFunction = require('postcss-color-mod-function');
 const FinalStatsWriterPlugin = require('../webpack-plugins/final-stats-writer-plugin');
 const { browserslist } = require('../../package.json');
 const vendorsToTranspile = require('./vendors-to-transpile');
+const hasJsxRuntime = require('./has-jsx-runtime');
 
 const optimizeCSSConfig = {
   // Since css-loader uses cssnano v3.1.0, it's best to stick with the
@@ -257,6 +258,9 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
                   require.resolve(
                     '@commercetools-frontend/babel-preset-mc-app'
                   ),
+                  {
+                    runtime: hasJsxRuntime ? 'automatic' : 'classic',
+                  },
                 ],
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/mc-scripts/src/config/has-jsx-runtime.js
+++ b/packages/mc-scripts/src/config/has-jsx-runtime.js
@@ -1,0 +1,14 @@
+function hasJsxRuntime() {
+  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+    return false;
+  }
+
+  try {
+    require.resolve('react/jsx-runtime');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = hasJsxRuntime;

--- a/packages/mc-scripts/src/config/has-jsx-runtime.js
+++ b/packages/mc-scripts/src/config/has-jsx-runtime.js
@@ -1,5 +1,5 @@
 function hasJsxRuntime() {
-  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+  if (process.env.ENABLE_NEW_JSX_TRANSFORM !== 'true') {
     return false;
   }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ const { packageJson: pkg } = readPkgUp.sync({
 const [, packageName] = pkg.name.split('@commercetools-frontend/');
 const extensions = ['.js', '.ts', '.tsx'];
 const babelOptions = getBabelPreset(null, {
-  runtime: 'automatic',
+  runtime: 'classic',
 });
 
 const createPlugins = (format) => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,9 @@ const { packageJson: pkg } = readPkgUp.sync({
 });
 const [, packageName] = pkg.name.split('@commercetools-frontend/');
 const extensions = ['.js', '.ts', '.tsx'];
-const babelOptions = getBabelPreset();
+const babelOptions = getBabelPreset(null, {
+  runtime: 'automatic',
+});
 
 const createPlugins = (format) => {
   const isFormatEs = format === 'es';


### PR DESCRIPTION
#### Summary

This pull request adds a `JSX_RUNTIME` environment variable which can be used to set the JSX runtime to e.g. `automatic`.

The JSX runtime is configured in the mc-babel-preset through the `preset-react`. It would always continue to default to `classic`. However, this way we'd allow experimentation with the `automatic` runtime. Which is not yet supported in TypeScript (starting 4.1). 

The new runtime doesn't require React to be in scope. This means we could potentially internally already experiment with it.

There are other ways to allow the configuration. We could also pass an `jsxRuntime` argument through our webpack configs and jest config to the babel preset. However, that seems far more invasive and also at times not possible as e.g. a webpack config just does

```js
presets: [
  require.resolve('@commercetools-frontend/babel-preset-mc-app'),
]
```

While a jest config does 

```js
transform: {
  '^.+\\.js$': resolveRelativePath('./transform-babel-jest.js'),
  '^.+\\.graphql$': 'jest-transform-graphql',
},
```

which in all I fear makes argument passing hard. So the env variable might be an easy middle ground and could be eventually also default to `automatic` or be removed entirely again.

I would leave it as a `patch` change for now and not document it until we tested it internally.

[1]: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html