### PR TITLE
test(starter): wait for processing text to be removed, before taking the snapshots

### DIFF
--- a/cypress/integration/template-starter/main.js
+++ b/cypress/integration/template-starter/main.js
@@ -4,6 +4,7 @@ describe('Main view', () => {
   it('should render page', () => {
     cy.login({ redirectToUri: URL_EXAMPLES_STARTER });
     cy.findByText('Hello, world').should('exist');
+    cy.findByText('Processing...').should('not.exist');
     cy.percySnapshot();
   });
 });


### PR DESCRIPTION
From time to time we get a flaky percy snapshot about the "Processing..." text being visible (or not).

This PR attempts to improve the test by ensuring that the text disappears before taking the snapshot.