### PR TITLE
feat(renovate): group some of our monorepos

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -7,6 +7,18 @@
   "separateMajorMinor": true,
   "packageRules": [
     {
+      "sourceUrlPrefixes": ["https://github.com/commercetools/ui-kit"],
+      "groupName": "all ui-kit packages"
+    },
+    {
+      "sourceUrlPrefixes": ["https://github.com/commercetools/commercetools-docs-kit"],
+      "groupName": "all docs-kit packages"
+    },
+    {
+      "sourceUrlPrefixes": ["https://github.com/commercetools/test-data"],
+      "groupName": "all test-data packages"
+    },
+    {
       "packagePatterns": [
         "*"
       ],


### PR DESCRIPTION
To group major updates of some of our CT monorepositories, for example [like here](https://github.com/commercetools/merchant-center-graphql-explorer/pull/59).

https://docs.renovatebot.com/configuration-options/#sourceurlprefixes