### PR TITLE
chore: remove react-intl from vendors to transpile list

### DIFF
--- a/.changeset/fluffy-crews-fly.md
+++ b/.changeset/fluffy-crews-fly.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Remove `react-intl` from the list of vendors to be transpiled

--- a/packages/mc-scripts/src/config/vendors-to-transpile.js
+++ b/packages/mc-scripts/src/config/vendors-to-transpile.js
@@ -1,9 +1,1 @@
-// https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md#esm-build
-const resolvePathToPackageDir = (packageName) =>
-  require
-    .resolve(packageName)
-    // `require.resolve` points to the entry point file of the package, which
-    // means we need to "cut" the path from the package directory onwards.
-    .replace(new RegExp(`(.*)/${packageName}/(.*)`), `$1/${packageName}`);
-
-module.exports = [resolvePathToPackageDir('react-intl')];
+module.exports = [];


### PR DESCRIPTION
We shouldn't need this anymore.