### PR TITLE
fix(mc-html-template): add no-referer policy to script-tags

### DIFF
--- a/.changeset/red-pigs-breathe.md
+++ b/.changeset/red-pigs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+---
+
+fix(mc-html-template): add no-referer policy to script-tags

--- a/packages/mc-html-template/src/generate-template.js
+++ b/packages/mc-html-template/src/generate-template.js
@@ -64,13 +64,13 @@ module.exports = function generateTemplate({
     <div id="app"></div>
 
     <!-- Loading screen handling -->
-    <script>__LOADING_SCREEN_JS__</script>
+    <script referrerpolicy="no-referrer">__LOADING_SCREEN_JS__</script>
 
     <!-- Application globals -->
-    <script>window.app = __APP_ENVIRONMENT__;</script>
+    <script referrerpolicy="no-referrer">window.app = __APP_ENVIRONMENT__;</script>
 
     <!-- Tracking scripts (load before application bundles) -->
-    <script>__DATALAYER_JS__</script>
+    <script referrerpolicy="no-referrer">__DATALAYER_JS__</script>
     __GTM_SCRIPT__
 
     <!-- Main application chunks -->

--- a/packages/mc-html-template/src/utils/replace-html-placeholders.js
+++ b/packages/mc-html-template/src/utils/replace-html-placeholders.js
@@ -8,7 +8,7 @@ const getGtmTrackingScript = (gtmId) => {
   if (!gtmId) return '';
   const url = `https://www.googletagmanager.com/gtm.js?id=${gtmId}`;
   return `
-<script async type="text/javascript" src="${url}"></script>
+<script async type="text/javascript" src="${url}" referrerpolicy="no-referrer"></script>
   `;
 };
 


### PR DESCRIPTION
#### Summary

This pull request is very similar to the #1994 just focussed on `script`-tags.

I noticed that we could also apply the same directive to script tags.

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script