### PR TITLE
chore: add tsc-files to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && tsc-files --noEmit
+yarn lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn typecheck
+yarn lint-staged && tsc-files --noEmit

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -18,6 +18,7 @@ module.exports = {
     //
     // For that reason, we move the `--onlyChanged` flag next to it.
     'yarn lint:js --reporters=jest-silent-reporter --onlyChanged',
+    'tsc-files --noEmit',
   ],
   '*.css': [
     'prettier --write --parser css',

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "stylelint-config-standard": "22.0.0",
     "stylelint-order": "4.1.0",
     "stylelint-value-no-unknown-custom-properties": "3.0.0",
+    "tsc-files": "1.1.2",
     "typescript": "4.2.4",
     "vfile-message": "2.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23502,6 +23502,11 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+tsc-files@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tsc-files/-/tsc-files-1.1.2.tgz#acd181949ef53811fc6df455baef41adaf616442"
+  integrity sha512-biLtl4npoohZ9MBnTFw4NttqYM60RscjzjWxT538UCS8iXaGRZMi+AXj+vEEpDdcjIS2Kx0Acj++1gor5dbbBw==
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
#### Summary

The project [tsc-files](https://github.com/gustavopch/tsc-files) allows to type check only files that changed. I wanted to suggest it as a pre-commit hook while CI still does the whole typecheck. I found out about it as the `lint-staged` owner recommended it online.