### PR TITLE
chore: add import export api target

### DIFF
--- a/.changeset/thick-wasps-hang.md
+++ b/.changeset/thick-wasps-hang.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/constants": patch
+---
+
+chore: add import export api target

--- a/.changeset/thick-wasps-hang.md
+++ b/.changeset/thick-wasps-hang.md
@@ -2,4 +2,4 @@
 "@commercetools-frontend/constants": patch
 ---
 
-chore: add import export api target
+chore: add import api target

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -131,7 +131,7 @@ export const MC_API_PROXY_TARGETS = {
   MACHINE_LEARNING: 'ml',
   PIM_SEARCH: 'pim-search',
   MC_METRICS: 'mc-metrics',
-  IMPORT_EXPORT: 'import-export',
+  IMPORT: 'import',
 } as const;
 export type TMcApiProxyTargets = typeof MC_API_PROXY_TARGETS[keyof typeof MC_API_PROXY_TARGETS];
 

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -131,6 +131,7 @@ export const MC_API_PROXY_TARGETS = {
   MACHINE_LEARNING: 'ml',
   PIM_SEARCH: 'pim-search',
   MC_METRICS: 'mc-metrics',
+  IMPORT_EXPORT: 'import-export',
 } as const;
 export type TMcApiProxyTargets = typeof MC_API_PROXY_TARGETS[keyof typeof MC_API_PROXY_TARGETS];
 


### PR DESCRIPTION
#### Summary

This adds an `IMPORT_EXPORT` HTTP target. This will become relevant when the respected API will be started to be integrated. 

This is not publicly supported yet. We will have to do some internal work to add proxying support. We can keep this on hold until then or prepare for it already.