### PR TITLE
refactor: remove second border and spacing for the Github icon

### DIFF
--- a/.changeset/gentle-mayflies-heal.md
+++ b/.changeset/gentle-mayflies-heal.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-website/custom-applications': patch
+---
+
+The second left border of the Github icon in the right column was removed.

--- a/website/src/@commercetools-docs/gatsby-theme-docs/overrides/page-header-side.js
+++ b/website/src/@commercetools-docs/gatsby-theme-docs/overrides/page-header-side.js
@@ -1,29 +1,16 @@
 import React from 'react';
-import { css } from '@emotion/react';
 import { useSiteData, Link } from '@commercetools-docs/gatsby-theme-docs';
-import { designSystem } from '@commercetools-docs/ui-kit';
-import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { GithubSvgIcon } from '../../../icons';
 
 const RepositoryLinks = () => {
   const siteData = useSiteData();
   return (
-    <div
-      css={css`
-        margin: ${designSystem.dimensions.spacings.m} 0;
-        padding: 0 ${designSystem.dimensions.spacings.m};
-        border-left: 1px solid ${designSystem.colors.light.borderPrimary};
-      `}
+    <Link
+      href={siteData.siteMetadata.repositoryUrl}
+      title="Application Kit repository"
     >
-      <SpacingsInline scale="l" alignItems="center" justifyContent="flex-start">
-        <Link
-          href={siteData.siteMetadata.repositoryUrl}
-          title="Application Kit repository"
-        >
-          <GithubSvgIcon />
-        </Link>
-      </SpacingsInline>
-    </div>
+      <GithubSvgIcon />
+    </Link>
   );
 };
 


### PR DESCRIPTION
closes #1931 