### PR TITLE
fix(eslint-config): to not error for container use

### DIFF
--- a/.changeset/soft-plants-destroy.md
+++ b/.changeset/soft-plants-destroy.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/eslint-config-mc-app": patch
+---
+
+Fix eslint-config to not error for container use in react-testing-library but only warn.

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -67,6 +67,7 @@ module.exports = {
     // Enabling these would be a breaking change to the config
     'testing-library/render-result-naming-convention': statusCode.off,
     'testing-library/prefer-screen-queries': statusCode.off,
+    'testing-library/no-container': statusCode.warn,
 
     // React
     'react/jsx-uses-vars': statusCode.error,


### PR DESCRIPTION
#### Summary

Erroring for a use of container is a bit to strict. Warning is more accurate.