### PR TITLE
chore(header-link): add operation name to missing target error

### DIFF
--- a/.changeset/seven-clocks-smell.md
+++ b/.changeset/seven-clocks-smell.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+Improve error message when graphql target is missing.

--- a/packages/application-shell/src/apollo-links/header-link.ts
+++ b/packages/application-shell/src/apollo-links/header-link.ts
@@ -49,7 +49,7 @@ const headerLink = new ApolloLink((operation, forward) => {
     !isKnownGraphQlTarget(graphQlTarget)
   )
     throw new Error(
-      `GraphQL target "${graphQlTarget}" is missing or is not supported`
+      `GraphQL target "${graphQlTarget}" is missing (or is not supported) in operation "${operation.operationName}"`
     );
 
   /**


### PR DESCRIPTION
I am investigating an error reported to Sentry from MC saying that `GraphQL target "undefined" is missing or is not supported`. Went manually through all the queries we sent in MC to try to find the one with a missing `target` param. No luck. 

So, I decided to extend the error message thrown from HttpLink so that it will include `operationName` to narrow down the scope of further investigation.