### PR TITLE
refactor(test-utils): to use flopflip test provider

### DIFF
--- a/.changeset/tidy-llamas-deliver.md
+++ b/.changeset/tidy-llamas-deliver.md
@@ -4,5 +4,7 @@
 
 refactor(test-utils): to use flopflip test provider
 
-In this release we use the `TestProviderFlopFlip` when using our `test-utils` or the `SetupFlipFlip` component. 
-This change just not affect consumers of those packages. You can remove any `adapter` you may have passed to any `react-testing-library` renderer. These are not needed anymore.
+When using `@commercetools-frontend/application-shell/test-utils`, we now render a `TestProviderFlopFlip` instead of the normal `ConfigureFlopFlip` with the `memory` adapter.<br/>
+This change simplifies how feature flags are propagated during tests and should not affect the usage of the test-utils.
+
+> In the very unlikely case that you have been passing the `adapter` option to the test-utils, you can remove that as it's not necessary anymore.

--- a/.changeset/tidy-llamas-deliver.md
+++ b/.changeset/tidy-llamas-deliver.md
@@ -1,0 +1,8 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+refactor(test-utils): to use flopflip test provider
+
+In this release we use the `TestProviderFlopFlip` when using our `test-utils` or the `SetupFlipFlip` component. 
+This change just not affect consumers of those packages. You can remove any `adapter` you may have passed to any `react-testing-library` renderer. These are not needed anymore.

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -63,7 +63,6 @@
     "@flopflip/combine-adapters": "0.0.14",
     "@flopflip/http-adapter": "0.0.5",
     "@flopflip/launchdarkly-adapter": "5.0.8",
-    "@flopflip/memory-adapter": "3.0.12",
     "@flopflip/react-broadcast": "12.2.0",
     "@flopflip/types": "4.1.10",
     "@types/classnames": "2.2.11",

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -64,7 +64,7 @@
     "@flopflip/http-adapter": "0.0.5",
     "@flopflip/launchdarkly-adapter": "5.0.8",
     "@flopflip/memory-adapter": "3.0.12",
-    "@flopflip/react-broadcast": "12.1.10",
+    "@flopflip/react-broadcast": "12.2.0",
     "@flopflip/types": "4.1.10",
     "@types/classnames": "2.2.11",
     "@types/common-tags": "^1.8.0",

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -117,11 +117,6 @@ export const SetupFlopFlipProvider = (props: Props) => {
       user: {
         key: props.user?.id,
       },
-      memory: {
-        user: {
-          key: props.user?.id,
-        },
-      },
       launchdarkly: {
         sdk: {
           // Allow to overwrite the client ID, passed via the `additionalEnv` properties
@@ -157,24 +152,6 @@ export const SetupFlopFlipProvider = (props: Props) => {
     }),
     [apolloClient, flags, props.ldClientSideId, props.projectKey, props.user]
   );
-
-  if (process.env.NODE_ENV === 'test') {
-    const memoryAdapter = require('@flopflip/memory-adapter').default;
-    return (
-      <ConfigureFlopFlip<typeof memoryAdapter>
-        adapter={memoryAdapter}
-        adapterArgs={adapterArgs.memory}
-        defaultFlags={defaultFlags}
-        shouldDeferAdapterConfiguration={
-          typeof props.shouldDeferAdapterConfiguration === 'boolean'
-            ? props.shouldDeferAdapterConfiguration
-            : !props.user || allMenuFeatureToggles.isLoading
-        }
-      >
-        {props.children}
-      </ConfigureFlopFlip>
-    );
-  }
 
   return (
     <ConfigureFlopFlip<typeof combineAdapters>

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -9,7 +9,10 @@ import { useApplicationContext } from '@commercetools-frontend/application-shell
 import ldAdapter from '@flopflip/launchdarkly-adapter';
 import httpAdapter from '@flopflip/http-adapter';
 import combineAdapters from '@flopflip/combine-adapters';
-import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
+import {
+  ConfigureFlopFlip,
+  TestProviderFlopFlip,
+} from '@flopflip/react-broadcast';
 import { useApolloClient } from '@apollo/client/react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import useAllMenuFeatureToggles from '../../hooks/use-all-menu-feature-toggles';
@@ -152,6 +155,14 @@ export const SetupFlopFlipProvider = (props: Props) => {
     }),
     [apolloClient, flags, props.ldClientSideId, props.projectKey, props.user]
   );
