### PR TITLE
fix(mc-html-template): permission policy to be joined with comma

### DIFF
--- a/.changeset/odd-dodos-tickle.md
+++ b/.changeset/odd-dodos-tickle.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+---
+
+Fix multiple permissions policies to be joined with comma not semicolon.

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -24,7 +24,7 @@ const mergeCspDirectives = (...csps) =>
       ),
     {}
   );
-const toHeaderString = (directives = {}) =>
+const toHeaderString = (directives = {}, seperator = '; ') =>
   Object.entries(directives)
     .map(
       ([directive, value]) =>
@@ -126,7 +126,8 @@ const processHeaders = (applicationConfig) => {
     }),
     ...(applicationConfig.headers.permissionsPolicies && {
       'Permissions-Policy': toHeaderString(
-        applicationConfig.headers.permissionsPolicies
+        applicationConfig.headers.permissionsPolicies,
+        ', '
       ),
     }),
   };


### PR DESCRIPTION
#### Summary

The permission policy header is joined by a `', '` separator in the specification. Not a `': '`.

<img width="1169" alt="CleanShot 2021-04-29 at 14 04 11@2x" src="https://user-images.githubusercontent.com/1877073/116548313-5535ae00-a8f4-11eb-8281-c71710142a86.png">
