### PR TITLE
fix(mc-scripts): regression when updating webpack-dev-server to 4.0.0-beta.3

### DIFF
--- a/.changeset/serious-numbers-mix.md
+++ b/.changeset/serious-numbers-mix.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix regression when updating `webpack-dev-server` to `v4.0.0-beta.3`

--- a/packages/mc-scripts/src/config/webpack-dev-server.config.js
+++ b/packages/mc-scripts/src/config/webpack-dev-server.config.js
@@ -20,7 +20,7 @@ module.exports = ({ allowedHost, contentBase, port, publicPath }) => ({
   },
   // Enable gzip compression of generated files.
   compress: true,
-  dev: {
+  devMiddleware: {
     // It is important to tell WebpackDevServer to use the same "publicPath" path as
     // we specified in the webpack config. When homepage is '.', default to serving
     // from the root.


### PR DESCRIPTION
Caused by #2199 

This slipped through in the latest dependency upgrade

<img width="813" alt="image" src="https://user-images.githubusercontent.com/1110551/117886369-647f0900-b2af-11eb-99dd-dfae5f368447.png">

causing local dev to not start:

<img width="1231" alt="image" src="https://user-images.githubusercontent.com/1110551/117886442-7fea1400-b2af-11eb-9d8a-272df0ea89a5.png">
