### PR TITLE
fix(public-page-layout): allow container to flex beyond 100vh

### DIFF
--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -36,7 +36,7 @@ type TProps = {
 
 const Container = styled.div`
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   padding-top: ${customProperties.spacingXl};
   justify-content: center;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

| Before | After |
| - | - |
| <img width="1440" alt="before" src="https://user-images.githubusercontent.com/1379086/105968844-e1330200-6087-11eb-8f63-d32a248c79a3.png"> | <img width="1440" alt="after" src="https://user-images.githubusercontent.com/1379086/105968892-ee4ff100-6087-11eb-8c0d-cce122cfbdb6.png"> |


<!-- provide a short summary of your changes -->

#### Description

Modify styles to allow container to flex beyond 100vh when there is enough content that overflows the viewport.


<!-- provide some context -->
