### PR TITLE
fix(website-content): Apollo Query component import path

### DIFF
--- a/.changeset/five-spies-carry.md
+++ b/.changeset/five-spies-carry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-website/custom-applications': patch
+---
+
+Fix apollo Query component import path

--- a/website/src/content/main-concepts/data-fetching.mdx
+++ b/website/src/content/main-concepts/data-fetching.mdx
@@ -40,7 +40,7 @@ Then we use the `Query` component of Apollo to send the query and render the res
 ```jsx
 // channel-details.js
 import React from 'react';
-import { Query } from '@apollo/client/react';
+import { Query } from '@apollo/client/react/components';
 import Text from '@commercetools-uikit/text';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { FetchChannelQuery } from './channels.graphql';


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Update outdated Apollo Query component import path. ([link to issue](https://github.com/commercetools/merchant-center-application-kit/issues/2219))

#### Description

Since @apollo/client v3, Query component needs to be imported from this path:
`import { Query, Mutation, Subscription } from '@apollo/client/react/components';`

See this [PR on @apollo](https://github.com/apollographql/apollo-client/pull/6558) for details.
