### PR TITLE
fix(app-shell): to re-export flag variation utils

### DIFF
--- a/.changeset/gold-doors-learn.md
+++ b/.changeset/gold-doors-learn.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+fix(app-shell): to re-export flag variation utils

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -55,6 +55,9 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
   useFeatureToggle,
+  useFeatureToggles,
+  useFlagVariation,
+  useFlagVariations,
   useAdapterStatus,
   useAdapterReconfiguration,
 } from '@flopflip/react-broadcast';


### PR DESCRIPTION
#### Summary

These have been around in flopflip for some time. They can be useful for us.