### PR TITLE
chore: remove pinOnlyDevDependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":pinOnlyDevDependencies", "schedule:weekly"],
+  "extends": ["config:base", "schedule:weekly"],
   "separateMajorMinor": true,
   "packageRules": [
     {


### PR DESCRIPTION
Follow up of #1964 , as it seems that this rule does not play nicely with `manypkg`