### PR TITLE
chore(package): add script to install canary version of ui-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "generate-types:settings": "./scripts/graphql-cli.sh codegen --project settings",
     "generate-types:proxy": "./scripts/graphql-cli.sh codegen --project proxy",
     "generate-types": "yarn generate-types:mc && yarn generate-types:ctp && yarn generate-types:settings && yarn generate-types:proxy",
+    "canary:uikit": "manypkg upgrade @commercetools-uikit canary",
     "versions:uikit": "manypkg upgrade @commercetools-uikit",
     "versions:docskit": "manypkg upgrade @commercetools-docs"
   },


### PR DESCRIPTION
#### Summary

Something I discovered we could do, in conjunction with the v12 migration of UI-kit.
I thought we should save the command under `scripts`