### PR TITLE
docs(contrib): update graphql files section to correct config files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Note that canary releases **will not create git tags and version bump commits**.
 
 In order to be able to validate GraphQL queries and mutations, defined as `.graphql` files, we use the [eslint-plugin-graphql](https://github.com/apollographql/eslint-plugin-graphql), which requires **introspection schemas** from the different GraphQL APIs being used.
 
-To download the remote schemas simply run `yarn get-schemas`. The configuration of each schema is defined in the `.graphqlconfig.yml` file, in the root directory. Running this script will download the schemas in the `schemas/*.json` files.
+To download the remote schemas simply run `yarn generate-types`. The configuration of each schema is defined in the `.graphqlrc.yml` file, in the root directory. Running this script will download the schemas in the `schemas/*.json` files.
 
 > NOTE that you need your user `mcAccessToken` to be defined as an environment variable `MC_ACCESS_TOKEN` in `.env` file. This will be used by the introspection queries to be able to download the schemas from the MC API. Additionally, you also need to specify one of your `CTP_PROJECT_KEY` where you have access to.
 
@@ -172,7 +172,7 @@ Since the MC uses multiple GraphQL APIs, we need to differentiate which queries 
 - **ctp**: instead of `.graphql` use `*.ctp.graphql` (_graphql target: `ctp`_)
 - **proxy**: instead of `.graphql` use `*.proxy.graphql` (_API in the MC frontend apps_)
 
-The regex to match the files to each project schema are defiend in the `.graphqlconfig.yml` file.
+The regex to match the files to each project schema are defined in the `.graphqlrc.yml` file.
 
 ## Visual Studio Code recommended workspace
 


### PR DESCRIPTION
#### Summary

- point to the correct yarn script command
- use `.graphqlrc.yml`