### PR TITLE
feat: add ability to additionally silence warnings

### DIFF
--- a/.changeset/tidy-boxes-drive.md
+++ b/.changeset/tidy-boxes-drive.md
@@ -1,0 +1,9 @@
+---
+"@commercetools-frontend/jest-preset-mc-app": minor
+---
+
+Add ability to additionally silence warnings of the `console`.
+
+The use of the `console` is discouraged on CI. As a result any log level will log a warning and throw an error. However, some logging (e.g. from libraries) can not be avoided. To circumvent this a `silenceConsoleWarnings` can be added on the `jest-preset-mc-app.config.js`. 
+
+In addition to be above this adds `console.config` object with `addSilencedWarning` and `addNotThrowingWarning`. Allowing to add additional silenced messages at runtime of a test.

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -17,7 +17,7 @@ window.MutationObserver = MutationObserver;
 global.Headers = global.Headers || Headers;
 
 let additionalSilencedWarnings = [];
-let additionalNotThrowingWarnings = [];
+let additionalNonThrowingWarnings = [];
 
 function hasMatchingRegexForMessage(messages, msgRegExps) {
   return msgRegExps.some((msgRegex) =>
@@ -43,17 +43,17 @@ function shouldNotThrowWarnings(...messages) {
     messages,
     jestConfig.notThrowWarnings
   );
-  const additionallyNotThrowing = hasMatchingRegexForMessage(
+  const additionallyNonThrowing = hasMatchingRegexForMessage(
     messages,
-    additionalNotThrowingWarnings
+    additionalNonThrowingWarnings
   );
 
-  return notThrowingByJestConfig || additionallyNotThrowing;
+  return notThrowingByJestConfig || additionallyNonThrowing;
 }
 
 // setup file
 function logOrThrow(log, method, messages) {
-  const warning = `console.${method} calls not allowed in tests`;
+  let warning = `@commercetools-frontend/jest-preset-mc-app: console.${method} calls should not be used in tests.`;
   if (process.env.CI) {
     if (shouldSilenceWarnings(messages)) return;
 
@@ -62,6 +62,8 @@ function logOrThrow(log, method, messages) {
     // NOTE: That some warnings should be logged allowing us to refactor graceully
     // without having to introduce a breaking change.
     if (shouldNotThrowWarnings(messages)) return;
+
+    warning = `@commercetools-frontend/jest-preset-mc-app: console.${method} calls not allowed in tests.`;
 
     throw new Error(...messages);
   } else {
@@ -97,5 +99,5 @@ global.console.config = {};
 
 global.console.config.addSilencedWarning = (rexExp) =>
   additionalSilencedWarnings.push(rexExp);
-global.console.config.addNotThrowingWarning = (rexExp) =>
-  additionalNotThrowingWarnings.push(rexExp);
+global.console.config.addNonThrowingWarning = (rexExp) =>
+  additionalNonThrowingWarnings.push(rexExp);


### PR DESCRIPTION
#### Summary

This pull request suggests to be able to add silenced and not throwing warnings of the console at run time.

#### Description

Internally we at times want to silence warnings globally when e.g. the come from ui-kit or app-kit or libraries. However, at times we also want to log or warn but not have tests fail due to that.

As a result an initial idea is to add the ability to add silenced and not throwing warnings to the console at run time.
