### PR TITLE
fix(webpack): to pass parallelism to thread-loader

### DIFF
--- a/.changeset/swift-pandas-punch.md
+++ b/.changeset/swift-pandas-punch.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-scripts": patch
+---
+
+fix(webpack): to pass parallelism to thread-loader

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -416,6 +416,9 @@ module.exports = function createWebpackConfigForProduction(options = {}) {
             {
               loader: require.resolve('babel-loader'),
               options: {
+                ...(Number.isInteger(mergedOptions.toggleFlags.parallelism)
+                  ? { workers: mergedOptions.toggleFlags.parallelism }
+                  : {}),
                 babelrc: false,
                 configFile: false,
                 compact: false,


### PR DESCRIPTION
#### Summary

Internally CircleCI fails at times. The assumption is that it doesn't report the CPUs right. We already pass this value to Terser for the same reason. We now would also pass it to the thread lower to limit the CPUs used.