### PR TITLE
fix(mc-html-template): fix processing of structured headers

### DIFF
--- a/.changeset/quiet-snails-reflect.md
+++ b/.changeset/quiet-snails-reflect.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+---
+
+Fix processing of structured headers

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -24,13 +24,20 @@ const mergeCspDirectives = (...csps) =>
       ),
     {}
   );
-const toHeaderString = (directives = {}, seperator = '; ') =>
+const toHeaderString = (directives = {}) =>
   Object.entries(directives)
     .map(
       ([directive, value]) =>
         `${directive} ${Array.isArray(value) ? value.join(' ') : value}`
     )
-    .join(seperator);
+    .join('; ');
+const toStructuredHeaderString = (directives = {}) =>
+  Object.entries(directives)
+    .map(
+      ([directive, value]) =>
+        `${directive} ${Array.isArray(value) ? value.join('=') : value}`
+    )
+    .join(', ');
 
 const processHeaders = (applicationConfig) => {
   const isMcDevEnv = applicationConfig.env.env === 'development';
@@ -125,9 +132,8 @@ const processHeaders = (applicationConfig) => {
       ),
     }),
     ...(applicationConfig.headers.permissionsPolicies && {
-      'Permissions-Policy': toHeaderString(
-        applicationConfig.headers.permissionsPolicies,
-        ', '
+      'Permissions-Policy': toStructuredHeaderString(
+        applicationConfig.headers.permissionsPolicies
       ),
     }),
   };


### PR DESCRIPTION
#### Summary

This fixes the processing of structured headers like the permissions policy.

A structured header format is `key=(), key2=()` not `key (),`.

In this fix I removed the seperator and created a second function. I subjectively found that easier to understand. 