### PR TITLE
chore: downgrade cypress to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "babel-plugin-transform-rename-import": "2.3.0",
     "babel-plugin-typescript-to-proptypes": "1.4.2",
     "cross-env": "7.0.3",
-    "cypress": "7.3.0",
+    "cypress": "7.2.0",
     "dotenv": "8.6.0",
     "eslint": "7.26.0",
     "eslint-formatter-pretty": "4.0.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -46,7 +46,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "cypress": "7.3.0"
+    "cypress": "7.2.0"
   },
   "peerDependencies": {
     "cypress": "5.x || 6.x || 7.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9147,10 +9147,10 @@ cwd@^0.10.0:
     find-pkg "^0.1.2"
     fs-exists-sync "^0.1.0"
 
-cypress@7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.3.0.tgz#17345b8d18681c120f033e7d8fd0f0271e9d0d51"
-  integrity sha512-aseRCH1tRVCrM6oEfja6fR/bo5l6e4SkHRRSATh27UeN4f/ANC8U7tGIulmrISJVy9xuOkOdbYKbUb2MNM+nrw==
+cypress@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.2.0.tgz#6a3364e18972f898fff1fb12c1ff747939e45ddc"
+  integrity sha512-lHHGay+YsffDn4M0bkkwezylBVHUpwwhtqte4LNPrFRCHy77X38+1PUe3neFb3glVTM+rbILtTN6FhO2djcOuQ==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
It seems that Cypress `7.3.0` has issues being downloaded. Let's downgrade to `7.2.0` in the meantime.