### PR TITLE
fix: release to fix from main by default

### DIFF
--- a/.changeset/nervous-cameras-visit.md
+++ b/.changeset/nervous-cameras-visit.md
@@ -1,0 +1,6 @@
+---
+'merchant-center-application-template-starter': patch
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Release to pull from main branch by default


### PR DESCRIPTION
#### Summary

This pull request releases the create-mc-app and template package to fix an issue caused by moving to `main` as a default branch. We forgot to publish when performing that change. As `master` doesn't exist anymore pulling and installing fails at the moment.

- Closes #2035