### PR TITLE
ci(changesets): to use conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           publish: yarn changeset publish
           version: yarn changeset:version-and-format
+          title: 'ci(changesets): version packages'
+          commit: 'ci(changesets): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
         with:
           publish: yarn changeset publish
           version: yarn changeset:version-and-format
-          title: 'ci(changesets): version packages'
           commit: 'ci(changesets): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
#### Summary

Suggesting to have `changesets` use a conventional commit pr title and commit.

I noticed that this breaks a husky v5 update in flopflip over the weekend.