### PR TITLE
feat(mc-scripts): add support for webpack config extensions

### DIFF
--- a/.changeset/ninety-ravens-beam.md
+++ b/.changeset/ninety-ravens-beam.md
@@ -1,7 +1,9 @@
 ---
-"@commercetools-frontend/mc-scripts": patch
+"@commercetools-frontend/eslint-config-mc-app": minor
+"@commercetools-frontend/jest-preset-mc-app": minor
+"@commercetools-frontend/mc-scripts": minor
 ---
 
-Add support for webpack configurations with different file extensions.
+Adds support for the `*.mjs` and `*.cjs` JavaScript file extensions.
 
-Previously webpack configurations could only have the `.js` extension. In order to support ES modules we now also support the `*.cjs` extension.
+Updates the webpack configurations, Jest and ESLint presets to support the `*.mjs` and `*.cjs` extensions. This allows better integration with packages using ES modules.

--- a/.changeset/ninety-ravens-beam.md
+++ b/.changeset/ninety-ravens-beam.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/mc-scripts": patch
+---
+
+Add support for webpack configurations with different file extensions.
+
+Previously webpack configurations could only have the `.js` extension. In order to support ES modules we now also support the `*.cjs` extension.

--- a/packages/eslint-config-mc-app/helpers/eslint.js
+++ b/packages/eslint-config-mc-app/helpers/eslint.js
@@ -3,5 +3,6 @@ const statusCode = {
   warn: 'warn',
   off: 'off',
 };
+const allSupportedExtensions = ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx'];
 
-module.exports = { statusCode };
+module.exports = { statusCode, allSupportedExtensions };

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -1,4 +1,4 @@
-const { statusCode } = require('./helpers/eslint');
+const { statusCode, allSupportedExtensions } = require('./helpers/eslint');
 const hasJsxRuntime = require('./helpers/has-jsx-runtime');
 
 module.exports = {
@@ -28,13 +28,6 @@ module.exports = {
     // https://github.com/prettier/prettier-eslint
     'prettier',
   ],
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.mjs', '.cjs'],
-      },
-    },
-  },
   rules: {
     // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
     'no-unused-expressions': 0,
@@ -80,6 +73,13 @@ module.exports = {
       'react/jsx-uses-react': statusCode.off,
       'react/react-in-jsx-scope': statusCode.off,
     }),
+  },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: allSupportedExtensions,
+      },
+    },
   },
   overrides: [
     {
@@ -127,7 +127,7 @@ module.exports = {
           'eslint-import-resolver-typescript': true,
           typescript: {},
           node: {
-            extensions: ['.js', '.jsx', '.ts', '.tsx'],
+            extensions: allSupportedExtensions,
           },
         },
       },

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -28,6 +28,13 @@ module.exports = {
     // https://github.com/prettier/prettier-eslint
     'prettier',
   ],
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.mjs'],
+      },
+    },
+  },
   rules: {
     // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
     'no-unused-expressions': 0,

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -31,7 +31,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.mjs'],
+        extensions: ['.js', '.mjs', '.cjs'],
       },
     },
   },

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -12,7 +12,7 @@ module.exports = {
       NODE_ENV: 'test',
     },
   },
