### PR TITLE
fix: vrt timeouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Running Visual Regression Tests for UI components
         uses: ianwalter/puppeteer-container@v4.0.0
+        timeout-minutes: 20
         with:
           args: "yarn vrt:components"
         env:

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,5 +6,6 @@ module.exports = {
   server: {
     command: 'yarn visual-testing-app:serve',
     port: 3001,
+    launchTimeout: 10000,
   },
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pretest:watch": "yarn compile-intl",
     "test": "jest --config jest.test.config.js",
     "test:watch": "jest --config jest.test.config.js --watch",
-    "test:visual": "jest --config jest.visual.config.js --runInBand",
+    "test:visual": "jest --config jest.visual.config.js --runInBand --testTimeout=10000",
     "test:e2e": "cypress run",
     "test:e2e:playground": "cypress run --spec cypress/integration/playground/**/*.js",
     "test:e2e:template-starter": "cypress run --spec cypress/integration/template-starter/**/*.js",


### PR DESCRIPTION
#### Summary

I noticed that the VRTs seem to timeout at times as percy is not responding. This is odd and causes GitHub jobs to run for 3 hours or more. Causing significant pressure on our time budget there.