### PR TITLE
feat(l10n): add graphql transformers and `localize`

### DIFF
--- a/.changeset/young-months-sing.md
+++ b/.changeset/young-months-sing.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/l10n': minor
+---
+
+feature: add `applyTransformedLocalizedFields` to `l10n`

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -227,9 +227,9 @@ As discussed under `applyTransformedLocalizedFields`, a `LocalizedString` is a v
 const product = {
   name: {
     en: 'Milk',
-    de: 'Milsch,
-  }
-}
+    de: 'Milch',
+  },
+};
 ```
 
 When rendering a Product in a view, we would like to render the value of a localized string field, such as `name`, given the selected **data locale** of the UI.

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -212,11 +212,11 @@ return (
 );
 ```
 
-### `localize` (DRAFT)
+### `formatLocalizedString` (DRAFT)
 
 > Transforms a `LocalizedString` to a String
 
-The `localize` util is a util we use internally inside the Merchant Center.
+The `formatLocalizedString` util is a util we use internally inside the Merchant Center.
 This util is at the moment subject to change, hence marked as Draft. Use with caution in your Custom Application.
 
 #### Context
@@ -235,9 +235,9 @@ const product = {
 When rendering a Product in a view, we would like to render the value of a localized string field, such as `name`, given the selected **data locale** of the UI.
 The **data locale** is a value controlled by the Merchant Center User (MC User) by changing the **data locale switcher** in the top bar of the Merchant Center. The list of available options is derived by the list of languages specified in the project. The selected value can be read from the **application context**.
 
-However, there might be a case where the selected **data locale** does not match any of the localized string values. In this case, it would be helpful to display a "fallback" value using the `localize` function.
+However, there might be a case where the selected **data locale** does not match any of the localized string values. In this case, it would be helpful to display a "fallback" value using the `formatLocalizedString` function.
 
-The `localize` util is authored with a couple of things in mind:
+The `formatLocalizedString` util is authored with a couple of things in mind:
 
 1. Help us Custom Application developers remain resilient as we attempt to derive a value of `LocalizedString` given a specified locale.
 2. Help us Custom Application developers remain consistent when rendering a value derived from `LocalizedString`.
@@ -262,8 +262,7 @@ const product = {
 Given that selected **data locale** of `de`
 
 ```js
-const translatedName = localize({
-  obj: product,
+const translatedName = formatLocalizedString(product, {
   key: 'name',
   locale: 'de',
 });
@@ -277,8 +276,7 @@ console.log(translatedName);
 Given that selected **data locale** of `sv`
 
 ```js
-const translatedName = localize({
-  obj: product,
+const translatedName = formatLocalizedString(product, {
   key: 'name',
   locale: 'sv',
 });
@@ -289,15 +287,14 @@ console.log(translatedName);
 
 **What happened?**
 
-Our product has no value for the selected **data locale** `sv`. The `localize` function selects the "next available value" from `product.name`, in this case `en`, and returns it with a hint `(EN)` that this value refers to another locale.
+Our product has no value for the selected **data locale** `sv`. The `formatLocalizedString` function selects the "next available value" from `product.name`, in this case `en`, and returns it with a hint `(EN)` that this value refers to another locale.
 
 ##### Scenario 3
 
 Given that selected **data locale** of `de-AT`
 
 ```js
-const translatedName = localize({
-  obj: product,
+const translatedName = formatLocalizedString(product, {
   key: 'name',
   locale: 'de-AT',
 });
@@ -309,14 +306,14 @@ console.log(translatedName);
 **What happened?**
 
 Our product has no matching value for the selected **data locale** `de-AT` but we still got `"Milch"`.
-This is because `localize` attempts to determine a **primary language tag** on the option `locale` and match that to the available values. Given that `de` is a [primary](https://en.wikipedia.org/wiki/IETF_language_tag) of `de-AT`, it determines that this is the _closest available value_ from `product.name`
+This is because `formatLocalizedString` attempts to determine a **primary language tag** on the option `locale` and match that to the available values. Given that `de` is a [primary](https://en.wikipedia.org/wiki/IETF_language_tag) of `de-AT`, it determines that this is the _closest available value_ from `product.name`
 
 #### Fallback
 
-Given that `localize` can not handle all scenario exemplified above, we can specify a `fallback` as a last resort:
+Given that `formatLocalizedString` can not handle all scenario exemplified above, we can specify a `fallback` as a last resort:
 
 ```js
-const translatedName = localize({
+const translatedName = formatLocalizedString(product, {
   obj: product,
   key: 'name',
   locale: 'sv',
@@ -328,14 +325,14 @@ The default value of `fallback` is a `""`.
 
 #### Fallback order
 
-In **Scenario 2** above, we discussed that `localize` will pick the "next available value" from `product.name` when there is no matching value. In our case, the next available value was the locale `en`.
-As Custom Application developers, it is possible for us to take control of the "next lookup" of the value, when there is no match (before `localize` proceeds to rendering  what is specified as `fallback`).
+In **Scenario 2** above, we discussed that `formatLocalizedString` will pick the "next available value" from `product.name` when there is no matching value. In our case, the next available value was the locale `en`.
+As Custom Application developers, it is possible for us to take control of the "next lookup" of the value, when there is no match (before `formatLocalizedString` proceeds to rendering what is specified as `fallback`).
 
-`localize` accepts `fallbackOrder`, and this [test exemplifies the use case and resolve](./src/localize.spec.ts#L151:L170).
+`formatLocalizedString` accepts `fallbackOrder`, and this [test exemplifies the use case and resolve](./src/localize.spec.ts#L151:L170).
 
 #### When to use it
 
-Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `localize` in conjunction with the Application Context.
+Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `formatLocalizedString` in conjunction with the Application Context.
 
 ```js
 import Text from '@commercetools-uikit/text';
@@ -353,8 +350,7 @@ const { dataLocale, projectLanguages } = useApplicationContext(
 
 return (
   <Text.Headline>
-    {localize({
-      obj: product,
+    {formatLocalizedString(product, {
       key: 'name',
       locale: dataLocale,
       fallback: '<MY_CUSTOM_FALLBACK>',

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -343,11 +343,9 @@ Given that we want to render `LocalizedString` of a given `Resource`, it is sens
 import { Text } from '@commercetools-frontend/ui-kit';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 
-const { language, projectLanguages } = useApplicationContext(
+const { dataLocale, projectLanguages } = useApplicationContext(
   (applicationContext) => ({
-    // The Application Context exposes the value emitted from the language switcher
-    // as `dataLocale`. We map that to `language` in our source code to make it readable.
-    language: applicationContext.dataLocale,
+    dataLocale: applicationContext.dataLocale,
     // The Application Context also exposes the languages that are defined on the Project settings
     // we can rely on this to determine the fallback order.
     // This helps with consistency, although you can specify the fallback order however you want
@@ -360,9 +358,9 @@ return (
     {localize({
       obj: product,
       key: 'name',
+      locale: dataLocale,
       fallback: '<MY_CUSTOM_FALLBACK>',
       fallbackOrder: projectLanguages,
-      language,
     })}
   </Text.Headline>
 );

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -123,7 +123,7 @@ The `LocalizedString` is a type reserved for values found in a [Resource](https:
 
 The documented `LocalizedString` in [https://docs.commercetools.com](https://docs.commercetools.com/) is a specification of the HTTP API.
 
-In the commercetools platform `/graphql` API, we also find `LocalizedString` value takes a different shape of the same name.
+However, the commercetools platform `/graphql` API represents the `LocalizedString` in a different format as a list, for technical reasons.
 
 ```js
 // Product, returned from the `graphql` API of commercetools platform
@@ -187,7 +187,7 @@ const transformedProduct = {
 return <LocalizedTextInput name="name" value={transformedProduct.name} />;
 ```
 
-### `injectTransformedLocalizedFields`
+### `applyTransformedLocalizedFields`
 
 > Transforms multiple `LocalizedField` -> `LocalizedString`, given `fieldNameTransformationMappings`
 
@@ -195,7 +195,7 @@ In the example above, we demonstrated that we can transform `LocalizedField -> L
 
 However, given that a Resource can have multiple values of the type `LocalizedField`, this can be a cumbersome task to do.
 
-We offer `injectTransformedLocalizedFields` that is meant to transform multiple values.
+We offer `applyTransformedLocalizedFields` that is authored to transform multiple values.
 
 #### Example usage
 
@@ -224,7 +224,7 @@ const fieldNameTransformationMappings = [
     to: 'description',
   },
 ];
-const transformedProduct = injectTransformedLocalizedFields(
+const transformedProduct = applyTransformedLocalizedFields(
   fetchedProduct,
   fieldNameTransformationMappings
 );

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -39,7 +39,7 @@ const { isLoading, data, error } = useCountries('en');
 ```js
 import { withCountries } from '@commercetools-frontend/l10n';
 
-withCountries(ownProps => ownProps.locale)(Component);
+withCountries((ownProps) => ownProps.locale)(Component);
 
 // format: { countryCode: countryLabel }
 // { "de":"Germany" }
@@ -48,7 +48,7 @@ withCountries(ownProps => ownProps.locale)(Component);
 ```js
 import { withCurrencies } from '@commercetools-frontend/l10n';
 
-withCurrencies(ownProps => ownProps.locale)(Component);
+withCurrencies((ownProps) => ownProps.locale)(Component);
 
 // format: { currencyCode: { label, symbol } }
 // { "EUR": { "label": "Euro", "symbol": "€" } }
@@ -57,7 +57,7 @@ withCurrencies(ownProps => ownProps.locale)(Component);
 ```js
 import { withLanguages } from '@commercetools-frontend/l10n';
 
-withLanguages(ownProps => ownProps.locale)(Component);
+withLanguages((ownProps) => ownProps.locale)(Component);
 
 // format: { languageCode: { language, country? } }
 // Case with main language
@@ -69,7 +69,7 @@ withLanguages(ownProps => ownProps.locale)(Component);
 ```js
 import { withTimeZones } from '@commercetools-frontend/l10n';
 
-withTimeZones(ownProps => ownProps.locale)(Component);
+withTimeZones((ownProps) => ownProps.locale)(Component);
 
 // format: { timezone: { name, abbr, offset } }
 // Case with main language
@@ -100,7 +100,7 @@ Run the script, which uses the new data.
 
 ## Utils
 
-### `transformLocalizedFieldToString`
+### `transformLocalizedFieldToLocalizedString`
 
 > Transforms a `LocalizedField` to a `LocalizedString`
 
@@ -135,7 +135,7 @@ In our `graphql` API, we also find `LocalizedString` value takes a different sha
 }
 ```
 
-To distinguish these in the source code of the Merchant Center, we name the graphql shaped value `LocalizedField`. When executing `transformLocalizedFieldToString`, we transform the graphql shaped value to the HTTP API shape.
+To distinguish these in the source code of the Merchant Center, we name the graphql shaped value `LocalizedField`. When executing `transformLocalizedFieldToLocalizedString`, we transform the graphql shaped value to the HTTP API shape.
 
 #### Example usage
 
@@ -148,7 +148,9 @@ const product = {
     },
   ],
 };
-const transformedName = transformLocalizedFieldToString(product.nameAllLocales);
+const transformedName = transformLocalizedFieldToLocalizedString(
+  product.nameAllLocales
+);
 console.log(transformedName);
 // { en: 'Milk' }
 ```
@@ -176,7 +178,7 @@ const transformedProduct = {
   ...fetchedProduct.data,
   // so we transform the LocalizedField to a LocalizedString
   // [{ locale: 'en', value: 'Milk' }] -> { en: 'Milk' }
-  name: transformLocalizedFieldToString(fetchedProduct.nameAllLocales),
+  name: transformLocalizedFieldToLocalizedString(fetchedProduct.nameAllLocales),
 };
 
 // finally, we are ready to render out LocalizedTextInput with a correctly transformed `name` value.
@@ -227,7 +229,7 @@ console.log(transformedProduct);
 // { name: { en: 'Milk' }, description: { en:  'This is milk' } }
 ```
 
-#### Slight difference to `transformLocalizedFieldToString`
+#### Slight difference to `transformLocalizedFieldToLocalizedString`
 
-Unlike `transformLocalizedFieldToString` where you pass in the `LocalizedField` value,
+Unlike `transformLocalizedFieldToLocalizedString` where you pass in the `LocalizedField` value,
 we need to pass the entire Resource and the `fieldTransformDefinitions`.

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -187,6 +187,8 @@ return <LocalizedTextInput name="name" value={transformedProduct.name} />;
 
 ### `injectTransformedLocalizedFields`
 
+> Transforms multiple `LocalizedField` -> `LocalizedString`, given `fieldNameTransformationMappings`
+
 In the example above, we demonstrated that you can transform `LocalizedField -> LocalizedString` for a field returned by the commercetools platform `/graphql` API.
 
 However, given that a Resource can have multiple values of the type `LocalizedField`, this can a cumbersome task to do.
@@ -210,7 +212,7 @@ const product = {
     },
   ],
 };
-const fieldTransformDefinitions = [
+const fieldNameTransformationMappings = [
   {
     from: 'nameAllLocales',
     to: 'name',
@@ -222,7 +224,7 @@ const fieldTransformDefinitions = [
 ];
 const transformedProduct = injectTransformedLocalizedFields(
   fetchedProduct,
-  fieldTransformDefinitions
+  fieldNameTransformationMappings
 );
 
 console.log(transformedProduct);
@@ -232,4 +234,4 @@ console.log(transformedProduct);
 #### Slight difference to `transformLocalizedFieldToLocalizedString`
 
 Unlike `transformLocalizedFieldToLocalizedString` where you pass in the `LocalizedField` value,
-we need to pass the entire Resource and the `fieldTransformDefinitions`.
+we need to pass the entire Resource and the `fieldNameTransformationMappings`.

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -108,11 +108,13 @@ Run the script, which uses the new data.
 
 Amongst [Common Types](https://docs.commercetools.com/api/types) in the commercetools platform API, we find [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring) type.
 
-The `LocalizedString` is a value type found in a [Resource](https://docs.commercetools.com/api/types#referencetype), for example `Product`:
+The `LocalizedString` is a type reserved for values found in a [Resource](https://docs.commercetools.com/api/types#referencetype), for example `Product`:
 
 ```js
 // Product
 {
+  // `name` is a `LocalizedString`
+  // as defined by https://docs.commercetools.com/api/projects/products#productdata
   name: {
     en: 'Milk';
   }
@@ -121,7 +123,7 @@ The `LocalizedString` is a value type found in a [Resource](https://docs.commerc
 
 The documented `LocalizedString` in [https://docs.commercetools.com](https://docs.commercetools.com/) is a specification of the HTTP API.
 
-In our `graphql` API, we also find `LocalizedString` value takes a different shape.
+In the commercetools platform `/graphql` API, we also find `LocalizedString` value takes a different shape of the same name.
 
 ```js
 // Product, returned from the `graphql` API of commercetools platform
@@ -135,7 +137,7 @@ In our `graphql` API, we also find `LocalizedString` value takes a different sha
 }
 ```
 
-To distinguish these in the source code of the Merchant Center, we name the graphql shaped value `LocalizedField`. When executing `transformLocalizedFieldToLocalizedString`, we transform the graphql shaped value to the HTTP API shape.
+To distinguish these in source code of the Merchant Center, we name the graphql shaped value `LocalizedField`. When executing `transformLocalizedFieldToLocalizedString`, we transform the graphql shaped value to the HTTP API shape.
 
 #### Example usage
 
@@ -157,28 +159,28 @@ console.log(transformedName);
 
 #### When to use it
 
-This transformation tool will be helpful when you consume the commercetools platform `/graphql` in conjunction with `apollo` and build form views consuming `@commercetools-frontend/ui-kit`.
+This transformation tool will be helpful when you consume the commercetools platform `/graphql` API in conjunction with authoring views consuming `@commercetools-frontend/ui-kit`.
 
 Given that you consume:
 
-- commercetools platform `/graphql` API
+- The commercetools platform `/graphql` API
 - [`LocalizedTextInput`](https://github.com/commercetools/ui-kit/blob/master/packages/components/inputs/localized-text-input/src/localized-text-input.js)
 
 This will be helpful transforming data from `response -> view`.
 
 ```js
-// fetching product from commercetools platform graphql API
+// fetching product from the commercetools platform graphql API
 // returns a product with a `nameAllLocales`
-const fetchedProduct = useQuery(ProductQuery, {
+const product = useMcQuery(ProductQuery, {
   context: GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
 });
 
 // Next, when we are aware that LocalizedTextInput accepts a value of `{ [key: string]: string }`
 const transformedProduct = {
-  ...fetchedProduct.data,
+  ...product.data,
   // so we transform the LocalizedField to a LocalizedString
   // [{ locale: 'en', value: 'Milk' }] -> { en: 'Milk' }
-  name: transformLocalizedFieldToLocalizedString(fetchedProduct.nameAllLocales),
+  name: transformLocalizedFieldToLocalizedString(product.nameAllLocales),
 };
 
 // finally, we are ready to render out LocalizedTextInput with a correctly transformed `name` value.
@@ -189,11 +191,11 @@ return <LocalizedTextInput name="name" value={transformedProduct.name} />;
 
 > Transforms multiple `LocalizedField` -> `LocalizedString`, given `fieldNameTransformationMappings`
 
-In the example above, we demonstrated that you can transform `LocalizedField -> LocalizedString` for a field returned by the commercetools platform `/graphql` API.
+In the example above, we demonstrated that we can transform `LocalizedField -> LocalizedString` of a `LocalizedString` value returned commercetools platform `/graphql` API.
 
-However, given that a Resource can have multiple values of the type `LocalizedField`, this can a cumbersome task to do.
+However, given that a Resource can have multiple values of the type `LocalizedField`, this can be a cumbersome task to do.
 
-So we offer `injectTransformedLocalizedFields` that is meant to transform multiple values.
+We offer `injectTransformedLocalizedFields` that is meant to transform multiple values.
 
 #### Example usage
 
@@ -233,5 +235,4 @@ console.log(transformedProduct);
 
 #### Slight difference to `transformLocalizedFieldToLocalizedString`
 
-Unlike `transformLocalizedFieldToLocalizedString` where you pass in the `LocalizedField` value,
-we need to pass the entire Resource and the `fieldNameTransformationMappings`.
+Unlike `transformLocalizedFieldToLocalizedString` where we pass in the `LocalizedField` value, we need to pass the entire Resource and the `fieldNameTransformationMappings`.

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -330,7 +330,7 @@ The default value of `fallback` is a `""`.
 
 #### Fallback order
 
-In **Scenario 2** above, we discussed that `localize` will pick the _next available value_ from `product.name` when there is matching value. In our case, the next available value was `en`.
+In **Scenario 2** above, we discussed that `localize` will pick the _next available value_ from `product.name` when there is no matching value. In our case, the next available value was `en`.
 As Application Developers, it is possible for us to take over control of the next "lookup" of the value, when there is no match (before `localize` proceeds to rendering `fallback` ).
 
 `localize` accepts `fallbackOrder`, and this [test exemplifies the use case and resolve](./src/localize.spec.ts#L151:L170).

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -252,35 +252,35 @@ All examples below will use the following `Product`:
 const product = {
   name: {
     en: 'Milk',
-    de: 'Milsch,
+    de: 'Milch,
   }
 }
 ```
 
 ##### Scenario 1
 
-Given that specified `language=de`
+Given that selected **data locale** of `de`
 
 ```js
 const translatedName = localize({
   obj: product,
   key: 'name',
-  language: 'de',
+  locale: 'de',
 });
 
 console.log(translatedName);
-// 'Milsch'
+// 'Milch'
 ```
 
 ##### Scenario 2
 
-Given that specified `language=sv`
+Given that selected **data locale** of `sv`
 
 ```js
 const translatedName = localize({
   obj: product,
   key: 'name',
-  language: 'sv',
+  locale: 'sv',
 });
 
 console.log(translatedName);
@@ -289,27 +289,27 @@ console.log(translatedName);
 
 **What happened?**
 
-Our product has no value for the specified language `sv`, what `localize` will do for us as Application Developers is _pick the next available value_ from `product.name`.
+Our product has no value for the selected **data locale** `sv`. The `localize` function selects the "next available value" from `product.name`, in this case `en`, and returns it with a hint `(EN)` that this value refers to another locale.
 
 ##### Scenario 3
 
-Given that specified `language=de-AT`
+Given that selected **data locale** of `de-AT`
 
 ```js
 const translatedName = localize({
   obj: product,
   key: 'name',
-  language: 'de-AT',
+  locale: 'de-AT',
 });
 
 console.log(translatedName);
-// 'Milsch'
+// 'Milch'
 ```
 
 **What happened?**
 
-Our product has no value for the specified language `de-AT` so there is no match, but we still got `"Milsch"`.
-This is because `localize` attempts to determine a **primary language** on the input `language` and match that to the available values. Given that `de` is a [primary](https://en.wikipedia.org/wiki/IETF_language_tag) of `de-AT`, it determines that this is the _closest available value_ from `product.name`
+Our product has no matching value for the selected **data locale** `de-AT` but we still got `"Milch"`.
+This is because `localize` attempts to determine a **primary language tag** on the option `locale` and match that to the available values. Given that `de` is a [primary](https://en.wikipedia.org/wiki/IETF_language_tag) of `de-AT`, it determines that this is the _closest available value_ from `product.name`
 
 #### Fallback
 
@@ -319,7 +319,7 @@ Given that `localize` can not handle all scenario exemplified above, we can spec
 const translatedName = localize({
   obj: product,
   key: 'name',
-  language: 'sv',
+  locale: 'sv',
   fallback: '-',
 });
 ```
@@ -328,8 +328,8 @@ The default value of `fallback` is a `""`.
 
 #### Fallback order
 
-In **Scenario 2** above, we discussed that `localize` will pick the _next available value_ from `product.name` when there is no matching value. In our case, the next available value was `en`.
-As Application Developers, it is possible for us to take over control of the next "lookup" of the value, when there is no match (before `localize` proceeds to rendering `fallback` ).
+In **Scenario 2** above, we discussed that `localize` will pick the "next available value" from `product.name` when there is no matching value. In our case, the next available value was the locale `en`.
+As Custom Application developers, it is possible for us to take control of the "next lookup" of the value, when there is no match (before `localize` proceeds to rendering  what is specified as `fallback`).
 
 `localize` accepts `fallbackOrder`, and this [test exemplifies the use case and resolve](./src/localize.spec.ts#L151:L170).
 
@@ -338,7 +338,7 @@ As Application Developers, it is possible for us to take over control of the nex
 Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `localize` in conjunction with the Application Context.
 
 ```js
-import { Text } from '@commercetools-frontend/ui-kit';
+import Text from '@commercetools-uikit/text';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 
 const { dataLocale, projectLanguages } = useApplicationContext(

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -235,14 +235,14 @@ const product = {
 When rendering a Product in a view, we would like to render the value of a localized string field, such as `name`, given the selected **data locale** of the UI.
 The **data locale** is a value controlled by the Merchant Center User (MC User) by changing the **data locale switcher** in the top bar of the Merchant Center. The list of available options is derived by the list of languages specified in the project. The selected value can be read from the **application context**.
 
-However, there might be a case where the selected **data locale** does not match any of the localized string values. In this case, it would be helpful to display a "fallback" value using the `formatLocalizedString` function.
+However, there might be a case where the selected **data locale** does not match any of the localized string values. In this case, it is recommended to display a "fallback" value using the `formatLocalizedString` function.
 
-The `formatLocalizedString` util is authored with a couple of things in mind:
+The `formatLocalizedString` util is authored with the following in mind:
 
 1. Help us Custom Application developers remain resilient as we attempt to derive a value of `LocalizedString` given a specified locale.
 2. Help us Custom Application developers remain consistent when rendering a value derived from `LocalizedString`.
 
-Let's take a look at the examples below to put this to action.
+Let us take a look at the examples below putting this to action.
 
 #### Example usage
 
@@ -287,7 +287,7 @@ console.log(translatedName);
 
 **What happened?**
 
-Our product has no value for the selected **data locale** `sv`. The `formatLocalizedString` function selects the "next available value" from `product.name`, in this case `en`, and returns it with a hint `(EN)` that this value refers to another locale.
+Our product has no value for the selected **data locale** `sv`. The `formatLocalizedString` function selects the "next available value" (more details on the order below) from `product.name`. In this case it's `en`, and returns it with a hint `(EN)` that this value refers to another locale.
 
 ##### Scenario 3
 
@@ -310,7 +310,7 @@ This is because `formatLocalizedString` attempts to determine a **primary langua
 
 #### Fallback
 
-Given that `formatLocalizedString` can not handle all scenario exemplified above, we can specify a `fallback` as a last resort:
+To provide even more freedom beyond cases mentioned above the `formatLocalizedString` allows specifying a `fallback` as a last resort:
 
 ```js
 const translatedName = formatLocalizedString(product, {
@@ -326,13 +326,13 @@ The default value of `fallback` is a `""`.
 #### Fallback order
 
 In **Scenario 2** above, we discussed that `formatLocalizedString` will pick the "next available value" from `product.name` when there is no matching value. In our case, the next available value was the locale `en`.
-As Custom Application developers, it is possible for us to take control of the "next lookup" of the value, when there is no match (before `formatLocalizedString` proceeds to rendering what is specified as `fallback`).
+Custom Application developers can take full control over the order of attempted lookups of the value while there is no match. Before `formatLocalizedString` eventually proceeds to rendering what is specified as `fallback`.
 
 `formatLocalizedString` accepts `fallbackOrder`, and this [test exemplifies the use case and resolve](./src/localize.spec.ts#L151:L170).
 
 #### When to use it
 
-Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `formatLocalizedString` in conjunction with the Application Context.
+Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `formatLocalizedString` in conjunction with the Application Context. A user usually has a defined preference of languages we can use. 
 
 ```js
 import Text from '@commercetools-uikit/text';

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -123,7 +123,7 @@ The `LocalizedString` is a type reserved for values found in a [Resource](https:
 
 The documented `LocalizedString` in [https://docs.commercetools.com](https://docs.commercetools.com/) is a specification of the HTTP API.
 
-However, the commercetools platform `/graphql` API represents the `LocalizedString` in a different format as a list, for technical reasons.
+However, the commercetools platform `/graphql` API represents the `LocalizedString` as a list of the same name.
 
 ```js
 // Product, returned from the `/graphql` API of commercetools platform
@@ -216,8 +216,7 @@ return (
 
 > Transforms a `LocalizedString` to a String
 
-The `formatLocalizedString` util is a util we use internally inside the Merchant Center.
-This util is at the moment subject to change, hence marked as Draft. Use with caution in your Custom Application.
+The `formatLocalizedString` util is a util we use internally inside the Merchant Center. This util is at the moment subject to change, hence marked as `Draft`.
 
 #### Context
 
@@ -332,7 +331,7 @@ Custom Application developers can take full control over the order of attempted 
 
 #### When to use it
 
-Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `formatLocalizedString` in conjunction with the Application Context. A user usually has a defined preference of languages we can use. 
+Given that we want to render `LocalizedString` of a given `Resource`, it is sensible to rely on `formatLocalizedString` in conjunction with the Application Context. A user usually has a defined preference of languages we can use.
 
 ```js
 import Text from '@commercetools-uikit/text';

--- a/packages/l10n/README.md
+++ b/packages/l10n/README.md
@@ -232,17 +232,15 @@ const product = {
 }
 ```
 
-When rendering a Product in a view, we would like to render the value of `name` given the `language` of the UI.
-The `language` is a value controlled by the Merchant Center User (MC User) by updating the language switcher on the Application Bar of the Merchant Center.
+When rendering a Product in a view, we would like to render the value of a localized string field, such as `name`, given the selected **data locale** of the UI.
+The **data locale** is a value controlled by the Merchant Center User (MC User) by changing the **data locale switcher** in the top bar of the Merchant Center. The list of available options is derived by the list of languages specified in the project. The selected value can be read from the **application context**.
 
-The language switcher emits a value that is intended to help us Application Developers display the Resource data (`Product` in our example) in the specified language. Given that the `product.name` has a value of the specified `language`, we can easily pick the value from the `product.name`.
-
-However there are scenarios where the MC User updates the language switcher to a value that our Product example has no matching value. What then? This is where `localize` plays its role.
+However, there might be a case where the selected **data locale** does not match any of the localized string values. In this case, it would be helpful to display a "fallback" value using the `localize` function.
 
 The `localize` util is authored with a couple of things in mind:
 
-1. Help us Application Developers remain resilient as we attempt to derive a value of `LocalizedString` given a specified language.
-2. Help us Application Developers remain consistent when rendering a value derived from `LocalizedString`
+1. Help us Custom Application developers remain resilient as we attempt to derive a value of `LocalizedString` given a specified locale.
+2. Help us Custom Application developers remain consistent when rendering a value derived from `LocalizedString`.
 
 Let's take a look at the examples below to put this to action.
 

--- a/packages/l10n/package.json
+++ b/packages/l10n/package.json
@@ -34,7 +34,8 @@
     "@babel/runtime-corejs3": "7.12.5",
     "@commercetools-frontend/sentry": "17.4.1",
     "@types/prop-types": "^15.7.3",
-    "lodash.omit": "^4.5.0",
+    "lodash": "4.17.20",
+    "lodash-es": "4.17.15",
     "moment": "^2.24.0",
     "prop-types": "15.7.2"
   },

--- a/packages/l10n/package.json
+++ b/packages/l10n/package.json
@@ -34,6 +34,7 @@
     "@babel/runtime-corejs3": "7.12.5",
     "@commercetools-frontend/sentry": "17.4.1",
     "@types/prop-types": "^15.7.3",
+    "lodash.omit": "^4.5.0",
     "moment": "^2.24.0",
     "prop-types": "15.7.2"
   },

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -20,6 +20,6 @@ export {
 } from './time-zone-information';
 
 export {
-  transformLocalizedFieldToString,
+  transformLocalizedFieldToLocalizedString,
   injectTransformedLocalizedFields,
 } from './localize';

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -18,3 +18,8 @@ export {
   withTimeZones,
   timeZonesShape,
 } from './time-zone-information';
+
+export {
+  transformLocalizedFieldToString,
+  injectTransformedLocalizedFields,
+} from './localize';

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -19,7 +19,4 @@ export {
   timeZonesShape,
 } from './time-zone-information';
 
-export {
-  transformLocalizedFieldToLocalizedString,
-  applyTransformedLocalizedFields,
-} from './localize';
+export { applyTransformedLocalizedFields } from './localize';

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -21,5 +21,5 @@ export {
 
 export {
   transformLocalizedFieldToLocalizedString,
-  injectTransformedLocalizedFields,
+  applyTransformedLocalizedFields,
 } from './localize';

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -19,4 +19,7 @@ export {
   timeZonesShape,
 } from './time-zone-information';
 
-export { applyTransformedLocalizedFields } from './localize';
+export {
+  applyTransformedLocalizedFields,
+  formatLocalizedString,
+} from './localize';

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -1,7 +1,7 @@
 import {
   transformLocalizedFieldToLocalizedString,
   applyTransformedLocalizedFields,
-  localize,
+  formatLocalizedString,
 } from './localize';
 
 describe('applyTransformedLocalizedFields', () => {
@@ -63,14 +63,13 @@ describe('transformLocalizedFieldToLocalizedString', () => {
   });
 });
 
-describe('localize', () => {
+describe('formatLocalizedString', () => {
   describe('when entity was not provided', () => {
     it('should return empty string', () => {
       expect(
-        localize({
+        formatLocalizedString(null, {
           locale: 'en',
           key: 'name',
-          obj: undefined,
         })
       ).toBe('');
     });
@@ -78,40 +77,46 @@ describe('localize', () => {
   describe('when entity does not have requested localized string', () => {
     it('should return empty string', () => {
       expect(
-        localize({
-          obj: { name: undefined },
-          locale: 'en',
-          key: 'name',
-        })
+        formatLocalizedString(
+          { name: undefined },
+          {
+            locale: 'en',
+            key: 'name',
+          }
+        )
       ).toBe('');
     });
   });
   describe('when localized string does not have any translations', () => {
     it('should return default fallback value', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               en: '',
             },
           },
-          key: 'localizedStringKey',
-          locale: 'de',
-        })
+          {
+            key: 'localizedStringKey',
+            locale: 'de',
+          }
+        )
       ).toBe('');
     });
     it('should return custom fallback value', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               en: '',
             },
           },
-          key: 'localizedStringKey',
-          locale: 'de',
-          fallback: 'custom fallback',
-        })
+          {
+            key: 'localizedStringKey',
+            locale: 'de',
+            fallback: 'custom fallback',
+          }
+        )
       ).toBe('custom fallback');
     });
   });
@@ -119,15 +124,17 @@ describe('localize', () => {
   describe('when localized string has prefered locale', () => {
     it('should return translation', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               'de-AT': 'a translation',
             },
           },
-          key: 'localizedStringKey',
-          locale: 'de-AT',
-        })
+          {
+            key: 'localizedStringKey',
+            locale: 'de-AT',
+          }
+        )
       ).toBe('a translation');
     });
   });
@@ -135,15 +142,17 @@ describe('localize', () => {
   describe('when localized sring has primary locale matching preferred (extended) langauge', () => {
     it('should return translation', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               de: 'a primary translation',
             },
           },
-          locale: 'de-AT',
-          key: 'localizedStringKey',
-        })
+          {
+            locale: 'de-AT',
+            key: 'localizedStringKey',
+          }
+        )
       ).toBe('a primary translation');
     });
   });
@@ -151,8 +160,8 @@ describe('localize', () => {
   describe('when preferred locale was not provided', () => {
     it('should fallback to the first locale according to fallback order', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               ru: '',
               fr: 'fr translation',
@@ -160,11 +169,13 @@ describe('localize', () => {
               it: 'it translation',
             },
           },
-          key: 'localizedStringKey',
-          // @ts-ignore
-          locale: undefined,
-          fallbackOrder: ['it', 'fr'],
-        })
+          {
+            key: 'localizedStringKey',
+            // @ts-ignore
+            locale: undefined,
+            fallbackOrder: ['it', 'fr'],
+          }
+        )
       ).toBe('it translation (IT)');
     });
   });
@@ -172,8 +183,8 @@ describe('localize', () => {
   describe('when localized string does not have locales related to preferred locale', () => {
     it('should fallback to the first non-empty locale', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               ru: '',
               fr: 'fr translation',
@@ -181,9 +192,11 @@ describe('localize', () => {
               it: 'it translation',
             },
           },
-          key: 'localizedStringKey',
-          locale: 'jp',
-        })
+          {
+            key: 'localizedStringKey',
+            locale: 'jp',
+          }
+        )
       ).toBe('fr translation (FR)');
     });
   });
