### PR TITLE
fix(express/auth): omit search params when reconstrucing audience URL

### DIFF
--- a/.changeset/few-snails-hunt.md
+++ b/.changeset/few-snails-hunt.md
@@ -2,4 +2,4 @@
 '@commercetools-backend/express': patch
 ---
 
-Fix issue with invalid `audience` in case the request contains query parameters.
+Fix issue with invalid JWT `aud` in case the request contains query string parameters. Now the constructed audience url omits the query string parameters.

--- a/.changeset/few-snails-hunt.md
+++ b/.changeset/few-snails-hunt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-backend/express': minor
+---
+
+update `getConfiguredAudience` with explicit return and not use `toString()`

--- a/.changeset/few-snails-hunt.md
+++ b/.changeset/few-snails-hunt.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-backend/express': minor
+'@commercetools-backend/express': patch
 ---
 
-update `getConfiguredAudience` with explicit return and not use `toString()`
+Fix issue with invalid `audience` in case the request contains query parameters.

--- a/packages-backend/express/src/auth.spec.js
+++ b/packages-backend/express/src/auth.spec.js
@@ -1,0 +1,76 @@
+import { getConfiguredAudience } from './auth';
+
+describe('getConfiguredAudience', () => {
+  let url;
+  let requestPath;
+  let search;
+  describe('when there is no `requestPath`', () => {
+    describe('when there is no `search`', () => {
+      beforeEach(() => {
+        url = 'https://example.com';
+        requestPath = '/';
+      });
+      it('should return `url`', () => {
+        expect(
+          getConfiguredAudience(
+            {
+              audience: url,
+            },
+            requestPath
+          )
+        ).toEqual(url);
+      });
+    });
+    describe('when there is `search`', () => {
+      beforeEach(() => {
+        search = '?hello=world';
+        url = `https://example.com${search}`;
+        requestPath = '/';
+      });
+      it('should return `url`', () => {
+        expect(
+          getConfiguredAudience(
+            {
+              audience: url,
+            },
+            requestPath
+          )
+        ).toEqual(url);
+      });
+    });
+  });
+  describe('when there is a `requestPath`', () => {
+    beforeEach(() => {
+      url = 'https://example.com';
+      requestPath = '/hello/world';
+    });
+    it('should return `url + requestPath`', () => {
+      expect(
+        getConfiguredAudience(
+          {
+            audience: url,
+          },
+          requestPath
+        )
+      ).toEqual('https://example.com/hello/world');
+    });
+    describe('when there is a `search`', () => {
+      beforeEach(() => {
+        search = '?hello=world';
+        // another-defined-path will be ignored
+        url = `https://example.com/another-defined-path${search}`;
+        requestPath = '/hello/world';
+      });
+      it('should rturn `url + requestPath + search`', () => {
+        expect(
+          getConfiguredAudience(
+            {
+              audience: url,
+            },
+            requestPath
+          )
+        ).toEqual(`https://example.com${requestPath}${search}`);
+      });
+    });
+  });
+});

--- a/packages-backend/express/src/auth.spec.js
+++ b/packages-backend/express/src/auth.spec.js
@@ -1,56 +1,21 @@
 import { getConfiguredAudience } from './auth';
 
 describe('getConfiguredAudience', () => {
-  let url;
-  let requestPath;
-  describe('when there is no `requestPath`', () => {
-    beforeEach(() => {
-      url = 'https://example.com';
-      requestPath = '/';
-    });
-    it('should return `url`', () => {
-      expect(
-        getConfiguredAudience(
-          {
-            audience: url,
-          },
-          requestPath
-        )
-      ).toEqual(url);
-    });
-  });
-  describe('when there is a `requestPath`', () => {
-    beforeEach(() => {
-      url = 'https://example.com';
-      requestPath = '/hello/world';
-      url = 'https://example.com';
-      requestPath = '/hello/world';
-    });
-    it('should return `url + requestPath`', () => {
-      expect(
-        getConfiguredAudience(
-          {
-            audience: url,
-          },
-          requestPath
-        )
-      ).toEqual('https://example.com/hello/world');
-    });
-    describe('with trailing slash on `options.audience`', () => {
-      beforeEach(() => {
-        url = 'https://example.com/';
-        requestPath = '/hello/world';
-      });
-      it('should return `url + requestPath`', () => {
+  describe.each`
+    audienceOriginUrl         | requestPath               | expectedAudienceUrl
+    ${'https://example.com'}  | ${'/'}                    | ${'https://example.com'}
+    ${'https://example.com'}  | ${'/hello/world'}         | ${'https://example.com/hello/world'}
+    ${'https://example.com/'} | ${'/'}                    | ${'https://example.com'}
+    ${'https://example.com/'} | ${'/hello/world'}         | ${'https://example.com/hello/world'}
+    ${'https://example.com'}  | ${'/hello/world?foo=bar'} | ${'https://example.com/hello/world'}
+  `(
+    'with audience "$audienceOriginUrl" and request path "$requestPath"',
+    ({ audienceOriginUrl, requestPath, expectedAudienceUrl }) => {
+      it(`should construct audience url as "${expectedAudienceUrl}"`, () => {
         expect(
-          getConfiguredAudience(
-            {
-              audience: url,
-            },
-            requestPath
-          )
-        ).toEqual('https://example.com/hello/world');
+          getConfiguredAudience({ audience: audienceOriginUrl }, requestPath)
+        ).toEqual(expectedAudienceUrl);
       });
-    });
-  });
+    }
+  );
 });

--- a/packages-backend/express/src/auth.spec.js
+++ b/packages-backend/express/src/auth.spec.js
@@ -23,6 +23,8 @@ describe('getConfiguredAudience', () => {
     beforeEach(() => {
       url = 'https://example.com';
       requestPath = '/hello/world';
+      url = 'https://example.com';
+      requestPath = '/hello/world';
     });
     it('should return `url + requestPath`', () => {
       expect(
@@ -33,6 +35,22 @@ describe('getConfiguredAudience', () => {
           requestPath
         )
       ).toEqual('https://example.com/hello/world');
+    });
+    describe('with trailing slash on `options.audience`', () => {
+      beforeEach(() => {
+        url = 'https://example.com/';
+        requestPath = '/hello/world';
+      });
+      it('should return `url + requestPath`', () => {
+        expect(
+          getConfiguredAudience(
+            {
+              audience: url,
+            },
+            requestPath
+          )
+        ).toEqual('https://example.com/hello/world');
+      });
     });
   });
 });

