### PR TITLE
refactor(jest-preset): to remove unhandled promise lockfile

### DIFF
--- a/.changeset/eleven-feet-repeat.md
+++ b/.changeset/eleven-feet-repeat.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/jest-preset-mc-app": patch
+---
+
+refactor(jest-preset): to remove unhandled promise lockfile

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -67,30 +67,3 @@ const logError = console.error;
 global.console.error = (...messages) => {
   logOrThrow(logError, 'error', messages);
 };
-
-// Avoid unhandled promise rejections from going unnoticed
-// https://github.com/facebook/jest/issues/3251#issuecomment-299183885
-// In Node v7 unhandled promise rejections will terminate the process
-if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {
-  process.on('unhandledRejection', (reason) => {
-    logMessage('UNHANDLED REJECTION', reason);
-
-    // We create a file in case there is an unhandled rejection
-    // We later check for the existence of this file to fail CI
-    if (process.env.CI && !process.env.HAS_CREATED_UNHANDLED_REJECTION_FILE) {
-      const rootDir = pkgDir.sync(__dirname);
-
-      fs.writeFileSync(
-        path.join(
-          rootDir,
-          'fail-tests-because-there-was-an-unhandled-rejection.lock'
-        ),
-        '',
-        { encoding: 'utf8' }
-      );
-      process.env.HAS_CREATED_UNHANDLED_REJECTION_FILE = true;
-    }
-  });
-  // Avoid memory leak by adding too many listeners
-  process.env.LISTENING_TO_UNHANDLED_REJECTION = true;
-}


### PR DESCRIPTION
#### Summary

This pull request suggests to remove the `fail-tests-because-there-was-an-unhandled-rejection.lock` file which is written when a unhandled promise rejection is detected by the Node.js process. 

#### Description

Jest can spawn various processes. This often made it hard to catch all unhandled promise rejections as some could originate in child processes and not communicate proper to the parent. As a result unhandled promise rejections might have gotten unnoticed when running a large test suite on machines with various cores.

The linked issue https://github.com/facebook/jest/issues/3251#issuecomment-299183885 discusses this at length.

However, in recent versions of Node.js unhandled promises will always immediately terminate the process. In addition in this https://github.com/facebook/jest/pull/4016 pull request the limitation causing the need for this, to my understanding, has been solved.

The resulting fix was available in Jest as of v21. The earliest visible blame on these lines in our preset are 3 year old. Before this was internal and existed. I suspect we just carried this forward but might not need it anymore.
