### PR TITLE
test(mc-html-template): add test for processing headers

### DIFF
--- a/.changeset/moody-bikes-rest.md
+++ b/.changeset/moody-bikes-rest.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+---
+
+Add test for processing headers while fixing a bug

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -35,7 +35,7 @@ const toStructuredHeaderString = (directives = {}) =>
   Object.entries(directives)
     .map(
       ([directive, value]) =>
-        `${directive} ${Array.isArray(value) ? value.join('=') : value}`
+        `${directive}=${Array.isArray(value) ? value.join(' ') : value}`
     )
     .join(', ');
 

--- a/packages/mc-html-template/src/process-headers.spec.js
+++ b/packages/mc-html-template/src/process-headers.spec.js
@@ -1,0 +1,98 @@
+import processConfig from './process-headers';
+
+const defaultApplicationConfig = {
+  name: 'Application test',
+  entryPointUriPath: 'test',
+  cloudIdentifier: 'test',
+  env: {
+    env: 'test',
+  },
+  headers: {},
+};
+
+describe('header string', () => {
+  describe('when value is a string', () => {
+    it('should convert to a header string', () => {
+      const testApplicationConfig = {
+        ...defaultApplicationConfig,
+        headers: {
+          featurePolicies: {
+            microphone: "'none'",
+            camera: ["'https://example.com'"],
+          },
+        },
+      };
+
+      const processedApplicationConfig = processConfig(testApplicationConfig);
+
+      expect(
+        processedApplicationConfig['Feature-Policy']
+      ).toMatchInlineSnapshot(
+        `"microphone 'none'; camera 'https://example.com'"`
+      );
+    });
+  });
+
+  describe('when value is an array', () => {
+    it('should convert to a header string', () => {
+      const testApplicationConfig = {
+        ...defaultApplicationConfig,
+        headers: {
+          featurePolicies: {
+            microphone: "'none'",
+            camera: ["'self'", "'https://example.com'"],
+          },
+        },
+      };
+
+      const processedApplicationConfig = processConfig(testApplicationConfig);
+
+      expect(
+        processedApplicationConfig['Feature-Policy']
+      ).toMatchInlineSnapshot(
+        `"microphone 'none'; camera 'self' 'https://example.com'"`
+      );
+    });
+  });
+});
+
+describe('structured header string', () => {
+  describe('when value is a string', () => {
+    it('should convert to a header string', () => {
+      const testApplicationConfig = {
+        ...defaultApplicationConfig,
+        headers: {
+          permissionsPolicies: {
+            microphone: '()',
+            camera: '(self)',
+          },
+        },
+      };
+
+      const processedApplicationConfig = processConfig(testApplicationConfig);
+
+      expect(
+        processedApplicationConfig['Permissions-Policy']
+      ).toMatchInlineSnapshot(`"microphone=(), camera=(self)"`);
+    });
+  });
+
+  describe('when value is an array', () => {
+    it('should convert to a header string', () => {
+      const testApplicationConfig = {
+        ...defaultApplicationConfig,
+        headers: {
+          permissionsPolicies: {
+            microphone: '(self http://example.com)',
+          },
+        },
+      };
+
+      const processedApplicationConfig = processConfig(testApplicationConfig);
+
+      expect(
+        processedApplicationConfig['Permissions-Policy']
+      ).toMatchInlineSnapshot(`"microphone=(self http://example.com)"`);
+    });
+  });
+});


### PR DESCRIPTION
#### Summary

This adds tests for processing the headers of an application config.

I felt we should have some tests for this logic given it didn't work as we wanted. While writing the tests I noticed that it still doesn't 🤕.