### PR TITLE
fix(babel): pragma frag to be Fragment not React.Fragment

### DIFF
--- a/.changeset/fifty-jeans-shave.md
+++ b/.changeset/fifty-jeans-shave.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/babel-preset-mc-app": patch
+---
+
+fix(babel): pragma frag to be Fragment not React.Fragment

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -59,7 +59,9 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
           development: isEnvDevelopment || isEnvTest,
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
-          ...(opts.runtime !== 'automatic' ? { useBuiltIns: true } : {}),
+          ...(opts.runtime !== 'automatic'
+            ? { useBuiltIns: true, pragmaFrag: 'Fragment' }
+            : {}),
           runtime: opts.runtime || 'classic',
         },
       ],


### PR DESCRIPTION
#### Summary

This pull request fixes the `pragmaFrag` of the babel config to be `Fragment` when using the `automatic` runtime.

#### Description

By default the babel transform seems to transform a `<></>` to `<React.Fragment></React.Fragment>` which will break in `automatic` mode as `React` is not in scope.

For instance at something like this.

<img width="276" alt="CleanShot 2020-10-31 at 19 36 23@2x" src="https://user-images.githubusercontent.com/1877073/97787284-63a74500-1bb1-11eb-9f67-0fa118a73d5c.png">

It should just compile it to `Fragment` as `React` doesn't have to be in scope for then it to be picked up.

Reference: https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#pragmafrag