### PR TITLE
refactor(playground): to use explicit imports of React

### DIFF
--- a/.changeset/moody-melons-arrive.md
+++ b/.changeset/moody-melons-arrive.md
@@ -1,0 +1,5 @@
+---
+"playground": patch
+---
+
+refactor(playground): to use explicit imports of React

--- a/playground/src/components/echo-server/echo-server.js
+++ b/playground/src/components/echo-server/echo-server.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useReducer, useCallback } from 'react';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { useAsyncDispatch, actions } from '@commercetools-frontend/sdk';
 import { useOnActionError } from '@commercetools-frontend/actions-global';
@@ -24,13 +24,13 @@ const reducer = (state, action) => {
 };
 
 const EchoServer = () => {
-  const [state, dispatchState] = React.useReducer(reducer, initialState);
+  const [state, dispatchState] = useReducer(reducer, initialState);
   const dispatch = useAsyncDispatch();
   const dispatchError = useOnActionError();
   const echoServerApiUrl = useApplicationContext(
     (context) => context.environment.echoServerApiUrl
   );
-  const handleSendRequest = React.useCallback(() => {
+  const handleSendRequest = useCallback(() => {
     async function ping() {
       try {
         const result = await dispatch(

--- a/playground/src/components/entry-point/entry-point.js
+++ b/playground/src/components/entry-point/entry-point.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy, Component } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import {
   ApplicationShell,
@@ -13,7 +13,7 @@ import loadMessages from '../../messages';
 // Here we split up the main (app) bundle with the actual application business logic.
 // Splitting by route is usually recommended and you can potentially have a splitting
 // point for each route. More info at https://reactjs.org/docs/code-splitting.html
-const AsyncStateMachines = React.lazy(
+const AsyncStateMachines = lazy(
   () => import('../../routes' /* webpackChunkName: "state-machines" */)
 );
 
@@ -53,7 +53,7 @@ ApplicationStateMachines.displayName = 'ApplicationStateMachines';
 // in order to catch possible errors on rendering/mounting.
 setupGlobalErrorListener();
 
-class EntryPoint extends React.Component {
+class EntryPoint extends Component {
   static displayName = 'EntryPoint';
   render() {
     return (

--- a/playground/src/components/state-machines-details/state-machines-details.js
+++ b/playground/src/components/state-machines-details/state-machines-details.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, useCallback, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -24,7 +24,7 @@ const initialState = {
 // the component, has currently a limitation when testing the component, as it throws
 // a warning about `act`. This will be fixed in react@16.9.
 // In the meantime we can use a plain old stateful class component.
-class StateMachinesDetailsFetcher extends React.Component {
+class StateMachinesDetailsFetcher extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     dataLocale: PropTypes.string.isRequired,
@@ -69,15 +69,15 @@ class StateMachinesDetailsFetcher extends React.Component {
 const StateMachinesDetails = (props) => {
   const dataLocale = useApplicationContext((context) => context.dataLocale);
   const dispatch = useDispatch();
-  const fetcher = React.useCallback(
+  const fetcher = useCallback(
     (...args) => dispatch(fetchStateMachine(...args)),
     [dispatch]
   );
   const showApiErrorNotification = useShowApiErrorNotification();
 
   // This tracking is just testing purposes
-  const { track } = React.useContext(GtmContext);
-  React.useEffect(() => {
+  const { track } = useContext(GtmContext);
+  useEffect(() => {
     track('rendered', 'State machine details');
   }, [track]);
 

--- a/playground/src/components/state-machines-list-connector/state-machines-list-connector.js
+++ b/playground/src/components/state-machines-list-connector/state-machines-list-connector.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Sdk } from '@commercetools-frontend/sdk';
 import * as actions from './actions';
 
-class StateMachinesListConnector extends React.Component {
+class StateMachinesListConnector extends Component {
   static displayName = 'StateMachinesListConnector';
   static propTypes = {
     children: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Summary

As an outcome of adopting the new JSX transform https://github.com/commercetools/merchant-center-application-kit/pull/1819 I suggest to add a small intermediate refactor to adjust the imports according to the codemod.

The benefits of this are that chore on codebase is separate and small when adopting transform and that we adopt the recommended style before.