### PR TITLE
fix(mc-html-template): add preload and includeSubDomains to header

### DIFF
--- a/.changeset/fuzzy-hounds-agree.md
+++ b/.changeset/fuzzy-hounds-agree.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+---
+
+Add `preload` and `includeSubDomains` to `Strict-Transport-Security` header

--- a/packages/mc-html-template/src/process-headers.js
+++ b/packages/mc-html-template/src/process-headers.js
@@ -120,7 +120,7 @@ const processHeaders = (applicationConfig) => {
   );
 
   return {
-    'Strict-Transport-Security': 'max-age=31536000',
+    'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
     'X-XSS-Protection': '1; mode=block',
     'X-Content-Type-Options': 'nosniff',
     'X-Frame-Options': 'DENY',


### PR DESCRIPTION
#### Summary

This adds the `preload` and `includeSubDomains` attributes to the `Strict-Transport-Security` header.

#### Description

Using [hstspreload.org](https://hstspreload.org) it is advised to `preload` (not part of the spec) and add the `includeSubDomains` attributes. More about HTS [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security).

<img width="937" alt="CleanShot 2021-06-04 at 09 08 46@2x" src="https://user-images.githubusercontent.com/1877073/120760527-7fdade00-c514-11eb-90c0-e1868ff5945e.png">

I don't see a strict reason against adding those.
