### PR TITLE
fix(eslint-config): to not error on new rtl rules

### DIFF
--- a/.changeset/witty-oranges-compare.md
+++ b/.changeset/witty-oranges-compare.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/eslint-config-mc-app": patch
+---
+
+Fix eslint-config not not error on new react-testing-library rules introduced by the v4 update.

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -64,6 +64,9 @@ module.exports = {
     // RTL
     'testing-library/prefer-presence-queries': statusCode.error,
     'testing-library/await-async-query': statusCode.error,
+    // Enabling these would be a breaking change to the config
+    'testing-library/render-result-naming-convention': statusCode.off,
+    'testing-library/prefer-screen-queries': statusCode.off,
 
     // React
     'react/jsx-uses-vars': statusCode.error,


### PR DESCRIPTION
#### Summary

Updating and hence enabling these rules is a breaking change.