### PR TITLE
Bugfix for error messages not showing in `mc-build`

### DIFF
--- a/.changeset/tricky-crews-breathe.md
+++ b/.changeset/tricky-crews-breathe.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix error messages not showing in mc-build

--- a/.changeset/tricky-crews-breathe.md
+++ b/.changeset/tricky-crews-breathe.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/mc-scripts': patch
 ---
 
-Fix error messages not showing in mc-build
+Temporary fix for parsing Webpack error messages until `react-dev-utils` supports Webpack v5.

--- a/packages/mc-scripts/src/build.js
+++ b/packages/mc-scripts/src/build.js
@@ -118,6 +118,7 @@ function build(previousFileSizes) {
           warnings: [],
         });
       } else {
+        //TODO: Remove after 'react-dev-utils' natively supports webpack@5
         const rawMessages = stats.toJson({
           all: false,
           warnings: true,

--- a/packages/mc-scripts/src/build.js
+++ b/packages/mc-scripts/src/build.js
@@ -118,9 +118,16 @@ function build(previousFileSizes) {
           warnings: [],
         });
       } else {
-        messages = formatWebpackMessages(
-          stats.toJson({ all: false, warnings: true, errors: true })
-        );
+        const rawMessages = stats.toJson({
+          all: false,
+          warnings: true,
+          errors: true,
+          moduleTrace: false,
+        });
+        messages = formatWebpackMessages({
+          errors: rawMessages.errors.map((e) => e.message),
+          warnings: rawMessages.warnings.map((e) => e.message),
+        });
       }
       if (messages.errors.length) {
         // Only keep the first error. Others are often indicative


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
React-dev-utils doesn't support the webpack 5 stats, so this is an adapter to allow errors to propogate properly to `mc-scripts build`.

#### Description
Resolves https://github.com/commercetools/merchant-center-application-kit/issues/2188
