### PR TITLE
fix(babel): regression, pass ROLLUP_BUILD env

### DIFF
--- a/.changeset/chilled-bats-eat.md
+++ b/.changeset/chilled-bats-eat.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/react-notifications': patch
+---
+
+Fix prop-types removal regression from production bundles.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.BUILD_ROLLUP = true;
+
 module.exports = {
   presets: ['@commercetools-frontend/babel-preset-mc-app'],
   plugins: [


### PR DESCRIPTION
Our babel preset uses a `ROLLUP_BUILD` env variable that we forgot to set when we moved to preconstruct.
It only affected prop types.