@@ -191,8 +204,8 @@ describe('localize', () => {
   describe('when localized string has locale from provided desired fallback locales order', () => {
     it('should return first non-empty translation', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               ru: '',
               fr: 'fr translation',
@@ -200,10 +213,12 @@ describe('localize', () => {
               it: 'it translation',
             },
           },
-          key: 'localizedStringKey',
-          fallbackOrder: ['ru', 'it'],
-          locale: 'de-AT',
-        })
+          {
+            key: 'localizedStringKey',
+            fallbackOrder: ['ru', 'it'],
+            locale: 'de-AT',
+          }
+        )
       ).toBe('it translation (IT)');
     });
   });
@@ -211,8 +226,8 @@ describe('localize', () => {
   describe('when localized string is missing locales from provided desired fallback locales order', () => {
     it('should fallback to first present locale', () => {
       expect(
-        localize({
-          obj: {
+        formatLocalizedString(
+          {
             localizedStringKey: {
               ru: '',
               fr: 'fr translation',
@@ -220,10 +235,12 @@ describe('localize', () => {
               it: 'it translation',
             },
           },
-          key: 'localizedStringKey',
-          locale: 'de-AT',
-          fallbackOrder: ['ru', 'pl'],
-        })
+          {
+            key: 'localizedStringKey',
+            locale: 'de-AT',
+            fallbackOrder: ['ru', 'pl'],
+          }
+        )
       ).toBe('fr translation (FR)');
     });
   });

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -68,7 +68,7 @@ describe('localize', () => {
     it('should return empty string', () => {
       expect(
         localize({
-          language: 'en',
+          locale: 'en',
           key: 'name',
           obj: undefined,
         })
@@ -80,7 +80,7 @@ describe('localize', () => {
       expect(
         localize({
           obj: { name: undefined },
-          language: 'en',
+          locale: 'en',
           key: 'name',
         })
       ).toBe('');
@@ -96,7 +96,7 @@ describe('localize', () => {
             },
           },
           key: 'localizedStringKey',
-          language: 'de',
+          locale: 'de',
         })
       ).toBe('');
     });
@@ -109,14 +109,14 @@ describe('localize', () => {
             },
           },
           key: 'localizedStringKey',
-          language: 'de',
+          locale: 'de',
           fallback: 'custom fallback',
         })
       ).toBe('custom fallback');
     });
   });
 
