### PR TITLE
fix(l10n/scripts): fix typo and locale name

### DIFF
--- a/packages/l10n/scripts/generate-l10n-data.js
+++ b/packages/l10n/scripts/generate-l10n-data.js
@@ -34,9 +34,9 @@ const getNorthernIrelandCountryCode = (locale) => {
       return { XI: 'Nordirland' };
     case 'es':
       return { XI: 'Irlanda del Norte' };
-    case 'fr-Fr':
+    case 'fr-FR':
       return { XI: 'Irlande du Nord' };
-    case 'zh-CN':
+    case 'zh_hans_cn':
       return { XI: '北爱尔兰' };
     case 'ja':
       return { XI: '北アイルランド' };


### PR DESCRIPTION
#### Summary

`generate-l10n-data.js` => fix typo in the french locale name and also fix the initial name for the Chinese locale 
