### PR TITLE
fix(webpack): babel preset syntax

### DIFF
--- a/.changeset/plenty-lies-serve.md
+++ b/.changeset/plenty-lies-serve.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix babel preset syntax

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.js
@@ -197,10 +197,14 @@ module.exports = ({
             options: {
               babelrc: false,
               presets: [
-                require.resolve('@commercetools-frontend/babel-preset-mc-app'),
-                {
-                  runtime: hasJsxRuntime() ? 'automatic' : 'classic',
-                },
+                [
+                  require.resolve(
+                    '@commercetools-frontend/babel-preset-mc-app'
+                  ),
+                  {
+                    runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                  },
+                ],
               ],
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -255,12 +255,14 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
               options: {
                 babelrc: false,
                 presets: [
-                  require.resolve(
-                    '@commercetools-frontend/babel-preset-mc-app'
-                  ),
-                  {
-                    runtime: hasJsxRuntime() ? 'automatic' : 'classic',
-                  },
+                  [
+                    require.resolve(
+                      '@commercetools-frontend/babel-preset-mc-app'
+                    ),
+                    {
+                      runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                    },
+                  ],
                 ],
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/


### PR DESCRIPTION
See https://github.com/facebook/create-react-app/blob/545d4607c81dd876c06f66b8104056a3570af242/packages/react-scripts/config/webpack.config.js#L409-L416

No idea how this wasn't caught here in this repo...