### PR TITLE
Fix application kit Github discussion link.

### DIFF
--- a/website/src/content/help-needed.mdx
+++ b/website/src/content/help-needed.mdx
@@ -12,7 +12,7 @@ This page documents known and recurring challenges with Custom Applications and 
 
 Something is not working as expected? Do you need general guidance? Do you have a technical question or are you simply looking for some advice?
 
-We strongly encourage and recommend to use [GitHub Discussions]([application-kit](https://github.com/commercetools/merchant-center-application-kit/discussions)) as a way of communicating with us (commercetools) and with the community. You can ask questions, share ideas, showcase your work, etc.
+We strongly encourage and recommend to use [GitHub Discussions](https://github.com/commercetools/merchant-center-application-kit/discussions) as a way of communicating with us (commercetools) and with the community. You can ask questions, share ideas, showcase your work, etc.
 
 Additionally, we also recommend checking for existing [GitHub Issues](https://github.com/commercetools/merchant-center-application-kit/issues) about similar problems you might have or [opening a new one](https://github.com/commercetools/merchant-center-application-kit/issues/new/choose).
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->
Application kit repo Github Discussion link is broken on the [docs](https://docs.commercetools.com/custom-applications/help-needed).
![image](https://user-images.githubusercontent.com/1124415/106788091-ceed3100-6650-11eb-8f85-61aad8212f81.png)

#### Description

Updated the Application kit repository Github Discussion link. 

