### PR TITLE
refactor(app-shell): remove updateFlags

### DIFF
--- a/.changeset/young-lions-confess.md
+++ b/.changeset/young-lions-confess.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+refactor(app-shell): remove unused `updateFlags` export for LaunchDarkly adapter.

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -58,7 +58,4 @@ export {
   useAdapterReconfiguration,
 } from '@flopflip/react-broadcast';
 
-export {
-  default as ldAdapter,
-  updateFlags,
-} from '@flopflip/launchdarkly-adapter';
+export { default as ldAdapter } from '@flopflip/launchdarkly-adapter';


### PR DESCRIPTION
#### Summary

This removes the `updateFlags` re-export from the `application-shell` package.

The re-export was not used internally and I presume nobody used it externally. The alternative is to use `ldAdapter.updateFlags`. The stand alone export was only a "redirect" anyway.

This re-export will not be present anymore in the upcoming major release of flopflip. Please apply the changeset you see adequate for this.