### PR TITLE
fix(sdk/middleware): support `apply` endpoint for `orderEdits`

### DIFF
--- a/.changeset/breezy-taxis-tie.md
+++ b/.changeset/breezy-taxis-tie.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/sdk': minor
+---
+
+support order/edits/apply in sdk/middleware

--- a/@types/commercetools__api-request-builder/index.d.ts
+++ b/@types/commercetools__api-request-builder/index.d.ts
@@ -1,6 +1,10 @@
 declare module '@commercetools/api-request-builder' {
+  type TUriOptions = {
+    withProjectKey?: boolean;
+    applyOrderEdit?: boolean;
+  };
   export type ServiceBuilder = {
-    build(): string;
+    build(uriOptions?: TUriOptions): string;
     parse(options: { [key: string]: unknown }): string;
   };
   export type ApiRequestBuilder = {

--- a/packages/sdk/src/middleware/middleware.spec.ts
+++ b/packages/sdk/src/middleware/middleware.spec.ts
@@ -283,6 +283,87 @@ describe('when the action is of type SDK', () => {
     });
   });
 
+  describe('when `service=orderEdits` and `applyOrderEditTo`', () => {
+    const dispatch = jest.fn();
+    const orderId = 'order-to-edit-id-1';
+    const action = sdkActions.post({
+      service: 'orderEdits',
+      options: { applyOrderEditTo: orderId },
+      payload: {},
+    });
+    const next = jest.fn();
+    const response = { body: { foo: 'bar' }, headers: {}, statusCode: 200 };
+    beforeEach(() => {
+      execute = jest.fn(() => Promise.resolve(response));
+      mocked(createClient).mockReturnValue({
+        execute,
+      });
+      resultPromise = createMiddleware(middlewareOptions)({
+        dispatch,
+        getState: jest.fn(),
+      })(next)(action);
+    });
+    it('should return the result the update', async () => {
+      await expect(resultPromise).resolves.toBe(response.body);
+    });
+    it('should call `client.execute`', () => {
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+    it('should call `client.execute` with uri, method, headers and body', () => {
+      expect(execute).toHaveBeenCalledWith({
+        // https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/create-service.js#L141:L141
+        // https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/build-query-string.js#L123:L123
+        uri: `/test-project/orders/edits/${orderId}/apply`,
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'X-Project-Key': 'test-project',
+        }),
+        body: expect.any(Object),
+      });
+    });
+  });
+  describe('when `service=orderEdits` and no `applyOrderEditTo`', () => {
+    const dispatch = jest.fn();
+    const orderId = 'order-to-edit-id-1';
+    const action = sdkActions.post({
+      service: 'orderEdits',
+      options: { id: orderId },
+      payload: {},
+    });
+    const next = jest.fn();
+    const response = { body: { foo: 'bar' }, headers: {}, statusCode: 200 };
+    beforeEach(() => {
+      execute = jest.fn(() => Promise.resolve(response));
+      mocked(createClient).mockReturnValue({
+        execute,
+      });
+      resultPromise = createMiddleware(middlewareOptions)({
+        dispatch,
+        getState: jest.fn(),
+      })(next)(action);
+    });
+    it('should return the result the update', async () => {
+      await expect(resultPromise).resolves.toBe(response.body);
+    });
+    it('should call `client.execute`', () => {
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+    it('should call `client.execute` with uri, method, headers and body', () => {
+      expect(execute).toHaveBeenCalledWith({
+        // https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/create-service.js#L141:L141
+        // https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/build-query-string.js#L123:L123
+        uri: `/test-project/orders/edits/${orderId}`,
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'X-Project-Key': 'test-project',
+        }),
+        body: expect.any(Object),
+      });
+    });
+  });
+
   describe('when the method is "post"', () => {
     const dispatch = jest.fn();
     const action = sdkActions.post({

--- a/packages/sdk/src/middleware/middleware.ts
+++ b/packages/sdk/src/middleware/middleware.ts
@@ -37,7 +37,17 @@ const actionToUri = (action: TSdkAction, projectKey?: string): string => {
   const service = requestBuilder[action.payload.service];
   if (action.payload.options) service.parse(action.payload.options);
 
-  return service.build();
+  return service.build({
+    // given `service=orderEdits` and given `applyOrderEditTo`, we build an apply endpoint
+    // given `service=orderEdits` and no `applyOrderEditTo`, we build an update endpoint
+    // https://docs.commercetools.com/api/projects/order-edits
+    applyOrderEdit:
+      action.payload.service === 'orderEdits' &&
+      typeof action.payload.options?.applyOrderEditTo === 'string',
+
+    // at this stage, the `projectKey` should be available already.
+    withProjectKey: true,
+  });
 };
 
 // Force TS cast of generic action to TNotificationAction

--- a/packages/sdk/src/middleware/middleware.ts
+++ b/packages/sdk/src/middleware/middleware.ts
@@ -20,6 +20,9 @@ const isSdkActionForUri = (
 ): actionPayload is TSdkActionPayloadForUri =>
   (actionPayload as TSdkActionPayloadForUri).uri !== undefined;
 
+// https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/default-services.js#L200:L200
+const ORDER_EDIT_SERVICE = 'orderEdits';
+
 const actionToUri = (action: TSdkAction, projectKey?: string): string => {
   if (isSdkActionForUri(action.payload)) return action.payload.uri;
 
@@ -42,9 +45,8 @@ const actionToUri = (action: TSdkAction, projectKey?: string): string => {
     // given `service=orderEdits` and no `applyOrderEditTo`, we build an update endpoint
     // https://docs.commercetools.com/api/projects/order-edits
     applyOrderEdit:
-      action.payload.service === 'orderEdits' &&
+      action.payload.service === ORDER_EDIT_SERVICE &&
       typeof action.payload.options?.applyOrderEditTo === 'string',
-
     // at this stage, the `projectKey` should be available already.
     withProjectKey: true,
   });


### PR DESCRIPTION
#### Summary

-  support `apply` endpoint for `orderEdits`
- closes #2058

#### Description

In `sdk/middleware`, we `build()` request [for the respective service](https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/default-services.js#L1:L1) in `sdk`.

It turned out that the `service.build()` is coupled to an option for `orderEdits` that determines whether an `order/edits/${id}/apply` endpoint should be build.

Here is how we reason when building the `order/edits/${id}/apply` endpoint in `sdk/middleware`:

- GIVEN that `service=orderEdits` and `applyOrderEditTo` has a value: [we build the apply endpoint](https://docs.commercetools.com/api/projects/order-edits#apply-an-orderedit)
- GIVEN that `service=orderEdits` and `applyOrderEditTo` has no value: [we build the update endpoint](https://docs.commercetools.com/api/projects/order-edits#update-orderedit-by-id)

