### PR TITLE
fix(headers): eval of dev environment

### DIFF
--- a/.changeset/dull-hounds-repair.md
+++ b/.changeset/dull-hounds-repair.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Evaluation of `env` flag from the application config, to set certain CSP directives for local development

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -33,7 +33,7 @@ const toHeaderString = (directives = {}) =>
     .join('; ');
 
 const processHeaders = (applicationConfig) => {
-  const isMcDevEnv = applicationConfig.env === 'development';
+  const isMcDevEnv = applicationConfig.env.env === 'development';
 
   // List hashes for injected inline scripts.
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src


### PR DESCRIPTION
This was broken for 4 months 🤦‍♂️

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/1110551/97726041-210d3c00-1acf-11eb-9dcd-3b6deee2aab9.png">


We should probably migrate this package to TS as well.