### PR TITLE
feat: new placeholder for missing values (i.e. NO_VALUE_FALLBACK)

### DIFF
--- a/.changeset/curvy-ears-move.md
+++ b/.changeset/curvy-ears-move.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-frontend/constants': major
+'@commercetools-frontend/constants': minor
 ---
 
 Change missing value placholder (i.e. `NO_VALUE_FALLBACK`) from `- - - -` to `- -`

--- a/.changeset/curvy-ears-move.md
+++ b/.changeset/curvy-ears-move.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/constants': major
+---
+
+Change missing value placholder (i.e. `NO_VALUE_FALLBACK`) from `- - - -` to `- -`

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -97,7 +97,7 @@ export type TAppNotificationSide = TAppNotification<{
 }>;
 
 // Fallback string when there is no localized value
-export const NO_VALUE_FALLBACK = '- - - -';
+export const NO_VALUE_FALLBACK = '- -';
 
 // HTTP requests and responses
 export const STATUS_CODES = {


### PR DESCRIPTION
There is a design decision to go from `- - - -` to `- -` across the MC. As `NO_VALUE_FALLBACK` is used in Application Shell too we have to change it in this repo. 

I guess that should be considered a braking change (custom apps relies on current value), hence there is a major version bump.