### PR TITLE
feat(l10n): update generate-data script

### DIFF
--- a/.changeset/ninety-donuts-tickle.md
+++ b/.changeset/ninety-donuts-tickle.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/l10n': minor
+---
+
+Update generate-l10n-data script to include Northern Ireland territory


### PR DESCRIPTION
#### Summary

The PR updates the  `generate-l10n-data` script of `l10n` package which is responsible for generating CLDR data. i.e. countries, currencies, timezones etc. 
Back in December 2020, we have to update manually the auto-generated file of countries data and add `Northern Ireland` to them. It was needed due to Brexit. Doing this was kinda of hot fix but it also blocks updating the `cldr` package.

The latest versions of CLDR data is still missing territory data for `Northern Ireland`. It seems that it might take a while for them to add this. You can check the discussion on https://github.com/commercetools/merchant-center-application-kit/pull/2054.

 In order to unblock the update of the `cldr` package and also avoid manual update of the auto-generated file by `generate-l10n-data` script, we would simply update the script and inject the `Northern Ireland` country code to the available countries and from the there the script will take care of it and add it to the auto-generated file by it self.

This PR also closes https://github.com/commercetools/merchant-center-application-kit/issues/1930
