### PR TITLE
feat(application-shell): add user business role custom dimension tracking 

### DIFF
--- a/.changeset/new-baboons-hide.md
+++ b/.changeset/new-baboons-hide.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/application-shell-connectors': minor
+---
+
+add user business role custom dimension tracking

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -360,7 +360,8 @@ export enum TPermissionScope {
   ViewShippingMethods = 'view_shipping_methods',
   ViewTaxCategories = 'view_tax_categories',
   ManageCategories = 'manage_categories',
-  ViewCategories = 'view_categories'
+  ViewCategories = 'view_categories',
+  ViewChangeHistory = 'view_change_history'
 }
 
 export type TProject = TMetaData & {

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -245,6 +245,7 @@ export const RestrictedApplication = <
                       <GtmApplicationTracker
                         applicationName={applicationEnvironment.applicationName}
                         projectKey={projectKeyFromUrl}
+                        userBusinessRole={user?.businessRole}
                       />
                       <div
                         role="application-layout"

--- a/packages/application-shell/src/components/gtm-application-tracker/gtm-application-tracker.spec.js
+++ b/packages/application-shell/src/components/gtm-application-tracker/gtm-application-tracker.spec.js
@@ -10,6 +10,7 @@ describe('rendering', () => {
       <GtmApplicationTracker
         applicationName="playground"
         projectKey="project-key"
+        userBusinessRole="Other"
       />
     );
     await waitFor(() => {
@@ -17,6 +18,7 @@ describe('rendering', () => {
         expect.arrayContaining([
           { applicationName: 'playground' },
           { projectKey: 'project-key' },
+          { userBusinessRole: 'Other' },
         ])
       );
     });

--- a/packages/application-shell/src/components/gtm-application-tracker/gtm-application-tracker.tsx
+++ b/packages/application-shell/src/components/gtm-application-tracker/gtm-application-tracker.tsx
@@ -4,13 +4,15 @@ import * as gtm from '../../utils/gtm';
 type Props = {
   applicationName: string;
   projectKey?: string;
+  userBusinessRole?: string;
 };
 
 const GtmApplicationTracker = (props: Props) => {
   React.useEffect(() => {
     gtm.trackApplicationName(props.applicationName);
     gtm.trackProjectKey(props.projectKey);
-  }, [props.applicationName, props.projectKey]);
+    gtm.trackUserBusinessRole(props.userBusinessRole);
+  }, [props.applicationName, props.projectKey, props.userBusinessRole]);
   return null;
 };
 GtmApplicationTracker.displayName = 'GtmApplicationTracker';

--- a/packages/application-shell/src/components/gtm-booter/gtm-booter.tsx
+++ b/packages/application-shell/src/components/gtm-booter/gtm-booter.tsx
@@ -23,6 +23,7 @@ export type Props = {
 export const GtmContext = React.createContext({
   track: gtm.track,
   getHierarchy: gtm.getHierarchy,
+  trackUserBusinessRole: gtm.trackUserBusinessRole,
 });
 
 const GtmBooter = (props: Props) => {

--- a/packages/application-shell/src/types/generated/ctp.ts
+++ b/packages/application-shell/src/types/generated/ctp.ts
@@ -7227,6 +7227,7 @@ export type TProjectCustomLimitsProjection = {
   shippingMethods: TShippingMethodLimitsProjection;
   carts: TCartLimitsProjection;
   customObjects: TCustomObjectLimitsProjection;
+  search: TSearchLimitsProjection;
 };
 
 /** Project contains information about project. */
@@ -8334,6 +8335,11 @@ export type TSearchKeywords = {
   __typename?: 'SearchKeywords';
   locale: Scalars['Locale'];
   searchKeywords: Array<TSearchKeyword>;
+};
+
+export type TSearchLimitsProjection = {
+  __typename?: 'SearchLimitsProjection';
+  maxTextSize: TLimit;
 };
 
 

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -360,7 +360,8 @@ export enum TPermissionScope {
   ViewShippingMethods = 'view_shipping_methods',
   ViewTaxCategories = 'view_tax_categories',
   ManageCategories = 'manage_categories',
-  ViewCategories = 'view_categories'
+  ViewCategories = 'view_categories',
+  ViewChangeHistory = 'view_change_history'
 }
 
 export type TProject = TMetaData & {

--- a/packages/application-shell/src/utils/gtm.ts
+++ b/packages/application-shell/src/utils/gtm.ts
@@ -144,6 +144,11 @@ export const trackProjectKey = (projectKey?: string) => {
   if (window.dataLayer && window.app.trackingGtm && projectKey)
     window.dataLayer.push({ projectKey });
 };
+export const trackUserBusinessRole = (userBusinessRole?: string) => {
+  if (window.dataLayer && window.app.trackingGtm && userBusinessRole) {
+    window.dataLayer.push({ userBusinessRole });
+  }
+};
 
 // Sometimes necessary to manually get the hierarchy.
 export const getHierarchy = (node: Node | null) => {

--- a/schemas/ctp.json
+++ b/schemas/ctp.json
@@ -30040,6 +30040,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "search",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SearchLimitsProjection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -30577,6 +30593,33 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "LimitWithCurrent",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SearchLimitsProjection",
+        "description": null,
+        "fields": [
+          {
+            "name": "maxTextSize",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Limit",
                 "ofType": null
               }
             },

--- a/schemas/mc.json
+++ b/schemas/mc.json
@@ -3310,6 +3310,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "view_change_history",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->
add user business role custom dimension tracking 

#### Description

<!-- provide some context -->
We want to always have the user business role custom dimensions information available when the application loads like we do for the application name and project key custom dimensions.