### PR TITLE
fix(mc-html-template): add no-referer policy

### DIFF
--- a/.changeset/gentle-pets-glow.md
+++ b/.changeset/gentle-pets-glow.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+---
+
+fix(mc-html-template): add no-referer policy

--- a/packages/mc-html-template/src/generate-template.js
+++ b/packages/mc-html-template/src/generate-template.js
@@ -4,10 +4,11 @@ module.exports = function generateTemplate({
 }) {
   const cssImports = cssChunks.map(
     (chunkPath) =>
-      `<link href="__CDN_URL__${chunkPath}" rel='stylesheet' type='text/css'></link>`
+      `<link href="__CDN_URL__${chunkPath}" rel='stylesheet' type='text/css' referrerpolicy='no-referrer'></link>`
   );
   const scriptImports = scriptChunks.map(
-    (chunkPath) => `<script src="__CDN_URL__${chunkPath}"></script>`
+    (chunkPath) =>
+      `<script src="__CDN_URL__${chunkPath}" referrerpolicy='no-referrer'></script>`
   );
 
   return `
@@ -16,23 +17,23 @@ module.exports = function generateTemplate({
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <link rel="preconnect" href="__CDN_URL__">
-    <link rel="preconnect" href="__MC_API_URL__">
+    <link rel="preconnect" href="__CDN_URL__" referrerpolicy="no-referrer">
+    <link rel="preconnect" href="__MC_API_URL__" referrerpolicy="no-referrer">
     <!-- Fav and touch icons -->
     <link rel="shortcut icon" type="image/png" href="/favicon.png">
     <!-- Standard iPhone -->
     <link rel="apple-touch-icon" sizes="57x57" href="/favicon_57x57px.png">
     <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/favicon_57x57px.png">
     <!-- Retina iPhone  - COMMENTED OUT AS ICON FILES DO NOT EXIST -->
-    <!-- <link rel="apple-touch-icon" sizes="114x114" href="/favicon_114x114px.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="114×114" href="/favicon_114x114px.png" />-->
+    <!-- <link rel="apple-touch-icon" sizes="114x114" href="/favicon_114x114px.png"/>
+    <link rel="apple-touch-icon-precomposed" sizes="114×114" href="/favicon_114x114px.png"/>-->
     <!-- Standard iPad -->
     <link rel="apple-touch-icon" sizes="72x72" href="/favicon_72x72px.png">
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/favicon_72x72px.png">
     <!-- Retina iPad -->
     <link rel="apple-touch-icon" sizes="144x144" href="/favicon_144x144px.png">
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/favicon_144x144px.png">
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i' rel='stylesheet' type='text/css'></link>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i' rel='stylesheet' type='text/css' referrerpolicy="no-referrer"></link>
     ${cssImports.join('\n')}
     <title>Merchant Center</title>
   </head>


### PR DESCRIPTION
#### Summary

This pull request suggests to add a `referrerpolicy="no-referrer"` to `link`-tags.

#### Description

Generally, to my understanding, the `link`-tags do not need the referrer. Hence we can opt-out of them. 

This should not be an issue as our urls do not contain any sensitive information. However, a Custom App can put anything into the url. Also we do not use external CDNs but we can still add additional security by not sending it.

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
