### PR TITLE
fix(mc-scripts): loading and parsing of dotenv files

### DIFF
--- a/.changeset/rotten-foxes-bake.md
+++ b/.changeset/rotten-foxes-bake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix loading and evaluation of custom dotenv files

--- a/packages/mc-scripts/src/commands/build.js
+++ b/packages/mc-scripts/src/commands/build.js
@@ -1,16 +1,4 @@
 /* eslint-disable no-console,global-require,import/no-dynamic-require */
-
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
-
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', (err) => {
-  throw err;
-});
-
 // NOTE: `react-dev-utils` does not currently fully support Webpack v5.
 // Most of the imports work, however we might bump into some edge cases.
 // In any case, once they release a compatible version, we should't have problems.

--- a/packages/mc-scripts/src/commands/compile-html.js
+++ b/packages/mc-scripts/src/commands/compile-html.js
@@ -1,15 +1,4 @@
 /* eslint-disable no-console,global-require,import/no-dynamic-require */
-
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.NODE_ENV = 'production';
-
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', (err) => {
-  throw err;
-});
-
 const fs = require('fs');
 const path = require('path');
 const shelljs = require('shelljs');

--- a/packages/mc-scripts/src/commands/serve.js
+++ b/packages/mc-scripts/src/commands/serve.js
@@ -1,15 +1,4 @@
 /* eslint-disable no-console,global-require,import/no-dynamic-require */
-
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.NODE_ENV = 'production';
-
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', (err) => {
-  throw err;
-});
-
 const fs = require('fs');
 const path = require('path');
 const http = require('http');

--- a/packages/mc-scripts/src/commands/start.js
+++ b/packages/mc-scripts/src/commands/start.js
@@ -1,16 +1,4 @@
 /* eslint-disable no-console,global-require,import/no-dynamic-require */
-
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
-
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', (err) => {
-  throw err;
-});
-
 const fs = require('fs');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');


### PR DESCRIPTION
Leftover of #2191 

Now custom `--env` options are correctly evaluated first

<img width="376" alt="image" src="https://user-images.githubusercontent.com/1110551/117286268-435e8880-ae69-11eb-95d7-7b01ab364fbc.png">
