### PR TITLE
fix(components): remove unnecessary apollo client dependency

### DIFF
--- a/.changeset/lovely-suns-drive.md
+++ b/.changeset/lovely-suns-drive.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Remove unused `@apollo/client` dependency (leftover from removing the experimental package)

--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -31,7 +31,6 @@
     "prepare": "./../../scripts/version.js replace"
   },
   "dependencies": {
-    "@apollo/client": "3.3.8",
     "@babel/runtime": "7.12.13",
     "@babel/runtime-corejs3": "7.12.13",
     "@commercetools-frontend/application-shell-connectors": "18.4.0",


### PR DESCRIPTION
I guess this was a leftover from removing the "experimental" entry point from the components package.