### PR TITLE
fix(babel): to use import source for emotion and automatic runtime

### DIFF
--- a/.changeset/witty-emus-share.md
+++ b/.changeset/witty-emus-share.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/babel-preset-mc-app": patch
+---
+
+fix(babel): to use import source for automatic runtime

--- a/.changeset/witty-emus-share.md
+++ b/.changeset/witty-emus-share.md
@@ -2,4 +2,4 @@
 "@commercetools-frontend/babel-preset-mc-app": patch
 ---
 
-fix(babel): to use import source for automatic runtime
+fix(babel): enable new JSX runtime for Emotion.

--- a/package.json
+++ b/package.json
@@ -190,7 +190,8 @@
     "pretty-format": "26.6.1",
     "intl-messageformat-parser": "6.0.11",
     "**/intl-messageformat-parser": "6.0.11",
-    "**/@commercetools-docs/gatsby-theme-docs/react-intl": "5.8.6"
+    "**/@commercetools-docs/gatsby-theme-docs/react-intl": "5.8.6",
+    "@emotion/core": "10.1.1"
   },
   "engines": {
     "node": ">=12",

--- a/package.json
+++ b/package.json
@@ -190,8 +190,7 @@
     "pretty-format": "26.6.1",
     "intl-messageformat-parser": "6.0.11",
     "**/intl-messageformat-parser": "6.0.11",
-    "**/@commercetools-docs/gatsby-theme-docs/react-intl": "5.8.6",
-    "@emotion/core": "10.1.1"
+    "**/@commercetools-docs/gatsby-theme-docs/react-intl": "5.8.6"
   },
   "engines": {
     "node": ">=12",

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -60,7 +60,10 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
           ...(opts.runtime !== 'automatic'
-            ? { useBuiltIns: true, pragmaFrag: 'Fragment' }
+            ? {
+                useBuiltIns: true,
+                importSource: '@emotion/core',
+              }
             : {}),
           runtime: opts.runtime || 'classic',
         },

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -59,13 +59,21 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
           development: isEnvDevelopment || isEnvTest,
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
-          ...(opts.runtime !== 'automatic'
-            ? {
-                useBuiltIns: true,
-                importSource: '@emotion/core',
-              }
-            : {}),
+          ...(opts.runtime === 'automatic'
+            ? // https://emotion.sh/docs/css-prop#babel-preset
+              { importSource: '@emotion/core' }
+            : { useBuiltIns: true }),
           runtime: opts.runtime || 'classic',
+        },
+      ],
+      // Use this preset only with the JSX runtime `classic`, otherwise
+      // use the `babel-plugin-emotion` plugin.
+      // https://emotion.sh/docs/@emotion/babel-preset-css-prop
+      opts.runtime !== 'automatic' && [
+        '@emotion/babel-preset-css-prop',
+        {
+          sourceMap: isEnvDevelopment,
+          autoLabel: !isEnvProduction,
         },
       ],
       require('@babel/preset-typescript').default,
@@ -129,7 +137,10 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
       ],
       require('@babel/plugin-proposal-do-expressions').default,
       require('@babel/plugin-proposal-logical-assignment-operators').default,
-      require('babel-plugin-emotion').default,
+      // Use this plugin only with the JSX runtime `automatic`, otherwise
+      // use the `@emotion/babel-preset-css-prop` preset.
+      // https://emotion.sh/docs/@emotion/babel-preset-css-prop
+      opts.runtime === 'automatic' && require('babel-plugin-emotion').default,
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -68,13 +68,6 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
           runtime: opts.runtime || 'classic',
         },
       ],
-      [
-        '@emotion/babel-preset-css-prop',
-        {
-          sourceMap: isEnvDevelopment,
-          autoLabel: !isEnvProduction,
-        },
-      ],
       require('@babel/preset-typescript').default,
     ].filter(Boolean),
     plugins: [
@@ -136,6 +129,7 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
       ],
       require('@babel/plugin-proposal-do-expressions').default,
       require('@babel/plugin-proposal-logical-assignment-operators').default,
