### PR TITLE
fix(application-shell/test-utils): `storeState` render option of `renderAppWithRedux` is unusable

### DIFF
--- a/.changeset/eighty-dogs-brake.md
+++ b/.changeset/eighty-dogs-brake.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+fix(test-utils): `storeState` render option of `renderAppWithRedux` is unusable

--- a/packages/application-shell/src/configure-store.ts
+++ b/packages/application-shell/src/configure-store.ts
@@ -5,7 +5,7 @@ import type {
   StoreEnhancer,
 } from 'redux';
 import type { ApplicationWindow } from '@commercetools-frontend/constants';
-import { mapValues } from 'lodash';
+import mapValues from 'lodash/mapValues';
 import { createStore, compose, applyMiddleware, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
 import {

--- a/packages/application-shell/src/configure-store.ts
+++ b/packages/application-shell/src/configure-store.ts
@@ -51,6 +51,15 @@ const mergeObjectValues = <T>(object: { [key: string]: T }) =>
 const patchedGetCorrelationId = () =>
   getCorrelationId({ userId: selectUserId() });
 
+const sdkMiddleware = createSdkMiddleware({
+  getCorrelationId: patchedGetCorrelationId,
+  getProjectKey: selectProjectKeyFromUrl,
+  getTeamId: selectTeamIdFromLocalStorage,
+});
+
+export const applyDefaultMiddlewares = (...middlewares: Middleware[]) =>
+  applyMiddleware(...middlewares, thunk, loggerMiddleware);
+
 const createInternalReducer = (
   injectedReducers: ReducersMapObject = {},
   preloadedState = {}
@@ -73,15 +82,6 @@ const createInternalReducer = (
     ...preloadedStateReducers,
   });
 };
-
-const sdkMiddleware = createSdkMiddleware({
-  getCorrelationId: patchedGetCorrelationId,
-  getProjectKey: selectProjectKeyFromUrl,
-  getTeamId: selectTeamIdFromLocalStorage,
-});
-
-export const applyDefaultMiddlewares = (...middlewares: Middleware[]) =>
-  applyMiddleware(...middlewares, thunk, loggerMiddleware);
 
 // We use a factory as it's more practicable for tests
 // The application can import the configured store (the default export)

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -12,13 +12,13 @@ import { gql } from '@apollo/client';
 import { useIntl } from 'react-intl';
 import { useSelector, useStore } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
+import { screen } from '@testing-library/react';
 import { useFeatureToggle } from '@flopflip/react-broadcast';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { useMcQuery } from '../hooks/apollo-hooks';
 import { renderApp, renderAppWithRedux, waitFor } from './test-utils';
-import { screen } from '@testing-library/react';
 
 const mockServer = setupServer();
 afterEach(() => {

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import { useIntl } from 'react-intl';
-import { useSelector } from 'react-redux';
+import { useSelector, useStore } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
 import { useFeatureToggle } from '@flopflip/react-broadcast';
 import { ApplicationContext } from '@commercetools-frontend/application-shell-connectors';
@@ -18,6 +18,7 @@ import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { useMcQuery } from '../hooks/apollo-hooks';
 import { renderApp, renderAppWithRedux, waitFor } from './test-utils';
+import { screen } from '@testing-library/react';
 
 const mockServer = setupServer();
 afterEach(() => {
@@ -402,5 +403,25 @@ describe('custom render functions', () => {
       await rendered.findByText('two');
       expect(rendered.queryByText('one')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('renderAppWithRedux', () => {
+  it('should be able to use storeState render option', () => {
+    const TestComponent = () => {
+      const store = useStore();
+      const state = store.getState();
+      return state.products.currentVisible.id;
+    };
+    renderAppWithRedux(<TestComponent />, {
+      storeState: {
+        products: {
+          currentVisible: {
+            id: 'current-visible-product-id',
+          },
+        },
+      },
+    });
+    expect(screen.getByText(/current-visible-product-id/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

The `storeState` render option of `renderAppWithRedux` is unusable.

#### Description

<!-- provide some context -->

Make it usable by passing preloaded state reducers to `combineReducers`.

Fixes https://github.com/commercetools/merchant-center-application-kit/issues/1900.