### PR TITLE
refactor(jest): remove jest-watch-master plugin

### DIFF
--- a/.changeset/three-rabbits-rest.md
+++ b/.changeset/three-rabbits-rest.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/jest-preset-mc-app': patch
+---
+
+Remove `jest-watch-master` plugin, as it defaults to the `master` branch.

--- a/jest.eslint.config.js
+++ b/jest.eslint.config.js
@@ -11,5 +11,5 @@ module.exports = {
     'generated',
   ],
   testMatch: ['<rootDir>/**/*.js', '<rootDir>/**/*.ts', '<rootDir>/**/*.tsx'],
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-master'],
+  watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/jest.stylelint.config.js
+++ b/jest.stylelint.config.js
@@ -19,5 +19,5 @@ module.exports = {
     '<rootDir>/packages/**/*.js',
     '<rootDir>/website/**/*.js',
   ],
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-master'],
+  watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/jest.text.config.js
+++ b/jest.text.config.js
@@ -4,5 +4,5 @@ module.exports = {
   moduleFileExtensions: ['md', 'mdx'],
   modulePathIgnorePatterns: ['build', 'dist', 'public/', 'CHANGELOG.md'],
   testMatch: ['<rootDir>/website/**/*.md', '<rootDir>/website/**/*.mdx'],
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-master'],
+  watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/jest.visual.config.js
+++ b/jest.visual.config.js
@@ -5,5 +5,5 @@ module.exports = {
   testRegex: './*\\.visualspec\\.ts$',
   transform: jestPresetForTypescript.transform,
   globals: jestPresetForTypescript.globals,
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-master'],
+  watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -36,5 +36,5 @@ module.exports = {
     '^.+\\.js$': resolveRelativePath('./transform-babel-jest.js'),
     '^.+\\.graphql$': 'jest-transform-graphql',
   },
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-master'],
+  watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -36,7 +36,6 @@
     "jest-localstorage-mock": "2.4.6",
     "jest-silent-reporter": "0.4.0",
     "jest-transform-graphql": "2.1.0",
-    "jest-watch-master": "1.0.0",
     "jest-watch-typeahead": "0.6.1",
     "make-plural": "6.2.2",
     "pkg-dir": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18417,13 +18417,6 @@ jest-validate@^26.6.2:
     leven "^3.1.0"
     pretty-format "^26.6.2"
 
-jest-watch-master@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jest-watch-master/-/jest-watch-master-1.0.0.tgz#b00e18879b281ec2477ebb98a485a3e13baa9497"
-  integrity sha512-k5cGkA9uHkPkBkLyOC6BWjhmqQay0Bm/yQdERNN3myaeSJhfSpjQ0YtLjanpNajv6WljrNjPx+5orPgiZhpkDw==
-  dependencies:
-    chalk "^2.0.0"
-
 jest-watch-typeahead@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.6.1.tgz#45221b86bb6710b7e97baaa1640ae24a07785e63"


### PR DESCRIPTION
We don't really need this, especially when we switch the branch to `main`.