+
+  if (process.env.NODE_ENV === 'test') {
+    return (
+      <TestProviderFlopFlip flags={defaultFlags}>
+        {props.children}
+      </TestProviderFlopFlip>
+    );
+  }
 
   return (
     <ConfigureFlopFlip<typeof combineAdapters>

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -9,10 +9,7 @@ import { useApplicationContext } from '@commercetools-frontend/application-shell
 import ldAdapter from '@flopflip/launchdarkly-adapter';
 import httpAdapter from '@flopflip/http-adapter';
 import combineAdapters from '@flopflip/combine-adapters';
-import {
-  ConfigureFlopFlip,
-  TestProviderFlopFlip,
-} from '@flopflip/react-broadcast';
+import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
 import { useApolloClient } from '@apollo/client/react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import useAllMenuFeatureToggles from '../../hooks/use-all-menu-feature-toggles';
@@ -157,6 +154,8 @@ export const SetupFlopFlipProvider = (props: Props) => {
   );
 
   if (process.env.NODE_ENV === 'test') {
+    const { TestProviderFlopFlip } = require('@flopflip/react-broadcast');
+
     return (
       <TestProviderFlopFlip flags={defaultFlags}>
         {props.children}

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -15,7 +15,6 @@ import * as rtl from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { IntlProvider } from 'react-intl';
 import { TestProviderFlopFlip } from '@flopflip/react-broadcast';
-import memoryAdapter from '@flopflip/memory-adapter';
 import { Provider as StoreProvider } from 'react-redux';
 import { createEnhancedHistory } from '@commercetools-frontend/browser-history';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
@@ -28,12 +27,6 @@ import { createTestMiddleware as createSdkTestMiddleware } from '@commercetools-
 import ApplicationEntryPoint from '../components/application-entry-point';
 import { createReduxStore } from '../configure-store';
 import createApolloClient from '../configure-apollo';
-
-// Reset memoryAdapter after each test, so that the next test accepts the
-// defaultFlags param.
-// This could also be moved into setup-test-framework, not sure which
-// location is better for it.
-afterEach(memoryAdapter.reset);
 
 // These default values get merged with the values provided by the test from
 // the call to "render"
@@ -263,7 +256,6 @@ export type TRenderAppOptions<AdditionalEnvironmentProperties = {}> = {
   route: string;
   disableAutomaticEntryPointRoutes: boolean;
   history: ReturnType<typeof createEnhancedHistory>;
-  adapter: typeof memoryAdapter;
   flags: TFlags;
   environment: Partial<
     TProviderProps<AdditionalEnvironmentProperties>['environment']
@@ -362,7 +354,6 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
       createMemoryHistory({ initialEntries: [route] })
     ),
     // flopflip
-    adapter = memoryAdapter,
     flags = {},
     // application-context
     environment,

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -14,7 +14,7 @@ import { MockedProvider as ApolloMockProvider } from '@apollo/client/testing';
 import * as rtl from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { IntlProvider } from 'react-intl';
-import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
+import { TestProviderFlopFlip } from '@flopflip/react-broadcast';
 import memoryAdapter from '@flopflip/memory-adapter';
 import { Provider as StoreProvider } from 'react-redux';
 import { createEnhancedHistory } from '@commercetools-frontend/browser-history';
@@ -107,17 +107,6 @@ const defaultEnvironment: Partial<TProviderProps<{}>['environment']> = {
 
 const LoadingFallback = () => <>{'Loading...'}</>;
 LoadingFallback.displayName = 'LoadingFallback';
-
-const defaultFlopflipAdapterArgs = {
-  clientSideId: 'test-client-side-id',
-  user: {
-    key: 'user-key',
-  },
-  adapterConfiguration: {
-    pollingInteral: 1,
-  },
-  flags: {},
-};
 
 // For backwards compatibility we need to denormalize the given `permissions` option
 // (which is now deprecated) to `allAppliedPermissions`, in order to pass the value
@@ -413,7 +402,6 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
     ...defaultEnvironment,
     ...environment,
   } as TProviderProps<AdditionalEnvironmentProperties>['environment'];
-  const hasFlags = flags && Object.keys(flags).length > 0;
 
   if (!disableAutomaticEntryPointRoutes) {
     invariant(
@@ -429,12 +417,7 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
         apolloClient={apolloClient}
         mocks={mocks}
       >
-        <ConfigureFlopFlip
-          adapter={adapter}
-          defaultFlags={flags}
-          adapterArgs={defaultFlopflipAdapterArgs}
-          shouldDeferAdapterConfiguration={!hasFlags}
-        >
+        <TestProviderFlopFlip flags={flags}>
           <ApplicationContextProvider
             user={mergedUser}
             project={mergedProject}
@@ -458,7 +441,7 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
               </React.Suspense>
             </Router>
           </ApplicationContextProvider>
-        </ConfigureFlopFlip>
+        </TestProviderFlopFlip>
       </ApolloProviderWrapper>
     </IntlProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,17 +3726,6 @@
   dependencies:
     "@flopflip/types" "4.1.10"
 
-"@flopflip/memory-adapter@3.0.12":
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/@flopflip/memory-adapter/-/memory-adapter-3.0.12.tgz#358f77982bb5e7276ef4795613e36009d15430c1"
-  integrity sha512-Iw4dyO5MV044mySFLonxTyyLlq2ylFxuDleHLkjqOWFqENCdF7bVm21dLXJwX294RDOuFUkJhLUdCVODB6+yNw==
-  dependencies:
-    "@babel/runtime" "7.12.5"
-    "@flopflip/adapter-utilities" "1.0.12"
-    "@flopflip/types" "4.1.10"
-    mitt "2.1.0"
-    tiny-warning "1.0.3"
-
 "@flopflip/react-broadcast@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@flopflip/react-broadcast/-/react-broadcast-12.2.0.tgz#21a2eb46f9c0b582ea517ef1900d66d32ec55784"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,19 +3737,19 @@
     mitt "2.1.0"
     tiny-warning "1.0.3"
 
-"@flopflip/react-broadcast@12.1.10":
-  version "12.1.10"
-  resolved "https://registry.yarnpkg.com/@flopflip/react-broadcast/-/react-broadcast-12.1.10.tgz#4dfd274003c056a2639bde44ed04fd3786fb951e"
-  integrity sha512-3lYrmQF/AajiBahRn/5aL0lDCqWRmkUrTYGe56m4KLZAJyj+Nxqy3+NjPt/sQmkg1HQA/itjhbNujB2s85dhjQ==
+"@flopflip/react-broadcast@12.2.0":
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/@flopflip/react-broadcast/-/react-broadcast-12.2.0.tgz#21a2eb46f9c0b582ea517ef1900d66d32ec55784"
+  integrity sha512-9aP85Zbz64tAAt2GNeogsnnXhd+NaGf2z6unxDtjjeOzxhXCCKQiEPsvHcT4stoblX092h5NLAnpyMhAdHktjw==
   dependencies:
     "@babel/runtime" "7.12.5"
-    "@flopflip/react" "^11.1.10"
+    "@flopflip/react" "^11.1.11"
     "@flopflip/types" "4.1.10"
 
-"@flopflip/react@^11.1.10":
-  version "11.1.10"
-  resolved "https://registry.yarnpkg.com/@flopflip/react/-/react-11.1.10.tgz#6a360e9687636575dc833204e28743f7a6f67f38"
-  integrity sha512-OhXozGy9XabsOBaAXV7+BMBZ53CeoDKlhNJWj/LLGmi9Opqm7ke1mkgjoYmvDWmGGqKWz2Gu89ELQZpc/WbreA==
+"@flopflip/react@^11.1.11":
+  version "11.1.11"
+  resolved "https://registry.yarnpkg.com/@flopflip/react/-/react-11.1.11.tgz#a3b03f97eb394b730f25a502f9f0c6cc0ad3646b"
+  integrity sha512-FD5AVzm06HpOvLL+mMRKfx7J5HLTXQpmSaTAlLWEyFcYa+ktO5sCzwU5ft8M1cGH8GpL/6Y8Yh0a1/x/Po6NLw==
   dependencies:
     "@babel/runtime" "7.12.5"
     "@flopflip/types" "4.1.10"


### PR DESCRIPTION
#### Summary

This pull request refactors our test-utils to use the new `TestProviderFlopFlip`.

#### Description

The mentioned provider reduces the amount of complexity for the test setup:

1. No more `memory-adapter` and `reset` on each tets
2. No "async" state of flags which leak into tests (wait until flags are flushed otherwise act warnings)