### PR TITLE
refactor: to rename to enableLongLivedFeatureFlags

### DIFF
--- a/.changeset/cuddly-kangaroos-hope.md
+++ b/.changeset/cuddly-kangaroos-hope.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/application-shell": patch
+"@commercetools-frontend/constants": patch
+---
+
+Rename to `enableFeatureConfigurationFetching` to `enableLongLivedFeatureFlags`

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -83,8 +83,8 @@ const parseFlags = (fetchedFlags: TFetchedFlags): TParsedHttpAdapterFlags =>
 
 export const SetupFlopFlipProvider = (props: Props) => {
   const apolloClient = useApolloClient();
-  const enableFeatureConfigurationFetching = useApplicationContext(
-    (context) => context.environment.enableFeatureConfigurationFetching
+  const enableLongLivedFeatureFlags = useApplicationContext(
+    (context) => context.environment.enableLongLivedFeatureFlags
   );
   const allMenuFeatureToggles = useAllMenuFeatureToggles();
   const flags = React.useMemo(
@@ -96,12 +96,12 @@ export const SetupFlopFlipProvider = (props: Props) => {
     [allMenuFeatureToggles.allFeatureToggles, props.flags]
   );
   React.useMemo(() => {
-    if (enableFeatureConfigurationFetching) {
+    if (enableLongLivedFeatureFlags) {
       combineAdapters.combine([ldAdapter, httpAdapter]);
     } else {
       combineAdapters.combine([ldAdapter]);
     }
-  }, [enableFeatureConfigurationFetching]);
+  }, [enableLongLivedFeatureFlags]);
 
   const defaultFlags = React.useMemo(
     () => ({

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -166,7 +166,7 @@ export interface ApplicationWindow extends Window {
     trackingSentry?: string;
     trackingGtm?: string;
     enableSignUp?: boolean;
-    enableFeatureConfigurationFetching?: boolean;
+    enableLongLivedFeatureFlags?: boolean;
     useFullRedirectsForLinks?: boolean;
     // Properties for OIDC-like workflow for development
     __DEVELOPMENT__?: ApplicationOidcForDevelopmentConfig;


### PR DESCRIPTION
#### Summary

This pull request suggests to rename `enableFeatureConfigurationFetching` to `enableLongLivedFeatureFlags`.

#### Description

While integrating this feature it became apparent that we will now naturally distinguish between short-lived flags (through LaunchDarkly) and long-running flags (through our GraphQL API).

This also means that we can keep this environment variable. Custom Applications will not have to fetch our long-running flags while they could (if e.g. an internal app) as an opt-in.

As a result, I think it makes sense to enable this with a more descriptive environment variable which indicates more clearly what it will cause.

<hr />

As a follow-up we can also discuss with we should have a `enableShortLivedFeatureFlags`. This would mean that Custom Applications would not receive feature flags from LaunchDarkly. Which could be nice as long as we do not use feature flags on the menu or we accept inconsistencies from Custom Applications with internal applications being under development. Note, that all internal applications can be hidden on a network layer (proxy) these days.