### PR TITLE
fix(navbar): remove title nowrap to accommodate long application names

### DIFF
--- a/.changeset/fuzzy-tomatoes-approve.md
+++ b/.changeset/fuzzy-tomatoes-approve.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+fix(navbar): remove title nowrap to accommodate long application names

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -165,7 +165,6 @@
 
 :global(.body__menu-open) .list-item .title {
   display: block;
-  white-space: nowrap;
   opacity: 1;
   margin-left: var(--spacing-m);
   color: var(--color-surface);


### PR DESCRIPTION
#### Summary

- Removed navbar title whitespace nowrap CSS

#### Description

When translated into Spanish and French, the Change History navbar item is too long to fit into the navbar's fixed width. I believe this is the first item to run into this issue.

**Before:**
![image](https://user-images.githubusercontent.com/8136478/103686482-e3101680-4f5c-11eb-8d3f-41a7817850d9.png)

**After:**
![Screen Shot 2021-01-05 at 11 11 23 AM](https://user-images.githubusercontent.com/8136478/103686549-fb803100-4f5c-11eb-9f21-e54c905e640a.png)
![image (4)](https://user-images.githubusercontent.com/8136478/103686596-0fc42e00-4f5d-11eb-8a4f-63fc25bb4bce.png)