+      require('babel-plugin-emotion').default,
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-typescript": "7.12.1",
     "@babel/runtime": "7.12.1",
     "@babel/runtime-corejs3": "7.12.1",
-    "@emotion/babel-preset-css-prop": "10.1.0",
+    "babel-plugin-emotion": "10.0.33",
     "babel-plugin-dev-expression": "0.2.2",
     "babel-plugin-macros": "2.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",

--- a/packages/babel-preset-mc-app/package.json
+++ b/packages/babel-preset-mc-app/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-typescript": "7.12.1",
     "@babel/runtime": "7.12.1",
     "@babel/runtime-corejs3": "7.12.1",
+    "@emotion/babel-preset-css-prop": "10.2.0",
     "babel-plugin-emotion": "10.0.33",
     "babel-plugin-dev-expression": "0.2.2",
     "babel-plugin-macros": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,6 +2644,17 @@
   dependencies:
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
+"@emotion/babel-preset-css-prop@10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.2.0.tgz#cddb662b0dace7ea62f69439965ea156a7a486b9"
+  integrity sha512-3I0CAZ+0fA/VjwNxL4/qfsgiuXtEM/Kvnl49oqSf51bl+kNxsHdypb0J/mdBY8OifuTbwjAOsQkRLVPdUtJN4Q==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.12.1"
+    "@babel/plugin-transform-react-jsx-development" "^7.12.1"
+    "@babel/runtime" "^7.5.5"
+    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.5"
+    babel-plugin-emotion "^10.0.27"
+
 "@emotion/babel-preset-css-prop@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.27.tgz#58868d9a6afee0eeaeb0fa9dc5ccb1b12d4f786b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2664,22 +2664,10 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@10.1.1":
+"@emotion/core@10.1.1", "@emotion/core@^10.0.34", "@emotion/core@^10.0.9":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/css" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
-"@emotion/core@^10.0.34", "@emotion/core@^10.0.9":
-  version "10.0.35"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
-  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@emotion/cache" "^10.0.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,17 +2644,6 @@
   dependencies:
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@emotion/babel-preset-css-prop@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.1.0.tgz#4800943dff35bd82a83891b278565918bbed14a7"
-  integrity sha512-t1ar2Zt3fJ/TuoEg7Oin4sYdYt4BMWbvsQkaO4rq0II4hb9t/NdbCUd0jXFIYDuf0FYhyDEHt6sqpdPAG4uQrA==
-  dependencies:
-    "@babel/plugin-transform-react-jsx" "^7.12.1"
-    "@babel/plugin-transform-react-jsx-development" "^7.12.1"
-    "@babel/runtime" "^7.5.5"
-    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.5"
-    babel-plugin-emotion "^10.0.27"
-
 "@emotion/babel-preset-css-prop@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.27.tgz#58868d9a6afee0eeaeb0fa9dc5ccb1b12d4f786b"
@@ -7675,7 +7664,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.27:
+babel-plugin-emotion@10.0.33, babel-plugin-emotion@^10.0.27:
   version "10.0.33"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
   integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==


### PR DESCRIPTION
#### Summary

This pull request intends to fix the setup of the automatic runtime in combination with emotion.

#### Description

Emotion has recently added support for the automatic runtime. Then changed a bit again how it works

From this

<img width="1005" alt="CleanShot 2020-11-08 at 15 55 51@2x" src="https://user-images.githubusercontent.com/1877073/98468479-ed22cc80-21da-11eb-96dd-90f423247c2d.png">

To this

<img width="1037" alt="CleanShot 2020-11-08 at 15 55 38@2x" src="https://user-images.githubusercontent.com/1877073/98468467-dc725680-21da-11eb-8fb5-c641526626bf.png">


Ref: https://emotion.sh/docs/css-prop#babel-preset

So I guess we're lucky to have been sitting that change out quietly ;)