### PR TITLE
chore: add `react-select` to resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
     "pretty-format": "26.6.2",
     "intl-messageformat-parser": "6.0.18",
     "**/intl-messageformat-parser": "6.0.18",
-    "**/@commercetools-docs/gatsby-theme-docs/react-intl": "5.10.6"
+    "**/@commercetools-docs/gatsby-theme-docs/react-intl": "5.10.6",
+    "react-select": "3.1.0"
   },
   "engines": {
     "node": ">=12",

--- a/packages/application-config/src/schema.ts
+++ b/packages/application-config/src/schema.ts
@@ -21,7 +21,7 @@ export interface JSONSchemaForCustomApplicationConfigurationFiles {
   /**
    * The cloud identifier where the Custom Application is running. This value is used to derive the Merchant Center API URL. Alternatively you can use the `mcApiUrl` property.
    */
-  cloudIdentifier: ('gcp-au' | 'gcp-eu' | 'gcp-us' | 'aws-fra' | 'aws-ohio') | EnvVariablePlaceholder;
+  cloudIdentifier: (('gcp-au' | 'gcp-eu' | 'gcp-us' | 'aws-fra' | 'aws-ohio') | EnvVariablePlaceholder) & string;
   /**
    * The URL of the Merchant Center API. We usually recommend to use the `cloudIdentifier` option to avoid possible typos.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -23491,10 +23491,10 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.1.tgz#156a5b4a6c22b1e3d62a919cb1fd827adb4060bc"
-  integrity sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==
+react-select@3.1.0, react-select@3.1.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
+  integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/cache" "^10.0.9"


### PR DESCRIPTION
> Note there is probably another way to do this, but this PR fixes the typecheck issue on master

#### Summary

- adds `react-select@3.1.0` to resolutions

#### Description

on `master` we get a typecheck error, where `OptionProps` and `CustomValueContainerProps` has a second required argument. I'm open to other approaches. I tried to fix the declaration file but spent too much time with it with no progress.
