### PR TITLE
refactor(l10n/localize): export transformLocalizedFieldToLocalizedString

### DIFF
--- a/.changeset/tricky-kiwis-drive.md
+++ b/.changeset/tricky-kiwis-drive.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/l10n': patch
+---
+
+export `transformLocalizedFieldToLocalizedString`, update `localize` to allow `locale` to be `null`

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -21,5 +21,6 @@ export {
 
 export {
   applyTransformedLocalizedFields,
+  transformLocalizedFieldToLocalizedString,
   formatLocalizedString,
 } from './localize';

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -111,18 +111,33 @@ export const formatLocalizedString = <Input extends Record<string, unknown>>(
     fallbackOrder = [],
     fallback = '',
   }: FormatLocalizedStringOptions<Input>
-): string => {
-  if (!entity || !entity[key] || !locale) return fallback;
+) => {
+  if (!entity || !entity[key]) return fallback;
   const localizedString = entity[key] as LocalizedString;
-  if (localizedString[locale]) return localizedString[locale];
-  // see if we can fallback to the primary locale, eg. de for de-AT
-  const primaryLocale = locale && getPrimaryLocale(locale);
-  if (localizedString[primaryLocale]) return localizedString[primaryLocale];
-  const fallbackLanguage = findFallbackLocale(localizedString, fallbackOrder);
-  return fallbackLanguage
+  const fallbackLocale = findFallbackLocale(localizedString, fallbackOrder);
+
+  const formattedLocalizedFallback = fallbackLocale
     ? formatLocalizedFallbackHint(
-        localizedString[fallbackLanguage],
-        fallbackLanguage
+        localizedString[fallbackLocale],
+        fallbackLocale
       )
     : fallback;
+
+  // GIVEN no `locale`
+  // THEN return formattedFallback by fallbackOrder
+  if (!locale) return formattedLocalizedFallback;
+
+  // GIVEN locale
+  // AND there is a value on `localizedString`
+  // THEN return value
+  if (localizedString[locale]) return localizedString[locale];
+
+  // GIVEN locale
+  // AND there is a value on primary locale
+  // THEN return value on primary locale
+  const primaryLocale = locale && getPrimaryLocale(locale);
+  if (localizedString[primaryLocale]) return localizedString[primaryLocale];
+
+  // use formattedFallback by fallbackOrder as last resort
+  return formattedLocalizedFallback;
 };

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -112,17 +112,12 @@ export const formatLocalizedString = <Input extends Record<string, unknown>>(
     fallback = '',
   }: FormatLocalizedStringOptions<Input>
 ): string => {
-  // if there is no entity to be localized or the field does not exist on the
-  // entity, then return the fallback
-  if (!entity || !entity[key]) return fallback;
+  if (!entity || !entity[key] || !locale) return fallback;
   const localizedString = entity[key] as LocalizedString;
-
   if (localizedString[locale]) return localizedString[locale];
-
   // see if we can fallback to the primary locale, eg. de for de-AT
   const primaryLocale = locale && getPrimaryLocale(locale);
   if (localizedString[primaryLocale]) return localizedString[primaryLocale];
-
   const fallbackLanguage = findFallbackLocale(localizedString, fallbackOrder);
   return fallbackLanguage
     ? formatLocalizedFallbackHint(

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -111,7 +111,7 @@ export const formatLocalizedString = <Input extends Record<string, unknown>>(
     fallbackOrder = [],
     fallback = '',
   }: FormatLocalizedStringOptions<Input>
-) => {
+): string => {
   if (!entity || !entity[key]) return fallback;
   const localizedString = entity[key] as LocalizedString;
   const fallbackLocale = findFallbackLocale(localizedString, fallbackOrder);

--- a/packages/l10n/src/types.ts
+++ b/packages/l10n/src/types.ts
@@ -33,7 +33,7 @@ export type FieldNameTranformationMapping = {
 
 export type FormatLocalizedStringOptions<T> = {
   key: keyof T;
-  locale: string;
+  locale: string | null;
   fallbackOrder?: string[];
   fallback?: string;
 };


### PR DESCRIPTION
#### Summary

- allow export of `transformLocalizedFieldToLocalizedString`
- allow `locale` to be passed as `null`, leverage type-guard for the "lookup"

---

This is cherry picked from a feature branch I'm working on