### PR TITLE
chore: update typescript to 4.2.3

### DIFF
--- a/.changeset/shiny-toes-tan.md
+++ b/.changeset/shiny-toes-tan.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/application-shell": patch
+"@commercetools-backend/express": patch
+---
+
+chore: update typescript to 4.2.3

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
     "stylelint-value-no-unknown-custom-properties": "3.0.0",
-    "typescript": "4.1.5",
+    "typescript": "4.2.3",
     "vfile-message": "2.0.4"
   },
   "resolutions": {

--- a/packages-backend/express/package.json
+++ b/packages-backend/express/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "jose": "2.0.4",
-    "msw": "0.27.0"
+    "msw": "0.27.1"
   }
 }

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -102,7 +102,7 @@
     "@types/react-redux": "7.1.16",
     "@types/react-router": "5.1.12",
     "@types/react-router-dom": "5.1.7",
-    "msw": "0.27.0",
+    "msw": "0.27.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "5.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20874,10 +20874,10 @@ ms@^2.1.1, ms@^2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msw@0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/msw/-/msw-0.27.0.tgz#d944489e6e27b1ed8deef127fa6e3a9397ebe6d3"
-  integrity sha512-QoU8NiFrKA572Dw3hA1k2vxtPttnHANtn+gpp3TTUtYtEpThXUMsjzuYgkD1JouW83HK+io+xKCmxE5qCmgUzQ==
+msw@0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.27.1.tgz#9dad215cd53b8b1b5e9446aa586e20cc8e2e086a"
+  integrity sha512-oAhqvOTEX16DjMFoYZaI10KeiYMMCnQR8EcXEFu2KzA6khmUe9tSM0rDRyO/wvuMLffODgVRdSkjCId90yFyVw==
   dependencies:
     "@open-draft/until" "^1.0.3"
     "@types/cookie" "^0.4.0"
@@ -27874,10 +27874,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 typescript@^4.0:
   version "4.1.3"


### PR DESCRIPTION
#### Summary

To my memory only `msw` blocked this update. Let's see what CI says.