-  moduleFileExtensions: ['js', 'jsx', 'json'],
+  moduleFileExtensions: ['js', 'mjs', 'jsx', 'json'],
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolveRelativePath(
@@ -33,7 +33,7 @@ module.exports = {
   testPathIgnorePatterns: ['node_modules', 'cypress'],
   testRegex: '\\.spec\\.jsx?$',
   transform: {
-    '^.+\\.js$': resolveRelativePath('./transform-babel-jest.js'),
+    '^.+\\.(js|mjs)$': resolveRelativePath('./transform-babel-jest.js'),
     '^.+\\.graphql$': 'jest-transform-graphql',
   },
   watchPlugins: ['jest-watch-typeahead/filename'],

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -12,7 +12,7 @@ module.exports = {
       NODE_ENV: 'test',
     },
   },
-  moduleFileExtensions: ['js', 'mjs', 'jsx', 'json'],
+  moduleFileExtensions: ['js', 'mjs', 'cjs', 'jsx', 'json'],
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': resolveRelativePath(

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.js
@@ -91,7 +91,9 @@ module.exports = function createWebpackConfigForDevelopment(options = {}) {
       // https://github.com/facebook/create-react-app/issues/290
       // `web` extension prefixes have been added for better support
       // for React Native Web.
-      extensions: ['js', 'ts', 'tsx', 'json', 'jsx'].map((ext) => `.${ext}`),
+      extensions: ['js', 'mjs', 'cjs', 'ts', 'tsx', 'json', 'jsx'].map(
+        (ext) => `.${ext}`
+      ),
     },
 
     entry: {
@@ -340,7 +342,7 @@ module.exports = function createWebpackConfigForDevelopment(options = {}) {
         },
         // Process JS with Babel.
         {
-          test: /\.(js|jsx|ts|tsx)$/,
+          test: /\.(js|mjs|cjs|jsx|ts|tsx)$/,
           use: [
             // This loader parallelizes code compilation, it is optional but
             // improves compile time on larger projects

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.js
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.js
@@ -132,7 +132,9 @@ module.exports = function createWebpackConfigForProduction(options = {}) {
       // https://github.com/facebook/create-react-app/issues/290
       // `web` extension prefixes have been added for better support
       // for React Native Web.
-      extensions: ['js', 'ts', 'tsx', 'json', 'jsx'].map((ext) => `.${ext}`),
+      extensions: ['js', 'mjs', 'cjs', 'ts', 'tsx', 'json', 'jsx'].map(
+        (ext) => `.${ext}`
+      ),
     },
 
     // In production, we only want to load the polyfills and the app code.
@@ -364,7 +366,7 @@ module.exports = function createWebpackConfigForProduction(options = {}) {
         },
         // Process application JavaScript with Babel.
         {
-          test: /\.(js|jsx|ts|tsx)$/,
+          test: /\.(js|mjs|cjs|jsx|ts|tsx)$/,
           use: [
             // This loader parallelizes code compilation, it is optional but
             // improves compile time on larger projects

--- a/packages/mc-scripts/src/config/paths.js
+++ b/packages/mc-scripts/src/config/paths.js
@@ -1,12 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 
-const moduleFileExtensions = ['js', 'jsx', 'ts', 'tsx'];
+const moduleFileExtensions = ['js', 'cjs', 'jsx', 'ts', 'tsx'];
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
+const resolveApp = (relativePath, extentions) =>
+  path.resolve(appDirectory, relativePath);
 
 // Resolve file paths in the same order as webpack
 const resolveModule = (resolveFn, filePath) => {
@@ -28,10 +29,9 @@ const paths = {
   appPublic: resolveApp('public'),
   appBuild: resolveApp('dist/assets'),
   appIndexHtml: resolveApp('dist/assets/index.html'),
-  appWebpackConfig: resolveApp(
-    `webpack.config.${
-      process.env.NODE_ENV === 'production' ? 'prod' : 'dev'
-    }.js`
+  appWebpackConfig: resolveModule(
+    resolveApp,
+    `webpack.config.${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`
   ),
   yarnLockFile: resolveApp('yarn.lock'),
   appRoot: resolveApp('.'),

--- a/packages/mc-scripts/src/config/paths.js
+++ b/packages/mc-scripts/src/config/paths.js
@@ -6,8 +6,7 @@ const moduleFileExtensions = ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx'];
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = (relativePath, extentions) =>
-  path.resolve(appDirectory, relativePath);
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
 // Resolve file paths in the order given
 const resolveModule = (resolveFn, filePath) => {

--- a/packages/mc-scripts/src/config/paths.js
+++ b/packages/mc-scripts/src/config/paths.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const moduleFileExtensions = ['js', 'jsx', 'ts', 'tsx'];
+const moduleFileExtensions = ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx'];
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
@@ -10,12 +10,8 @@ const resolveApp = (relativePath, extentions) =>
   path.resolve(appDirectory, relativePath);
 
 // Resolve file paths in the order given
-const resolveModule = (
-  resolveFn,
-  filePath,
-  extensions = moduleFileExtensions
-) => {
-  const extension = extensions.find((extension) =>
+const resolveModule = (resolveFn, filePath) => {
+  const extension = moduleFileExtensions.find((extension) =>
     fs.existsSync(resolveFn(`${filePath}.${extension}`))
   );
 
@@ -35,8 +31,7 @@ const paths = {
   appIndexHtml: resolveApp('dist/assets/index.html'),
   appWebpackConfig: resolveModule(
     resolveApp,
-    `webpack.config.${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`,
-    ['.js', '.cjs']
+    `webpack.config.${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`
   ),
   yarnLockFile: resolveApp('yarn.lock'),
   appRoot: resolveApp('.'),

--- a/packages/mc-scripts/src/config/paths.js
+++ b/packages/mc-scripts/src/config/paths.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const moduleFileExtensions = ['js', 'cjs', 'jsx', 'ts', 'tsx'];
+const moduleFileExtensions = ['js', 'jsx', 'ts', 'tsx'];
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
@@ -9,9 +9,13 @@ const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath, extentions) =>
   path.resolve(appDirectory, relativePath);
 
-// Resolve file paths in the same order as webpack
-const resolveModule = (resolveFn, filePath) => {
-  const extension = moduleFileExtensions.find((extension) =>
+// Resolve file paths in the order given
+const resolveModule = (
+  resolveFn,
+  filePath,
+  extensions = moduleFileExtensions
+) => {
+  const extension = extensions.find((extension) =>
     fs.existsSync(resolveFn(`${filePath}.${extension}`))
   );
 
@@ -31,7 +35,8 @@ const paths = {
   appIndexHtml: resolveApp('dist/assets/index.html'),
   appWebpackConfig: resolveModule(
     resolveApp,
-    `webpack.config.${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`
+    `webpack.config.${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`,
+    ['.js', '.cjs']
   ),
   yarnLockFile: resolveApp('yarn.lock'),
   appRoot: resolveApp('.'),


### PR DESCRIPTION
#### Summary

This pull request intends to add support for webpack configs with different file endings such as `webpack.config.prod.cjs`

#### Description

The original reason for this pull request is to support webpack configs in projects running on ES modules. Those packages at times have a `type: "module"` in their `package.json`. 

Whenever, our `mc-scripts build` then loads the webpack configs from those modules the `package.json` config is read. Node.js will then throw as the e.g. `webpack.config.prod.js` contains `require` statements not only `import`.

ESLint solves this by supporting `.cjs` extension for their configurations while not supporting ES module configurations. This is a good middle ground to allow the ecosystem to migrate while not blocking them.

As a side-effect this pull request allows `ts` configurations which should be fine. It's a bit odd to support `jsx` but I am not sure if we want to prohibit it. Is so we could split our supported extension list more meaningfully.