-  describe('when localized string has prefered language', () => {
+  describe('when localized string has prefered locale', () => {
     it('should return translation', () => {
       expect(
         localize({
@@ -126,13 +126,13 @@ describe('localize', () => {
             },
           },
           key: 'localizedStringKey',
-          language: 'de-AT',
+          locale: 'de-AT',
         })
       ).toBe('a translation');
     });
   });
 
-  describe('when localized sring has primary language matching preferred (extended) langauge', () => {
+  describe('when localized sring has primary locale matching preferred (extended) langauge', () => {
     it('should return translation', () => {
       expect(
         localize({
@@ -141,15 +141,15 @@ describe('localize', () => {
               de: 'a primary translation',
             },
           },
-          language: 'de-AT',
+          locale: 'de-AT',
           key: 'localizedStringKey',
         })
       ).toBe('a primary translation');
     });
   });
 
-  describe('when preferred language was not provided', () => {
-    it('should fallback to the first language according to fallback order', () => {
+  describe('when preferred locale was not provided', () => {
+    it('should fallback to the first locale according to fallback order', () => {
       expect(
         localize({
           obj: {
@@ -162,15 +162,15 @@ describe('localize', () => {
           },
           key: 'localizedStringKey',
           // @ts-ignore
-          language: undefined,
+          locale: undefined,
           fallbackOrder: ['it', 'fr'],
         })
       ).toBe('it translation (IT)');
     });
   });
 
-  describe('when localized string does not have languages related to preferred language', () => {
-    it('should fallback to the first non-empty language', () => {
+  describe('when localized string does not have locales related to preferred locale', () => {
+    it('should fallback to the first non-empty locale', () => {
       expect(
         localize({
           obj: {
@@ -182,13 +182,13 @@ describe('localize', () => {
             },
           },
           key: 'localizedStringKey',
-          language: 'jp',
+          locale: 'jp',
         })
       ).toBe('fr translation (FR)');
     });
   });
 
-  describe('when localized string has language from provided desired fallback languages order', () => {
+  describe('when localized string has locale from provided desired fallback locales order', () => {
     it('should return first non-empty translation', () => {
       expect(
         localize({
@@ -202,14 +202,14 @@ describe('localize', () => {
           },
           key: 'localizedStringKey',
           fallbackOrder: ['ru', 'it'],
-          language: 'de-AT',
+          locale: 'de-AT',
         })
       ).toBe('it translation (IT)');
     });
   });
 
-  describe('when localized string is missing languages from provided desired fallback languages order', () => {
-    it('should fallback to first present language', () => {
+  describe('when localized string is missing locales from provided desired fallback locales order', () => {
+    it('should fallback to first present locale', () => {
       expect(
         localize({
           obj: {
@@ -221,7 +221,7 @@ describe('localize', () => {
             },
           },
           key: 'localizedStringKey',
-          language: 'de-AT',
+          locale: 'de-AT',
           fallbackOrder: ['ru', 'pl'],
         })
       ).toBe('fr translation (FR)');

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -1,13 +1,13 @@
 import {
   transformLocalizedFieldToLocalizedString,
-  injectTransformedLocalizedFields,
+  applyTransformedLocalizedFields,
 } from './localize';
 
-describe('injectTransformedLocalizedFields', () => {
+describe('applyTransformedLocalizedFields', () => {
   describe('when entity contains list of locale fields', () => {
     it('should inject localized string object field and remove outdated key', () => {
       expect(
-        injectTransformedLocalizedFields(
+        applyTransformedLocalizedFields(
           {
             id: '1',
             nameAllLocales: [
@@ -23,7 +23,7 @@ describe('injectTransformedLocalizedFields', () => {
   describe('when entity does not contain list of locale fields', () => {
     it('should inject localized string object field as null and remove outdated key', () => {
       expect(
-        injectTransformedLocalizedFields({ id: '1' }, [
+        applyTransformedLocalizedFields({ id: '1' }, [
           { from: 'nameAllLocales', to: 'name' },
         ])
       ).toEqual({ id: '1', name: null });
@@ -33,7 +33,7 @@ describe('injectTransformedLocalizedFields', () => {
   describe('when array of locale fields is empty', () => {
     it('should not change entity shape', () => {
       expect(
-        injectTransformedLocalizedFields({ id: '1', version: 2 }, [])
+        applyTransformedLocalizedFields({ id: '1', version: 2 }, [])
       ).toEqual({ id: '1', version: 2 });
     });
   });

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -1,5 +1,5 @@
 import {
-  transformLocalizedFieldToString,
+  transformLocalizedFieldToLocalizedString,
   injectTransformedLocalizedFields,
 } from './localize';
 
@@ -39,21 +39,21 @@ describe('injectTransformedLocalizedFields', () => {
   });
 });
 
-describe('transformLocalizedFieldToString', () => {
+describe('transformLocalizedFieldToLocalizedString', () => {
   describe('when array is not defined', () => {
     it('should return null', () => {
-      expect(transformLocalizedFieldToString()).toBe(null);
+      expect(transformLocalizedFieldToLocalizedString()).toBe(null);
     });
   });
   describe('when array is empty', () => {
     it('should return null', () => {
-      expect(transformLocalizedFieldToString([])).toBe(null);
+      expect(transformLocalizedFieldToLocalizedString([])).toBe(null);
     });
   });
   describe('when array is defined', () => {
     it('should return LocalizedString object', () => {
       expect(
-        transformLocalizedFieldToString([
+        transformLocalizedFieldToLocalizedString([
           { locale: 'en', value: 'Hello' },
           { locale: 'it', value: 'Ciao' },
         ])

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -1,6 +1,7 @@
 import {
   transformLocalizedFieldToLocalizedString,
   applyTransformedLocalizedFields,
+  localize,
 } from './localize';
 
 describe('applyTransformedLocalizedFields', () => {
@@ -58,6 +59,172 @@ describe('transformLocalizedFieldToLocalizedString', () => {
           { locale: 'it', value: 'Ciao' },
         ])
       ).toEqual({ en: 'Hello', it: 'Ciao' });
+    });
+  });
+});
+
+describe('localize', () => {
+  describe('when entity was not provided', () => {
+    it('should return empty string', () => {
+      expect(
+        localize({
+          language: 'en',
+          key: 'name',
+          obj: undefined,
+        })
+      ).toBe('');
+    });
+  });
+  describe('when entity does not have requested localized string', () => {
+    it('should return empty string', () => {
+      expect(
+        localize({
+          obj: { name: undefined },
+          language: 'en',
+          key: 'name',
+        })
+      ).toBe('');
+    });
+  });
+  describe('when localized string does not have any translations', () => {
+    it('should return default fallback value', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              en: '',
+            },
+          },
+          key: 'localizedStringKey',
+          language: 'de',
+        })
+      ).toBe('');
+    });
+    it('should return custom fallback value', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              en: '',
+            },
+          },
+          key: 'localizedStringKey',
+          language: 'de',
+          fallback: 'custom fallback',
+        })
+      ).toBe('custom fallback');
+    });
+  });
+
+  describe('when localized string has prefered language', () => {
+    it('should return translation', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              'de-AT': 'a translation',
+            },
+          },
+          key: 'localizedStringKey',
+          language: 'de-AT',
+        })
+      ).toBe('a translation');
+    });
+  });
+
+  describe('when localized sring has primary language matching preferred (extended) langauge', () => {
+    it('should return translation', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              de: 'a primary translation',
+            },
+          },
+          language: 'de-AT',
+          key: 'localizedStringKey',
+        })
+      ).toBe('a primary translation');
+    });
+  });
+
+  describe('when preferred language was not provided', () => {
+    it('should fallback to the first language according to fallback order', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              ru: '',
+              fr: 'fr translation',
+              en: 'en translation',
+              it: 'it translation',
+            },
+          },
+          key: 'localizedStringKey',
+          // @ts-ignore
+          language: undefined,
+          fallbackOrder: ['it', 'fr'],
+        })
+      ).toBe('it translation (IT)');
+    });
+  });
+
+  describe('when localized string does not have languages related to preferred language', () => {
+    it('should fallback to the first non-empty language', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              ru: '',
+              fr: 'fr translation',
+              en: 'en translation',
+              it: 'it translation',
+            },
+          },
+          key: 'localizedStringKey',
+          language: 'jp',
+        })
+      ).toBe('fr translation (FR)');
+    });
+  });
+
+  describe('when localized string has language from provided desired fallback languages order', () => {
+    it('should return first non-empty translation', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              ru: '',
+              fr: 'fr translation',
+              en: 'en translation',
+              it: 'it translation',
+            },
+          },
+          key: 'localizedStringKey',
+          fallbackOrder: ['ru', 'it'],
+          language: 'de-AT',
+        })
+      ).toBe('it translation (IT)');
+    });
+  });
+
+  describe('when localized string is missing languages from provided desired fallback languages order', () => {
+    it('should fallback to first present language', () => {
+      expect(
+        localize({
+          obj: {
+            localizedStringKey: {
+              ru: '',
+              fr: 'fr translation',
+              en: 'en translation',
+              it: 'it translation',
+            },
+          },
+          key: 'localizedStringKey',
+          language: 'de-AT',
+          fallbackOrder: ['ru', 'pl'],
+        })
+      ).toBe('fr translation (FR)');
     });
   });
 });

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -1,0 +1,63 @@
+import {
+  transformLocalizedFieldToString,
+  injectTransformedLocalizedFields,
+} from './localize';
+
+describe('injectTransformedLocalizedFields', () => {
+  describe('when entity contains list of locale fields', () => {
+    it('should inject localized string object field and remove outdated key', () => {
+      expect(
+        injectTransformedLocalizedFields(
+          {
+            id: '1',
+            nameAllLocales: [
+              { locale: 'en', value: 'CD' },
+              { locale: 'de', value: 'CD' },
+            ],
+          },
+          [{ from: 'nameAllLocales', to: 'name' }]
+        )
+      ).toEqual({ id: '1', name: { en: 'CD', de: 'CD' } });
+    });
+  });
+  describe('when entity does not contain list of locale fields', () => {
+    it('should inject localized string object field as null and remove outdated key', () => {
+      expect(
+        injectTransformedLocalizedFields({ id: '1' }, [
+          { from: 'nameAllLocales', to: 'name' },
+        ])
+      ).toEqual({ id: '1', name: null });
+    });
+  });
+
+  describe('when array of locale fields is empty', () => {
+    it('should not change entity shape', () => {
+      expect(
+        injectTransformedLocalizedFields({ id: '1', version: 2 }, [])
+      ).toEqual({ id: '1', version: 2 });
+    });
+  });
+});
+
+describe('transformLocalizedFieldToString', () => {
+  describe('when array is not defined', () => {
+    it('should return null', () => {
+      expect(transformLocalizedFieldToString()).toBe(null);
+    });
+  });
+  describe('when array is empty', () => {
+    it('should return null', () => {
+      expect(transformLocalizedFieldToString([])).toBe(null);
+    });
+  });
+  describe('when array is defined', () => {
+    it('should return LocalizedString object', () => {
+      expect(
+        transformLocalizedFieldToString([
+          { locale: 'en', value: 'Hello' },
+          { locale: 'it', value: 'Ciao' },
+        ])
+      ).toEqual({ en: 'Hello', it: 'Ciao' });
+    });
+  });
+});

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -5,11 +5,7 @@ import {
   FieldNameTranformationMapping,
   LocalizeSignatureOptions,
 } from './types';
-import {
-  getPrimaryLanguage,
-  findFallbackLanguage,
-  addFallbackHint,
-} from './utils';
+import { getPrimaryLocale, findFallbackLocale, addFallbackHint } from './utils';
 
 /**
  * Transforms a list of `LocalizedField` into a `LocalizedString` object
@@ -112,7 +108,7 @@ export const applyTransformedLocalizedFields = <
 export const localize = <Input extends Record<string, unknown>>({
   obj: entity,
   key = '',
-  language,
+  locale,
   fallbackOrder = [],
   fallback = '',
 }: LocalizeSignatureOptions<Input>): string => {
@@ -121,13 +117,13 @@ export const localize = <Input extends Record<string, unknown>>({
   if (!entity || !entity[key]) return fallback;
   const localizedString = entity[key] as LocalizedString;
 
-  if (localizedString[language]) return localizedString[language];
+  if (localizedString[locale]) return localizedString[locale];
 
-  // see if we can fallback to the primary language, eg. de for de-AT
-  const primaryLanguage = language && getPrimaryLanguage(language);
-  if (localizedString[primaryLanguage]) return localizedString[primaryLanguage];
+  // see if we can fallback to the primary locale, eg. de for de-AT
+  const primaryLocale = locale && getPrimaryLocale(locale);
+  if (localizedString[primaryLocale]) return localizedString[primaryLocale];
 
-  const fallbackLanguage = findFallbackLanguage(localizedString, fallbackOrder);
+  const fallbackLanguage = findFallbackLocale(localizedString, fallbackOrder);
   return fallbackLanguage
     ? addFallbackHint(localizedString[fallbackLanguage], fallbackLanguage)
     : fallback;

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -44,7 +44,7 @@ export const transformLocalizedFieldToLocalizedString = (
  *   * `from`: the field to transform and to remove after
  *   * `to`: the target field to write the transformed shape
  */
-export const injectTransformedLocalizedFields = <
+export const applyTransformedLocalizedFields = <
   Input extends Record<string, unknown>,
   Output extends Record<string, unknown>
 >(

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -18,7 +18,7 @@ type TFieldNameTranformationMapping = {
  * Transforms a list of `LocalizedField` into a `LocalizedString` object
  * [{ locale: 'sv', value: 'Hej' }] -> { sv: 'Hej' }
  */
-export const transformLocalizedFieldToString = (
+export const transformLocalizedFieldToLocalizedString = (
   localizedFields?: TLocalizedField[]
 ): TLocalizedString | null => {
   if (!localizedFields || localizedFields.length === 0) return null;
@@ -54,7 +54,7 @@ export const injectTransformedLocalizedFields = <
   const transformedFieldDefinitions = fieldNames.reduce(
     (nextTransformed, fieldName) => ({
       ...nextTransformed,
-      [fieldName.to]: transformLocalizedFieldToString(
+      [fieldName.to]: transformLocalizedFieldToLocalizedString(
         objectWithLocalizedFields[fieldName.from] as
           | TLocalizedField[]
           | undefined

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -1,0 +1,73 @@
+import omit from 'lodash.omit';
+
+type TLocalizedField = {
+  locale: string;
+  value: string;
+};
+
+type TLocalizedString = {
+  [key: string]: string;
+};
+
+type TFieldNameTranformationDefinition = {
+  from: string;
+  to: string;
+};
+
+type TRecordOfLocalizedString = Record<string, TLocalizedString | null>;
+type TObjectContainsLocalizedString = Partial<TRecordOfLocalizedString>;
+
+/**
+ * Transforms a list of `LocalizedField` into a `LocalizedString` object
+ * [{ locale: 'sv', value: 'Hej' }] -> { sv: 'Hej' }
+ */
+export const transformLocalizedFieldToString = (
+  localizedFields?: TLocalizedField[] | null
+): TLocalizedString | null => {
+  if (!localizedFields || localizedFields.length === 0) return null;
+  return localizedFields.reduce(
+    (nextLocalizedString, field) => ({
+      ...nextLocalizedString,
+      [field.locale]: field.value,
+    }),
+    {}
+  );
+};
+
+/**
+ * Given a list of localized field names to map, replace the fields in the
+ * format of `LocalizedField` to a `LocalizedString` object.
+ * The existing "localized" fields (the list version) will be removed.
+ *
+ * @param objectWithLocalizedFields
+ * the object with `LocalizedField` fields
+ * that need to be transformed into `LocalizedStrings`
+ * @param fieldNames
+ * An array of objects with following shape:
+ *   * `from`: the field to transform and to remove after
+ *   * `to`: the target field to write the transformed shape
+ */
+export const injectTransformedLocalizedFields = <
+  T extends Record<string, TLocalizedField[] | unknown>
+>(
+  objectWithLocalizedFields: T,
+  fieldNames: TFieldNameTranformationDefinition[]
+): TObjectContainsLocalizedString => {
+  const transformedFieldDefinitions: TRecordOfLocalizedString = fieldNames.reduce(
+    (nextTransformed, fieldName): TRecordOfLocalizedString => ({
+      ...nextTransformed,
+      [fieldName.to]: transformLocalizedFieldToString(
+        objectWithLocalizedFields[fieldName.from] as TLocalizedField[]
+      ),
+    }),
+    {}
+  );
+  const objectWithoutLocalizedFields: Partial<Record<keyof T, unknown>> = omit(
+    objectWithLocalizedFields,
+    fieldNames.map((field) => field.from)
+  );
+  return {
+    ...objectWithoutLocalizedFields,
+    ...transformedFieldDefinitions,
+  };
+};

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -5,7 +5,11 @@ import {
   FieldNameTranformationMapping,
   LocalizeSignatureOptions,
 } from './types';
-import { getPrimaryLocale, findFallbackLocale, addFallbackHint } from './utils';
+import {
+  getPrimaryLocale,
+  findFallbackLocale,
+  formatLocalizedFallbackHint,
+} from './utils';
 
 /**
  * Transforms a list of `LocalizedField` into a `LocalizedString` object
@@ -119,6 +123,9 @@ export const localize = <Input extends Record<string, unknown>>({
 
   const fallbackLanguage = findFallbackLocale(localizedString, fallbackOrder);
   return fallbackLanguage
-    ? addFallbackHint(localizedString[fallbackLanguage], fallbackLanguage)
+    ? formatLocalizedFallbackHint(
+        localizedString[fallbackLanguage],
+        fallbackLanguage
+      )
     : fallback;
 };

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -1,4 +1,4 @@
-import omit from 'lodash.omit';
+import omit from 'lodash/omit';
 
 type TLocalizedField = {
   locale: string;

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
   LocalizedField,
   FieldNameTranformationMapping,
-  LocalizeSignatureOptions,
+  FormatLocalizedStringOptions,
 } from './types';
 import {
   getPrimaryLocale,
@@ -110,7 +110,7 @@ export const formatLocalizedString = <Input extends Record<string, unknown>>(
     locale,
     fallbackOrder = [],
     fallback = '',
-  }: LocalizeSignatureOptions<Input>
+  }: FormatLocalizedStringOptions<Input>
 ): string => {
   // if there is no entity to be localized or the field does not exist on the
   // entity, then return the fallback

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -3,7 +3,13 @@ import {
   LocalizedString,
   LocalizedField,
   FieldNameTranformationMapping,
+  LocalizeSignatureOptions,
 } from './types';
+import {
+  getPrimaryLanguage,
+  findFallbackLanguage,
+  addFallbackHint,
+} from './utils';
 
 /**
  * Transforms a list of `LocalizedField` into a `LocalizedString` object
@@ -68,4 +74,61 @@ export const applyTransformedLocalizedFields = <
     ...objectWithouLocalizedFields,
     ...transformedFieldDefinitions,
   } as Output;
+};
+
+/**
+ * Translates a localized string on an entity.
+ *
+ * The `localize` function receives a complete entity that can have several
+ * localized fields.
+ *
+ * Arguments
+ *  - `obj`: that entity
+ *  - `key`: the field within `obj` that might contain a localized strings
+ *  - `language`: the language key that should be the first choice to show
+ *  - `fallbackOrder`: an array of language keys which will be tried in the
+ *     provided order for any set value
+ *  - `fallback`: the final fallback that should be displayed as a last resort.
+ *     This fallback will also be shown in case the field does not exist on the
+ *     provided object.
+ *
+ * Before `fallback` kicks in, the following is tried to display a meaningful value:
+ *  - if `language` is `<language>-<extlang>`, eg. `de-AT`, try if `de` is set
+ *  - if not, iterate through all languages of project-settings
+ *    (passed as `fallbackOrder`) and pick the first one with a value
+ *  - if nothing is found, go through all the languages in provided localized
+ *    string an pick the first with a value
+ *  - if still no value is found display `fallback`
+ *
+ * NOTE: It is known that this might lead to strings displayed in different
+ *       languages within the same page. This is an accepted downside.
+ *
+ * NOTE: A missing field is treated like a localied string with no translations:
+ *       let a = localize({ obj: { name: { en: '', de: '' } }, language: 'en' })
+ *       let b = localize({ obj: {}, language: 'en' })
+ *       let c = localize({ obj: undefined, language: 'en' })
+ *       a === b && a === c -> true
+ */
+export const localize = <Input extends Record<string, unknown>>({
+  obj: entity,
+  key = '',
+  language,
+  fallbackOrder = [],
+  fallback = '',
+}: LocalizeSignatureOptions<Input>): string => {
+  // if there is no entity to be localized or the field does not exist on the
+  // entity, then return the fallback
+  if (!entity || !entity[key]) return fallback;
+  const localizedString = entity[key] as LocalizedString;
+
+  if (localizedString[language]) return localizedString[language];
+
+  // see if we can fallback to the primary language, eg. de for de-AT
+  const primaryLanguage = language && getPrimaryLanguage(language);
+  if (localizedString[primaryLanguage]) return localizedString[primaryLanguage];
+
+  const fallbackLanguage = findFallbackLanguage(localizedString, fallbackOrder);
+  return fallbackLanguage
+    ? addFallbackHint(localizedString[fallbackLanguage], fallbackLanguage)
+    : fallback;
 };

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -79,7 +79,7 @@ export const applyTransformedLocalizedFields = <
  * Arguments
  *  - `obj`: that entity
  *  - `key`: the field within `obj` that might contain a localized strings
- *  - `language`: the language key that should be the first choice to show
+ *  - `locale`: the language key that should be the first choice to show
  *  - `fallbackOrder`: an array of language keys which will be tried in the
  *     provided order for any set value
  *  - `fallback`: the final fallback that should be displayed as a last resort.
@@ -87,7 +87,7 @@ export const applyTransformedLocalizedFields = <
  *     provided object.
  *
  * Before `fallback` kicks in, the following is tried to display a meaningful value:
- *  - if `language` is `<language>-<extlang>`, eg. `de-AT`, try if `de` is set
+ *  - if `locale` is `<language>-<extlang>`, eg. `de-AT`, try if `de` is set
  *  - if not, iterate through all languages of project-settings
  *    (passed as `fallbackOrder`) and pick the first one with a value
  *  - if nothing is found, go through all the languages in provided localized
@@ -98,9 +98,9 @@ export const applyTransformedLocalizedFields = <
  *       languages within the same page. This is an accepted downside.
  *
  * NOTE: A missing field is treated like a localied string with no translations:
- *       let a = localize({ obj: { name: { en: '', de: '' } }, language: 'en' })
- *       let b = localize({ obj: {}, language: 'en' })
- *       let c = localize({ obj: undefined, language: 'en' })
+ *       let a = localize({ obj: { name: { en: '', de: '' } }, locale: 'en' })
+ *       let b = localize({ obj: {}, locale: 'en' })
+ *       let c = localize({ obj: undefined, locale: 'en' })
  *       a === b && a === c -> true
  */
 export const localize = <Input extends Record<string, unknown>>({

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -1,30 +1,21 @@
 import omit from 'lodash/omit';
-
-type TLocalizedField = {
-  locale: string;
-  value: string;
-};
-
-type TLocalizedString = {
-  [key: string]: string;
-};
-
-type TFieldNameTranformationMapping = {
-  from: string;
-  to: string;
-};
+import {
+  LocalizedString,
+  LocalizedField,
+  FieldNameTranformationMapping,
+} from './types';
 
 /**
  * Transforms a list of `LocalizedField` into a `LocalizedString` object
  * [{ locale: 'sv', value: 'Hej' }] -> { sv: 'Hej' }
  */
 export const transformLocalizedFieldToLocalizedString = (
-  localizedFields?: TLocalizedField[]
-): TLocalizedString | null => {
+  localizedFields?: LocalizedField[]
+): LocalizedString | null => {
   if (!localizedFields || localizedFields.length === 0) return null;
   return localizedFields.reduce(
-    (nextLocalizedString, field) => ({
-      ...nextLocalizedString,
+    (nexLocalizedString, field) => ({
+      ...nexLocalizedString,
       [field.locale]: field.value,
     }),
     {}
@@ -49,14 +40,14 @@ export const applyTransformedLocalizedFields = <
   Output extends Record<string, unknown>
 >(
   objectWithLocalizedFields: Input,
-  fieldNames: TFieldNameTranformationMapping[]
+  fieldNames: FieldNameTranformationMapping[]
 ): Output => {
   const transformedFieldDefinitions = fieldNames.reduce(
     (nextTransformed, fieldName) => ({
       ...nextTransformed,
       [fieldName.to]: transformLocalizedFieldToLocalizedString(
         objectWithLocalizedFields[fieldName.from] as
-          | TLocalizedField[]
+          | LocalizedField[]
           | undefined
       ),
     }),
@@ -69,12 +60,12 @@ export const applyTransformedLocalizedFields = <
     }),
     {}
   );
-  const objectWithoutLocalizedFields = omit<Input>(
+  const objectWithouLocalizedFields = omit<Input>(
     objectWithLocalizedFields,
     Object.keys(namesToOmit)
   );
   return {
-    ...objectWithoutLocalizedFields,
+    ...objectWithouLocalizedFields,
     ...transformedFieldDefinitions,
   } as Output;
 };

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -98,18 +98,20 @@ export const applyTransformedLocalizedFields = <
  *       languages within the same page. This is an accepted downside.
  *
  * NOTE: A missing field is treated like a localied string with no translations:
- *       let a = localize({ obj: { name: { en: '', de: '' } }, locale: 'en' })
- *       let b = localize({ obj: {}, locale: 'en' })
- *       let c = localize({ obj: undefined, locale: 'en' })
+ *       let a = formatLocalizedString({ name: { en: '', de: '' } }, { locale: 'en' })
+ *       let b = formatLocalizedString({}, { locale: 'en' })
+ *       let c = formatLocalizedString(undefined, { locale: 'en' })
  *       a === b && a === c -> true
  */
-export const localize = <Input extends Record<string, unknown>>({
-  obj: entity,
-  key = '',
-  locale,
-  fallbackOrder = [],
-  fallback = '',
-}: LocalizeSignatureOptions<Input>): string => {
+export const formatLocalizedString = <Input extends Record<string, unknown>>(
+  entity: Input | null,
+  {
+    key = '',
+    locale,
+    fallbackOrder = [],
+    fallback = '',
+  }: LocalizeSignatureOptions<Input>
+): string => {
   // if there is no entity to be localized or the field does not exist on the
   // entity, then return the fallback
   if (!entity || !entity[key]) return fallback;

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -55,16 +55,10 @@ export const applyTransformedLocalizedFields = <
     }),
     {}
   );
-  const namesToOmit = fieldNames.reduce<{ [key: string]: string }>(
-    (nextKeysToOmit, field) => ({
-      ...nextKeysToOmit,
-      [field.from]: field.from,
-    }),
-    {}
-  );
+  const namesToOmit = fieldNames.map((fieldName) => fieldName.from);
   const objectWithouLocalizedFields = omit<Input>(
     objectWithLocalizedFields,
-    Object.keys(namesToOmit)
+    namesToOmit
   );
   return {
     ...objectWithouLocalizedFields,

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -34,7 +34,6 @@ export type FieldNameTranformationMapping = {
 };
 
 export type LocalizeSignatureOptions<T> = {
-  obj?: T | null;
   key: keyof T;
   locale: string;
   fallbackOrder?: string[];

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -18,3 +18,17 @@ export type TimeZone = {
   offset: string;
 };
 export type TimeZones = Record<string, TimeZone>;
+
+export type LocalizedField = {
+  locale: string;
+  value: string;
+};
+
+export type LocalizedString = {
+  [key: string]: string;
+};
+
+export type FieldNameTranformationMapping = {
+  from: string;
+  to: string;
+};

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -36,7 +36,7 @@ export type FieldNameTranformationMapping = {
 export type LocalizeSignatureOptions<T> = {
   obj?: T | null;
   key: keyof T;
-  language: string;
+  locale: string;
   fallbackOrder?: string[];
   fallback?: string;
 };

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -32,3 +32,11 @@ export type FieldNameTranformationMapping = {
   from: string;
   to: string;
 };
+
+export type LocalizeSignatureOptions<T> = {
+  obj?: T | null;
+  key: keyof T;
+  language: string;
+  fallbackOrder?: string[];
+  fallback?: string;
+};

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -33,7 +33,7 @@ export type FieldNameTranformationMapping = {
   to: string;
 };
 
-export type LocalizeSignatureOptions<T> = {
+export type FormatLocalizedStringOptions<T> = {
   key: keyof T;
   locale: string;
   fallbackOrder?: string[];

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -24,9 +24,7 @@ export type LocalizedField = {
   value: string;
 };
 
-export type LocalizedString = {
-  [key: string]: string;
-};
+export type LocalizedString = Record<string, string>;
 
 export type FieldNameTranformationMapping = {
   from: string;

--- a/packages/l10n/src/utils.ts
+++ b/packages/l10n/src/utils.ts
@@ -51,8 +51,10 @@ export const getDisplayName = <Props extends {}>(
 export const getPrimaryLocale = (locale: string): string =>
   locale.split('-')[0];
 
-export const addFallbackHint = (value: string, locale: string): string =>
-  `${value} (${locale.toUpperCase()})`;
+export const formatLocalizedFallbackHint = (
+  value: string,
+  locale: string
+): string => `${value} (${locale.toUpperCase()})`;
 
 export const findFallbackLocale = (
   localizedString: LocalizedString,

--- a/packages/l10n/src/utils.ts
+++ b/packages/l10n/src/utils.ts
@@ -48,13 +48,13 @@ export const getDisplayName = <Props extends {}>(
   return Component.displayName || Component.name || 'Component';
 };
 
-export const getPrimaryLanguage = (language: string): string =>
-  language.split('-')[0];
+export const getPrimaryLocale = (locale: string): string =>
+  locale.split('-')[0];
 
-export const addFallbackHint = (value: string, language: string): string =>
-  `${value} (${language.toUpperCase()})`;
+export const addFallbackHint = (value: string, locale: string): string =>
+  `${value} (${locale.toUpperCase()})`;
 
-export const findFallbackLanguage = (
+export const findFallbackLocale = (
   localizedString: LocalizedString,
   fallbackOrder: string[]
 ) =>

--- a/packages/l10n/src/utils.ts
+++ b/packages/l10n/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Currencies } from './types';
+import type { Currencies, LocalizedString } from './types';
 
 export const mapLocaleToIntlLocale = (locale: string) => {
   if (locale.startsWith('de')) return 'de';
@@ -47,3 +47,17 @@ export const getDisplayName = <Props extends {}>(
 
   return Component.displayName || Component.name || 'Component';
 };
+
+export const getPrimaryLanguage = (language: string): string =>
+  language.split('-')[0];
+
+export const addFallbackHint = (value: string, language: string): string =>
+  `${value} (${language.toUpperCase()})`;
+
+export const findFallbackLanguage = (
+  localizedString: LocalizedString,
+  fallbackOrder: string[]
+) =>
+  fallbackOrder
+    .concat(Object.keys(localizedString))
+    .find((lang) => Boolean(localizedString[lang]));

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,12 +66,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/compat-data@^7.12.1", "@babel/compat-data@^7.12.5":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
-  integrity sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==
-
-"@babel/compat-data@^7.12.7":
+"@babel/compat-data@^7.12.5", "@babel/compat-data@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
   integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
@@ -143,18 +138,18 @@
     source-map "^0.5.0"
 
 "@babel/core@>=7.9.0", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
-  version "7.12.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
-  integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
+  version "7.12.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.8.tgz#8ad76c1a7d2a6a3beecc4395fa4f7b4cb88390e6"
+  integrity sha512-ra28JXL+5z73r1IC/t+FT1ApXU5LsulFDnTDntNfLQaScJUJmcHL5Qxm/IWanCToQk3bPWQo5bflbplU5r15pg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.1"
+    "@babel/generator" "^7.12.5"
     "@babel/helper-module-transforms" "^7.12.1"
-    "@babel/helpers" "^7.12.1"
-    "@babel/parser" "^7.12.3"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.12.1"
-    "@babel/types" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.7"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.8"
+    "@babel/types" "^7.12.7"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
@@ -188,7 +183,7 @@
     "@babel/helper-explode-assignable-expression" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-builder-react-jsx-experimental@^7.12.1", "@babel/helper-builder-react-jsx-experimental@^7.12.4":
+"@babel/helper-builder-react-jsx-experimental@^7.12.4":
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz#55fc1ead5242caa0ca2875dcb8eed6d311e50f48"
   integrity sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==
@@ -205,7 +200,7 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-compilation-targets@^7.12.1", "@babel/helper-compilation-targets@^7.12.5":
+"@babel/helper-compilation-targets@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz#cb470c76198db6a24e9dbc8987275631e5d29831"
   integrity sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
@@ -227,12 +222,11 @@
     "@babel/helper-split-export-declaration" "^7.10.4"
 
 "@babel/helper-create-regexp-features-plugin@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz#18b1302d4677f9dc4740fe8c9ed96680e29d37e8"
-  integrity sha512-rsZ4LGvFTZnzdNZR5HZdmJVuXK8834R5QkF3WvcnBhrlVtF0HSIUC6zbreL9MgjTywhKokn8RIYRiq99+DLAxA==
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz#2084172e95443fa0a09214ba1bb328f9aea1278f"
+  integrity sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
     regexpu-core "^4.7.1"
 
 "@babel/helper-define-map@^7.10.4":
@@ -275,11 +269,11 @@
     "@babel/types" "^7.10.4"
 
 "@babel/helper-member-expression-to-functions@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz#fba0f2fcff3fba00e6ecb664bb5e6e26e2d6165c"
-  integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz#aa77bd0396ec8114e5e30787efa78599d874a855"
+  integrity sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==
   dependencies:
-    "@babel/types" "^7.12.1"
+    "@babel/types" "^7.12.7"
 
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.0.0-beta.49", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.0":
   version "7.12.5"
@@ -304,23 +298,16 @@
     lodash "^4.17.19"
 
 "@babel/helper-optimise-call-expression@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
-  integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz#7f94ae5e08721a49467346aa04fd22f750033b9c"
+  integrity sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.7"
 
 "@babel/helper-plugin-utils@7.10.4", "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
-
-"@babel/helper-regex@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.10.5.tgz#32dfbb79899073c415557053a19bd055aae50ae0"
-  integrity sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==
-  dependencies:
-    lodash "^4.17.19"
 
 "@babel/helper-remap-async-to-generator@^7.12.1":
   version "7.12.1"
@@ -382,7 +369,7 @@
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helpers@^7.10.4", "@babel/helpers@^7.12.1", "@babel/helpers@^7.12.5":
+"@babel/helpers@^7.10.4", "@babel/helpers@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.5.tgz#1a1ba4a768d9b58310eda516c449913fe647116e"
   integrity sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
@@ -405,12 +392,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5", "@babel/parser@^7.12.1", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.7.0", "@babel/parser@^7.9.6":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
-  integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
-
-"@babel/parser@^7.12.7":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5", "@babel/parser@^7.12.1", "@babel/parser@^7.12.5", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.7.0", "@babel/parser@^7.9.6":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
   integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
@@ -488,14 +470,6 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-numeric-separator@^7.12.1":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz#b1ce757156d40ed79d59d467cb2b154a5c4149ba"
-  integrity sha512-UiAnkKuOrCyjZ3sYNHlRlfuZJbBHknMQ9VMwVeX97Ofwx7RpD6gS2HfqTCh8KNUQgcOm8IKt103oR4KIjh7Q8g==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-
 "@babel/plugin-proposal-numeric-separator@^7.12.5", "@babel/plugin-proposal-numeric-separator@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz#8bf253de8139099fea193b297d23a9d406ef056b"
@@ -539,16 +513,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz#cce122203fc8a32794296fc377c6dedaf4363797"
-  integrity sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-
-"@babel/plugin-proposal-optional-chaining@^7.12.7":
+"@babel/plugin-proposal-optional-chaining@^7.12.1", "@babel/plugin-proposal-optional-chaining@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
   integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
@@ -919,16 +884,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx-development@^7.12.1", "@babel/plugin-transform-react-jsx-development@^7.12.5":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.5.tgz#677de5b96da310430d6cfb7fee16a1603afa3d56"
-  integrity sha512-1JJusg3iPgsZDthyWiCr3KQiGs31ikU/mSf2N2dSYEAO0GEImmVUbWf0VoSDGDFTAn5Dj4DUiR6SdIXHY7tELA==
-  dependencies:
-    "@babel/helper-builder-react-jsx-experimental" "^7.12.1"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-jsx" "^7.12.1"
-
-"@babel/plugin-transform-react-jsx-development@^7.12.7":
+"@babel/plugin-transform-react-jsx-development@^7.12.1", "@babel/plugin-transform-react-jsx-development@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.7.tgz#4c2a647de79c7e2b16bfe4540677ba3121e82a08"
   integrity sha512-Rs3ETtMtR3VLXFeYRChle5SsP/P9Jp/6dsewBQfokDSzKJThlsuFcnzLTDRALiUmTC48ej19YD9uN1mupEeEDg==
@@ -951,17 +907,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.12.1", "@babel/plugin-transform-react-jsx@^7.12.5":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.5.tgz#39ede0e30159770561b6963be143e40af3bde00c"
-  integrity sha512-2xkcPqqrYiOQgSlM/iwto1paPijjsDbUynN13tI6bosDz/jOW3CRzYguIE8wKX32h+msbBM22Dv5fwrFkUOZjQ==
-  dependencies:
-    "@babel/helper-builder-react-jsx" "^7.10.4"
-    "@babel/helper-builder-react-jsx-experimental" "^7.12.1"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-jsx" "^7.12.1"
-
-"@babel/plugin-transform-react-jsx@^7.12.7":
+"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.12.1", "@babel/plugin-transform-react-jsx@^7.12.5", "@babel/plugin-transform-react-jsx@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.7.tgz#8b14d45f6eccd41b7f924bcb65c021e9f0a06f7f"
   integrity sha512-YFlTi6MEsclFAPIDNZYiCRbneg1MFGao9pPG9uD5htwE0vDbPaMUMeYd6itWjw7K4kro4UbdQf3ljmFl9y48dQ==
@@ -1018,14 +964,6 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
 
-"@babel/plugin-transform-sticky-regex@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz#5c24cf50de396d30e99afc8d1c700e8bce0f5caf"
-  integrity sha512-CiUgKQ3AGVk7kveIaPEET1jNDhZZEl1RPMWdTBE1799bdz++SwqDHStmxfCtDfBhQgCl38YRiSnrMuUMZIWSUQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
-
 "@babel/plugin-transform-sticky-regex@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz#560224613ab23987453948ed21d0b0b193fa7fad"
@@ -1071,7 +1009,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/preset-env@7.12.7":
+"@babel/preset-env@7.12.7", "@babel/preset-env@^7.11.5", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.9.5":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.7.tgz#54ea21dbe92caf6f10cb1a0a576adc4ebf094b55"
   integrity sha512-OnNdfAr1FUQg7ksb7bmbKoby4qFOHw6DKWWUNB9KqnnCldxhxJlP+21dpyaWFmf2h0rTbOkXJtAGevY3XW1eew==
@@ -1143,78 +1081,6 @@
     core-js-compat "^3.7.0"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.11.5", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.9.5":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.1.tgz#9c7e5ca82a19efc865384bb4989148d2ee5d7ac2"
-  integrity sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==
-  dependencies:
-    "@babel/compat-data" "^7.12.1"
-    "@babel/helper-compilation-targets" "^7.12.1"
-    "@babel/helper-module-imports" "^7.12.1"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-validator-option" "^7.12.1"
-    "@babel/plugin-proposal-async-generator-functions" "^7.12.1"
-    "@babel/plugin-proposal-class-properties" "^7.12.1"
-    "@babel/plugin-proposal-dynamic-import" "^7.12.1"
-    "@babel/plugin-proposal-export-namespace-from" "^7.12.1"
-    "@babel/plugin-proposal-json-strings" "^7.12.1"
-    "@babel/plugin-proposal-logical-assignment-operators" "^7.12.1"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
-    "@babel/plugin-proposal-numeric-separator" "^7.12.1"
-    "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.12.1"
-    "@babel/plugin-proposal-optional-chaining" "^7.12.1"
-    "@babel/plugin-proposal-private-methods" "^7.12.1"
-    "@babel/plugin-proposal-unicode-property-regex" "^7.12.1"
-    "@babel/plugin-syntax-async-generators" "^7.8.0"
-    "@babel/plugin-syntax-class-properties" "^7.12.1"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
-    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
-    "@babel/plugin-syntax-json-strings" "^7.8.0"
-    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
-    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-    "@babel/plugin-syntax-top-level-await" "^7.12.1"
-    "@babel/plugin-transform-arrow-functions" "^7.12.1"
-    "@babel/plugin-transform-async-to-generator" "^7.12.1"
-    "@babel/plugin-transform-block-scoped-functions" "^7.12.1"
-    "@babel/plugin-transform-block-scoping" "^7.12.1"
-    "@babel/plugin-transform-classes" "^7.12.1"
-    "@babel/plugin-transform-computed-properties" "^7.12.1"
-    "@babel/plugin-transform-destructuring" "^7.12.1"
-    "@babel/plugin-transform-dotall-regex" "^7.12.1"
-    "@babel/plugin-transform-duplicate-keys" "^7.12.1"
-    "@babel/plugin-transform-exponentiation-operator" "^7.12.1"
-    "@babel/plugin-transform-for-of" "^7.12.1"
-    "@babel/plugin-transform-function-name" "^7.12.1"
-    "@babel/plugin-transform-literals" "^7.12.1"
-    "@babel/plugin-transform-member-expression-literals" "^7.12.1"
-    "@babel/plugin-transform-modules-amd" "^7.12.1"
-    "@babel/plugin-transform-modules-commonjs" "^7.12.1"
-    "@babel/plugin-transform-modules-systemjs" "^7.12.1"
-    "@babel/plugin-transform-modules-umd" "^7.12.1"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.12.1"
-    "@babel/plugin-transform-new-target" "^7.12.1"
-    "@babel/plugin-transform-object-super" "^7.12.1"
-    "@babel/plugin-transform-parameters" "^7.12.1"
-    "@babel/plugin-transform-property-literals" "^7.12.1"
-    "@babel/plugin-transform-regenerator" "^7.12.1"
-    "@babel/plugin-transform-reserved-words" "^7.12.1"
-    "@babel/plugin-transform-shorthand-properties" "^7.12.1"
-    "@babel/plugin-transform-spread" "^7.12.1"
-    "@babel/plugin-transform-sticky-regex" "^7.12.1"
-    "@babel/plugin-transform-template-literals" "^7.12.1"
-    "@babel/plugin-transform-typeof-symbol" "^7.12.1"
-    "@babel/plugin-transform-unicode-escapes" "^7.12.1"
-    "@babel/plugin-transform-unicode-regex" "^7.12.1"
-    "@babel/preset-modules" "^0.1.3"
-    "@babel/types" "^7.12.1"
-    core-js-compat "^3.6.2"
-    semver "^5.5.0"
-
 "@babel/preset-modules@^0.1.3":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e"
@@ -1226,7 +1092,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-react@7.12.7":
+"@babel/preset-react@7.12.7", "@babel/preset-react@^7.10.4", "@babel/preset-react@^7.12.5", "@babel/preset-react@^7.9.4":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.12.7.tgz#36d61d83223b07b6ac4ec55cf016abb0f70be83b"
   integrity sha512-wKeTdnGUP5AEYCYQIMeXMMwU7j+2opxrG0WzuZfxuuW9nhKvvALBjl67653CWamZJVefuJGI219G591RSldrqQ==
@@ -1235,19 +1101,6 @@
     "@babel/plugin-transform-react-display-name" "^7.12.1"
     "@babel/plugin-transform-react-jsx" "^7.12.7"
     "@babel/plugin-transform-react-jsx-development" "^7.12.7"
-    "@babel/plugin-transform-react-jsx-self" "^7.12.1"
-    "@babel/plugin-transform-react-jsx-source" "^7.12.1"
-    "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
-
-"@babel/preset-react@^7.10.4", "@babel/preset-react@^7.12.5", "@babel/preset-react@^7.9.4":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.12.5.tgz#d45625f65d53612078a43867c5c6750e78772c56"
-  integrity sha512-jcs++VPrgyFehkMezHtezS2BpnUlR7tQFAyesJn1vGTO9aTFZrgIQrA5YydlTwxbcjMwkFY6i04flCigRRr3GA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-transform-react-display-name" "^7.12.1"
-    "@babel/plugin-transform-react-jsx" "^7.12.5"
-    "@babel/plugin-transform-react-jsx-development" "^7.12.5"
     "@babel/plugin-transform-react-jsx-self" "^7.12.1"
     "@babel/plugin-transform-react-jsx-source" "^7.12.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
@@ -1299,20 +1152,11 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/standalone@^7.12.6":
-  version "7.12.7"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.7.tgz#07dc3d76bea978d5c5a3fd0966c218da3fae89c9"
-  integrity sha512-KsNrLEOTUDg/QZ2KdPUqC+PamvbIDBqrfdbkHxnY9TWyedSUch+KU/TDoj/1kg55rmma595fnVWVqQ1eCOwsaA==
+  version "7.12.8"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.8.tgz#c4915f7120462b75b63a396088e14361dca86be6"
+  integrity sha512-0NPKt9h+d9ZC2bgOuh2zlM5RwaHgOol9XhMH1Jlk3oRCvHU+FSVhr7AGUtq2oRS4IDo2oULj+AKj8nj1NMKppA==
 
-"@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
-  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/parser" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/template@^7.12.7":
+"@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
   integrity sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
@@ -1336,25 +1180,10 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
-  integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.5"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.12.5"
-    "@babel/types" "^7.12.5"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.19"
-
-"@babel/traverse@^7.12.7":
-  version "7.12.7"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.7.tgz#572a722408681cef17d6b0bef69ef2e728ca69f1"
-  integrity sha512-nMWaqsQEeSvMNypswUDzjqQ+0rR6pqCtoQpsqGJC4/Khm9cISwPTSpai57F6/jDaOoEGz8yE/WxcO3PV6tKSmQ==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.12.7", "@babel/traverse@^7.12.8", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0":
+  version "7.12.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.8.tgz#c1c2983bf9ba0f4f0eaa11dff7e77fa63307b2a4"
+  integrity sha512-EIRQXPTwFEGRZyu6gXbjfpNORN1oZvwuzJbxcXjAgWV0iqXYDszN1Hx3FVm6YgZfu1ZQbCVAk3l+nIw95Xll9Q==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.12.5"
@@ -1375,16 +1204,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.12.6", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.1", "@babel/types@^7.7.0", "@babel/types@^7.9.6":
-  version "7.12.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
-  integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.7":
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.12.6", "@babel/types@^7.12.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.1", "@babel/types@^7.7.0", "@babel/types@^7.9.6":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
   integrity sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
@@ -1399,27 +1219,28 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@changesets/apply-release-plan@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-4.0.0.tgz#e78efb56a4e459a8dab814ba43045f2ace0f27c9"
-  integrity sha512-MrcUd8wIlQ4S/PznzqJVsmnEpUGfPEkCGF54iqt8G05GEqi/zuxpoTfebcScpj5zeiDyxFIcA9RbeZ3pvJJxoA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-4.1.0.tgz#ec67c9a0f507c19740d9344766e37dd51fc981ee"
+  integrity sha512-NKMg0In+945eCGxPQJa6haKMDIr6WFngnsqRICaTH28WJy0NZoURoTUcAUSdgvur1J+9rWuVgWAfISyRpLErzg==
   dependencies:
-    "@babel/runtime" "^7.4.4"
+    "@babel/runtime" "^7.10.4"
     "@changesets/config" "^1.2.0"
     "@changesets/get-version-range-type" "^0.3.2"
     "@changesets/git" "^1.0.5"
     "@changesets/types" "^3.1.0"
     "@manypkg/get-packages" "^1.0.1"
+    detect-indent "^6.0.0"
     fs-extra "^7.0.1"
     lodash.startcase "^4.4.0"
     outdent "^0.5.0"
-    prettier "^1.18.2"
+    prettier "^1.19.1"
     resolve-from "^5.0.0"
     semver "^5.4.1"
 
 "@changesets/assemble-release-plan@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-4.0.0.tgz#60c2392c0e2c99f24778ab3a5c8e8c80ddaaaa59"
-  integrity sha512-3Kv21FNvysTQvZs3fHr6aZeDibhZHtgI1++fMZplzVtwNVmpjow3zv9lcZmJP26LthbpVH3I8+nqlU7M43lfWA==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-4.0.1.tgz#37906bd89226274c6a67ba2598de001b617e01ab"
+  integrity sha512-1UqJpX5Tj2kGtcI3anG3vsLFfX6na5fLsPaxwgS7T/zt1jJ1hv0cMC+iP6fd9BuCHvcFn22GT74bcRaVnAvm3Q==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/errors" "^0.1.4"
@@ -1708,23 +1529,6 @@
     "@babel/runtime-corejs3" "7.12.1"
     "@jackfranklin/test-data-bot" "1.3.0"
 
-"@commercetools-uikit/accessible-button@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/accessible-button/-/accessible-button-10.39.8.tgz#d61afbfdfb16e5765af1c8c27a017017f13951c1"
-  integrity sha512-90lMtmv+zd6OQGAQyg8PVP0C0bwZmnna8bpcBWPF4eWFGpfr7MI0fYsf2YklJrEEtawddlXmtx5qxA3ayEjlAA==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    common-tags "1.8.0"
-    lodash "4.17.20"
-    lodash-es "4.17.15"
-    prop-types "15.7.2"
-
 "@commercetools-uikit/accessible-button@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/accessible-button/-/accessible-button-10.42.2.tgz#08f1196deabf2eae944a36ab2c1970a042522737"
@@ -1770,17 +1574,29 @@
     "@commercetools-uikit/secondary-button" "10.42.2"
     "@commercetools-uikit/secondary-icon-button" "10.42.2"
 
-"@commercetools-uikit/calendar-utils@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/calendar-utils/-/calendar-utils-10.39.8.tgz#b810ae49477422f1efe715e6ea350f254ea48b26"
-  integrity sha512-h5bc2y+YRZPANyg0W6e8ovzg53nxIMCIj68VvHChyoFwcWHHU3q68gc8yCCPHkH2A7RiVFLOyrdnpkvX1Y2IDw==
+"@commercetools-uikit/calendar-utils@10.42.2":
+  version "10.42.2"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/calendar-utils/-/calendar-utils-10.42.2.tgz#6eaa882b1ea43a903fb7a223f00c92f199f4e282"
+  integrity sha512-kx24JPAIMJjUsnus8CBFC/sozY6aK/BVlLyyOY4YhKKp+Z3+4pMY4l48Fj2cwN06oM0APEjZqX7U9tQH0kLcTg==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
+    "@commercetools-uikit/accessible-button" "10.42.2"
+    "@commercetools-uikit/design-system" "10.42.2"
+    "@commercetools-uikit/hooks" "10.42.2"
+    "@commercetools-uikit/icons" "10.42.2"
+    "@commercetools-uikit/input-utils" "10.42.2"
+    "@commercetools-uikit/secondary-icon-button" "10.42.2"
+    "@commercetools-uikit/spacings-inline" "10.42.2"
+    "@commercetools-uikit/text" "10.42.2"
+    "@commercetools-uikit/tooltip" "10.42.2"
+    "@commercetools-uikit/utils" "10.42.2"
+    "@emotion/react" "^11.1.1"
+    "@emotion/styled" "^11.0.0"
+    prop-types "15.7.2"
+    react-select "3.1.1"
 
-"@commercetools-uikit/card@10.42.2", "@commercetools-uikit/card@^10.42.2":
+"@commercetools-uikit/card@10.42.2", "@commercetools-uikit/card@^10.39.8", "@commercetools-uikit/card@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/card/-/card-10.42.2.tgz#baf6a996b038932641ea990cb21d328f22040bdb"
   integrity sha512-k7+qtQLktkepEpq5BMjIlX4bH1dvMnvDNCJ8X5mrDw8O0/n+4kPNJ7sQRAQuumF4g5TysG3bCKpVHh3YEVoWwg==
@@ -1793,52 +1609,23 @@
     "@emotion/styled" "^11.0.0"
     prop-types "15.7.2"
 
-"@commercetools-uikit/card@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/card/-/card-10.39.8.tgz#756dea67a46c8e4f8d2dc097f920ab97740487f0"
-  integrity sha512-frmWHS/VJrJCYRJnzTK3O04SmN6VwrAKZOzEqlvKMq9qrkOzq8NNlb937+tsLMvBaIHvCxOmowyLi+ElwAnZKQ==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    prop-types "15.7.2"
-
 "@commercetools-uikit/checkbox-input@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/checkbox-input/-/checkbox-input-10.39.8.tgz#8391e470e350e25dfb67b0da10ff2393f3d142b8"
-  integrity sha512-nIDTeGvErv77LR1iRwC2TSP0pyPIglF0Tm37CFDzRyc1ZkXtSZY2pidV0IltE6c34aS11qirTkDkTODt9IyeVg==
+  version "10.42.2"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/checkbox-input/-/checkbox-input-10.42.2.tgz#ed841bdbe90c587c25616b59645c6582c8b5cf8c"
+  integrity sha512-Us1o5HojdOdID/+jtXD8r9COjW4+ArVp2WMXYf3q618d7NeoKiyiuiXm7HtUApzzYHPZif2OE4Xe73rtmyz5qA==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/icons" "10.39.8"
-    "@commercetools-uikit/select-utils" "10.39.8"
-    "@commercetools-uikit/text" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    emotion-theming "^10.0.27"
+    "@commercetools-uikit/design-system" "10.42.2"
+    "@commercetools-uikit/icons" "10.42.2"
+    "@commercetools-uikit/input-utils" "10.42.2"
+    "@commercetools-uikit/select-utils" "10.42.2"
+    "@commercetools-uikit/text" "10.42.2"
+    "@commercetools-uikit/utils" "10.42.2"
+    "@emotion/react" "^11.1.1"
+    "@emotion/styled" "^11.0.0"
     prop-types "15.7.2"
     tiny-invariant "1.1.0"
-
-"@commercetools-uikit/constraints@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/constraints/-/constraints-10.39.8.tgz#46d6eabb94c4338a759dd8c26699a202d62ab1aa"
-  integrity sha512-MkWOqVSu0QAUAguYbDeYeg65ax/Qq4r9JoOemGIibLMeK2/wW3VuyTulnxebHdarD8XPif5YvU15rEJmPW4aeg==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    prop-types "15.7.2"
 
 "@commercetools-uikit/constraints@10.42.2", "@commercetools-uikit/constraints@^10.42.2":
   version "10.42.2"
@@ -1875,27 +1662,26 @@
     tiny-invariant "1.1.0"
 
 "@commercetools-uikit/date-input@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/date-input/-/date-input-10.39.8.tgz#c2d1309b3eeb97bbe36dc7c92404d46a8f78258f"
-  integrity sha512-zlZM3azG0sxxc4PgN1AoPSOUecXnWc2XOQ6evtZAUm6LrR3jkRx/QBm2LdJPI3G/UlNe+ugF8gA8V272qIyP9Q==
+  version "10.42.2"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/date-input/-/date-input-10.42.2.tgz#a8a40dbfd5d912a8699b1ca4c68c0f8883c62d50"
+  integrity sha512-MX1MlE3Oaskf15D2akteAW3e2p+Kiv3qvHKa6YvWkA0lwiY9JS7yC28asF/t2ZFUryfgpwTGFO6ctLCJgj+6hw==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.39.8"
-    "@commercetools-uikit/calendar-utils" "10.39.8"
-    "@commercetools-uikit/constraints" "10.39.8"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/hooks" "10.39.8"
-    "@commercetools-uikit/icons" "10.39.8"
-    "@commercetools-uikit/secondary-icon-button" "10.39.8"
-    "@commercetools-uikit/select-utils" "10.39.8"
-    "@commercetools-uikit/spacings-inline" "10.39.8"
-    "@commercetools-uikit/text" "10.39.8"
-    "@commercetools-uikit/tooltip" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
+    "@commercetools-uikit/accessible-button" "10.42.2"
+    "@commercetools-uikit/calendar-utils" "10.42.2"
+    "@commercetools-uikit/constraints" "10.42.2"
+    "@commercetools-uikit/design-system" "10.42.2"
+    "@commercetools-uikit/hooks" "10.42.2"
+    "@commercetools-uikit/icons" "10.42.2"
+    "@commercetools-uikit/secondary-icon-button" "10.42.2"
+    "@commercetools-uikit/select-utils" "10.42.2"
+    "@commercetools-uikit/spacings-inline" "10.42.2"
+    "@commercetools-uikit/text" "10.42.2"
+    "@commercetools-uikit/tooltip" "10.42.2"
+    "@commercetools-uikit/utils" "10.42.2"
+    "@emotion/react" "^11.1.1"
+    "@emotion/styled" "^11.0.0"
     common-tags "1.8.0"
     downshift "6.0.6"
     prop-types "15.7.2"
@@ -1904,15 +1690,7 @@
     tiny-invariant "1.1.0"
     warning "4.0.3"
 
-"@commercetools-uikit/design-system@10.39.8", "@commercetools-uikit/design-system@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-10.39.8.tgz#39461dbdb0bdb17bdb329841030d453ffffb3ce8"
-  integrity sha512-OKQ7HhFu2fujjZKyRHBBM3PS2kt77x9pn+Lzzr0MhlD5uarBvm5WPL8xaMFbuFXfZwsYct9K5ylSBKK/65Sc4Q==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-
-"@commercetools-uikit/design-system@10.42.2", "@commercetools-uikit/design-system@^10.42.2":
+"@commercetools-uikit/design-system@10.42.2", "@commercetools-uikit/design-system@^10.39.8", "@commercetools-uikit/design-system@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-10.42.2.tgz#bdb802b8c91726dbf8b5d57d25bb04f2254eebdf"
   integrity sha512-d7nkE536Y1v9JwW0yw4z2xxl+okLiZ2BwS//lK0jSCwYTLVBiZ19lszHQnFpd9IoWiXkYP+JvgT3GKHPr9Se5A==
@@ -1982,15 +1760,6 @@
     "@emotion/styled" "^11.0.0"
     prop-types "15.7.2"
 
-"@commercetools-uikit/hooks@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/hooks/-/hooks-10.39.8.tgz#b40bac2553fcc4f2cd713e39503b5ab134906435"
-  integrity sha512-CZT1fGTRYQQ2RKE5ONmi1ilAwXuq6NLeQcb1yswAYR8If3duvEbLGoxwhdyilmgMqlDA3GJK2m6Hhv6RRdgDsQ==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/utils" "10.39.8"
-
 "@commercetools-uikit/hooks@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/hooks/-/hooks-10.42.2.tgz#c926c3a2599b6f7cd5f3b6771a25471faf1a0b07"
@@ -2009,7 +1778,7 @@
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
 
-"@commercetools-uikit/icon-button@10.42.2", "@commercetools-uikit/icon-button@^10.42.2":
+"@commercetools-uikit/icon-button@10.42.2", "@commercetools-uikit/icon-button@^10.39.8", "@commercetools-uikit/icon-button@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/icon-button/-/icon-button-10.42.2.tgz#07030289114a45f43dbf99a81e11a8cc17aac1db"
   integrity sha512-olSLnsd1Mtt8bgZVFSzWlqSvpi6ChQ/3KaoLYBmlQvO0X1+X6wr7JBFv5zFW3mzC84MUEqzZzriDjWTMKcc6Iw==
@@ -2029,44 +1798,7 @@
     react-required-if "1.0.3"
     tiny-invariant "1.1.0"
 
-"@commercetools-uikit/icon-button@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icon-button/-/icon-button-10.39.8.tgz#51e49738ca55596198428ea4d7b02468bf876ee4"
-  integrity sha512-edRrHcNF9FN2mgVQ6A/gbZpGYDkdkSJFibSdgxiTNoVHwKz0fBo8Jimv7UXRqt7zvCSWpu4d8LlnlMU51A6OTA==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.39.8"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/spacings" "10.39.8"
-    "@commercetools-uikit/text" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    common-tags "1.8.0"
-    lodash "4.17.20"
-    lodash-es "4.17.15"
-    prop-types "15.7.2"
-    react-required-if "1.0.3"
-    tiny-invariant "1.1.0"
-
-"@commercetools-uikit/icons@10.39.8", "@commercetools-uikit/icons@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-10.39.8.tgz#268b2191f0ebb6c1be0d9c987a386399f1d4cb5e"
-  integrity sha512-sS72yo7t2zci7n5rQ9rYmf3ejPkJI2yd5duwLa5+w69R0uFvK/jwhs5fPNHDQJj44gqssHaGZN1JUwrMLADI1g==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    emotion-theming "^10.0.27"
-    prop-types "15.7.2"
-    tiny-invariant "1.1.0"
-
-"@commercetools-uikit/icons@10.42.2", "@commercetools-uikit/icons@^10.42.2":
+"@commercetools-uikit/icons@10.42.2", "@commercetools-uikit/icons@^10.39.8", "@commercetools-uikit/icons@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-10.42.2.tgz#9cc3fa1f9d7deefef8e94df9b3491c7d3c7a2f9e"
   integrity sha512-zeJZgofZVbrZv9mMyS7bbYthQhqISd1C5od4dgOXDqStrNYm2UISSOE4op5uGJW0E1pg5novd1aBDkBp18Xn1g==
@@ -2129,7 +1861,7 @@
     prop-types "15.7.2"
     react-required-if "1.0.3"
 
-"@commercetools-uikit/loading-spinner@10.42.2", "@commercetools-uikit/loading-spinner@^10.42.2":
+"@commercetools-uikit/loading-spinner@10.42.2", "@commercetools-uikit/loading-spinner@^10.39.8", "@commercetools-uikit/loading-spinner@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/loading-spinner/-/loading-spinner-10.42.2.tgz#89f7066f258c07f9d92c87a6d826ea660ea80409"
   integrity sha512-JZBdJQuuNbB7MEhUBU1SSpyGcorrGOCWCVDqYw8d0etazozTKQaXFmttyXE22fajidGQxqOb1M90ZUXkoiQGFQ==
@@ -2141,20 +1873,6 @@
     "@commercetools-uikit/text" "10.42.2"
     "@commercetools-uikit/utils" "10.42.2"
     "@emotion/react" "^11.1.1"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/loading-spinner@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/loading-spinner/-/loading-spinner-10.39.8.tgz#01a61f1ae8dff91452ef80c18e65d784c17c7c6e"
-  integrity sha512-VNQKK+bvprm85sifx82svmQAcK5cFIZ8D2lUY0T1h1TzEFlRIfor/zxLDccWtxCOzUhE/kNQXn0gTyHTqyKFgw==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/spacings-inline" "10.39.8"
-    "@commercetools-uikit/text" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
     prop-types "15.7.2"
 
 "@commercetools-uikit/messages@10.42.2":
@@ -2268,29 +1986,7 @@
     react-required-if "1.0.3"
     tiny-invariant "1.1.0"
 
-"@commercetools-uikit/secondary-icon-button@10.39.8", "@commercetools-uikit/secondary-icon-button@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-10.39.8.tgz#87805ae8e62aefddbee3b52aa5db6c8634b2ca4e"
-  integrity sha512-NSqL8z2AGPcQw4L/O5Esyxt4dbAFN3HZWEsOTo5VeaoOqqMNqVOZhjrY01QkEhLHH6gFh+o/PLFSa3vUD51Wdw==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.39.8"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/spacings" "10.39.8"
-    "@commercetools-uikit/text" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    common-tags "1.8.0"
-    emotion-theming "^10.0.27"
-    lodash "4.17.20"
-    lodash-es "4.17.15"
-    prop-types "15.7.2"
-    react-required-if "1.0.3"
-
-"@commercetools-uikit/secondary-icon-button@10.42.2", "@commercetools-uikit/secondary-icon-button@^10.42.2":
+"@commercetools-uikit/secondary-icon-button@10.42.2", "@commercetools-uikit/secondary-icon-button@^10.39.8", "@commercetools-uikit/secondary-icon-button@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-10.42.2.tgz#3684230e2ab8ba4b4da14722af2c342795fcb680"
   integrity sha512-fdCup7bOy5HC4Ot3Y81Xp+OYHGDrDA5jc4ulKDeMQqpOupOgn2mF2mHyTeTff/otNgbqiJFb1uC6HlrPV8J7Ow==
@@ -2347,27 +2043,6 @@
     prop-types "15.7.2"
     react-select "3.1.1"
 
-"@commercetools-uikit/select-utils@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-10.39.8.tgz#17a3dc9ff01a60c15dfb1718718d05d8cffe66d4"
-  integrity sha512-J193lgdv/yPQLS0tyQwUkCZyLz3DbddBxize2CCqC63SJ+2Fbtuem7G+01f/M1813r7qBhU4lSza3+59zhK91A==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.39.8"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/icons" "10.39.8"
-    "@commercetools-uikit/spacings" "10.39.8"
-    "@commercetools-uikit/text" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    lodash "4.17.20"
-    lodash-es "4.17.15"
-    prop-types "15.7.2"
-    react-select "3.1.0"
-
 "@commercetools-uikit/select-utils@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-10.42.2.tgz#662e9161bf1254c55ab95109a6ee900b45a50b57"
@@ -2387,19 +2062,7 @@
     prop-types "15.7.2"
     react-select "3.1.1"
 
-"@commercetools-uikit/spacings-inline@10.39.8", "@commercetools-uikit/spacings-inline@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inline/-/spacings-inline-10.39.8.tgz#1c6ceb00fb8c3c113080c1c1e412bed3cf0b926d"
-  integrity sha512-Fm8TBDjqmwZb3xVfcAA6rqD6CDKWcLvqMdlnziiTQbXy5Yp1Ftl9oWUkyADjfQ0/RFkzm1em6fNm8QF2ceqpGg==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/spacings-inline@10.42.2":
+"@commercetools-uikit/spacings-inline@10.42.2", "@commercetools-uikit/spacings-inline@^10.39.8":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inline/-/spacings-inline-10.42.2.tgz#25e41f845de597c23adaef8365072008ee94dc64"
   integrity sha512-63BfDNXCEjklHvK4qGNvb3FHVbC3s5ggEnXF5i4KVurHXbamf4o2oyVcDS2zW9x0RwPlVGJu5yAfYnrZwS/gWw==
@@ -2409,18 +2072,6 @@
     "@commercetools-uikit/design-system" "10.42.2"
     "@commercetools-uikit/utils" "10.42.2"
     "@emotion/react" "^11.1.1"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/spacings-inset-squish@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inset-squish/-/spacings-inset-squish-10.39.8.tgz#64e4b8c3620e8a27879ed7cce6285068fb4184b6"
-  integrity sha512-qDyH1QiVZ3CaUmHZeDtRi4jza62Kcnt5y4dVhNKkspERlm29Gs/omNSGOEm8Dz0pK62Y29YXOe/g4xzfrJoGWw==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
     prop-types "15.7.2"
 
 "@commercetools-uikit/spacings-inset-squish@10.42.2":
@@ -2435,18 +2086,6 @@
     "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
 
-"@commercetools-uikit/spacings-inset@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inset/-/spacings-inset-10.39.8.tgz#7e722141d2ca612903901a13cd33d5a07ba01f85"
-  integrity sha512-qjxR6iqfu+YDCMn5xzHB/ECI7F7tBbnGzW0B1eSkUPODcmK4akID3cWu6Y8XWX06yKAxj5yI1EEYrgel4UwIjA==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    prop-types "15.7.2"
-
 "@commercetools-uikit/spacings-inset@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inset/-/spacings-inset-10.42.2.tgz#1773fef64900633d891fdb05885367394f645036"
@@ -2459,19 +2098,7 @@
     "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
 
-"@commercetools-uikit/spacings-stack@10.39.8", "@commercetools-uikit/spacings-stack@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-stack/-/spacings-stack-10.39.8.tgz#c4afd34fc9074a9f30ededba96217616b7336d5e"
-  integrity sha512-32O04HB9EH+YCFskDCZGb6ICsdUQOSRQQl7+SKDzz0HOLW0LQG2UV9mxLfpKIAT4ewUoY7yYI1FJw+1BZvhvrA==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/spacings-stack@10.42.2":
+"@commercetools-uikit/spacings-stack@10.42.2", "@commercetools-uikit/spacings-stack@^10.39.8":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-stack/-/spacings-stack-10.42.2.tgz#f67d65937bf47d6146d141b88302a047172bb023"
   integrity sha512-+Yapu8a8NayDWss9sSLrj9Ggli/F9rBdJ09awCVuoIvTPi7q4cn2TUKqwo7lnQB75ZgIssdLDqw/D3kCMFf8kw==
@@ -2482,18 +2109,6 @@
     "@commercetools-uikit/utils" "10.42.2"
     "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
-
-"@commercetools-uikit/spacings@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings/-/spacings-10.39.8.tgz#2099131d99df83d046bb5249426101f75b879152"
-  integrity sha512-0OPsafNb4znGz2GrrE9qr5+qCa+kfdxJC9449gvLDYUY+rEBGVi3JdqOZfbSsmLp/a7bt6AosvNLzfj4R1Q2ZA==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/spacings-inline" "10.39.8"
-    "@commercetools-uikit/spacings-inset" "10.39.8"
-    "@commercetools-uikit/spacings-inset-squish" "10.39.8"
-    "@commercetools-uikit/spacings-stack" "10.39.8"
 
 "@commercetools-uikit/spacings@10.42.2", "@commercetools-uikit/spacings@^10.42.2":
   version "10.42.2"
@@ -2508,15 +2123,14 @@
     "@commercetools-uikit/spacings-stack" "10.42.2"
 
 "@commercetools-uikit/stamp@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/stamp/-/stamp-10.39.8.tgz#73650e468c05c1bbd994318d384a1faf1f61ef95"
-  integrity sha512-OYcZhPFFlACiqMz3fFFa6KZV5NEKwAG6kCDLzzF6aX2QEbw2zAAkmBk2h2+7j5jf5EtSpcHw7tPkiVx8rbRd3g==
+  version "10.42.2"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/stamp/-/stamp-10.42.2.tgz#20b6d0e4e231853b16f7340bd86554b3ed0ff077"
+  integrity sha512-A45NXVb67gCaeNqJ5Ceh1myQUnvVYmAJT2Y0f/ZEocP63tPYWVaCAmZiR7EdSHVuRgUjqX+Lgv7tZBg5askymw==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    emotion-theming "^10.0.27"
+    "@commercetools-uikit/design-system" "10.42.2"
+    "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
 
 "@commercetools-uikit/text-field@10.42.2":
@@ -2554,24 +2168,6 @@
     prop-types "15.7.2"
     react-required-if "1.0.3"
 
-"@commercetools-uikit/text@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/text/-/text-10.39.8.tgz#8d91679d56af87bafb8caa24ebcc1aa517ede15a"
-  integrity sha512-omQgl9u1dBlKkgTypMKhbmLXQ2OZkl4fdDGcriD4CgnmHNUmsna4GhYYC9YRlHlFvxWBCBj5sMQF5XS5LjPksA==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    common-tags "1.8.0"
-    emotion-theming "^10.0.27"
-    lodash "4.17.20"
-    lodash-es "4.17.15"
-    prop-types "15.7.2"
-    react-required-if "1.0.3"
-    warning "4.0.3"
-
 "@commercetools-uikit/text@10.42.2", "@commercetools-uikit/text@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/text/-/text-10.42.2.tgz#14b66a6f1bf47bcf51db09fc4171acb9d5578683"
@@ -2588,27 +2184,7 @@
     react-required-if "1.0.3"
     warning "4.0.3"
 
-"@commercetools-uikit/tooltip@10.39.8", "@commercetools-uikit/tooltip@^10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/tooltip/-/tooltip-10.39.8.tgz#1fef5177446792fe8d3e219d1ad4c4ffebdda556"
-  integrity sha512-b3jyCFc6quiFO5EKXyaeqd9mdqswbp2SLxf6zZUUwJ4Q965T7Sx5SlezVRpDaybVhMRZ6lEIdvFbUcZg64fEAw==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.39.8"
-    "@commercetools-uikit/hooks" "10.39.8"
-    "@commercetools-uikit/utils" "10.39.8"
-    "@emotion/core" "^10.0.34"
-    "@emotion/styled" "^10.0.27"
-    "@emotion/styled-base" "^10.0.31"
-    lodash "4.17.20"
-    lodash-es "4.17.15"
-    prop-types "15.7.2"
-    react-is "16.13.1"
-    tiny-invariant "1.1.0"
-    use-popper "1.1.6"
-
-"@commercetools-uikit/tooltip@10.42.2":
+"@commercetools-uikit/tooltip@10.42.2", "@commercetools-uikit/tooltip@^10.39.8":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/tooltip/-/tooltip-10.42.2.tgz#acff7ca0229aa939c02aa53728a46280a6feb3e3"
   integrity sha512-73JMoa4jVFbTHTyKlJiRPCmni0ebu6KRQOBxqK2JAz747ipALDy/tdCeVd3ChmG6O49K/LzzsM+W5I1og/+qNg==
@@ -2626,16 +2202,6 @@
     react-is "16.13.1"
     tiny-invariant "1.1.0"
     use-popper "1.1.6"
-
-"@commercetools-uikit/utils@10.39.8":
-  version "10.39.8"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/utils/-/utils-10.39.8.tgz#2ef5cc1b7cc6a02284156bc9159d77c3e5923e56"
-  integrity sha512-vGkCbDvF3qY1s7fQRC9WBoaNV3bfNlJgQnS3VJtwCmUbQRcOLoWtgCKS6iJpej+28Ip4/JYz8+xTpZqPMn114A==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@babel/runtime-corejs3" "7.12.5"
-    "@emotion/is-prop-valid" "0.8.8"
-    warning "4.0.3"
 
 "@commercetools-uikit/utils@10.42.2":
   version "10.42.2"
@@ -2963,7 +2529,7 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "^4.0.3"
 
-"@emotion/core@^10.0.34", "@emotion/core@^10.0.9":
+"@emotion/core@^10.0.9":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -2988,13 +2554,6 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
-
-"@emotion/is-prop-valid@0.8.8":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
-  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
-  dependencies:
-    "@emotion/memoize" "0.7.4"
 
 "@emotion/is-prop-valid@1.0.0", "@emotion/is-prop-valid@^1.0.0":
   version "1.0.0"
@@ -3053,16 +2612,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.0.tgz#a0ef06080f339477ad4ba7f56e1c931f7ba50822"
   integrity sha512-cdCHfZtf/0rahPDCZ9zyq+36EqfD/6c0WUqTFZ/hv9xadTUv2lGE5QK7/Z6Dnx2oRxC0usfVM2/BYn9q9B9wZA==
 
-"@emotion/styled-base@^10.0.27", "@emotion/styled-base@^10.0.31":
-  version "10.0.31"
-  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.31.tgz#940957ee0aa15c6974adc7d494ff19765a2f742a"
-  integrity sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/is-prop-valid" "0.8.8"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/utils" "0.11.3"
-
 "@emotion/styled@11.0.0", "@emotion/styled@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.0.0.tgz#698196c2822746360a8644a73a5d842b2d1a78a5"
@@ -3073,14 +2622,6 @@
     "@emotion/is-prop-valid" "^1.0.0"
     "@emotion/serialize" "^1.0.0"
     "@emotion/utils" "^1.0.0"
-
-"@emotion/styled@^10.0.27":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
-  integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
-  dependencies:
-    "@emotion/styled-base" "^10.0.27"
-    babel-plugin-emotion "^10.0.27"
 
 "@emotion/stylis@0.8.5":
   version "0.8.5"
@@ -3559,22 +3100,7 @@
     auto-bind "~4.0.0"
     tslib "~2.0.1"
 
-"@graphql-codegen/visitor-plugin-common@^1.17.16":
-  version "1.17.17"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.17.tgz#8966903786c58e809e1b9bd093684da3c7c4ccf4"
-  integrity sha512-UGstk36jlGSUXg2Z1/22B8qeVTY18mW6kuQVNY32kB5sy1wIVDi4eNS3OJdBTYDvL5MGTHjeWXk7EhSt3NP7gQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.18.1"
-    "@graphql-tools/relay-operation-optimizer" "^6"
-    array.prototype.flatmap "^1.2.3"
-    auto-bind "~4.0.0"
-    dependency-graph "^0.9.0"
-    graphql-tag "^2.11.0"
-    parse-filepath "^1.0.2"
-    pascal-case "^3.1.1"
-    tslib "~2.0.1"
-
-"@graphql-codegen/visitor-plugin-common@^1.17.18":
+"@graphql-codegen/visitor-plugin-common@^1.17.16", "@graphql-codegen/visitor-plugin-common@^1.17.18":
   version "1.17.18"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.18.tgz#68bd0465e29e6aef20617894fd668625daf81acc"
   integrity sha512-/E083ja1vcl5GCnoeC7BObbTq6N1hpIXF3lQElLMvVvegSRzEm3XtvMNGQIumd6t3RDdpGT87ebSAS3lKPj8Pw==
@@ -3663,13 +3189,12 @@
     tslib "~2.0.1"
 
 "@graphql-tools/code-file-loader@^6", "@graphql-tools/code-file-loader@^6.0.0":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-6.2.5.tgz#02832503e96c6c537083570208bd55ca1fbfaa68"
-  integrity sha512-KMy8c/I4NeQZUI9InydR14qP1pqPeJfgVJLri0RgJRWDiLAj/nIb2oDioN9AgBX3XYNijJT+pH0//B5EOO0BiA==
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-6.2.6.tgz#f89ffb1a5ca48c67dcf2cff97e1a5d06eabc81c2"
+  integrity sha512-oDuMiXy1Rj1KszY7no+PFNzw2H25PVJKg9K/deK+IHL1631Q+VLK6/czBIw4TMEsbYhlKErgWDI+XBzK73VZSQ==
   dependencies:
     "@graphql-tools/graphql-tag-pluck" "^6.2.6"
     "@graphql-tools/utils" "^7.0.0"
-    fs-extra "9.0.1"
     tslib "~2.0.1"
 
 "@graphql-tools/delegate@^7.0.0", "@graphql-tools/delegate@^7.0.1":
@@ -3705,13 +3230,12 @@
     tslib "~2.0.1"
 
 "@graphql-tools/graphql-file-loader@^6", "@graphql-tools/graphql-file-loader@^6.0.0":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.2.5.tgz#831289675e5f446baa19afbc0af8ea6bc94063bf"
-  integrity sha512-vYDn71FHqwCxWgw8swoVOsD5C0xGz/Lw4zUQnPcgZfAzhAAwl6e/rVWl/HF1UNNSf5CSZu+2oidjOWCI5Wl6Gg==
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.2.6.tgz#5b907d21b0f947df892ed837db74cd3f6d771c34"
+  integrity sha512-L+RdYl5C6+X0zdOTUotY0K5zwqvSGpqI/qcZpVvCDenoAcVTyaNLmnd/ViErwedhCaGqAAV0wI1nPtyKFPlMUg==
   dependencies:
-    "@graphql-tools/import" "^6.2.4"
+    "@graphql-tools/import" "^6.2.5"
     "@graphql-tools/utils" "^7.0.0"
-    fs-extra "9.0.1"
     tslib "~2.0.1"
 
 "@graphql-tools/graphql-tag-pluck@^6.2.6":
@@ -3727,22 +3251,20 @@
   optionalDependencies:
     vue-template-compiler "^2.6.12"
 
-"@graphql-tools/import@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.2.4.tgz#0547f6d4754a924e80439d6af013577cdb617194"
-  integrity sha512-Q6fk6hbtDevoEVcgwb3WRn7XOqGY4MnX3Mvc+x8/b8k4RZ4wT+0WSLRDXGAKiVKRxGhgouU2lZVnGE/LDrGSCg==
+"@graphql-tools/import@^6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.2.5.tgz#5f279815229320128a07cad188c4860be18cb422"
+  integrity sha512-ZGXT5tDod7m+LO38fc+o0JzR1LstL0RF35HKEWoUdxRIVaaeYH9VMuan9Gn+9M9RDME3RnzEa9aGzf9ATj8bTA==
   dependencies:
-    fs-extra "9.0.1"
     resolve-from "5.0.0"
     tslib "~2.0.1"
 
 "@graphql-tools/json-file-loader@^6", "@graphql-tools/json-file-loader@^6.0.0":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-6.2.5.tgz#1357d2efd2f416f44e0dd717da06463c29adbf60"
-  integrity sha512-9LS7WuQdSHlRUvXD7ixt5aDpr3hWsueURHOaWe7T0xZ+KWMTw+LIRtWIliCRzbjNmZ+4ZhwHB3Vc1SO2bfYLgg==
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-6.2.6.tgz#830482cfd3721a0799cbf2fe5b09959d9332739a"
+  integrity sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==
   dependencies:
     "@graphql-tools/utils" "^7.0.0"
-    fs-extra "9.0.1"
     tslib "~2.0.1"
 
 "@graphql-tools/load@6.2.4":
@@ -3785,9 +3307,9 @@
     tslib "~2.0.1"
 
 "@graphql-tools/prisma-loader@^6", "@graphql-tools/prisma-loader@^6.0.0":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.2.5.tgz#1de03e548ef2c0c301b2386e0e8f4a715036adde"
-  integrity sha512-Xm/cQMV0oKm9tlmz3kMS0G+IRVsC8fJuOmYWvTxc4GorJpMnKCnYu0L7JDSMRBp0Q9yLEbh1ticGEMvjozD4OA==
+  version "6.2.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.2.7.tgz#0a9aa8f40c79a926f2d4f157dc282478bccafaca"
+  integrity sha512-o0QHl767uaLZVjb9NlupZjCzjfC5Zo79G6QLnK0Rbi0Ldk5Lf05HDZIfMhiyd9tsw73d0GQY7yIPvQJFE2S5Tw==
   dependencies:
     "@graphql-tools/url-loader" "^6.3.1"
     "@graphql-tools/utils" "^7.0.0"
@@ -3795,13 +3317,12 @@
     "@types/js-yaml" "^3.12.5"
     "@types/json-stable-stringify" "^1.0.32"
     "@types/jsonwebtoken" "^8.5.0"
-    ajv "^6.12.5"
+    ajv "^6.12.6"
     bluebird "^3.7.2"
     chalk "^4.1.0"
     debug "^4.2.0"
     dotenv "^8.2.0"
-    fs-extra "9.0.1"
-    graphql-request "^3.2.0"
+    graphql-request "^3.3.0"
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"
     isomorphic-fetch "^3.0.0"
@@ -5585,9 +5106,9 @@
   integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
 
 "@percy/agent@~0":
-  version "0.28.4"
-  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.28.4.tgz#b6929ee7f6d4900751cfd6b8681558e2994f022e"
-  integrity sha512-Lw5y26opxhVGDCzRJhs3TzT/ia87flsSluYfAVNcDJ7AZCAUakSMzhUZRvMYxU+B/unc1pbfS2i+//Mttjny6Q==
+  version "0.28.5"
+  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.28.5.tgz#6ca7c1d8f86585757b0ad2e13137a3c0cb375eb7"
+  integrity sha512-gGKSS76jlNtRwjmlBlz4JkDP4rh5wBYcfqBYTVFBGf9bjMTrhMv0O9HQDyCa1+KIGkoQC80scES/QSLgamG6YA==
   dependencies:
     "@oclif/command" "1.5.19"
     "@oclif/config" "^1"
@@ -6061,21 +5582,7 @@
     "@babel/runtime" "^7.11.2"
     "@testing-library/dom" "^7.22.2"
 
-"@testing-library/dom@^7.22.2":
-  version "7.26.6"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.6.tgz#d558db63070a3acea5bea7e2497e631cd12541cc"
-  integrity sha512-/poL7WMpolcGFOHMcxfcFkf1u38DcBUjk3YwNYpBs/MdJ546lg0YdvP2Lq3ujuQzAZxgs8vVvadj3MBnZsBjjA==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
-
-"@testing-library/dom@^7.28.1":
+"@testing-library/dom@^7.22.2", "@testing-library/dom@^7.28.1":
   version "7.28.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.28.1.tgz#dea78be6e1e6db32ddcb29a449e94d9700c79eb9"
   integrity sha512-acv3l6kDwZkQif/YqJjstT3ks5aaI33uxGNVIQmdKzbZ2eMKgg3EV2tB84GDdc72k3Kjhl6mO8yUt6StVIdRDg==
@@ -6283,9 +5790,9 @@
     "@types/express-unless" "*"
 
 "@types/express-serve-static-core@*":
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
-  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.14.tgz#cabf91debeeb3cb04b798e2cff908864e89b6106"
+  integrity sha512-uFTLwu94TfUFMToXNgRZikwPuZdOtDgs3syBtAIr/OXorL1kJqUJT9qCLnRZ5KBOWfZQikQ2xKgR2tnDj1OgDA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -6511,20 +6018,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@14", "@types/node@>= 8":
-  version "14.14.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.7.tgz#8ea1e8f8eae2430cf440564b98c6dfce1ec5945d"
-  integrity sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==
-
-"@types/node@14.14.9":
+"@types/node@*", "@types/node@14", "@types/node@14.14.9", "@types/node@>= 8":
   version "14.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
   integrity sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==
 
 "@types/node@^12.7.1":
-  version "12.19.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.4.tgz#cdfbb62e26c7435ed9aab9c941393cc3598e9b46"
-  integrity sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w==
+  version "12.19.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.6.tgz#fbf249fa46487dd8c7386d785231368b92a33a53"
+  integrity sha512-U2VopDdmBoYBmtm8Rz340mvvSz34VgX/K9+XCuckvcLGMkt3rbMX8soqFOikIPlPBc5lmw8By9NUK7bEFSBFlQ==
 
 "@types/node@^8.5.7":
   version "8.10.66"
@@ -6580,9 +6082,9 @@
     "@types/react" "*"
 
 "@types/react-dom@*":
-  version "16.9.9"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.9.tgz#d2d0a6f720a0206369ccbefff752ba37b9583136"
-  integrity sha512-jE16FNWO3Logq/Lf+yvEAjKzhpST/Eac8EMd1i4dgZdMczfgqC8EjpxwNgEe3SExHYLliabXDh9DEhhqnlXJhg==
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
   dependencies:
     "@types/react" "*"
 
@@ -6644,9 +6146,9 @@
     "@types/react-transition-group" "*"
 
 "@types/react-test-renderer@*":
-  version "16.9.3"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
-  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
+  integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
   dependencies:
     "@types/react" "*"
 
@@ -6708,9 +6210,9 @@
   integrity sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==
 
 "@types/serve-static@*":
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.7.tgz#e51b51a0becda910f9fd04c718044da69d6c492e"
-  integrity sha512-3diZWucbR+xTmbDlU+FRRxBf+31OhFew7cJXML/zh9NmvSPTNoFecAwHB66BUqFgENJtqMiyl7JAwUE/siqdLw==
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz#851129d434433c7082148574ffec263d58309c46"
+  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
   dependencies:
     "@types/mime" "*"
     "@types/node" "*"
@@ -6848,9 +6350,9 @@
     "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
-  version "15.0.9"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.9.tgz#524cd7998fe810cdb02f26101b699cccd156ff19"
-  integrity sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
+  version "15.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.10.tgz#0fe3c8173a0d5c3e780b389050140c3f5ea6ea74"
+  integrity sha512-z8PNtlhrj7eJNLmrAivM7rjBESG6JwC5xP3RVk12i/8HVP7Xnx/sEmERnRImyEuUaJfO942X0qMOYsoupaJbZQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -6904,7 +6406,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@4.8.2":
+"@typescript-eslint/experimental-utils@4.8.2", "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.2.tgz#8909a5732f19329cf5ef0c39766170476bff5e50"
   integrity sha512-hpTw6o6IhBZEsQsjuw/4RWmceRyESfAiEzAEnXHKG1X7S5DXFaZ4IO1JO7CW1aQ604leQBzjZmuMI9QBCAJX8Q==
@@ -6924,18 +6426,6 @@
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/types" "3.10.1"
     "@typescript-eslint/typescript-estree" "3.10.1"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.7.0.tgz#8d1058c38bec3d3bbd9c898a1c32318d80faf3c5"
-  integrity sha512-cymzovXAiD4EF+YoHAB5Oh02MpnXjvyaOb+v+BdpY7lsJXZQN34oIETeUwVT2XfV9rSNpXaIcknDLfupO/tUoA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.7.0"
-    "@typescript-eslint/types" "4.7.0"
-    "@typescript-eslint/typescript-estree" "4.7.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -6959,14 +6449,6 @@
     "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/scope-manager@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.7.0.tgz#2115526085fb72723ccdc1eeae75dec7126220ed"
-  integrity sha512-ILITvqwDJYbcDCROj6+Ob0oCKNg3SH46iWcNcTIT9B5aiVssoTYkhKjxOMNzR1F7WSJkik4zmuqve5MdnA0DyA==
-  dependencies:
-    "@typescript-eslint/types" "4.7.0"
-    "@typescript-eslint/visitor-keys" "4.7.0"
-
 "@typescript-eslint/scope-manager@4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz#a18388c63ae9c17adde519384f539392f2c4f0d9"
@@ -6979,11 +6461,6 @@
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
   integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
-
-"@typescript-eslint/types@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.7.0.tgz#5e95ef5c740f43d942542b35811f87b62fccca69"
-  integrity sha512-uLszFe0wExJc+I7q0Z/+BnP7wao/kzX0hB5vJn4LIgrfrMLgnB2UXoReV19lkJQS1a1mHWGGODSxnBx6JQC3Sg==
 
 "@typescript-eslint/types@4.8.2":
   version "4.8.2"
@@ -7017,20 +6494,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.7.0.tgz#539531167f05ba20eb0b6785567076679e29d393"
-  integrity sha512-5XZRQznD1MfUmxu1t8/j2Af4OxbA7EFU2rbo0No7meb46eHgGkSieFdfV6omiC/DGIBhH9H9gXn7okBbVOm8jw==
-  dependencies:
-    "@typescript-eslint/types" "4.7.0"
-    "@typescript-eslint/visitor-keys" "4.7.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
 "@typescript-eslint/typescript-estree@4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz#eeec34707d8577600fb21661b5287226cc8b3bed"
@@ -7051,14 +6514,6 @@
   integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
   dependencies:
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/visitor-keys@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.7.0.tgz#6783824f22acfc49e754970ed21b88ac03b80e6f"
-  integrity sha512-aDJDWuCRsf1lXOtignlfiPODkzSxxop7D0rZ91L6ZuMlcMCSh0YyK+gAfo5zN/ih6WxMwhoXgJWC3cWQdaKC+A==
-  dependencies:
-    "@typescript-eslint/types" "4.7.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.8.2":
   version "4.8.2"
@@ -7428,7 +6883,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@6.12.6, ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@6.12.6, ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -7760,20 +7215,22 @@ array.prototype.find@^2.1.1:
     es-abstract "^1.17.4"
 
 array.prototype.flat@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
-  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
+  integrity sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
 
 array.prototype.flatmap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
-  integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
+  integrity sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
 
 arraybuffer.slice@~0.0.7:
@@ -7953,9 +7410,9 @@ aws4@^1.8.0:
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axe-core@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.0.tgz#93d395e6262ecdde5cb52a5d06533d0a0c7bb4cd"
-  integrity sha512-9atDIOTDLsWL+1GbBec6omflaT5Cxh88J0GtJtGfCVIXpI02rXHkju59W5mMqWa7eiC5OR168v3TK3kUKBW98g==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
+  integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
 axios@^0.19.0, axios@^0.19.2:
   version "0.19.2"
@@ -9137,9 +8594,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001157:
-  version "1.0.30001158"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz#fce86d321369603c2bc855ee0e901a7f49f8310b"
-  integrity sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g==
+  version "1.0.30001161"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz#64f7ffe79ee780b8c92843ff34feb36cea4651e0"
+  integrity sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -9459,9 +8916,9 @@ clean-stack@^2.0.0:
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 clean-stack@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.0.tgz#a7c249369fcf0f33c7888c20ea3f3dc79620211f"
-  integrity sha512-RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
+  integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
   dependencies:
     escape-string-regexp "4.0.0"
 
@@ -9517,15 +8974,15 @@ cli-cursor@^3.1.0:
     restore-cursor "^3.1.0"
 
 cli-highlight@^2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.4.tgz#098cb642cf17f42adc1c1145e07f960ec4d7522b"
-  integrity sha512-s7Zofobm20qriqDoU9sXptQx0t2R9PEgac92mENNm7xaEe1hn71IIMsXMK+6encA6WRCWWxIGQbipr3q998tlQ==
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.8.tgz#aa3130b481649d631ab913ae60becf81c69c3887"
+  integrity sha512-mFuTW5UOV3/S0wZE9/1b0EcAM0XOJIhoAWPhWm5voiJ6ugVBkvYBIEL7sbHo9sEtWdEmwDIWab32qpaRI3cfqQ==
   dependencies:
-    chalk "^3.0.0"
-    highlight.js "^9.6.0"
+    chalk "^4.0.0"
+    highlight.js "^10.0.0"
     mz "^2.4.0"
     parse5 "^5.1.1"
-    parse5-htmlparser2-tree-adapter "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
     yargs "^15.0.0"
 
 cli-spinners@^2.0.0, cli-spinners@^2.4.0:
@@ -10234,7 +9691,7 @@ copyfiles@^2.3.0:
     untildify "^4.0.0"
     yargs "^15.3.1"
 
-core-js-compat@^3.6.2, core-js-compat@^3.6.5, core-js-compat@^3.7.0:
+core-js-compat@^3.6.5, core-js-compat@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.7.0.tgz#8479c5d3d672d83f1f5ab94cf353e57113e065ed"
   integrity sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==
@@ -10592,11 +10049,11 @@ css-tree@1.0.0-alpha.37:
     source-map "^0.6.1"
 
 css-tree@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.1.tgz#7726678dfe2a57993a018d9dce519bf1760e3b6d"
-  integrity sha512-WroX+2MvsYcRGP8QA0p+rxzOniT/zpAoQ/DTKDSJzh5T3IQKUkFHeIIfgIapm2uaP178GWY3Mime1qbk8GO/tA==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.1.tgz#30b8c0161d9fb4e9e2141d762589b6ec2faebd2e"
+  integrity sha512-NVN42M2fjszcUNpDbdkvutgQSlFYsr1z7kqeuCagHnNLBfYor6uP1WL1KrkmdYZ5Y1vTBCIOI/C/+8T98fJ71w==
   dependencies:
-    mdn-data "2.0.12"
+    mdn-data "2.0.14"
     source-map "^0.6.1"
 
 css-what@2.1:
@@ -10952,14 +10409,7 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
-  dependencies:
-    ms "2.1.2"
-
-debug@4.3.1:
+debug@4, debug@4.3.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -10967,9 +10417,9 @@ debug@4.3.1:
     ms "2.1.2"
 
 debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 
@@ -11778,9 +11228,9 @@ ejs@^3.1.5:
     jake "^10.6.1"
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.591:
-  version "1.3.596"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz#c7ed98512c7ff36ddcbfed9e54e6355335c35257"
-  integrity sha512-nLO2Wd2yU42eSoNJVQKNf89CcEGqeFZd++QsnN2XIgje1s/19AgctfjLIbPORlvcCO8sYjLwX4iUgDdusOY8Sg==
+  version "1.3.606"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.606.tgz#6ef2655d9a7c1b447dfdd6344657d00461a65e26"
+  integrity sha512-+/2yPHwtNf6NWKpaYt0KoqdSZ6Qddt6nDfH/pnhcrHq9hSb23e5LFy06Mlf0vF2ykXvj7avJ597psqcbKnG5YQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -12429,9 +11879,9 @@ eslint-rule-composer@^0.3.0:
   integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-rule-docs@^1.1.5:
-  version "1.1.214"
-  resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.214.tgz#ba4f6482e8cb7988b38e4d3015c52205c8f5291e"
-  integrity sha512-n/RwtMfAbBc8nO2IYjsBUFx4SUFQA3DqWTevKMSwY64bpAm9WiGesjoMiagufQhkYAKnaAvJ+XL5rMDuYjl18A==
+  version "1.1.215"
+  resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.215.tgz#21efe592d319216a67787b20be45247c39cf4c70"
+  integrity sha512-lADlvFuceJvlU/NhD9gpnCt2lfdfpkz2BizeJNy7bkTr0VQA4w+vW3Nh4G569w6a8SPQczKL4PDB83s6j5i++A==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -13897,20 +13347,7 @@ gatsby-cli@2.14.0, gatsby-cli@^2.14.0:
     yoga-layout-prebuilt "^1.9.6"
     yurnalist "^1.1.2"
 
-gatsby-core-utils@^1.3.24:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.4.0.tgz#d42234b8a15b34237921522f9ae303a2bb833c78"
-  integrity sha512-wU6huyGZ8aJ/8Izfc7D39ujxaCz/jFtznufmMSXLnEBwLF5MWGsmECx4i2nfTb2kkkTFc+n0i/rx///UnPUURg==
-  dependencies:
-    ci-info "2.0.0"
-    configstore "^5.0.1"
-    fs-extra "^8.1.0"
-    node-object-hash "^2.0.0"
-    proper-lockfile "^4.1.1"
-    tmp "^0.2.1"
-    xdg-basedir "^4.0.0"
-
-gatsby-core-utils@^1.5.0:
+gatsby-core-utils@^1.3.24, gatsby-core-utils@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.5.0.tgz#0834b561ab32b8b93db2ddb3ee695188f8d2eea9"
   integrity sha512-hCt44m7I9Kmra/iVJwrmHXK8WFK9I1JwXQZquIVZ/JaG8UgqroxW1wpsY7ColbHGMATOmp13Efqn02VNPnms5Q==
@@ -15134,25 +14571,7 @@ graphql-config@3.0.3:
     string-env-interpolation "1.0.1"
     tslib "^2.0.0"
 
-graphql-config@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.1.0.tgz#91101f28b0ae524d01efde1f4cb13b710aea6d5d"
-  integrity sha512-tOjgUqB6W+vIzGRn20LogMujoRTAsdwO1gGg6l3SF3xaUjI9/uaCpvy3kJHbZcRiRuOTocmysdBU+hOs3Npx6Q==
-  dependencies:
-    "@endemolshinegroup/cosmiconfig-typescript-loader" "3.0.2"
-    "@graphql-tools/graphql-file-loader" "^6.0.0"
-    "@graphql-tools/json-file-loader" "^6.0.0"
-    "@graphql-tools/load" "^6.0.0"
-    "@graphql-tools/merge" "^6.0.0"
-    "@graphql-tools/url-loader" "^6.0.0"
-    "@graphql-tools/utils" "^6.0.0"
-    cosmiconfig "6.0.0"
-    cosmiconfig-toml-loader "1.0.0"
-    minimatch "3.0.4"
-    string-env-interpolation "1.0.1"
-    tslib "^2.0.0"
-
-graphql-config@^3.2.0:
+graphql-config@^3.0.2, graphql-config@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.2.0.tgz#3ec3a7e319792086b80e54db4b37372ad4a79a32"
   integrity sha512-ygEKDeQNZKpm4137560n2oY3bGM0D5zyRsQVaJntKkufWdgPg6sb9/4J1zJW2y/yC1ortAbhNho09qmeJeLa9g==
@@ -15184,7 +14603,7 @@ graphql-playground-middleware-express@^1.7.18:
   dependencies:
     graphql-playground-html "^1.6.29"
 
-graphql-request@^3.2.0:
+graphql-request@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.3.0.tgz#1b9003f34b73cd40d691803d2d422fde5c713af3"
   integrity sha512-NHj65WSIUh8j7TBYgzWU0fqvLfxrqFDrLG8nZUh+IREZw50ljR6JXlXRkr52/fL/46wpItiQNLDrG+UZI+KmzA==
@@ -15497,9 +14916,9 @@ hast-util-raw@6.0.1:
     zwitch "^1.0.0"
 
 hast-util-sanitize@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-3.0.1.tgz#c6a0853a3cbd174995e394aa1fee218f2dafbfad"
-  integrity sha512-XQmIuBSa+DHfAhkrVvtHoSdSLgOnNeBijLY4NPIJgxvpH8MjLof0p68ZADWfWebU7nCWY450HQJZvas6RFKwDA==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz#b0b783220af528ba8fe6999f092d138908678520"
+  integrity sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==
   dependencies:
     xtend "^4.0.0"
 
@@ -15561,15 +14980,15 @@ hicat@^0.7.0:
     highlight.js "^8.1.0"
     minimist "^0.2.0"
 
+highlight.js@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
+  integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
+
 highlight.js@^8.1.0:
   version "8.9.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-8.9.1.tgz#b8a9c5493212a9392f0222b649c9611497ebfb88"
   integrity sha1-uKnFSTISqTkvAiK2SclhFJfr+4g=
-
-highlight.js@^9.6.0:
-  version "9.18.3"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"
-  integrity sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==
 
 history-query-enhancer@1.0.4:
   version "1.0.4"
@@ -15960,9 +15379,9 @@ icss-utils@^2.1.0:
     postcss "^6.0.1"
 
 icss-utils@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.0.0.tgz#03ed56c3accd32f9caaf1752ebf64ef12347bb84"
-  integrity sha512-aF2Cf/CkEZrI/vsu5WI/I+akFgdbwQHVE9YRZxATrhH4PVIe6a3BIjwjEcW+z+jP/hNh+YvM3lAAn1wJQ6opSg==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
 idb-wrapper@^1.5.0:
   version "1.7.2"
@@ -18505,14 +17924,6 @@ limiter@^1.1.5:
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
   integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
 
-line-column@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
-  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
-  dependencies:
-    isarray "^1.0.0"
-    isobject "^2.0.0"
-
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -19529,10 +18940,10 @@ mdast-util-toc@^3.1.0:
     unist-util-is "^2.1.2"
     unist-util-visit "^1.1.0"
 
-mdn-data@2.0.12:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.12.tgz#bbb658d08b38f574bbb88f7b83703defdcc46844"
-  integrity sha512-ULbAlgzVb8IqZ0Hsxm6hHSlQl3Jckst2YEQS7fODu9ilNWy2LvcoSY7TRFIktABP2mdppBioc66va90T+NUs8Q==
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -19545,9 +18956,9 @@ mdurl@^1.0.0:
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 meant@^1.0.1, meant@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.2.tgz#5d0c78310a3d8ae1408a16be0fe0bd42a969f560"
-  integrity sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.3.tgz#67769af9de1d158773e928ae82c456114903554c"
+  integrity sha512-88ZRGcNxAq4EH38cQ4D85PM57pikCwS8Z99EWHODxN7KBY+UuPiqzRTtZzS8KTXO/ywSWbdjjJST2Hly/EQxLw==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -20206,11 +19617,6 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.1.16:
-  version "3.1.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
-  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
-
 nanoid@^3.1.18:
   version "3.1.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.18.tgz#0680db22ab01c372e89209f5d18283d98de3e96d"
@@ -20251,9 +19657,9 @@ natural-compare@^1.4.0:
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 nearley@^2.7.10:
-  version "2.19.7"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.7.tgz#eafbe3e2d8ccfe70adaa5c026ab1f9709c116218"
-  integrity sha512-Y+KNwhBPcSJKeyQCFjn8B/MIe+DDlhaaDgjVldhy5xtFewIbiQgcbZV8k2gCVwkI1ZsKCnjIYZbR+0Fim5QYgg==
+  version "2.19.8"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.8.tgz#2c6e2f9e8c0daa145e78c9734b4ad7713e96fcca"
+  integrity sha512-te4JCrxbzLvVqUWfVOASgsbkWaFvJ6JlHTRQzfnU862bnyHGHEGX2s5OYvLAS4NDPmQvRtC2tBdV6THy6xHFyQ==
   dependencies:
     commander "^2.19.0"
     moo "^0.5.0"
@@ -20307,9 +19713,9 @@ no-case@^3.0.3:
     tslib "^1.10.0"
 
 node-abi@^2.7.0:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
-  integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
+  integrity sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
   dependencies:
     semver "^5.4.1"
 
@@ -20455,9 +19861,9 @@ node-readfiles@^0.2.0:
     es6-promise "^3.2.1"
 
 node-releases@^1.1.61, node-releases@^1.1.66:
-  version "1.1.66"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz#609bd0dc069381015cd982300bae51ab4f1b1814"
-  integrity sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==
+  version "1.1.67"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
+  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
 
 node-request-interceptor@^0.5.3:
   version "0.5.4"
@@ -20709,33 +20115,33 @@ oas-linter@^3.2.1:
     should "^13.2.1"
     yaml "^1.10.0"
 
-oas-resolver@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/oas-resolver/-/oas-resolver-2.5.2.tgz#62d26f8db7a4afd697f27ae9b283e79300dd2366"
-  integrity sha512-dEuG5nE9IMl0FQNQuROsoriP4/944PajSBKAoZMyp9b2eXfmPv9ZKeHRCKjf5RWLm0GezaPKcdCLbB0/Xiqtdw==
+oas-resolver@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/oas-resolver/-/oas-resolver-2.5.3.tgz#1e124aa4dcee6822166e06a3d392b07237f8e01b"
+  integrity sha512-y4gP5tabqP3YcNVHNAEJAlcqZ40Y9lxemzmXvt54evbrvuGiK5dEhuE33Rf+191TOwzlxMoIgbwMYeuOM7BwjA==
   dependencies:
     node-fetch-h2 "^2.3.0"
     oas-kit-common "^1.0.8"
-    reftools "^1.1.6"
+    reftools "^1.1.7"
     yaml "^1.10.0"
-    yargs "^15.3.1"
+    yargs "^16.1.1"
 
 oas-schema-walker@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz#74c3cd47b70ff8e0b19adada14455b5d3ac38a22"
   integrity sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==
 
-oas-validator@^5.0.2, oas-validator@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/oas-validator/-/oas-validator-5.0.3.tgz#b128d1e0cf7f734e98dbd5fc16037c6907261d93"
-  integrity sha512-PYhenXnQr/T+MmrzBT+cTnyOcIZ4wVzvjS/gvbZZNexnhl1Gu/UiCg6rsEmBetE9CfthoxG0gfGTUSYPRmUlWA==
+oas-validator@^5.0.2, oas-validator@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/oas-validator/-/oas-validator-5.0.4.tgz#f3b094192a4637b94ce4a61c66657f4d7b523a3a"
+  integrity sha512-/v+5BbPXl7JuKf1bYhEGIfbJZR7zBf5QJNM2RAe1e0bsABsp35nAfeptZq0hb+9RMecGSFxmzhuvlOT0/KioiQ==
   dependencies:
     call-me-maybe "^1.0.1"
     oas-kit-common "^1.0.8"
     oas-linter "^3.2.1"
-    oas-resolver "^2.5.2"
+    oas-resolver "^2.5.3"
     oas-schema-walker "^1.1.5"
-    reftools "^1.1.6"
+    reftools "^1.1.7"
     should "^13.2.1"
     yaml "^1.10.0"
 
@@ -20996,9 +20402,9 @@ opn@^5.5.0:
     is-wsl "^1.1.0"
 
 optimism@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.0.tgz#c08904e1439a0eb9e7f86183dafa06cc715ff351"
-  integrity sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.1.tgz#df2e6102c973f870d6071712fffe4866bb240384"
+  integrity sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==
   dependencies:
     "@wry/context" "^0.5.2"
 
@@ -21162,9 +20568,9 @@ p-defer@^3.0.0:
   integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
 
 p-each-series@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
-  integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
+  integrity sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==
 
 p-event@^1.0.0:
   version "1.3.0"
@@ -21562,12 +20968,12 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
-parse5-htmlparser2-tree-adapter@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.1.tgz#e8c743d4e92194d5293ecde2b08be31e67461cbc"
-  integrity sha512-CF+TKjXqoqyDwHqBhFQ+3l5t83xYi6fVT1tQNg+Ye0JRLnTxWvIroCjEp1A0k4lneHNBGnICUf0cfYVYGEazqw==
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
   dependencies:
-    parse5 "^5.1.1"
+    parse5 "^6.0.1"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -21579,7 +20985,7 @@ parse5@5.1.1, parse5@^5.1.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
-parse5@6.0.1, parse5@^6.0.0:
+parse5@6.0.1, parse5@^6.0.0, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -22836,14 +22242,14 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     supports-color "^6.1.0"
 
 postcss@^8.1.0, postcss@^8.1.4:
-  version "8.1.7"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.7.tgz#ff6a82691bd861f3354fd9b17b2332f88171233f"
-  integrity sha512-llCQW1Pz4MOPwbZLmOddGM9eIJ8Bh7SZ2Oj5sxZva77uVaotYDsYTch1WBTNu7fUY0fpWp0fdt7uW40D4sRiiQ==
+  version "8.1.10"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.10.tgz#129834f94c720554d2cfdaeb27d5542ac4a026ea"
+  integrity sha512-iBXEV5VTTYaRRdxiFYzTtuv2lGMQBExqkZKSzkJe+Fl6rvQrA/49UVGKqB+LG54hpW/TtDBMGds8j33GFNW7pg==
   dependencies:
     colorette "^1.2.1"
-    line-column "^1.0.2"
-    nanoid "^3.1.16"
+    nanoid "^3.1.18"
     source-map "^0.6.1"
+    vfile-location "^3.2.0"
 
 potrace@^2.1.8:
   version "2.1.8"
@@ -22910,20 +22316,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.2.0:
+prettier@2.2.0, prettier@^2.0.4, prettier@^2.0.5:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
   integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
 
-prettier@^1.18.2:
+prettier@^1.18.2, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
-prettier@^2.0.4, prettier@^2.0.5:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
-  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.4.1"
@@ -23721,20 +23122,6 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
-  integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
-    react-transition-group "^4.3.0"
-
 react-select@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.1.tgz#156a5b4a6c22b1e3d62a919cb1fd827adb4060bc"
@@ -24095,10 +23482,10 @@ reflect.ownkeys@^0.2.0:
   resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
   integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
-reftools@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/reftools/-/reftools-1.1.6.tgz#841b1ac241259632d63167bf708eccfbfbbba5b5"
-  integrity sha512-rQfJ025lvPjw9qyQuNPqE+cRs5qVs7BMrZwgRJnmuMcX/8r/eJE8f5/RCunJWViXKHmN5K2DFafYzglLOHE/tw==
+reftools@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/reftools/-/reftools-1.1.7.tgz#7cb7d7c448d296717f541e878ffac67bdbd7c4ad"
+  integrity sha512-I+KZFkQvZjMZqVWxRezTC/kQ2kLhGRZ7C+4ARbgmb5WJbvFUlbrZ/6qlz6mb+cGcPNYib+xqL8kZlxCsSZ7Hew==
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -26160,40 +25547,42 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     strip-ansi "^6.0.0"
 
 string.prototype.matchall@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
-  integrity sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz#24243399bc31b0a49d19e2b74171a15653ec996a"
+  integrity sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0"
+    es-abstract "^1.18.0-next.1"
     has-symbols "^1.0.1"
     internal-slot "^1.0.2"
     regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.2"
+    side-channel "^1.0.3"
 
 string.prototype.trim@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz#f538d0bacd98fc4297f0bef645226d5aaebf59f3"
-  integrity sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.3.tgz#d23a22fde01c1e6571a7fadcb9be11decd8061a7"
+  integrity sha512-16IL9pIBA5asNOSukPfxX2W68BaBvxyiRK16H3RA/lWW9BDosh+w7f+LhomPHpXJ82QEe7w7/rY/S1CV97raLg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.0"
+    es-abstract "^1.18.0-next.1"
 
 string.prototype.trimend@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz#6ddd9a8796bc714b489a3ae22246a208f37bfa46"
-  integrity sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
+  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
 
 string.prototype.trimstart@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz#22d45da81015309cd0cdd79787e8919fc5c613e7"
-  integrity sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
+  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -26607,21 +25996,21 @@ svgo@1.3.2, svgo@^1.0.0, svgo@^1.2.2:
     util.promisify "~1.0.0"
 
 swagger2openapi@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/swagger2openapi/-/swagger2openapi-7.0.3.tgz#aa16cf00ea368028f6f41fcab3074cff223cfb8a"
-  integrity sha512-JSFUmXSR7Qx9WwSKCEqaL4oQfhLLCU2r8Zgf30g15FdSkihItZ6fKFnqSsfqQ6MsmnLlcBf8+OhnQHbi1R0ydg==
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/swagger2openapi/-/swagger2openapi-7.0.4.tgz#63f20ecc6a57a8dde33c92cc4aeb8dc34671e1b0"
+  integrity sha512-MGzJU44XSXHKxvtx/NbBnP3z5s1KzN5xhqIBERoZEKfRiZ56lNUo5TGOv0dJ8n7JGeheCeU0CydfvbSOh+DaXg==
   dependencies:
     call-me-maybe "^1.0.1"
     node-fetch "^2.6.1"
     node-fetch-h2 "^2.3.0"
     node-readfiles "^0.2.0"
     oas-kit-common "^1.0.8"
-    oas-resolver "^2.5.2"
+    oas-resolver "^2.5.3"
     oas-schema-walker "^1.1.5"
-    oas-validator "^5.0.3"
-    reftools "^1.1.6"
+    oas-validator "^5.0.4"
+    reftools "^1.1.7"
     yaml "^1.10.0"
-    yargs "^15.3.1"
+    yargs "^16.1.1"
 
 swap-case@^1.1.0:
   version "1.1.2"
@@ -26845,9 +26234,9 @@ terser@^4.1.2, terser@^4.6.12, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.4:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.4.0.tgz#9815c0839072d5c894e22c6fc508fbe9f5e7d7e8"
-  integrity sha512-3dZunFLbCJis9TAF2VnX+VrQLctRUmt1p3W2kCsJuZE4ZgWqh//+1MZ62EanewrqKoUf4zIaDGZAvml4UDc0OQ==
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.5.0.tgz#1406fcb4d4bc517add3b22a9694284c040e33448"
+  integrity sha512-eopt1Gf7/AQyPhpygdKePTzaet31TvQxXvrf7xYUvD/d8qkCJm4SKPDzu+GHK5ZaYTn8rvttfqaZc3swK21e5g==
   dependencies:
     commander "^2.20.0"
     source-map "~0.7.2"
@@ -27025,9 +26414,9 @@ title-case@^2.1.0:
     upper-case "^1.0.3"
 
 tlds@^1.203.0:
-  version "1.212.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.212.0.tgz#f3f29bd5d10d0fd9a6f171a5f9d57d58b71eccf7"
-  integrity sha512-03rYYO1rGhOYpdYB+wlLY2d0xza6hdN/S67ol2ZpaH+CtFedMVAVhj8ft0rwxEkr90zatou8opBv7Xp6X4cK6g==
+  version "1.213.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.213.0.tgz#2b7c32f0f5a6545a31a81bbc3b2468a1a62c07f6"
+  integrity sha512-ypkf6Ca37CbqSNxq//Pyr4C40Rnzxnau+NvFt0D4yEPo8/xfAujITRfpOwyMIYNE2jhXljkOxApBW9J2Ib8W2A==
 
 tmp@0.2.1, tmp@^0.2.1, tmp@~0.2.1:
   version "0.2.1"
@@ -27466,15 +26855,10 @@ typeface-roboto@1.1.13:
   resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-1.1.13.tgz#9c4517cb91e311706c74823e857b4bac9a764ae5"
   integrity sha512-YXvbd3a1QTREoD+FJoEkl0VQNJoEjewR2H11IjVv4bp6ahuIcw0yyw/3udC4vJkHw3T3cUh85FTg8eWef3pSaw==
 
-typescript@4.1.2:
+typescript@4.1.2, typescript@^4.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
-
-typescript@^4.0:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.22"
@@ -27490,9 +26874,9 @@ uglify-es@3.3.9:
     source-map "~0.6.1"
 
 uglify-js@^3.1.4:
-  version "3.11.6"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.6.tgz#144b50d3e05eadd3ad4dd047c60ca541a8cd4e9c"
-  integrity sha512-oASI1FOJ7BBFkSCNDZ446EgkSuHkOZBuqRFrwXIKWCoXw8ZXQETooTQjkAcBS03Acab7ubCKsXnwuV2svy061g==
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.0.tgz#b943f129275c41d435eb54b643bbffee71dccf57"
+  integrity sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==
 
 uglifycss@0.0.29:
   version "0.0.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,7 +470,15 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-numeric-separator@^7.12.5", "@babel/plugin-proposal-numeric-separator@^7.12.7":
+"@babel/plugin-proposal-numeric-separator@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz#b1ce757156d40ed79d59d467cb2b154a5c4149ba"
+  integrity sha512-UiAnkKuOrCyjZ3sYNHlRlfuZJbBHknMQ9VMwVeX97Ofwx7RpD6gS2HfqTCh8KNUQgcOm8IKt103oR4KIjh7Q8g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
+"@babel/plugin-proposal-numeric-separator@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz#8bf253de8139099fea193b297d23a9d406ef056b"
   integrity sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
@@ -1105,13 +1113,21 @@
     "@babel/plugin-transform-react-jsx-source" "^7.12.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
-"@babel/preset-typescript@7.12.7", "@babel/preset-typescript@^7.12.1":
+"@babel/preset-typescript@7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz#fc7df8199d6aae747896f1e6c61fc872056632a3"
   integrity sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-validator-option" "^7.12.1"
+    "@babel/plugin-transform-typescript" "^7.12.1"
+
+"@babel/preset-typescript@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz#86480b483bb97f75036e8864fe404cc782cc311b"
+  integrity sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-transform-typescript" "^7.12.1"
 
 "@babel/runtime-corejs3@7.12.1":
@@ -1152,9 +1168,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/standalone@^7.12.6":
-  version "7.12.8"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.8.tgz#c4915f7120462b75b63a396088e14361dca86be6"
-  integrity sha512-0NPKt9h+d9ZC2bgOuh2zlM5RwaHgOol9XhMH1Jlk3oRCvHU+FSVhr7AGUtq2oRS4IDo2oULj+AKj8nj1NMKppA==
+  version "7.12.6"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.6.tgz#fa59cf6f1cea940a790179f1375394ab31f025b9"
+  integrity sha512-yA/OV3jN1nhr0JsAdYWAqbeZ7cAOw/6Fh52rxVMzujr0HF4Z3cau0JBzJfQppFfR9IArrUtcqhBu/+Q/IevoyQ==
 
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.12.7"
@@ -1529,6 +1545,23 @@
     "@babel/runtime-corejs3" "7.12.1"
     "@jackfranklin/test-data-bot" "1.3.0"
 
+"@commercetools-uikit/accessible-button@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/accessible-button/-/accessible-button-10.40.0.tgz#d4dc6b060db8d25aa2ebf3afff1766452efa7314"
+  integrity sha512-emNW8cFSLB/aU9Y6ebdBV4O7pYIv3LtFBwW33VtU3akwkqwQlSdh1AEz9bO6yy31Gi/x8yNi+dbLtHg261kx3g==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    common-tags "1.8.0"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+
 "@commercetools-uikit/accessible-button@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/accessible-button/-/accessible-button-10.42.2.tgz#08f1196deabf2eae944a36ab2c1970a042522737"
@@ -1574,29 +1607,29 @@
     "@commercetools-uikit/secondary-button" "10.42.2"
     "@commercetools-uikit/secondary-icon-button" "10.42.2"
 
-"@commercetools-uikit/calendar-utils@10.42.2":
-  version "10.42.2"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/calendar-utils/-/calendar-utils-10.42.2.tgz#6eaa882b1ea43a903fb7a223f00c92f199f4e282"
-  integrity sha512-kx24JPAIMJjUsnus8CBFC/sozY6aK/BVlLyyOY4YhKKp+Z3+4pMY4l48Fj2cwN06oM0APEjZqX7U9tQH0kLcTg==
+"@commercetools-uikit/calendar-utils@10.40.1":
+  version "10.40.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/calendar-utils/-/calendar-utils-10.40.1.tgz#b45a8e52f519e864551f28b8832cecfeb858421d"
+  integrity sha512-+eKFp7o7UZFvzQDIHlNPPk3V7PYTVOL4LvSJzwfuzhIUUDQZmZiqiHtvqPcRoggN79/AVe9OUiQOxS1aZniPsw==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.42.2"
-    "@commercetools-uikit/design-system" "10.42.2"
-    "@commercetools-uikit/hooks" "10.42.2"
-    "@commercetools-uikit/icons" "10.42.2"
-    "@commercetools-uikit/input-utils" "10.42.2"
-    "@commercetools-uikit/secondary-icon-button" "10.42.2"
-    "@commercetools-uikit/spacings-inline" "10.42.2"
-    "@commercetools-uikit/text" "10.42.2"
-    "@commercetools-uikit/tooltip" "10.42.2"
-    "@commercetools-uikit/utils" "10.42.2"
-    "@emotion/react" "^11.1.1"
-    "@emotion/styled" "^11.0.0"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/hooks" "10.40.0"
+    "@commercetools-uikit/icons" "10.40.1"
+    "@commercetools-uikit/input-utils" "10.40.1"
+    "@commercetools-uikit/secondary-icon-button" "10.40.0"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/tooltip" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
     prop-types "15.7.2"
-    react-select "3.1.1"
+    react-select "3.1.0"
 
-"@commercetools-uikit/card@10.42.2", "@commercetools-uikit/card@^10.39.8", "@commercetools-uikit/card@^10.42.2":
+"@commercetools-uikit/card@10.42.2", "@commercetools-uikit/card@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/card/-/card-10.42.2.tgz#baf6a996b038932641ea990cb21d328f22040bdb"
   integrity sha512-k7+qtQLktkepEpq5BMjIlX4bH1dvMnvDNCJ8X5mrDw8O0/n+4kPNJ7sQRAQuumF4g5TysG3bCKpVHh3YEVoWwg==
@@ -1609,21 +1642,52 @@
     "@emotion/styled" "^11.0.0"
     prop-types "15.7.2"
 
-"@commercetools-uikit/checkbox-input@^10.39.8":
-  version "10.42.2"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/checkbox-input/-/checkbox-input-10.42.2.tgz#ed841bdbe90c587c25616b59645c6582c8b5cf8c"
-  integrity sha512-Us1o5HojdOdID/+jtXD8r9COjW4+ArVp2WMXYf3q618d7NeoKiyiuiXm7HtUApzzYHPZif2OE4Xe73rtmyz5qA==
+"@commercetools-uikit/card@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/card/-/card-10.40.0.tgz#37bdb0ca967122b1646477c63e7b932b5b1b52c2"
+  integrity sha512-lFZIhR6g7Ysb1gCcLBSUXRKfqYsXBWDCavSTzuTAyXj3E65cmej1kQ+eWynWwdJ5V+UwpA/m3mK5Ahetzu67EQ==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.42.2"
-    "@commercetools-uikit/icons" "10.42.2"
-    "@commercetools-uikit/input-utils" "10.42.2"
-    "@commercetools-uikit/select-utils" "10.42.2"
-    "@commercetools-uikit/text" "10.42.2"
-    "@commercetools-uikit/utils" "10.42.2"
-    "@emotion/react" "^11.1.1"
-    "@emotion/styled" "^11.0.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    prop-types "15.7.2"
+
+"@commercetools-uikit/checkbox-input@^10.39.8":
+  version "10.40.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/checkbox-input/-/checkbox-input-10.40.1.tgz#85fa9d83cb2454b1a75853ca6bc7492ebc018166"
+  integrity sha512-6ZNSMwDzxiYZUBxO1Ja/B6LAKRbyaVqn9iOaEh3tXqYK/5rtQ+pYkKETRAwYPzmZYNw8uXWRe7o4GCxxZlmLXg==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/icons" "10.40.1"
+    "@commercetools-uikit/input-utils" "10.40.1"
+    "@commercetools-uikit/select-utils" "10.40.1"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    emotion-theming "^10.0.27"
+    prop-types "15.7.2"
+    tiny-invariant "1.1.0"
+
+"@commercetools-uikit/constraints@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/constraints/-/constraints-10.40.0.tgz#4d080c2358180b300e06d2cd36d40f3d964afa66"
+  integrity sha512-UA1L6w1DOliQR2qUGZA2cWDjnaE7I0jO5lC1EmPxB51o9ZtZxmHOVYE9FG5qajGWOtolYVd8Ol9l8Hg27zTfgw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
     prop-types "15.7.2"
     tiny-invariant "1.1.0"
 
@@ -1662,26 +1726,27 @@
     tiny-invariant "1.1.0"
 
 "@commercetools-uikit/date-input@^10.39.8":
-  version "10.42.2"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/date-input/-/date-input-10.42.2.tgz#a8a40dbfd5d912a8699b1ca4c68c0f8883c62d50"
-  integrity sha512-MX1MlE3Oaskf15D2akteAW3e2p+Kiv3qvHKa6YvWkA0lwiY9JS7yC28asF/t2ZFUryfgpwTGFO6ctLCJgj+6hw==
+  version "10.40.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/date-input/-/date-input-10.40.1.tgz#47f0694c13d9785741e91c89944cfc2b7d2b077f"
+  integrity sha512-MGTYfRoVkPeeRhsvHsMuMmYbRXQhL04ZOVdhz6w2M+EJ82o3Zmk6ijcypjOlSinMDUl+/WKkuOTPDV/4vCENBA==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.42.2"
-    "@commercetools-uikit/calendar-utils" "10.42.2"
-    "@commercetools-uikit/constraints" "10.42.2"
-    "@commercetools-uikit/design-system" "10.42.2"
-    "@commercetools-uikit/hooks" "10.42.2"
-    "@commercetools-uikit/icons" "10.42.2"
-    "@commercetools-uikit/secondary-icon-button" "10.42.2"
-    "@commercetools-uikit/select-utils" "10.42.2"
-    "@commercetools-uikit/spacings-inline" "10.42.2"
-    "@commercetools-uikit/text" "10.42.2"
-    "@commercetools-uikit/tooltip" "10.42.2"
-    "@commercetools-uikit/utils" "10.42.2"
-    "@emotion/react" "^11.1.1"
-    "@emotion/styled" "^11.0.0"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/calendar-utils" "10.40.1"
+    "@commercetools-uikit/constraints" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/hooks" "10.40.0"
+    "@commercetools-uikit/icons" "10.40.1"
+    "@commercetools-uikit/secondary-icon-button" "10.40.0"
+    "@commercetools-uikit/select-utils" "10.40.1"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/tooltip" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
     common-tags "1.8.0"
     downshift "6.0.6"
     prop-types "15.7.2"
@@ -1690,7 +1755,15 @@
     tiny-invariant "1.1.0"
     warning "4.0.3"
 
-"@commercetools-uikit/design-system@10.42.2", "@commercetools-uikit/design-system@^10.39.8", "@commercetools-uikit/design-system@^10.42.2":
+"@commercetools-uikit/design-system@10.40.0", "@commercetools-uikit/design-system@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-10.40.0.tgz#b5985750d7f6ce4c2252fd644a7c0119937159b3"
+  integrity sha512-2sjDAoCA48GBAcxtZ5G5BGCi0PG3zjIXBZnZwfkAQ6qpnUk6Vib/0hBW7QbtgCFnxDO19SSoctQy8Nyo8ZbTvA==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+
+"@commercetools-uikit/design-system@10.42.2", "@commercetools-uikit/design-system@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-10.42.2.tgz#bdb802b8c91726dbf8b5d57d25bb04f2254eebdf"
   integrity sha512-d7nkE536Y1v9JwW0yw4z2xxl+okLiZ2BwS//lK0jSCwYTLVBiZ19lszHQnFpd9IoWiXkYP+JvgT3GKHPr9Se5A==
@@ -1730,6 +1803,28 @@
     react-required-if "1.0.3"
     tiny-invariant "1.1.0"
 
+"@commercetools-uikit/flat-button@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/flat-button/-/flat-button-10.40.0.tgz#0dc8aecf3e617b74b2a211d966eb4774c91c495c"
+  integrity sha512-rvn9ReIXz0SDSbUSQrNUQ3NW6aw9SHbW8wnoJWATcO6DsP0i9C9ncTLBWa6U8UGyZbxv+xf9IL/FsjY59QXK1g==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    common-tags "1.8.0"
+    emotion-theming "^10.0.27"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+
 "@commercetools-uikit/flat-button@10.42.2", "@commercetools-uikit/flat-button@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/flat-button/-/flat-button-10.42.2.tgz#d3f091a81eb075571465ae35cf23d41bc0e6c6a6"
@@ -1760,6 +1855,15 @@
     "@emotion/styled" "^11.0.0"
     prop-types "15.7.2"
 
+"@commercetools-uikit/hooks@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/hooks/-/hooks-10.40.0.tgz#b6708ba35aff607072da989223c421747a09fc22"
+  integrity sha512-ibvbXBMBqQhq/3/G487iZgcMkK50JVOh7TdBg7hb/qe/hugUjy1+f3gwWBCtZz1lFCZmaWHNiIk9dwAaqc+mzg==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/utils" "10.40.0"
+
 "@commercetools-uikit/hooks@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/hooks/-/hooks-10.42.2.tgz#c926c3a2599b6f7cd5f3b6771a25471faf1a0b07"
@@ -1778,7 +1882,29 @@
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
 
-"@commercetools-uikit/icon-button@10.42.2", "@commercetools-uikit/icon-button@^10.39.8", "@commercetools-uikit/icon-button@^10.42.2":
+"@commercetools-uikit/icon-button@10.40.0", "@commercetools-uikit/icon-button@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icon-button/-/icon-button-10.40.0.tgz#e08b6c0453933ec61fb3bf3f8cbc85350b426e4c"
+  integrity sha512-Zj9UwNb/IgVU6NbfgNo4TZs3IwEg15yb5oalDv27cT2gDXviMw5MlVlrLr1FHp+gnOfy10PEDAVOot6nKIDd5Q==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    common-tags "1.8.0"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+    tiny-invariant "1.1.0"
+
+"@commercetools-uikit/icon-button@10.42.2", "@commercetools-uikit/icon-button@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/icon-button/-/icon-button-10.42.2.tgz#07030289114a45f43dbf99a81e11a8cc17aac1db"
   integrity sha512-olSLnsd1Mtt8bgZVFSzWlqSvpi6ChQ/3KaoLYBmlQvO0X1+X6wr7JBFv5zFW3mzC84MUEqzZzriDjWTMKcc6Iw==
@@ -1798,7 +1924,22 @@
     react-required-if "1.0.3"
     tiny-invariant "1.1.0"
 
-"@commercetools-uikit/icons@10.42.2", "@commercetools-uikit/icons@^10.39.8", "@commercetools-uikit/icons@^10.42.2":
+"@commercetools-uikit/icons@10.40.1", "@commercetools-uikit/icons@^10.39.8":
+  version "10.40.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-10.40.1.tgz#068378cf8a9fdf03ab45d795a00f067c7f1fffea"
+  integrity sha512-XM6x9dbQ/FuLM6xMbyxgj+iycKTSDpiRLR+XTZ0qYbkeiY+RBkehP/Uv1yoBWBYlIQvr2c+zapncH6ChHxZXYA==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    emotion-theming "^10.0.27"
+    prop-types "15.7.2"
+    tiny-invariant "1.1.0"
+
+"@commercetools-uikit/icons@10.42.2", "@commercetools-uikit/icons@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-10.42.2.tgz#9cc3fa1f9d7deefef8e94df9b3491c7d3c7a2f9e"
   integrity sha512-zeJZgofZVbrZv9mMyS7bbYthQhqISd1C5od4dgOXDqStrNYm2UISSOE4op5uGJW0E1pg5novd1aBDkBp18Xn1g==
@@ -1810,6 +1951,23 @@
     "@emotion/styled" "^11.0.0"
     prop-types "15.7.2"
     tiny-invariant "1.1.0"
+
+"@commercetools-uikit/input-utils@10.40.1":
+  version "10.40.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/input-utils/-/input-utils-10.40.1.tgz#19e3013da8f5b5813fa9dcb7df4dace5a8bb4437"
+  integrity sha512-IG2x/IL7jALRvRDWAzsl1/VBa5JtdznrbvM7KydWG/0dHowJT+6Oko/UmC5ABuoh5mt5CQlHJRagBixbh9V9zg==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/flat-button" "10.40.0"
+    "@commercetools-uikit/icons" "10.40.1"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    emotion-theming "^10.0.27"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+    react-textarea-autosize "8.3.0"
 
 "@commercetools-uikit/input-utils@10.42.2":
   version "10.42.2"
@@ -1842,26 +2000,28 @@
     react-required-if "1.0.3"
     tiny-invariant "1.1.0"
 
-"@commercetools-uikit/link-button@10.42.2":
-  version "10.42.2"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/link-button/-/link-button-10.42.2.tgz#b44281d8dad814ff6eb48161211bbe1a5d2aa9f1"
-  integrity sha512-WDNgHX8GGl4D2PZaAfEviPERD64XGawjHNGIIPDVw4NbaR7tn9KaextR6v39tTEk5LRitPQH+8+JJKcsL3jxIQ==
+"@commercetools-uikit/link-button@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/link-button/-/link-button-10.40.0.tgz#6255d32d64e683031bbbbec968b659101565e8aa"
+  integrity sha512-bfG1j3tAvdTeow4N1i3RpDfhhV5eGhzTPqd2NPd40WvgpfSHxuaw9+Yiu+BKOGB06fxQGPX6enI3NQWDqMevhQ==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/accessible-button" "10.42.2"
-    "@commercetools-uikit/design-system" "10.42.2"
-    "@commercetools-uikit/spacings-inline" "10.42.2"
-    "@commercetools-uikit/text" "10.42.2"
-    "@commercetools-uikit/utils" "10.42.2"
-    "@emotion/react" "^11.1.1"
-    "@emotion/styled" "^11.0.0"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
     common-tags "1.8.0"
     lodash "4.17.20"
+    lodash-es "4.17.15"
     prop-types "15.7.2"
     react-required-if "1.0.3"
 
-"@commercetools-uikit/loading-spinner@10.42.2", "@commercetools-uikit/loading-spinner@^10.39.8", "@commercetools-uikit/loading-spinner@^10.42.2":
+"@commercetools-uikit/loading-spinner@10.42.2", "@commercetools-uikit/loading-spinner@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/loading-spinner/-/loading-spinner-10.42.2.tgz#89f7066f258c07f9d92c87a6d826ea660ea80409"
   integrity sha512-JZBdJQuuNbB7MEhUBU1SSpyGcorrGOCWCVDqYw8d0etazozTKQaXFmttyXE22fajidGQxqOb1M90ZUXkoiQGFQ==
@@ -1873,6 +2033,20 @@
     "@commercetools-uikit/text" "10.42.2"
     "@commercetools-uikit/utils" "10.42.2"
     "@emotion/react" "^11.1.1"
+    prop-types "15.7.2"
+
+"@commercetools-uikit/loading-spinner@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/loading-spinner/-/loading-spinner-10.40.0.tgz#0a0c1fe037ca3a8dfd4316f8345f6bb112dbabe7"
+  integrity sha512-KvOm+7wqNZ9Q9+GhC5fVOpcvILETnr5kZo4N0hVGjO7AGY//DIsw9lP+IUHDhrkxF8QpRjsvah8uCxmdwF5MRw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
     prop-types "15.7.2"
 
 "@commercetools-uikit/messages@10.42.2":
@@ -1947,6 +2121,27 @@
     prop-types "15.7.2"
     react-required-if "1.0.3"
 
+"@commercetools-uikit/primary-button@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/primary-button/-/primary-button-10.40.0.tgz#93e5039e96ce15350d8b80bb9872610607e0a242"
+  integrity sha512-tLtjtYD5jpx+OxY9on7uicraXPVdyT3Wv41txIGv2zb0pm0MVPyUKtkohdrMWjKos4FnNHkkcanrGN2zZHnAWw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    common-tags "1.8.0"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+
 "@commercetools-uikit/primary-button@10.42.2", "@commercetools-uikit/primary-button@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/primary-button/-/primary-button-10.42.2.tgz#9bb655ade8b1be2a7ccfc63582703d9e74af2f4c"
@@ -1965,6 +2160,28 @@
     lodash "4.17.20"
     prop-types "15.7.2"
     react-required-if "1.0.3"
+
+"@commercetools-uikit/secondary-button@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-button/-/secondary-button-10.40.0.tgz#a3edfbde9969b990c911777dd6d04b9e1f382a3c"
+  integrity sha512-YKNbtVA/H0MiBY9SlJ1MHRYxFk55jMrxwLUKwzSFb1vxH0odGY+/NTV0HTGS8n0JqpJ6npV0YdIaqpu6kkfQtA==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    common-tags "1.8.0"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+    tiny-invariant "1.1.0"
 
 "@commercetools-uikit/secondary-button@10.42.2", "@commercetools-uikit/secondary-button@^10.42.2":
   version "10.42.2"
@@ -1986,7 +2203,29 @@
     react-required-if "1.0.3"
     tiny-invariant "1.1.0"
 
-"@commercetools-uikit/secondary-icon-button@10.42.2", "@commercetools-uikit/secondary-icon-button@^10.39.8", "@commercetools-uikit/secondary-icon-button@^10.42.2":
+"@commercetools-uikit/secondary-icon-button@10.40.0", "@commercetools-uikit/secondary-icon-button@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-10.40.0.tgz#381f77023020020853f3d2ce543b47479e674f9b"
+  integrity sha512-VA6tyMDeTYzuIN3+xr/AyeHdSO0MqDA/WV2x1ucCW0lJJf0wra8id+iXXvsQdikFrEemPKCY4B5ukmrWUEYyTw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/spacings" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    common-tags "1.8.0"
+    emotion-theming "^10.0.27"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+
+"@commercetools-uikit/secondary-icon-button@10.42.2", "@commercetools-uikit/secondary-icon-button@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-10.42.2.tgz#3684230e2ab8ba4b4da14722af2c342795fcb680"
   integrity sha512-fdCup7bOy5HC4Ot3Y81Xp+OYHGDrDA5jc4ulKDeMQqpOupOgn2mF2mHyTeTff/otNgbqiJFb1uC6HlrPV8J7Ow==
@@ -2043,6 +2282,27 @@
     prop-types "15.7.2"
     react-select "3.1.1"
 
+"@commercetools-uikit/select-utils@10.40.1":
+  version "10.40.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-10.40.1.tgz#20c68b76a82d9a3a02d9b75b776d39b32ce5b255"
+  integrity sha512-a+ATFCZAKyBne+V/ay2RPF+s5XIItUZ9n0ub6c8y4x8j7SCOd+oZ1l8erNqgHNt+7N+C4QUptlgqwL0FKu3Hlg==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/accessible-button" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/icons" "10.40.1"
+    "@commercetools-uikit/spacings" "10.40.0"
+    "@commercetools-uikit/text" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-select "3.1.0"
+
 "@commercetools-uikit/select-utils@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-10.42.2.tgz#662e9161bf1254c55ab95109a6ee900b45a50b57"
@@ -2062,7 +2322,19 @@
     prop-types "15.7.2"
     react-select "3.1.1"
 
-"@commercetools-uikit/spacings-inline@10.42.2", "@commercetools-uikit/spacings-inline@^10.39.8":
+"@commercetools-uikit/spacings-inline@10.40.0", "@commercetools-uikit/spacings-inline@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inline/-/spacings-inline-10.40.0.tgz#551dafa237e0c0f3bf06f6798872d918a70c4d9b"
+  integrity sha512-HHEj74bBXdUwfDucb81N6JI70wO4Qm0EqcYACiC+cQCkMCk8OzaGAcGCPboyeWDl9VaNsPt80QvMhxzAysY5eA==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    prop-types "15.7.2"
+
+"@commercetools-uikit/spacings-inline@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inline/-/spacings-inline-10.42.2.tgz#25e41f845de597c23adaef8365072008ee94dc64"
   integrity sha512-63BfDNXCEjklHvK4qGNvb3FHVbC3s5ggEnXF5i4KVurHXbamf4o2oyVcDS2zW9x0RwPlVGJu5yAfYnrZwS/gWw==
@@ -2072,6 +2344,18 @@
     "@commercetools-uikit/design-system" "10.42.2"
     "@commercetools-uikit/utils" "10.42.2"
     "@emotion/react" "^11.1.1"
+    prop-types "15.7.2"
+
+"@commercetools-uikit/spacings-inset-squish@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inset-squish/-/spacings-inset-squish-10.40.0.tgz#1f5a73cc9b3666928bbd4881b447c238874e654c"
+  integrity sha512-fAikzTRzWxy8SdZ3h8SCT2++D7nvPgu9uHWSEtUa0OFN4Uyqct49gP2aK2++aPY9/gEWqK7jliMn6skC7A7Hjw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
     prop-types "15.7.2"
 
 "@commercetools-uikit/spacings-inset-squish@10.42.2":
@@ -2086,6 +2370,18 @@
     "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
 
+"@commercetools-uikit/spacings-inset@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inset/-/spacings-inset-10.40.0.tgz#21d5d99285329d3fdb9f722c4c50807c46ec48c0"
+  integrity sha512-ytk+yxFpiwRlEfssW7/ynlEaIPx0mCfGp74Rse/iTvmtD+SY7Mo88mn60kW/XG4OhkqXbFMWpJ/d8RmUFd393w==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    prop-types "15.7.2"
+
 "@commercetools-uikit/spacings-inset@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inset/-/spacings-inset-10.42.2.tgz#1773fef64900633d891fdb05885367394f645036"
@@ -2098,7 +2394,19 @@
     "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
 
-"@commercetools-uikit/spacings-stack@10.42.2", "@commercetools-uikit/spacings-stack@^10.39.8":
+"@commercetools-uikit/spacings-stack@10.40.0", "@commercetools-uikit/spacings-stack@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-stack/-/spacings-stack-10.40.0.tgz#0f91d4b34dd8770536278b17e05e80a7d566b210"
+  integrity sha512-2S6MQNoJSTIUUZ38mJX/v8lMHjlfHFkXuOhtObQHL2qarCEQ6xUwz9Wsa0p4is5m4A+SOLtuOq6YvqEWBfrPIA==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    prop-types "15.7.2"
+
+"@commercetools-uikit/spacings-stack@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-stack/-/spacings-stack-10.42.2.tgz#f67d65937bf47d6146d141b88302a047172bb023"
   integrity sha512-+Yapu8a8NayDWss9sSLrj9Ggli/F9rBdJ09awCVuoIvTPi7q4cn2TUKqwo7lnQB75ZgIssdLDqw/D3kCMFf8kw==
@@ -2109,6 +2417,18 @@
     "@commercetools-uikit/utils" "10.42.2"
     "@emotion/react" "^11.1.1"
     prop-types "15.7.2"
+
+"@commercetools-uikit/spacings@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings/-/spacings-10.40.0.tgz#86dde2a2c327c45f4283fd34cdf4cbf7deb4991a"
+  integrity sha512-AanJgR0LDFiOugJJ4MqHFucxCJ2KO+bTiwe76Y1v3cvl57kffiHMuvhlceI8rxrt4i/duFtSbOdzsEgIbErHhw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/spacings-inline" "10.40.0"
+    "@commercetools-uikit/spacings-inset" "10.40.0"
+    "@commercetools-uikit/spacings-inset-squish" "10.40.0"
+    "@commercetools-uikit/spacings-stack" "10.40.0"
 
 "@commercetools-uikit/spacings@10.42.2", "@commercetools-uikit/spacings@^10.42.2":
   version "10.42.2"
@@ -2123,14 +2443,15 @@
     "@commercetools-uikit/spacings-stack" "10.42.2"
 
 "@commercetools-uikit/stamp@^10.39.8":
-  version "10.42.2"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/stamp/-/stamp-10.42.2.tgz#20b6d0e4e231853b16f7340bd86554b3ed0ff077"
-  integrity sha512-A45NXVb67gCaeNqJ5Ceh1myQUnvVYmAJT2Y0f/ZEocP63tPYWVaCAmZiR7EdSHVuRgUjqX+Lgv7tZBg5askymw==
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/stamp/-/stamp-10.40.0.tgz#1f0c8f618274bdc6e7c5aaf102beed6ac434cd4b"
+  integrity sha512-L7yRMgHTo2qW7X99xE7cYdPN45ySABK2zHPhIDPlKpbzjuZt0nKxaalodb83XQj2dB53GZStPqzs6iFFMzukew==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@babel/runtime-corejs3" "7.12.5"
-    "@commercetools-uikit/design-system" "10.42.2"
-    "@emotion/react" "^11.1.1"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    emotion-theming "^10.0.27"
     prop-types "15.7.2"
 
 "@commercetools-uikit/text-field@10.42.2":
@@ -2168,6 +2489,24 @@
     prop-types "15.7.2"
     react-required-if "1.0.3"
 
+"@commercetools-uikit/text@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/text/-/text-10.40.0.tgz#cb635bd9a0b7945dc2efeab623a22a26b98142be"
+  integrity sha512-mp8/BP59mOQZp1UuMmz97Lcwj0PagdVrUZQH9PJTcf2Yr2iphryfc3a0gFnzamya7CKHDkjtUiwRyQIpJEvyDw==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    common-tags "1.8.0"
+    emotion-theming "^10.0.27"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-required-if "1.0.3"
+    warning "4.0.3"
+
 "@commercetools-uikit/text@10.42.2", "@commercetools-uikit/text@^10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/text/-/text-10.42.2.tgz#14b66a6f1bf47bcf51db09fc4171acb9d5578683"
@@ -2184,7 +2523,28 @@
     react-required-if "1.0.3"
     warning "4.0.3"
 
-"@commercetools-uikit/tooltip@10.42.2", "@commercetools-uikit/tooltip@^10.39.8":
+"@commercetools-uikit/tooltip@10.40.0", "@commercetools-uikit/tooltip@^10.39.8":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/tooltip/-/tooltip-10.40.0.tgz#3313a6711b2a337c5f086ecc2126349208acd7b0"
+  integrity sha512-a/XUpq0v8isRHNt6Z7myx3hswXAJ1jW9UKA72/UyOa8HDTZ1KAG+0lD+hQ74D3uJnO9n+L5W7l4HtLYkVX+YGQ==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@commercetools-uikit/constraints" "10.40.0"
+    "@commercetools-uikit/design-system" "10.40.0"
+    "@commercetools-uikit/hooks" "10.40.0"
+    "@commercetools-uikit/utils" "10.40.0"
+    "@emotion/core" "^10.0.34"
+    "@emotion/styled" "^10.0.27"
+    "@emotion/styled-base" "^10.0.31"
+    lodash "4.17.20"
+    lodash-es "4.17.15"
+    prop-types "15.7.2"
+    react-is "16.13.1"
+    tiny-invariant "1.1.0"
+    use-popper "1.1.6"
+
+"@commercetools-uikit/tooltip@10.42.2":
   version "10.42.2"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/tooltip/-/tooltip-10.42.2.tgz#acff7ca0229aa939c02aa53728a46280a6feb3e3"
   integrity sha512-73JMoa4jVFbTHTyKlJiRPCmni0ebu6KRQOBxqK2JAz747ipALDy/tdCeVd3ChmG6O49K/LzzsM+W5I1og/+qNg==
@@ -2202,6 +2562,16 @@
     react-is "16.13.1"
     tiny-invariant "1.1.0"
     use-popper "1.1.6"
+
+"@commercetools-uikit/utils@10.40.0":
+  version "10.40.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/utils/-/utils-10.40.0.tgz#66eaedaf6f07986220fbc49daa2c47aa88d13d1f"
+  integrity sha512-lRwvHBDaAVgPZsHHayH27y6hj5eaJ1KcOE1YnXzV3fy4uyN5NpPtUE4KpJ/MGj63bnudxPSoryZh45WmwzO3og==
+  dependencies:
+    "@babel/runtime" "7.12.5"
+    "@babel/runtime-corejs3" "7.12.5"
+    "@emotion/is-prop-valid" "0.8.8"
+    warning "4.0.3"
 
 "@commercetools-uikit/utils@10.42.2":
   version "10.42.2"
@@ -2529,7 +2899,7 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "^4.0.3"
 
-"@emotion/core@^10.0.9":
+"@emotion/core@^10.0.34", "@emotion/core@^10.0.9":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -2554,6 +2924,13 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/is-prop-valid@0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
 
 "@emotion/is-prop-valid@1.0.0", "@emotion/is-prop-valid@^1.0.0":
   version "1.0.0"
@@ -2612,6 +2989,16 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.0.tgz#a0ef06080f339477ad4ba7f56e1c931f7ba50822"
   integrity sha512-cdCHfZtf/0rahPDCZ9zyq+36EqfD/6c0WUqTFZ/hv9xadTUv2lGE5QK7/Z6Dnx2oRxC0usfVM2/BYn9q9B9wZA==
 
+"@emotion/styled-base@^10.0.27", "@emotion/styled-base@^10.0.31":
+  version "10.0.31"
+  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.31.tgz#940957ee0aa15c6974adc7d494ff19765a2f742a"
+  integrity sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/is-prop-valid" "0.8.8"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+
 "@emotion/styled@11.0.0", "@emotion/styled@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.0.0.tgz#698196c2822746360a8644a73a5d842b2d1a78a5"
@@ -2622,6 +3009,14 @@
     "@emotion/is-prop-valid" "^1.0.0"
     "@emotion/serialize" "^1.0.0"
     "@emotion/utils" "^1.0.0"
+
+"@emotion/styled@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
+  integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
+  dependencies:
+    "@emotion/styled-base" "^10.0.27"
+    babel-plugin-emotion "^10.0.27"
 
 "@emotion/stylis@0.8.5":
   version "0.8.5"
@@ -3307,9 +3702,9 @@
     tslib "~2.0.1"
 
 "@graphql-tools/prisma-loader@^6", "@graphql-tools/prisma-loader@^6.0.0":
-  version "6.2.7"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.2.7.tgz#0a9aa8f40c79a926f2d4f157dc282478bccafaca"
-  integrity sha512-o0QHl767uaLZVjb9NlupZjCzjfC5Zo79G6QLnK0Rbi0Ldk5Lf05HDZIfMhiyd9tsw73d0GQY7yIPvQJFE2S5Tw==
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.2.6.tgz#50660c2613597640a08ee52c2dceabc48de4f306"
+  integrity sha512-fjDVAuPAtQIglP7+X9BZ9F69Q0urkbq36ksJjjk+iV+6XpnS/Q46/3YmghGKFUMAuPWQ49UobWYyCN6ctqR89Q==
   dependencies:
     "@graphql-tools/url-loader" "^6.3.1"
     "@graphql-tools/utils" "^7.0.0"
@@ -3322,6 +3717,7 @@
     chalk "^4.1.0"
     debug "^4.2.0"
     dotenv "^8.2.0"
+    fs-extra "9.0.1"
     graphql-request "^3.3.0"
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"
@@ -5582,7 +5978,21 @@
     "@babel/runtime" "^7.11.2"
     "@testing-library/dom" "^7.22.2"
 
-"@testing-library/dom@^7.22.2", "@testing-library/dom@^7.28.1":
+"@testing-library/dom@^7.22.2":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.28.0.tgz#4d68a39675dbf0fa2f3c53bc2b9ab9e1dd1d55b2"
+  integrity sha512-jY9wE3eF/fjrxUCC1VTCnMWE/g+aCP582Df4H6H9wQYY0yLglyevTO7TET9pgg0w9Yzm8n7ck0Hxzi18pN5+4w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/dom@^7.28.1":
   version "7.28.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.28.1.tgz#dea78be6e1e6db32ddcb29a449e94d9700c79eb9"
   integrity sha512-acv3l6kDwZkQif/YqJjstT3ks5aaI33uxGNVIQmdKzbZ2eMKgg3EV2tB84GDdc72k3Kjhl6mO8yUt6StVIdRDg==
@@ -6406,7 +6816,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@4.8.2", "@typescript-eslint/experimental-utils@^4.0.1":
+"@typescript-eslint/experimental-utils@4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.2.tgz#8909a5732f19329cf5ef0c39766170476bff5e50"
   integrity sha512-hpTw6o6IhBZEsQsjuw/4RWmceRyESfAiEzAEnXHKG1X7S5DXFaZ4IO1JO7CW1aQ604leQBzjZmuMI9QBCAJX8Q==
@@ -6426,6 +6836,18 @@
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/types" "3.10.1"
     "@typescript-eslint/typescript-estree" "3.10.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.1.tgz#27275c20fa4336df99ebcf6195f7d7aa7aa9f22d"
+  integrity sha512-WigyLn144R3+lGATXW4nNcDJ9JlTkG8YdBWHkDlN0lC3gUGtDi7Pe3h5GPvFKMcRz8KbZpm9FJV9NTW8CpRHpg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.8.1"
+    "@typescript-eslint/types" "4.8.1"
+    "@typescript-eslint/typescript-estree" "4.8.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -6449,6 +6871,14 @@
     "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-visitor-keys "^1.1.0"
 
+"@typescript-eslint/scope-manager@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.8.1.tgz#e343c475f8f1d15801b546cb17d7f309b768fdce"
+  integrity sha512-r0iUOc41KFFbZdPAdCS4K1mXivnSZqXS5D9oW+iykQsRlTbQRfuFRSW20xKDdYiaCoH+SkSLeIF484g3kWzwOQ==
+  dependencies:
+    "@typescript-eslint/types" "4.8.1"
+    "@typescript-eslint/visitor-keys" "4.8.1"
+
 "@typescript-eslint/scope-manager@4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz#a18388c63ae9c17adde519384f539392f2c4f0d9"
@@ -6461,6 +6891,11 @@
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
   integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
+
+"@typescript-eslint/types@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.8.1.tgz#23829c73c5fc6f4fcd5346a7780b274f72fee222"
+  integrity sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==
 
 "@typescript-eslint/types@4.8.2":
   version "4.8.2"
@@ -6494,6 +6929,20 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz#7307e3f2c9e95df7daa8dc0a34b8c43b7ec0dd32"
+  integrity sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==
+  dependencies:
+    "@typescript-eslint/types" "4.8.1"
+    "@typescript-eslint/visitor-keys" "4.8.1"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/typescript-estree@4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz#eeec34707d8577600fb21661b5287226cc8b3bed"
@@ -6514,6 +6963,14 @@
   integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/visitor-keys@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz#794f68ee292d1b2e3aa9690ebedfcb3a8c90e3c3"
+  integrity sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==
+  dependencies:
+    "@typescript-eslint/types" "4.8.1"
+    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.8.2":
   version "4.8.2"
@@ -8594,9 +9051,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001157:
-  version "1.0.30001161"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz#64f7ffe79ee780b8c92843ff34feb36cea4651e0"
-  integrity sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==
+  version "1.0.30001159"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
+  integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -11228,9 +11685,9 @@ ejs@^3.1.5:
     jake "^10.6.1"
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.591:
-  version "1.3.606"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.606.tgz#6ef2655d9a7c1b447dfdd6344657d00461a65e26"
-  integrity sha512-+/2yPHwtNf6NWKpaYt0KoqdSZ6Qddt6nDfH/pnhcrHq9hSb23e5LFy06Mlf0vF2ykXvj7avJ597psqcbKnG5YQ==
+  version "1.3.603"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz#1b71bec27fb940eccd79245f6824c63d5f7e8abf"
+  integrity sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -17924,6 +18381,14 @@ limiter@^1.1.5:
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
   integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
 
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
+  dependencies:
+    isarray "^1.0.0"
+    isobject "^2.0.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -18899,13 +19364,13 @@ mdast-util-to-hast@^10.0.0:
     unist-util-visit "^2.0.0"
 
 mdast-util-to-markdown@^0.5.0:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.5.4.tgz#be680ed0c0e11a07d07c7adff9551eec09c1b0f9"
-  integrity sha512-0jQTkbWYx0HdEA/h++7faebJWr5JyBoBeiRf0u3F4F3QtnyyGaWIsOwo749kRb1ttKrLLr+wRtOkfou9yB0p6A==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.5.3.tgz#e05c54a3ccd239bab63c48a1e5b5747f0dcd5aca"
+  integrity sha512-sr8q7fQJ1xoCqZSXW6dO/MYu2Md+a4Hfk9uO+XHCfiBhVM0EgWtfAV7BuN+ff6otUeu2xDyt1o7vhZGwOG3+BA==
   dependencies:
     "@types/unist" "^2.0.0"
     longest-streak "^2.0.0"
-    mdast-util-to-string "^2.0.0"
+    mdast-util-to-string "^1.0.0"
     parse-entities "^2.0.0"
     repeat-string "^1.0.0"
     zwitch "^1.0.0"
@@ -18924,11 +19389,6 @@ mdast-util-to-string@^1.0.0, mdast-util-to-string@^1.0.5, mdast-util-to-string@^
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
-
-mdast-util-to-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
-  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdast-util-toc@^3.1.0:
   version "3.1.0"
@@ -19616,6 +20076,11 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nanoid@^3.1.16:
+  version "3.1.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.17.tgz#948d606594e925dff72076201922f6e22d4cc543"
+  integrity sha512-5mmlQz73ohlISpARejqTwgYzh92wwBccatETsLOI+VKkY6Lx/Dj3wvG7tCoKjX+eEaZWn0gB7Xkfl5JatHQTeA==
 
 nanoid@^3.1.18:
   version "3.1.18"
@@ -22242,14 +22707,14 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     supports-color "^6.1.0"
 
 postcss@^8.1.0, postcss@^8.1.4:
-  version "8.1.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.10.tgz#129834f94c720554d2cfdaeb27d5542ac4a026ea"
-  integrity sha512-iBXEV5VTTYaRRdxiFYzTtuv2lGMQBExqkZKSzkJe+Fl6rvQrA/49UVGKqB+LG54hpW/TtDBMGds8j33GFNW7pg==
+  version "8.1.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.8.tgz#697439e7276735ecdd2893d2cf8efb2236693ac3"
+  integrity sha512-hO6jFWBy0QnBBRaw+s0F4hVPKGDICec/nLNEG1D4qqw9/LBzWMkTjckqqELXAo0J42jN8GFZXtgQfezEaoG9gQ==
   dependencies:
     colorette "^1.2.1"
-    nanoid "^3.1.18"
+    line-column "^1.0.2"
+    nanoid "^3.1.16"
     source-map "^0.6.1"
-    vfile-location "^3.2.0"
 
 potrace@^2.1.8:
   version "2.1.8"
@@ -23121,6 +23586,20 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-select@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
+  integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/cache" "^10.0.9"
+    "@emotion/core" "^10.0.9"
+    "@emotion/css" "^10.0.9"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-input-autosize "^2.2.2"
+    react-transition-group "^4.3.0"
 
 react-select@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
#### Summary

- adds `injectTransformedLocalizedFields`
- adds `transformLocalizedFieldToString`
- [x] update `README`

#### Description

With an upcoming feature in `AppKit`, it makes sense to expose these utils.
These transformations are useful for transforming `graphql` shaped `*AllLocales` fields to a normalized [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)
