### PR TITLE
fix(mc-scripts): to add jsx runtime for js files not only svg

### DIFF
--- a/.changeset/old-carpets-accept.md
+++ b/.changeset/old-carpets-accept.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-scripts": patch
+---
+
+fix(mc-scripts): to add jsx runtime for js files not only svg

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.js
@@ -387,10 +387,14 @@ module.exports = ({
               configFile: false,
               compact: false,
               presets: [
-                require.resolve('@commercetools-frontend/babel-preset-mc-app'),
-                {
-                  runtime: hasJsxRuntime() ? 'automatic' : 'classic',
-                },
+                [
+                  require.resolve(
+                    '@commercetools-frontend/babel-preset-mc-app'
+                  ),
+                  {
+                    runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                  },
+                ],
               ],
               plugins: [
                 hasReactRefresh && require.resolve('react-refresh/babel'),

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.js
@@ -387,8 +387,10 @@ module.exports = ({
               configFile: false,
               compact: false,
               presets: [
-                // TODO: add support for JSX runtime (https://github.com/facebook/create-react-app/blob/e63de79cc4530efc7402e38923d875f27cdef0c3/packages/react-scripts/config/webpack.config.js#L415-L417)
                 require.resolve('@commercetools-frontend/babel-preset-mc-app'),
+                {
+                  runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                },
               ],
               plugins: [
                 hasReactRefresh && require.resolve('react-refresh/babel'),

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -450,6 +450,9 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
                   require.resolve(
                     '@commercetools-frontend/babel-preset-mc-app'
                   ),
+                  {
+                    runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                  },
                 ],
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -447,12 +447,14 @@ module.exports = ({ distPath, entryPoint, sourceFolders, toggleFlags }) => {
                 configFile: false,
                 compact: false,
                 presets: [
-                  require.resolve(
-                    '@commercetools-frontend/babel-preset-mc-app'
-                  ),
-                  {
-                    runtime: hasJsxRuntime() ? 'automatic' : 'classic',
-                  },
+                  [
+                    require.resolve(
+                      '@commercetools-frontend/babel-preset-mc-app'
+                    ),
+                    {
+                      runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+                    },
+                  ],
                 ],
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/


### PR DESCRIPTION
#### Summary

This pull request intends to fix the mc-scripts to also pass the jsx runtime property to the babel preset on js files.

#### Description

The prior addition seems to have only passed the babel config to svg files which "makes sense" as they are also transformed.

However by not passing it ot js files internally the build would fail. What I fail to understand is why it works in this repo.