--- a/packages-backend/express/src/auth.spec.js
+++ b/packages-backend/express/src/auth.spec.js
@@ -3,40 +3,20 @@ import { getConfiguredAudience } from './auth';
 describe('getConfiguredAudience', () => {
   let url;
   let requestPath;
-  let search;
   describe('when there is no `requestPath`', () => {
-    describe('when there is no `search`', () => {
-      beforeEach(() => {
-        url = 'https://example.com';
-        requestPath = '/';
-      });
-      it('should return `url`', () => {
-        expect(
-          getConfiguredAudience(
-            {
-              audience: url,
-            },
-            requestPath
-          )
-        ).toEqual(url);
-      });
+    beforeEach(() => {
+      url = 'https://example.com';
+      requestPath = '/';
     });
-    describe('when there is `search`', () => {
-      beforeEach(() => {
-        search = '?hello=world';
-        url = `https://example.com${search}`;
-        requestPath = '/';
-      });
-      it('should return `url`', () => {
-        expect(
-          getConfiguredAudience(
-            {
-              audience: url,
-            },
-            requestPath
-          )
-        ).toEqual(url);
-      });
+    it('should return `url`', () => {
+      expect(
+        getConfiguredAudience(
+          {
+            audience: url,
+          },
+          requestPath
+        )
+      ).toEqual(url);
     });
   });
   describe('when there is a `requestPath`', () => {
@@ -53,24 +33,6 @@ describe('getConfiguredAudience', () => {
           requestPath
         )
       ).toEqual('https://example.com/hello/world');
-    });
-    describe('when there is a `search`', () => {
-      beforeEach(() => {
-        search = '?hello=world';
-        // another-defined-path will be ignored
-        url = `https://example.com/another-defined-path${search}`;
-        requestPath = '/hello/world';
-      });
-      it('should rturn `url + requestPath + search`', () => {
-        expect(
-          getConfiguredAudience(
-            {
-              audience: url,
-            },
-            requestPath
-          )
-        ).toEqual(`https://example.com${requestPath}${search}`);
-      });
     });
   });
 });

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -110,9 +110,9 @@ const getConfiguredAudience = (
 ) => {
   const url = new URL(options.audience);
   if (requestPath !== '/') {
-    url.pathname = requestPath;
+    return `${url.origin}${requestPath}${url.search}`;
   }
-  return url.toString();
+  return `${url.origin}${url.search}`;
 };
 
 function createSessionAuthVerifier<

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -108,11 +108,12 @@ export const getConfiguredAudience = (
   options: TSessionMiddlewareOptions,
   requestPath: string
 ) => {
-  const url = new URL(options.audience);
-  if (requestPath !== '/') {
-    return `${url.origin}${requestPath}`;
+  // remove the trailing slash
+  const url = new URL(`${options.audience.replace(/\/?$/, '')}${requestPath}`);
+  if (requestPath === '/') {
+    return url.origin;
   }
-  return url.origin;
+  return `${url.origin}${url.pathname}`;
 };
 
 function createSessionAuthVerifier<

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -104,7 +104,7 @@ const getConfiguredDefaultIssuer = (options: TSessionMiddlewareOptions) => {
 // Construct the audience from the given option + the request path.
 // If the request path is `/`, do not append it to the audience, otherwise
 // the token validation might fail because of mismatching audiences.
-const getConfiguredAudience = (
+export const getConfiguredAudience = (
   options: TSessionMiddlewareOptions,
   requestPath: string
 ) => {

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -110,9 +110,9 @@ export const getConfiguredAudience = (
 ) => {
   const url = new URL(options.audience);
   if (requestPath !== '/') {
-    return `${url.origin}${requestPath}${url.search}`;
+    return `${url.origin}${requestPath}`;
   }
-  return `${url.origin}${url.search}`;
+  return url.origin;
 };
 
 function createSessionAuthVerifier<


### PR DESCRIPTION
Ref #2115 

Fix issue with invalid `audience` in case the request contains query parameters.

We now omit the search params when validating the audience (PR in MC API also needs to be merged first).