### PR TITLE
feat(graphql targets): added change history graphql target

### DIFF
--- a/.changeset/young-rings-kiss.md
+++ b/.changeset/young-rings-kiss.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/constants': patch
+---
+
+Addition of new change history GraphQL Target

--- a/packages/application-shell/src/apollo-links/utils.spec.js
+++ b/packages/application-shell/src/apollo-links/utils.spec.js
@@ -26,6 +26,14 @@ describe('supported GraphQL targets', () => {
     ).toBe(false);
   });
 
+  it('should not support the `change history` GraphQL target', () => {
+    expect(
+      getDoesGraphQLTargetSupportTokenRetry({
+        headers: { 'X-Graphql-Target': GRAPHQL_TARGETS.CHANGE_HISTORY },
+      })
+    ).toBe(false);
+  });
+
   it('should not support the `settings service` GraphQL target', () => {
     expect(
       getDoesGraphQLTargetSupportTokenRetry({

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -119,6 +119,7 @@ export const GRAPHQL_TARGETS = {
   MERCHANT_CENTER_BACKEND: 'mc',
   COMMERCETOOLS_PLATFORM: 'ctp',
   DASHBOARD_SERVICE: 'dashboard',
+  CHANGE_HISTORY: 'change-history',
   PIM_INDEXER: 'pim-indexer',
   SETTINGS_SERVICE: 'settings',
   ADMINISTRATION_SERVICE: 'administration',

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -119,7 +119,7 @@ export const GRAPHQL_TARGETS = {
   MERCHANT_CENTER_BACKEND: 'mc',
   COMMERCETOOLS_PLATFORM: 'ctp',
   DASHBOARD_SERVICE: 'dashboard',
-  CHANGE_HISTORY: 'change-history',
+  CHANGE_HISTORY_SERVICE: 'change-history',
   PIM_INDEXER: 'pim-indexer',
   SETTINGS_SERVICE: 'settings',
   ADMINISTRATION_SERVICE: 'administration',


### PR DESCRIPTION
#### Summary:
As part of the work to integrate Change History with Merchant Center, a new GraphQL Target should be set up to be used for configuring a proxy for Change History API requests.

#### Solution:
* Added new target value for change history
* Adjusted tests