### PR TITLE
feat(test-utils): add renderHook wrapper

### DIFF
--- a/.changeset/heavy-ligers-admire.md
+++ b/.changeset/heavy-ligers-admire.md
@@ -2,4 +2,25 @@
 '@commercetools-frontend/application-shell': minor
 ---
 
-feat(test-utils): add wrapped renderHook util
+Re-export `@testing-library/react-hooks` from `test-utils` with `renderHook` functions wrapped in all the app-kit providers.
+
+`renderHooks` is wrapped the same way the existing `renderAppWithRedux` helper is:
+
+- all the `options` which can be passed to `renderAppWithRedux`can be passed to `renderHooks` as well
+- all the additional poperties returned as a result of `renderAppWithRedux` invokation (like `store` or `history`) is returend from the wrapped `renderHooks` too.
+
+All the `@testing-library/react-hooks` content is exported under the namespace `hooks` from the package '@commercetools-frontend/application-shell/test-utils'.
+
+**Usage example**
+
+```jsx
+import { hooks } from '@commercetools-frontend/application-shell/test-utils';
+
+const { act, renderHook } = hooks;
+
+it('should navigate to a route', () => {
+  const { result, history } = renderHook(useRoutes);
+  act(() => result.current.someRoute.go());
+  expect(history.location.pathname).toBe('/some-route');
+});
+```

--- a/.changeset/heavy-ligers-admire.md
+++ b/.changeset/heavy-ligers-admire.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+feat(test-utils): add wrapped renderHook util

--- a/.changeset/heavy-ligers-admire.md
+++ b/.changeset/heavy-ligers-admire.md
@@ -2,14 +2,14 @@
 '@commercetools-frontend/application-shell': minor
 ---
 
-Re-export `@testing-library/react-hooks` from `test-utils` with `renderHook` functions wrapped in all the app-kit providers.
+Adds re-export of `@testing-library/react-hooks` from `test-utils` with `renderHook` functions wrapped with app-kit providers.
 
-`renderHooks` is wrapped the same way the existing `renderAppWithRedux` helper is:
+The `renderHook` function is wrapped similarily to the existing `renderAppWithRedux`:
 
-- all the `options` which can be passed to `renderAppWithRedux`can be passed to `renderHooks` as well
-- all the additional poperties returned as a result of `renderAppWithRedux` invokation (like `store` or `history`) is returend from the wrapped `renderHooks` too.
+- All `options` which can be passed to `renderAppWithRedux` can be passed to `renderHooks`
+- All additional poperties returned as a result of an `renderAppWithRedux` call (like `store` or `history`) are returend from the wrapped `renderHook` too
 
-All the `@testing-library/react-hooks` content is exported under the namespace `hooks` from the package '@commercetools-frontend/application-shell/test-utils'.
+All `@testing-library/react-hooks` functionality is exported under the namespace `hooks` from the package '@commercetools-frontend/application-shell/test-utils'.
 
 **Usage example**
 

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -101,6 +101,7 @@
   "devDependencies": {
     "@apollo/client": "3.3.14",
     "@testing-library/react": "11.2.6",
+    "@testing-library/react-hooks": "5.1.1",
     "msw": "0.28.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -113,6 +114,7 @@
   "peerDependencies": {
     "@apollo/client": "3.x",
     "@testing-library/react": "11.x",
+    "@testing-library/react-hooks": "5.x",
     "react": "17.x",
     "react-dom": "17.x",
     "react-intl": "5.x",

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -685,9 +685,9 @@ function renderHook<
     ...options,
     // eslint-disable-next-line react/display-name
     wrapper: ({ children }) => (
-      <ReduxProviders>
-        <ApplicationProviders>{children}</ApplicationProviders>
-      </ReduxProviders>
+      <ApplicationProviders>
+        <ReduxProviders>{children}</ReduxProviders>
+      </ApplicationProviders>
     ),
   });
 

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -629,10 +629,7 @@ export type TRenderHookOptions<
   RenderedHookProps,
   AdditionalEnvironmentProperties = {},
   StoreState = {}
-> = Omit<
-  TRenderAppWithReduxOptions<AdditionalEnvironmentProperties, StoreState>,
-  'disableApolloMocks'
-> &
+> = TRenderAppWithReduxOptions<AdditionalEnvironmentProperties, StoreState> &
   rtlHooks.RenderHookOptions<RenderedHookProps>;
 
 export type TRenderHookResult<
@@ -676,10 +673,7 @@ function renderHook<
     mergedProject,
     mergedEnvironment,
     history,
-  } = createApplicationProviders({
-    ...options,
-    disableApolloMocks: true,
-  });
+  } = createApplicationProviders(options);
 
   const rendered = rtlHooks.renderHook(callback, {
     ...options,
@@ -706,4 +700,10 @@ function renderHook<
 // re-export everything
 export * from '@testing-library/react';
 
-export { renderApp, renderAppWithRedux, renderHook };
+// namespace for hooks related helpers
+const hooks = {
+  ...rtlHooks,
+  renderHook,
+};
+
+export { renderApp, renderAppWithRedux, hooks };

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -656,13 +656,13 @@ function renderHook<
   StoreState = {}
 >(
   callback: (props: RenderedHookProps) => RenderedHookResult,
-  options?: Partial<
+  options: Partial<
     TRenderHookOptions<
       RenderedHookProps,
       AdditionalEnvironmentProperties,
       StoreState
     >
-  >
+  > = {}
 ): TRenderHookResult<
   RenderedHookProps,
   RenderedHookResult,
@@ -686,7 +686,9 @@ function renderHook<
     // eslint-disable-next-line react/display-name
     wrapper: ({ children }) => (
       <ApplicationProviders>
-        <ReduxProviders>{children}</ReduxProviders>
+        <ReduxProviders>
+          {wrapIfNeeded(children, options.wrapper)}
+        </ReduxProviders>
       </ApplicationProviders>
     ),
   });


### PR DESCRIPTION
The more logic we move to hooks in MC the more we observe the need to pass a `wrapper` combined from all the `application-shell` providers used by a hook under test in `renderHook` function in corresponding tests. For instance, whenever we want to test a hook which use Apollo under the hood, we have to wrap rendered hook in `<ApolloProvider />`. When testing logic related to tracking we wrap everything in `<GtmContext.Provider />`. And so on. 

Given that our `renderApp*` functions from `test-utils` already nicely mock all the providers one option is to test hooks via these `render*` function and not rely on `renderHooks`. Add people do it indeed. But that's not really nice, because of all the boilerplate needed to map hook inputs/outputs to a wrapping test component, so that it can be checked via rtl assertions.

Why not provide our own custom `renderHooks` wrapped in all the mocked providers in the same fashion we do with `renderApp*` utils and get rid off all the boilerplate?

That's basically what this PR is about. =)