### PR TITLE
refactor: menu links to use their own permission data

### DIFF
--- a/.changeset/tall-meals-brush.md
+++ b/.changeset/tall-meals-brush.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/application-shell-connectors': minor
+'@commercetools-frontend/permissions': minor
+---
+
+Fetch permissions for menu links using a separate query field `allPermissionsForAllApplications`.

--- a/graphql-test-utils/graphql-models/project.js
+++ b/graphql-test-utils/graphql-models/project.js
@@ -23,8 +23,13 @@ const Project = new Factory()
   })
   .attr('allAppliedPermissions', [])
   .attr('allAppliedActionRights', [])
-  .attr('allAppliedMenuVisibilities', [])
   .attr('allAppliedDataFences', [])
+  .attr('allPermissionsForAllApplications', () => ({
+    allAppliedPermissions: [],
+    allAppliedActionRights: [],
+    allAppliedDataFences: [],
+    allAppliedMenuVisibilities: [],
+  }))
   .attr('owner', () => ({
     __typename: 'Organization',
     id: faker.random.uuid(),

--- a/packages/application-config/src/schema.ts
+++ b/packages/application-config/src/schema.ts
@@ -21,7 +21,7 @@ export interface JSONSchemaForCustomApplicationConfigurationFiles {
   /**
    * The cloud identifier where the Custom Application is running. This value is used to derive the Merchant Center API URL. Alternatively you can use the `mcApiUrl` property.
    */
-  cloudIdentifier: ('gcp-au' | 'gcp-eu' | 'gcp-us' | 'aws-fra' | 'aws-ohio') | EnvVariablePlaceholder;
+  cloudIdentifier: (('gcp-au' | 'gcp-eu' | 'gcp-us' | 'aws-fra' | 'aws-ohio') | EnvVariablePlaceholder) & string;
   /**
    * The URL of the Merchant Center API. We usually recommend to use the `cloudIdentifier` option to avoid possible typos.
    */

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -54,7 +54,12 @@ const createTestProject = (custom = {}) => ({
   allAppliedPermissions: [{ name: 'canManageProjectSettings', value: true }],
   allAppliedActionRights: [],
   allAppliedDataFences: [],
-  allAppliedMenuVisibilities: [],
+  allPermissionsForAllApplications: {
+    allAppliedPermissions: [],
+    allAppliedActionRights: [],
+    allAppliedDataFences: [],
+    allAppliedMenuVisibilities: [],
+  },
   // Fields that should not be exposed
   initialized: true,
   expiry: {

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -9,7 +9,6 @@ import moment from 'moment-timezone';
 import getDisplayName from '../../utils/get-display-name';
 import {
   normalizeAllAppliedActionRights,
-  normalizeAllAppliedMenuVisibilities,
   normalizeAllAppliedPermissions,
   normalizeAllAppliedDataFences,
 } from './normalizers';
@@ -19,7 +18,6 @@ type TFetchedUser = TFetchLoggedInUserQuery['user'];
 type TFetchedProject = TFetchProjectQuery['project'];
 
 type TApplicationContextPermissions = { [key: string]: boolean };
-type TApplicationContextMenuVisibilities = { [key: string]: boolean };
 type TActionRight = {
   [key: string]: boolean;
 };
@@ -112,7 +110,6 @@ export type TApplicationContext<AdditionalEnvironmentProperties extends {}> = {
   project: ReturnType<typeof mapProjectToApplicationContextProject>;
   permissions: TApplicationContextPermissions | null;
   actionRights: TApplicationContextActionRights | null;
-  menuVisibilities: TApplicationContextMenuVisibilities | null;
   dataFences: TApplicationContextDataFences | null;
   dataLocale: string | null;
 };
@@ -146,7 +143,6 @@ const createApplicationContext: <AdditionalEnvironmentProperties extends {}>(
   project: mapProjectToApplicationContextProject(project),
   permissions: normalizeAllAppliedPermissions(project),
   actionRights: normalizeAllAppliedActionRights(project),
-  menuVisibilities: normalizeAllAppliedMenuVisibilities(project),
   dataFences: normalizeAllAppliedDataFences(project),
   dataLocale: projectDataLocale || null,
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -141,9 +141,11 @@ const createApplicationContext: <AdditionalEnvironmentProperties extends {}>(
   environment: mapEnvironmentToApplicationContextEnvironment(environment),
   user: mapUserToApplicationContextUser(user),
   project: mapProjectToApplicationContextProject(project),
-  permissions: normalizeAllAppliedPermissions(project),
-  actionRights: normalizeAllAppliedActionRights(project),
-  dataFences: normalizeAllAppliedDataFences(project),
+  permissions: normalizeAllAppliedPermissions(project?.allAppliedPermissions),
+  actionRights: normalizeAllAppliedActionRights(
+    project?.allAppliedActionRights
+  ),
+  dataFences: normalizeAllAppliedDataFences(project?.allAppliedDataFences),
   dataLocale: projectDataLocale || null,
 });
 

--- a/packages/application-shell-connectors/src/components/application-context/index.ts
+++ b/packages/application-shell-connectors/src/components/application-context/index.ts
@@ -2,6 +2,12 @@ import type {
   ProviderProps,
   TApplicationContext as ApplicationContext,
 } from './application-context';
+import type {
+  TMenuVisibilities as NormalizedMenuVisibilities,
+  TPermissions as NormalizedPermissions,
+  TActionRights as NormalizedActionRights,
+  TDataFences as NormalizedDataFences,
+} from './normalizers';
 
 export type TProviderProps<
   AdditionalEnvironmentProperties extends {}
@@ -10,6 +16,11 @@ export type TApplicationContext<
   AdditionalEnvironmentProperties extends {}
 > = ApplicationContext<AdditionalEnvironmentProperties>;
 
+export type TNormalizedMenuVisibilities = NormalizedMenuVisibilities;
+export type TNormalizedPermissions = NormalizedPermissions;
+export type TNormalizedActionRights = NormalizedActionRights;
+export type TNormalizedDataFences = NormalizedDataFences;
+
 export {
   Context,
   ApplicationContext,
@@ -17,3 +28,9 @@ export {
   withApplicationContext,
   useApplicationContext,
 } from './application-context';
+export {
+  normalizeAllAppliedActionRights,
+  normalizeAllAppliedDataFences,
+  normalizeAllAppliedMenuVisibilities,
+  normalizeAllAppliedPermissions,
+} from './normalizers';

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.spec.ts
@@ -1,4 +1,9 @@
-import type { TFetchProjectQuery } from '../../types/generated/mc';
+import type {
+  TAppliedPermission,
+  TAppliedActionRight,
+  TAppliedMenuVisibilities,
+  TStoreDataFence,
+} from '../../types/generated/mc';
 
 import {
   normalizeAllAppliedActionRights,
@@ -7,45 +12,15 @@ import {
   normalizeAllAppliedDataFences,
 } from './normalizers';
 
-const createTestProject = (
-  custom: Partial<TFetchProjectQuery['project']> = {}
-): TFetchProjectQuery['project'] => ({
-  key: 'foo-1',
-  version: 1,
-  name: 'Foo 1',
-  countries: ['us'],
-  currencies: ['USD'],
-  languages: ['en'],
-  allAppliedPermissions: [],
-  allAppliedActionRights: [],
-  allAppliedDataFences: [],
-  allAppliedMenuVisibilities: [],
-  // Fields that should not be exposed
-  initialized: true,
-  expiry: {
-    isActive: false,
-    daysLeft: undefined,
-  },
-  suspension: {
-    isActive: false,
-    reason: undefined,
-  },
-  owner: { id: 'o1', name: 'Organization 1' },
-  ...custom,
-});
-
 describe('normalizeAllAppliedPermissions', () => {
-  const project = createTestProject({
-    allAppliedPermissions: [
-      {
-        name: 'canManageProjectSettings',
-        value: true,
-      },
-    ],
-  });
-
+  const allAppliedPermissions: TAppliedPermission[] = [
+    {
+      name: 'canManageProjectSettings',
+      value: true,
+    },
+  ];
   it('should normalize permissions', () => {
-    expect(normalizeAllAppliedPermissions(project)).toEqual(
+    expect(normalizeAllAppliedPermissions(allAppliedPermissions)).toEqual(
       expect.objectContaining({
         canManageProjectSettings: true,
       })
@@ -53,18 +28,15 @@ describe('normalizeAllAppliedPermissions', () => {
   });
 });
 describe('normalizeAllAppliedActionRights', () => {
-  const project = createTestProject({
-    allAppliedActionRights: [
-      {
-        group: 'products',
-        name: 'canEditPrices',
-        value: true,
-      },
-    ],
-  });
-
+  const allAppliedActionRights: TAppliedActionRight[] = [
+    {
+      group: 'products',
+      name: 'canEditPrices',
+      value: true,
+    },
+  ];
   it('should normalize action rights', () => {
-    expect(normalizeAllAppliedActionRights(project)).toEqual(
+    expect(normalizeAllAppliedActionRights(allAppliedActionRights)).toEqual(
       expect.objectContaining({
         products: { canEditPrices: true },
       })
@@ -72,17 +44,16 @@ describe('normalizeAllAppliedActionRights', () => {
   });
 });
 describe('normalizeAllAppliedMenuVisibilities', () => {
-  const project = createTestProject({
-    allAppliedMenuVisibilities: [
-      {
-        name: 'hideDashboard',
-        value: true,
-      },
-    ],
-  });
-
+  const allAppliedMenuVisibilities: TAppliedMenuVisibilities[] = [
+    {
+      name: 'hideDashboard',
+      value: true,
+    },
+  ];
   it('should normalize menu visibilities', () => {
-    expect(normalizeAllAppliedMenuVisibilities(project)).toEqual(
+    expect(
+      normalizeAllAppliedMenuVisibilities(allAppliedMenuVisibilities)
+    ).toEqual(
       expect.objectContaining({
         hideDashboard: true,
       })
@@ -91,33 +62,31 @@ describe('normalizeAllAppliedMenuVisibilities', () => {
 });
 describe('normalizeAllAppliedDataFences', () => {
   describe('with store types', () => {
-    const project = createTestProject({
-      allAppliedDataFences: [
-        {
-          __typename: 'StoreDataFence',
-          value: 'usa',
-          type: 'store',
-          group: 'orders',
-          name: 'canManageOrders',
-        },
-        {
-          __typename: 'StoreDataFence',
-          value: 'germany',
-          type: 'store',
-          group: 'orders',
-          name: 'canManageOrders',
-        },
-        {
-          __typename: 'StoreDataFence',
-          value: 'canada',
-          type: 'store',
-          group: 'orders',
-          name: 'canViewOrders',
-        },
-      ],
-    });
+    const allAppliedDataFences: TStoreDataFence[] = [
+      {
+        __typename: 'StoreDataFence',
+        value: 'usa',
+        type: 'store',
+        group: 'orders',
+        name: 'canManageOrders',
+      },
+      {
+        __typename: 'StoreDataFence',
+        value: 'germany',
+        type: 'store',
+        group: 'orders',
+        name: 'canManageOrders',
+      },
+      {
+        __typename: 'StoreDataFence',
+        value: 'canada',
+        type: 'store',
+        group: 'orders',
+        name: 'canViewOrders',
+      },
+    ];
     it('should normalized the data fences of type "store"', () => {
-      expect(normalizeAllAppliedDataFences(project)).toEqual({
+      expect(normalizeAllAppliedDataFences(allAppliedDataFences)).toEqual({
         store: {
           orders: {
             canManageOrders: {

--- a/packages/application-shell-connectors/src/components/application-context/normalizers.ts
+++ b/packages/application-shell-connectors/src/components/application-context/normalizers.ts
@@ -1,6 +1,7 @@
 import type {
-  Maybe,
-  TFetchProjectQuery,
+  TAppliedPermission,
+  TAppliedActionRight,
+  TAppliedMenuVisibilities,
   TStoreDataFence,
 } from '../../types/generated/mc';
 
@@ -59,10 +60,8 @@ export type TDataFences = Partial<
  * to move this over to `permissions` and export it there.
  */
 export const normalizeAllAppliedPermissions = (
-  project: TFetchProjectQuery['project']
+  allAppliedPermissions?: TAppliedPermission[]
 ): TPermissions | null => {
-  if (!project) return null;
-  const allAppliedPermissions = project.allAppliedPermissions;
   if (!allAppliedPermissions || allAppliedPermissions.length === 0) {
     return null;
   }
@@ -79,10 +78,8 @@ export const normalizeAllAppliedPermissions = (
 };
 
 export const normalizeAllAppliedMenuVisibilities = (
-  project: TFetchProjectQuery['project']
+  allAppliedMenuVisibilities?: TAppliedMenuVisibilities[]
 ): TMenuVisibilities | null => {
-  if (!project) return null;
-  const allAppliedMenuVisibilities = project.allAppliedMenuVisibilities;
   if (!allAppliedMenuVisibilities || allAppliedMenuVisibilities.length === 0) {
     return null;
   }
@@ -99,10 +96,8 @@ export const normalizeAllAppliedMenuVisibilities = (
 };
 
 export const normalizeAllAppliedActionRights = (
-  project: TFetchProjectQuery['project']
+  allAppliedActionRights?: TAppliedActionRight[]
 ): TActionRights | null => {
-  if (!project) return null;
-  const allAppliedActionRights = project.allAppliedActionRights;
   if (!allAppliedActionRights || allAppliedActionRights.length === 0) {
     return null;
   }
@@ -123,7 +118,7 @@ export const normalizeAllAppliedActionRights = (
 };
 
 const normalizeAppliedDataFencesForStoresByResourceType = (
-  dataFences: Maybe<TStoreDataFence>[]
+  dataFences: TStoreDataFence[]
 ): TDataFenceGroupedByResourceType => {
   const groupedByResourceType = dataFences.reduce<TDataFenceStoresGroupByResourceType>(
     (previousGroupsOfSameType, appliedDataFence) => {
@@ -196,10 +191,8 @@ const normalizeAppliedDataFencesForStoresByResourceType = (
 // }
 
 export const normalizeAllAppliedDataFences = (
-  project: TFetchProjectQuery['project']
+  allAppliedDataFences?: TStoreDataFence[]
 ): TDataFences | null => {
-  if (!project) return null;
-  const allAppliedDataFences = project.allAppliedDataFences;
   if (!allAppliedDataFences || allAppliedDataFences.length === 0) {
     return null;
   }

--- a/packages/application-shell-connectors/src/index.ts
+++ b/packages/application-shell-connectors/src/index.ts
@@ -26,6 +26,10 @@ export {
   ApplicationContextProvider,
   withApplicationContext,
   useApplicationContext,
+  normalizeAllAppliedActionRights,
+  normalizeAllAppliedDataFences,
+  normalizeAllAppliedMenuVisibilities,
+  normalizeAllAppliedPermissions,
 } from './components/application-context';
 
 export {

--- a/packages/application-shell-connectors/src/index.ts
+++ b/packages/application-shell-connectors/src/index.ts
@@ -2,6 +2,10 @@ export { default as version } from './version';
 import type {
   TProviderProps as ProviderProps,
   TApplicationContext as ApplicationContext,
+  TNormalizedMenuVisibilities as NormalizedMenuVisibilities,
+  TNormalizedPermissions as NormalizedPermissions,
+  TNormalizedActionRights as NormalizedActionRights,
+  TNormalizedDataFences as NormalizedDataFences,
 } from './components/application-context';
 
 export type TProviderProps<
@@ -10,6 +14,11 @@ export type TProviderProps<
 export type TApplicationContext<
   AdditionalEnvironmentProperties extends {}
 > = ApplicationContext<AdditionalEnvironmentProperties>;
+
+export type TNormalizedMenuVisibilities = NormalizedMenuVisibilities;
+export type TNormalizedPermissions = NormalizedPermissions;
+export type TNormalizedActionRights = NormalizedActionRights;
+export type TNormalizedDataFences = NormalizedDataFences;
 
 export {
   Context,

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -1,5 +1,7 @@
 export type Maybe<T> = T | undefined;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -12,6 +14,15 @@ export type Scalars = {
 export type TAdditionalUserInfo = {
   firstName: Scalars['String'];
   lastName: Scalars['String'];
+};
+
+/** Only used by the navbar menu component in ApplicationShell. */
+export type TAllPermissionsForAllApplications = {
+  __typename?: 'AllPermissionsForAllApplications';
+  allAppliedPermissions: Array<TAppliedPermission>;
+  allAppliedDataFences: Array<TAppliedDataFence>;
+  allAppliedActionRights: Array<TAppliedActionRight>;
+  allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
 };
 
 export type TAppliedActionRight = {
@@ -283,7 +294,6 @@ export type TOrganization = {
   id: Scalars['ID'];
   /** @deprecated This field will be removed in the future. */
   createdAt: Scalars['String'];
-  /** @deprecated This field will be removed in the future. */
   name: Scalars['String'];
 };
 
@@ -339,6 +349,7 @@ export enum TPermissionScope {
   ManageCartDiscounts = 'manage_cart_discounts',
   ManageShippingMethods = 'manage_shipping_methods',
   ManageTaxCategories = 'manage_tax_categories',
+  ManageKeyValueDocuments = 'manage_key_value_documents',
   ViewApiClients = 'view_api_clients',
   ViewCustomers = 'view_customers',
   ViewDiscountCodes = 'view_discount_codes',
@@ -361,7 +372,8 @@ export enum TPermissionScope {
   ViewTaxCategories = 'view_tax_categories',
   ManageCategories = 'manage_categories',
   ViewCategories = 'view_categories',
-  ViewChangeHistory = 'view_change_history'
+  ViewChangeHistory = 'view_change_history',
+  ViewKeyValueDocuments = 'view_key_value_documents'
 }
 
 export type TProject = TMetaData & {
@@ -386,7 +398,9 @@ export type TProject = TMetaData & {
   allAppliedPermissions: Array<TAppliedPermission>;
   allAppliedDataFences: Array<TAppliedDataFence>;
   allAppliedActionRights: Array<TAppliedActionRight>;
+  /** @deprecated This field has been moved into the menuPermissionsForAllApplications field. */
   allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
+  allPermissionsForAllApplications: TAllPermissionsForAllApplications;
 };
 
 export type TProjectDraftType = {
@@ -720,13 +734,25 @@ export type TFetchProjectQuery = (
     )>, allAppliedActionRights: Array<(
       { __typename?: 'AppliedActionRight' }
       & Pick<TAppliedActionRight, 'group' | 'name' | 'value'>
-    )>, allAppliedMenuVisibilities: Array<(
-      { __typename?: 'AppliedMenuVisibilities' }
-      & Pick<TAppliedMenuVisibilities, 'name' | 'value'>
     )>, allAppliedDataFences: Array<(
       { __typename: 'StoreDataFence' }
       & Pick<TStoreDataFence, 'type' | 'name' | 'value' | 'group'>
-    )>, owner: (
+    )>, allPermissionsForAllApplications: (
+      { __typename?: 'AllPermissionsForAllApplications' }
+      & { allAppliedPermissions: Array<(
+        { __typename?: 'AppliedPermission' }
+        & Pick<TAppliedPermission, 'name' | 'value'>
+      )>, allAppliedActionRights: Array<(
+        { __typename?: 'AppliedActionRight' }
+        & Pick<TAppliedActionRight, 'group' | 'name' | 'value'>
+      )>, allAppliedMenuVisibilities: Array<(
+        { __typename?: 'AppliedMenuVisibilities' }
+        & Pick<TAppliedMenuVisibilities, 'name' | 'value'>
+      )>, allAppliedDataFences: Array<(
+        { __typename: 'StoreDataFence' }
+        & Pick<TStoreDataFence, 'type' | 'name' | 'value' | 'group'>
+      )> }
+    ), owner: (
       { __typename?: 'Organization' }
       & Pick<TOrganization, 'id' | 'name'>
     ) }

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -816,13 +816,18 @@ describe('when navbar menu items are hidden', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedMenuVisibilities: [
-              {
-                __typename: 'AppliedMenuVisibilities',
-                name: 'hideFoo',
-                value: true,
-              },
-            ],
+            allPermissionsForAllApplications: {
+              allAppliedPermissions: [],
+              allAppliedActionRights: [],
+              allAppliedDataFences: [],
+              allAppliedMenuVisibilities: [
+                {
+                  __typename: 'AppliedMenuVisibilities',
+                  name: 'hideFoo',
+                  value: true,
+                },
+              ],
+            },
           }),
         ],
       })

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -56,6 +56,22 @@ const createTestProps = (props) => ({
   },
   ...props,
 });
+const createTestAppliedPermissions = ({
+  allAppliedPermissions = [],
+  allAppliedActionRights = [],
+  allAppliedDataFences = [],
+  allAppliedMenuVisibilities = [],
+} = {}) => ({
+  allAppliedPermissions,
+  allAppliedActionRights,
+  allAppliedDataFences,
+  allPermissionsForAllApplications: {
+    allAppliedPermissions,
+    allAppliedActionRights,
+    allAppliedDataFences,
+    allAppliedMenuVisibilities,
+  },
+});
 
 const renderApp = (ui, options = {}) => {
   const { route, ...customProps } = options;
@@ -479,7 +495,9 @@ describe('when user does not have permissions to access the project', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [],
+            }),
           }),
         ],
       })
@@ -816,10 +834,7 @@ describe('when navbar menu items are hidden', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allPermissionsForAllApplications: {
-              allAppliedPermissions: [],
-              allAppliedActionRights: [],
-              allAppliedDataFences: [],
+            ...createTestAppliedPermissions({
               allAppliedMenuVisibilities: [
                 {
                   __typename: 'AppliedMenuVisibilities',
@@ -827,7 +842,7 @@ describe('when navbar menu items are hidden', () => {
                   value: true,
                 },
               ],
-            },
+            }),
           }),
         ],
       })
@@ -866,13 +881,15 @@ describe('when navbar menu items match given permissions', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [
-              {
-                __typename: 'AppliedPermission',
-                name: 'canManageOrders',
-                value: true,
-              },
-            ],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [
+                {
+                  __typename: 'AppliedPermission',
+                  name: 'canManageOrders',
+                  value: true,
+                },
+              ],
+            }),
           }),
         ],
       })
@@ -902,13 +919,15 @@ describe('when navbar menu items do not match given permissions', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [
-              {
-                __typename: 'AppliedPermission',
-                name: 'canManageOrders',
-                value: false,
-              },
-            ],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [
+                {
+                  __typename: 'AppliedPermission',
+                  name: 'canManageOrders',
+                  value: false,
+                },
+              ],
+            }),
           }),
         ],
       })
@@ -944,21 +963,23 @@ describe('when navbar menu items match given action rights', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [
-              {
-                __typename: 'AppliedPermission',
-                name: 'canManageOrders',
-                value: true,
-              },
-            ],
-            allAppliedActionRights: [
-              {
-                __typename: 'AppliedActionRight',
-                group: 'orders',
-                name: 'canAddOrders',
-                value: true,
-              },
-            ],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [
+                {
+                  __typename: 'AppliedPermission',
+                  name: 'canManageOrders',
+                  value: true,
+                },
+              ],
+              allAppliedActionRights: [
+                {
+                  __typename: 'AppliedActionRight',
+                  group: 'orders',
+                  name: 'canAddOrders',
+                  value: true,
+                },
+              ],
+            }),
           }),
         ],
       })
@@ -989,21 +1010,23 @@ describe('when navbar menu items do not match given action rights', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [
-              {
-                __typename: 'AppliedPermission',
-                name: 'canManageOrders',
-                value: true,
-              },
-            ],
-            allAppliedActionRights: [
-              {
-                __typename: 'AppliedActionRight',
-                group: 'orders',
-                name: 'canAddOrders',
-                value: false,
-              },
-            ],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [
+                {
+                  __typename: 'AppliedPermission',
+                  name: 'canManageOrders',
+                  value: true,
+                },
+              ],
+              allAppliedActionRights: [
+                {
+                  __typename: 'AppliedActionRight',
+                  group: 'orders',
+                  name: 'canAddOrders',
+                  value: false,
+                },
+              ],
+            }),
           }),
         ],
       })
@@ -1040,22 +1063,24 @@ describe('when navbar menu items match given data fences', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [
-              {
-                __typename: 'AppliedPermission',
-                name: 'canManageOrders',
-                value: true,
-              },
-            ],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                value: 'usa',
-                type: 'store',
-                group: 'orders',
-                name: 'canManageOrders',
-              },
-            ],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [
+                {
+                  __typename: 'AppliedPermission',
+                  name: 'canManageOrders',
+                  value: true,
+                },
+              ],
+              allAppliedDataFences: [
+                {
+                  __typename: 'StoreDataFence',
+                  value: 'usa',
+                  type: 'store',
+                  group: 'orders',
+                  name: 'canManageOrders',
+                },
+              ],
+            }),
           }),
         ],
       })
@@ -1092,22 +1117,24 @@ describe('when navbar menu items do not match given data fences', () => {
       ...getDefaultMockResolvers({
         projects: [
           ProjectMock.build({
-            allAppliedPermissions: [
-              {
-                __typename: 'AppliedPermission',
-                name: 'canViewOrders',
-                value: true,
-              },
-            ],
-            allAppliedDataFences: [
-              {
-                __typename: 'StoreDataFence',
-                value: 'usa',
-                type: 'store',
-                group: 'orders',
-                name: 'canViewOrders',
-              },
-            ],
+            ...createTestAppliedPermissions({
+              allAppliedPermissions: [
+                {
+                  __typename: 'AppliedPermission',
+                  name: 'canViewOrders',
+                  value: true,
+                },
+              ],
+              allAppliedDataFences: [
+                {
+                  __typename: 'StoreDataFence',
+                  value: 'usa',
+                  type: 'store',
+                  group: 'orders',
+                  name: 'canViewOrders',
+                },
+              ],
+            }),
           }),
         ],
       })

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -366,12 +366,15 @@ export const RestrictedApplication = <
                                   return (
                                     <ApplicationContextProvider<AdditionalEnvironmentProperties>
                                       user={user}
-                                      project={project}
                                       environment={applicationEnvironment}
+                                      // NOTE: do not pass the `project` into the application context.
+                                      // The permissions for the Navbar are resolved separately, within
+                                      // a different React context.
                                     >
                                       <NavBar<AdditionalEnvironmentProperties>
                                         applicationLocale={locale}
                                         projectKey={projectKeyFromUrl}
+                                        project={project}
                                         environment={applicationEnvironment}
                                         DEV_ONLY__loadNavbarMenuConfig={
                                           props.DEV_ONLY__loadNavbarMenuConfig

--- a/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
@@ -33,7 +33,7 @@ query FetchProject($projectKey: String!) {
         __typename
       }
     }
-    menuPermissionsForAllApplications {
+    allPermissionsForAllApplications {
       allAppliedPermissions {
         name
         value

--- a/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
@@ -24,10 +24,6 @@ query FetchProject($projectKey: String!) {
       name
       value
     }
-    allAppliedMenuVisibilities {
-      name
-      value
-    }
     allAppliedDataFences {
       ... on StoreDataFence {
         type
@@ -36,6 +32,31 @@ query FetchProject($projectKey: String!) {
         group
         __typename
       }
+    }
+    menuPermissionsForAllApplications {
+      allAppliedPermissions {
+        name
+        value
+      }
+      allAppliedActionRights {
+        group
+        name
+        value
+      }
+      allAppliedMenuVisibilities {
+        name
+        value
+      }
+      allAppliedDataFences {
+        ... on StoreDataFence {
+          type
+          name
+          value
+          group
+          __typename
+        }
+      }
+
     }
     owner {
       id

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -583,14 +583,24 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
 
   const projectPermissions: TProjectPermissions = React.useMemo(
     () => ({
-      permissions: normalizeAllAppliedPermissions(props.project),
-      actionRights: normalizeAllAppliedActionRights(props.project),
-      dataFences: normalizeAllAppliedDataFences(props.project),
+      permissions: normalizeAllAppliedPermissions(
+        props.project.allPermissionsForAllApplications.allAppliedPermissions
+      ),
+      actionRights: normalizeAllAppliedActionRights(
+        props.project.allPermissionsForAllApplications.allAppliedActionRights
+      ),
+      dataFences: normalizeAllAppliedDataFences(
+        props.project.allPermissionsForAllApplications.allAppliedDataFences
+      ),
     }),
     [props.project]
   );
   const menuVisibilities = React.useMemo(
-    () => normalizeAllAppliedMenuVisibilities(props.project),
+    () =>
+      normalizeAllAppliedMenuVisibilities(
+        props.project.allPermissionsForAllApplications
+          .allAppliedMenuVisibilities
+      ),
     [props.project]
   );
 

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -584,13 +584,13 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
   const projectPermissions: TProjectPermissions = React.useMemo(
     () => ({
       permissions: normalizeAllAppliedPermissions(
-        props.project.allPermissionsForAllApplications.allAppliedPermissions
+        props.project?.allPermissionsForAllApplications.allAppliedPermissions
       ),
       actionRights: normalizeAllAppliedActionRights(
-        props.project.allPermissionsForAllApplications.allAppliedActionRights
+        props.project?.allPermissionsForAllApplications.allAppliedActionRights
       ),
       dataFences: normalizeAllAppliedDataFences(
-        props.project.allPermissionsForAllApplications.allAppliedDataFences
+        props.project?.allPermissionsForAllApplications.allAppliedDataFences
       ),
     }),
     [props.project]
@@ -598,7 +598,7 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
   const menuVisibilities = React.useMemo(
     () =>
       normalizeAllAppliedMenuVisibilities(
-        props.project.allPermissionsForAllApplications
+        props.project?.allPermissionsForAllApplications
           .allAppliedMenuVisibilities
       ),
     [props.project]

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -63,6 +63,12 @@ import useLoadingMenuLayoutEffect from './use-loading-menu-layout-effect';
 import useNavbarStateManager from './use-navbar-state-manager';
 import nonNullable from './non-nullable';
 
+type TProjectPermissions = {
+  permissions: TNormalizedPermissions | null;
+  actionRights: TNormalizedActionRights | null;
+  dataFences: TNormalizedDataFences | null;
+};
+
 /*
 <DataMenu data={[]}>
   <MenuGroup>
@@ -129,8 +135,6 @@ const IconSwitcher = ({ iconName, ...iconProps }: IconSwitcherProps) => {
   }
 };
 IconSwitcher.displayName = 'IconSwitcher';
-
-const NavbarContext = React.createContext({});
 
 type MenuExpanderProps = {
   isVisible: boolean;
@@ -289,7 +293,7 @@ MenuItemDivider.displayName = 'MenuItemDivider';
 // prop is defined. This is because `<ToggleFeature>` will not render any
 // children if the flag is missing/not found.
 const isEveryMenuVisibilitySetToHidden = (
-  menuVisibilities?: TApplicationContext<{}>['menuVisibilities'],
+  menuVisibilities?: TNormalizedMenuVisibilities | null,
   namesOfMenuVisibilities?: string[]
 ) =>
   Array.isArray(namesOfMenuVisibilities) &&
@@ -302,11 +306,7 @@ const isEveryMenuVisibilitySetToHidden = (
 type RestrictedMenuItemProps = {
   featureToggle?: string;
   namesOfMenuVisibilities?: string[];
-  projectPermissions: {
-    permissions: TNormalizedPermissions;
-    actionRights: TNormalizedActionRights;
-    dataFences: TNormalizedDataFences;
-  } | null;
+  projectPermissions: TProjectPermissions;
   menuVisibilities: TNormalizedMenuVisibilities | null;
   keyOfMenuItem: string;
   permissions: string[];
@@ -404,11 +404,7 @@ type ApplicationMenuProps = {
   isActive: boolean;
   isMenuOpen: boolean;
   shouldCloseMenuFly: MouseEventHandler<HTMLElement>;
-  projectPermissions: {
-    permissions: TNormalizedPermissions;
-    actionRights: TNormalizedActionRights;
-    dataFences: TNormalizedDataFences;
-  } | null;
+  projectPermissions: TProjectPermissions;
   menuVisibilities: TNormalizedMenuVisibilities | null;
   handleToggleItem: () => void;
   applicationLocale: string;
@@ -502,6 +498,7 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
                     permissions={submenu.permissions}
                     actionRights={submenu.actionRights}
                     dataFences={submenu.dataFences}
+                    projectPermissions={props.projectPermissions}
                     menuVisibilities={props.menuVisibilities}
                     namesOfMenuVisibilities={
                       submenu.menuVisibility
@@ -584,7 +581,7 @@ const NavBar = <AdditionalEnvironmentProperties extends {}>(
   );
   const location = useLocation();
 
-  const projectPermissions = React.useMemo(
+  const projectPermissions: TProjectPermissions = React.useMemo(
     () => ({
       permissions: normalizeAllAppliedPermissions(props.project),
       actionRights: normalizeAllAppliedActionRights(props.project),

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -368,16 +368,27 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
   }: Partial<TRenderAppOptions<AdditionalEnvironmentProperties>> = {}
 ): TRenderAppResult<AdditionalEnvironmentProperties> {
   const mergedUser = user === null ? undefined : { ...defaultUser, ...user };
-  const mergedProject =
-    project === null
-      ? undefined
-      : {
-          ...defaultProject,
-          ...project,
-          allAppliedPermissions: denormalizePermissions(permissions),
-          allAppliedActionRights: denormalizeActionRights(actionRights),
-          allAppliedDataFences: denormalizeDataFences(dataFences),
-        };
+  const mergedProject = (() => {
+    if (project === null) {
+      return undefined;
+    }
+    const allAppliedPermissions = denormalizePermissions(permissions);
+    const allAppliedActionRights = denormalizeActionRights(actionRights);
+    const allAppliedDataFences = denormalizeDataFences(dataFences);
+    return {
+      ...defaultProject,
+      ...project,
+      allAppliedPermissions,
+      allAppliedActionRights,
+      allAppliedDataFences,
+      allPermissionsForAllApplications: {
+        allAppliedPermissions,
+        allAppliedActionRights,
+        allAppliedDataFences,
+        allAppliedMenuVisibilities: [],
+      },
+    };
+  })();
   const mergedEnvironment = {
     ...defaultEnvironment,
     ...environment,

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -59,8 +59,15 @@ const defaultProject = {
   },
   allAppliedPermissions: [],
   allAppliedActionRights: [],
-  allAppliedMenuVisibilities: [],
   allAppliedDataFences: [],
+  allPermissionsForAllApplications: {
+    allAppliedPermissions: [],
+    allAppliedActionRights: [],
+    allAppliedDataFences: [],
+    allAppliedMenuVisibilities: [],
+  },
+  // Deprecated!
+  allAppliedMenuVisibilities: [],
 };
 
 const defaultUser = {

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -1,5 +1,7 @@
 export type Maybe<T> = T | undefined;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -12,6 +14,15 @@ export type Scalars = {
 export type TAdditionalUserInfo = {
   firstName: Scalars['String'];
   lastName: Scalars['String'];
+};
+
+/** Only used by the navbar menu component in ApplicationShell. */
+export type TAllPermissionsForAllApplications = {
+  __typename?: 'AllPermissionsForAllApplications';
+  allAppliedPermissions: Array<TAppliedPermission>;
+  allAppliedDataFences: Array<TAppliedDataFence>;
+  allAppliedActionRights: Array<TAppliedActionRight>;
+  allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
 };
 
 export type TAppliedActionRight = {
@@ -283,7 +294,6 @@ export type TOrganization = {
   id: Scalars['ID'];
   /** @deprecated This field will be removed in the future. */
   createdAt: Scalars['String'];
-  /** @deprecated This field will be removed in the future. */
   name: Scalars['String'];
 };
 
@@ -339,6 +349,7 @@ export enum TPermissionScope {
   ManageCartDiscounts = 'manage_cart_discounts',
   ManageShippingMethods = 'manage_shipping_methods',
   ManageTaxCategories = 'manage_tax_categories',
+  ManageKeyValueDocuments = 'manage_key_value_documents',
   ViewApiClients = 'view_api_clients',
   ViewCustomers = 'view_customers',
   ViewDiscountCodes = 'view_discount_codes',
@@ -361,7 +372,8 @@ export enum TPermissionScope {
   ViewTaxCategories = 'view_tax_categories',
   ManageCategories = 'manage_categories',
   ViewCategories = 'view_categories',
-  ViewChangeHistory = 'view_change_history'
+  ViewChangeHistory = 'view_change_history',
+  ViewKeyValueDocuments = 'view_key_value_documents'
 }
 
 export type TProject = TMetaData & {
@@ -386,7 +398,9 @@ export type TProject = TMetaData & {
   allAppliedPermissions: Array<TAppliedPermission>;
   allAppliedDataFences: Array<TAppliedDataFence>;
   allAppliedActionRights: Array<TAppliedActionRight>;
+  /** @deprecated This field has been moved into the menuPermissionsForAllApplications field. */
   allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
+  allPermissionsForAllApplications: TAllPermissionsForAllApplications;
 };
 
 export type TProjectDraftType = {
@@ -720,13 +734,25 @@ export type TFetchProjectQuery = (
     )>, allAppliedActionRights: Array<(
       { __typename?: 'AppliedActionRight' }
       & Pick<TAppliedActionRight, 'group' | 'name' | 'value'>
-    )>, allAppliedMenuVisibilities: Array<(
-      { __typename?: 'AppliedMenuVisibilities' }
-      & Pick<TAppliedMenuVisibilities, 'name' | 'value'>
     )>, allAppliedDataFences: Array<(
       { __typename: 'StoreDataFence' }
       & Pick<TStoreDataFence, 'type' | 'name' | 'value' | 'group'>
-    )>, owner: (
+    )>, allPermissionsForAllApplications: (
+      { __typename?: 'AllPermissionsForAllApplications' }
+      & { allAppliedPermissions: Array<(
+        { __typename?: 'AppliedPermission' }
+        & Pick<TAppliedPermission, 'name' | 'value'>
+      )>, allAppliedActionRights: Array<(
+        { __typename?: 'AppliedActionRight' }
+        & Pick<TAppliedActionRight, 'group' | 'name' | 'value'>
+      )>, allAppliedMenuVisibilities: Array<(
+        { __typename?: 'AppliedMenuVisibilities' }
+        & Pick<TAppliedMenuVisibilities, 'name' | 'value'>
+      )>, allAppliedDataFences: Array<(
+        { __typename: 'StoreDataFence' }
+        & Pick<TStoreDataFence, 'type' | 'name' | 'value' | 'group'>
+      )> }
+    ), owner: (
       { __typename?: 'Organization' }
       & Pick<TOrganization, 'id' | 'name'>
     ) }

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -1,19 +1,16 @@
+import type {
+  TNormalizedPermissions,
+  TNormalizedActionRights,
+  TNormalizedDataFences,
+} from '@commercetools-frontend/application-shell-connectors';
+
 import React from 'react';
 import useIsAuthorized from '../../hooks/use-is-authorized';
 import getDisplayName from '../../utils/get-display-name';
 
 // Permissions
 type TPermissionName = string;
-type TPermissions = {
-  [key: string]: boolean;
-};
 // Action rights
-type TActionRight = {
-  [key: string]: boolean;
-};
-type TActionRights = {
-  [key: string]: TActionRight;
-};
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
@@ -21,18 +18,6 @@ type TDemandedActionRight = {
   name: TActionRightName;
 };
 // Data fences
-type TDataFenceGroupedByPermission = {
-  // E.g. { canManageOrders: { values: [] } }
-  [key: string]: { values: string[] } | null;
-};
-type TDataFenceGroupedByResourceType = {
-  // E.g. { orders: {...} }
-  [key: string]: TDataFenceGroupedByPermission | null;
-};
-type TDataFenceType = 'store';
-type TDataFences = Partial<
-  Record<TDataFenceType, TDataFenceGroupedByResourceType>
->;
 type TDemandedDataFence = {
   group: string;
   name: string;
@@ -44,9 +29,9 @@ type TSelectDataFenceData = (
   }
 ) => string[] | null;
 type TProjectPermissions = {
-  permissions: TPermissions;
-  actionRights: TActionRights;
-  dataFences: TDataFences;
+  permissions: TNormalizedPermissions | null;
+  actionRights: TNormalizedActionRights | null;
+  dataFences: TNormalizedDataFences | null;
 };
 
 type Props = {

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -4,15 +4,35 @@ import getDisplayName from '../../utils/get-display-name';
 
 // Permissions
 type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 // Action rights
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TActionRights = {
+  [key: string]: TActionRight;
+};
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
   group: TActionRightGroup;
   name: TActionRightName;
 };
-
 // Data fences
+type TDataFenceGroupedByPermission = {
+  // E.g. { canManageOrders: { values: [] } }
+  [key: string]: { values: string[] } | null;
+};
+type TDataFenceGroupedByResourceType = {
+  // E.g. { orders: {...} }
+  [key: string]: TDataFenceGroupedByPermission | null;
+};
+type TDataFenceType = 'store';
+type TDataFences = Partial<
+  Record<TDataFenceType, TDataFenceGroupedByResourceType>
+>;
 type TDemandedDataFence = {
   group: string;
   name: string;
@@ -23,6 +43,11 @@ type TSelectDataFenceData = (
     actualDataFenceValues: string[];
   }
 ) => string[] | null;
+type TProjectPermissions = {
+  permissions: TPermissions;
+  actionRights: TActionRights;
+  dataFences: TDataFences;
+};
 
 type Props = {
   demandedPermissions: TPermissionName[];
@@ -30,6 +55,7 @@ type Props = {
   demandedDataFences?: TDemandedDataFence[];
   shouldMatchSomePermissions?: boolean;
   selectDataFenceData?: TSelectDataFenceData;
+  projectPermissions?: TProjectPermissions;
   render: (isAuthorized: boolean) => React.ReactNode;
   children?: never;
 };
@@ -44,6 +70,7 @@ const Authorized = (props: Props) => {
     demandedDataFences: props.demandedDataFences,
     selectDataFenceData: props.selectDataFenceData,
     shouldMatchSomePermissions: props.shouldMatchSomePermissions,
+    projectPermissions: props.projectPermissions,
   });
 
   return <React.Fragment>{props.render(isAuthorized)}</React.Fragment>;

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -67,7 +67,12 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
           },
         ],
         allAppliedDataFences: [],
-        allAppliedMenuVisibilities: [],
+        allPermissionsForAllApplications: {
+          allAppliedPermissions: [],
+          allAppliedActionRights: [],
+          allAppliedDataFences: [],
+          allAppliedMenuVisibilities: [],
+        },
       }}
       projectDataLocale="en"
       environment={{

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -65,8 +65,13 @@ const testRender = ({
         },
         allAppliedPermissions,
         allAppliedActionRights,
-        allAppliedMenuVisibilities,
         allAppliedDataFences,
+        allPermissionsForAllApplications: {
+          allAppliedPermissions,
+          allAppliedActionRights,
+          allAppliedDataFences,
+          allAppliedMenuVisibilities,
+        },
       }}
       environment={{
         revision: '1',

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -1,3 +1,9 @@
+import type {
+  TNormalizedPermissions,
+  TNormalizedActionRights,
+  TNormalizedDataFences,
+} from '@commercetools-frontend/application-shell-connectors';
+
 import React from 'react';
 import invariant from 'tiny-invariant';
 import isNil from 'lodash/isNil';
@@ -8,16 +14,7 @@ const getHasChildren = (children: React.ReactNode) =>
 
 // Permissions
 type TPermissionName = string;
-type TPermissions = {
-  [key: string]: boolean;
-};
 // Action rights
-type TActionRight = {
-  [key: string]: boolean;
-};
-type TActionRights = {
-  [key: string]: TActionRight;
-};
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
@@ -25,18 +22,6 @@ type TDemandedActionRight = {
   name: TActionRightName;
 };
 // Data fences
-type TDataFenceGroupedByPermission = {
-  // E.g. { canManageOrders: { values: [] } }
-  [key: string]: { values: string[] } | null;
-};
-type TDataFenceGroupedByResourceType = {
-  // E.g. { orders: {...} }
-  [key: string]: TDataFenceGroupedByPermission | null;
-};
-type TDataFenceType = 'store';
-type TDataFences = Partial<
-  Record<TDataFenceType, TDataFenceGroupedByResourceType>
->;
 type TDemandedDataFence = {
   group: string;
   name: string;
@@ -48,9 +33,9 @@ type TSelectDataFenceData = (
   }
 ) => string[] | null;
 type TProjectPermissions = {
-  permissions: TPermissions;
-  actionRights: TActionRights;
-  dataFences: TDataFences;
+  permissions: TNormalizedPermissions | null;
+  actionRights: TNormalizedActionRights | null;
+  dataFences: TNormalizedDataFences | null;
 };
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.tsx
@@ -8,7 +8,16 @@ const getHasChildren = (children: React.ReactNode) =>
 
 // Permissions
 type TPermissionName = string;
+type TPermissions = {
+  [key: string]: boolean;
+};
 // Action rights
+type TActionRight = {
+  [key: string]: boolean;
+};
+type TActionRights = {
+  [key: string]: TActionRight;
+};
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
@@ -16,6 +25,18 @@ type TDemandedActionRight = {
   name: TActionRightName;
 };
 // Data fences
+type TDataFenceGroupedByPermission = {
+  // E.g. { canManageOrders: { values: [] } }
+  [key: string]: { values: string[] } | null;
+};
+type TDataFenceGroupedByResourceType = {
+  // E.g. { orders: {...} }
+  [key: string]: TDataFenceGroupedByPermission | null;
+};
+type TDataFenceType = 'store';
+type TDataFences = Partial<
+  Record<TDataFenceType, TDataFenceGroupedByResourceType>
+>;
 type TDemandedDataFence = {
   group: string;
   name: string;
@@ -26,7 +47,11 @@ type TSelectDataFenceData = (
     actualDataFenceValues: string[];
   }
 ) => string[] | null;
-
+type TProjectPermissions = {
+  permissions: TPermissions;
+  actionRights: TActionRights;
+  dataFences: TDataFences;
+};
 type TRenderProp = (props: { isAuthorized: boolean }) => React.ReactNode;
 
 type Props = {
@@ -36,6 +61,7 @@ type Props = {
   dataFences?: TDemandedDataFence[];
   selectDataFenceData?: TSelectDataFenceData;
   unauthorizedComponent?: React.ComponentType;
+  projectPermissions?: TProjectPermissions;
   render?: TRenderProp;
   children?: TRenderProp | React.ReactNode;
 };
@@ -55,6 +81,7 @@ const RestrictedByPermissions = (props: Props) => {
       demandedActionRights={props.actionRights}
       demandedDataFences={props.dataFences}
       selectDataFenceData={props.selectDataFenceData}
+      projectPermissions={props.projectPermissions}
       render={(isAuthorized: boolean) => {
         if (typeof props.children === 'function')
           return props.children({

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -110,8 +110,13 @@ const render = ({
         },
         allAppliedPermissions,
         allAppliedActionRights,
-        allAppliedMenuVisibilities,
         allAppliedDataFences,
+        allPermissionsForAllApplications: {
+          allAppliedPermissions,
+          allAppliedActionRights,
+          allAppliedDataFences,
+          allAppliedMenuVisibilities,
+        },
       }}
       environment={{
         revision: '1',

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -51,6 +51,11 @@ type TSelectDataFenceData = (
     actualDataFenceValues: string[];
   }
 ) => string[] | null;
+type TProjectPermissions = {
+  permissions: TPermissions;
+  actionRights: TActionRights;
+  dataFences: TDataFences;
+};
 
 // Log a warning only once, and not on each render.
 const useWarning = (condition: boolean, message: string) => {
@@ -66,12 +71,14 @@ const useIsAuthorized = ({
   demandedDataFences,
   selectDataFenceData,
   shouldMatchSomePermissions = false,
+  projectPermissions,
 }: {
   demandedPermissions: TPermissionName[];
   demandedActionRights?: TDemandedActionRight[];
   demandedDataFences?: TDemandedDataFence[];
   selectDataFenceData?: TSelectDataFenceData;
   shouldMatchSomePermissions?: boolean;
+  projectPermissions?: TProjectPermissions;
 }): boolean => {
   const impliedPermissions = getImpliedPermissions(demandedPermissions);
 
@@ -95,13 +102,16 @@ const useIsAuthorized = ({
   );
 
   const actualPermissions = useApplicationContext<TPermissions | null>(
-    (applicationContext) => applicationContext.permissions
+    (applicationContext) =>
+      projectPermissions?.permissions ?? applicationContext.permissions
   );
   const actualActionRights = useApplicationContext<TActionRights | null>(
-    (applicationContext) => applicationContext.actionRights
+    (applicationContext) =>
+      projectPermissions?.actionRights ?? applicationContext.actionRights
   );
   const actualDataFences = useApplicationContext<TDataFences | null>(
-    (applicationContext) => applicationContext.dataFences
+    (applicationContext) =>
+      projectPermissions?.dataFences ?? applicationContext.dataFences
   );
 
   // if the user has no permissions and no dataFences assigned to them, they are not authorized

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.ts
@@ -1,3 +1,9 @@
+import type {
+  TNormalizedPermissions,
+  TNormalizedActionRights,
+  TNormalizedDataFences,
+} from '@commercetools-frontend/application-shell-connectors';
+
 import { useEffect } from 'react';
 import warning from 'tiny-warning';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
@@ -12,16 +18,7 @@ import {
 
 // Permissions
 type TPermissionName = string;
-type TPermissions = {
-  [key: string]: boolean;
-};
 // Action rights
-type TActionRight = {
-  [key: string]: boolean;
-};
-type TActionRights = {
-  [key: string]: TActionRight;
-};
 type TActionRightName = string;
 type TActionRightGroup = string;
 type TDemandedActionRight = {
@@ -29,18 +26,6 @@ type TDemandedActionRight = {
   name: TActionRightName;
 };
 // Data fences
-type TDataFenceGroupedByPermission = {
-  // E.g. { canManageOrders: { values: [] } }
-  [key: string]: { values: string[] } | null;
-};
-type TDataFenceGroupedByResourceType = {
-  // E.g. { orders: {...} }
-  [key: string]: TDataFenceGroupedByPermission | null;
-};
-type TDataFenceType = 'store';
-type TDataFences = Partial<
-  Record<TDataFenceType, TDataFenceGroupedByResourceType>
->;
 type TDemandedDataFence = {
   group: string;
   name: string;
@@ -52,9 +37,9 @@ type TSelectDataFenceData = (
   }
 ) => string[] | null;
 type TProjectPermissions = {
-  permissions: TPermissions;
-  actionRights: TActionRights;
-  dataFences: TDataFences;
+  permissions: TNormalizedPermissions | null;
+  actionRights: TNormalizedActionRights | null;
+  dataFences: TNormalizedDataFences | null;
 };
 
 // Log a warning only once, and not on each render.
@@ -101,15 +86,15 @@ const useIsAuthorized = ({
     )}.`
   );
 
-  const actualPermissions = useApplicationContext<TPermissions | null>(
+  const actualPermissions = useApplicationContext<TNormalizedPermissions | null>(
     (applicationContext) =>
       projectPermissions?.permissions ?? applicationContext.permissions
   );
-  const actualActionRights = useApplicationContext<TActionRights | null>(
+  const actualActionRights = useApplicationContext<TNormalizedActionRights | null>(
     (applicationContext) =>
       projectPermissions?.actionRights ?? applicationContext.actionRights
   );
-  const actualDataFences = useApplicationContext<TDataFences | null>(
+  const actualDataFences = useApplicationContext<TNormalizedDataFences | null>(
     (applicationContext) =>
       projectPermissions?.dataFences ?? applicationContext.dataFences
   );

--- a/schemas/mc.json
+++ b/schemas/mc.json
@@ -1443,6 +1443,22 @@
                 }
               }
             },
+            "isDeprecated": true,
+            "deprecationReason": "This field has been moved into the menuPermissionsForAllApplications field."
+          },
+          {
+            "name": "allPermissionsForAllApplications",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllPermissionsForAllApplications",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -1508,8 +1524,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": true,
-            "deprecationReason": "This field will be removed in the future."
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -2223,6 +2239,113 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AllPermissionsForAllApplications",
+        "description": "Only used by the navbar menu component in ApplicationShell.",
+        "fields": [
+          {
+            "name": "allAppliedPermissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppliedPermission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allAppliedDataFences",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "UNION",
+                    "name": "AppliedDataFence",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allAppliedActionRights",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppliedActionRight",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allAppliedMenuVisibilities",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppliedMenuVisibilities",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -3180,6 +3303,12 @@
             "deprecationReason": null
           },
           {
+            "name": "manage_key_value_documents",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "view_api_clients",
             "description": null,
             "isDeprecated": false,
@@ -3313,6 +3442,12 @@
           },
           {
             "name": "view_change_history",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "view_key_value_documents",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/test-data/project/transformers.ts
+++ b/test-data/project/transformers.ts
@@ -32,8 +32,13 @@ const transformers = {
       __typename: 'Project',
       allAppliedPermissions: AppliedPermissionMock.random().buildGraphql<AppliedPermissionMock.TAppliedPermissionGraphql>(),
       allAppliedActionRights: AppliedActionRightMock.random().buildGraphql<AppliedActionRightMock.TAppliedActionRightsGraphql>(),
-      allAppliedMenuVisibilities: AppliedMenuVisibilitiesMock.random().buildGraphql<AppliedMenuVisibilitiesMock.TAppliedMenuVisibilitiesGraphql>(),
       allAppliedDataFences: AppliedStoreDataFenceMock.random().buildGraphql<AppliedStoreDataFenceMock.TAppliedStoreDataFencesGraphql>(),
+      allPermissionsForAllApplications: {
+        allAppliedPermissions: AppliedPermissionMock.random().buildGraphql<AppliedPermissionMock.TAppliedPermissionGraphql>(),
+        allAppliedActionRights: AppliedActionRightMock.random().buildGraphql<AppliedActionRightMock.TAppliedActionRightsGraphql>(),
+        allAppliedDataFences: AppliedStoreDataFenceMock.random().buildGraphql<AppliedStoreDataFenceMock.TAppliedStoreDataFencesGraphql>(),
+        allAppliedMenuVisibilities: AppliedMenuVisibilitiesMock.random().buildGraphql<AppliedMenuVisibilitiesMock.TAppliedMenuVisibilitiesGraphql>(),
+      },
     }),
     removeFields: [
       'permissions',

--- a/test-data/project/types.ts
+++ b/test-data/project/types.ts
@@ -54,6 +54,11 @@ export type TProjectGraphql = TBaseProject & {
   expiry: TProjectExpiryGraphql;
   allAppliedPermissions: TAppliedPermissionGraphql;
   allAppliedActionRights: TAppliedActionRightsGraphql;
-  allAppliedMenuVisibilities: TAppliedMenuVisibilitiesGraphql;
   allAppliedDataFences: TAppliedStoreDataFencesGraphql;
+  allPermissionsForAllApplications: {
+    allAppliedPermissions: TAppliedPermissionGraphql;
+    allAppliedActionRights: TAppliedActionRightsGraphql;
+    allAppliedDataFences: TAppliedStoreDataFencesGraphql;
+    allAppliedMenuVisibilities: TAppliedMenuVisibilitiesGraphql;
+  };
 };


### PR DESCRIPTION
As we are introducing some changes related to permissions in the MC API, we need to ensure that the menu links are not affected by that. This is because menu links are considered a "shared" resource across all applications.

~~**DO NOT MERGE THIS FOR NOW UNTIL THE CHANGES IN THE MC API ARE LIVE**~~