### PR TITLE
feat(playground): echo server to allow custom header forwarding

### DIFF
--- a/playground/src/components/echo-server/echo-server.js
+++ b/playground/src/components/echo-server/echo-server.js
@@ -46,10 +46,19 @@ const EchoServer = () => {
   );
   const [shouldIncludeParamInRequest, setShouldIncludeParamInRequest] =
     useState(false);
+  const [
+    shouldIncludeForwardHeaderInRequest,
+    setShouldIncludeForwardHeaderInRequest,
+  ] = useState(false);
 
   const onChangeShouldIncludeParamInRequest = (event) => {
     const nextValue = event.target.value === 'false' ? true : false;
     setShouldIncludeParamInRequest(nextValue);
+  };
+
+  const onChangeShouldIncludeForwardHeaderInRequest = (event) => {
+    const nextValue = event.target.value === 'false' ? true : false;
+    setShouldIncludeForwardHeaderInRequest(nextValue);
   };
 
   const handleSendRequest = useCallback(() => {
@@ -66,6 +75,9 @@ const EchoServer = () => {
             payload: {
               say: 'Hello',
             },
+            headers: shouldIncludeForwardHeaderInRequest && {
+              'custom-header-name': 'custom-header-value',
+            },
           })
         );
         dispatchState({ type: 'complete', payload: result });
@@ -76,7 +88,13 @@ const EchoServer = () => {
     }
     dispatchState({ type: 'loading' });
     ping();
-  }, [dispatch, dispatchError, echoServerApiUrl, shouldIncludeParamInRequest]);
+  }, [
+    dispatch,
+    dispatchError,
+    echoServerApiUrl,
+    shouldIncludeParamInRequest,
+    shouldIncludeForwardHeaderInRequest,
+  ]);
   return (
     <Spacings.Inset>
       <Spacings.Stack>
@@ -112,6 +130,16 @@ const EchoServer = () => {
                 onChange={onChangeShouldIncludeParamInRequest}
               >
                 {intl.formatMessage(messages.labelIncludeParamsInRequest)}
+              </CheckboxInput>
+              <CheckboxInput
+                name="should-include-forward-header-in-request"
+                value={shouldIncludeForwardHeaderInRequest}
+                isChecked={shouldIncludeForwardHeaderInRequest}
+                onChange={onChangeShouldIncludeForwardHeaderInRequest}
+              >
+                {intl.formatMessage(
+                  messages.labelIncludeForwardHeaderInRequest
+                )}
               </CheckboxInput>
             </Spacings.Inline>
             {state.result && (

--- a/playground/src/components/echo-server/messages.js
+++ b/playground/src/components/echo-server/messages.js
@@ -22,4 +22,8 @@ export default defineMessages({
     id: 'StateMachines.EchoServer.labelIncludeParamsInRequest',
     defaultMessage: 'Inlude Parameter in request',
   },
+  labelIncludeForwardHeaderInRequest: {
+    id: 'StateMachines.EchoServer.labelIncludeForwardHeaderInRequest',
+    defaultMessage: 'Inlude Forward Header in request',
+  },
 });

--- a/playground/src/i18n/data/core.json
+++ b/playground/src/i18n/data/core.json
@@ -1,5 +1,6 @@
 {
   "StateMachines.EchoServer.description": "This page demonstrates how to connect a Custom Application to an external API, using the <linkDocs>\"/proxy/forward-to\" endpoint</linkDocs>. For demo purposes, the external API used by this page is a simple echo server, which just returns some information about the request sent.",
+  "StateMachines.EchoServer.labelIncludeForwardHeaderInRequest": "Inlude Forward Header in request",
   "StateMachines.EchoServer.labelIncludeParamsInRequest": "Inlude Parameter in request",
   "StateMachines.EchoServer.labelSendRequest": "Send request",
   "StateMachines.EchoServer.labelSending": "Sending...",


### PR DESCRIPTION
#### Summary

This allows custom headers through the echo server. Was needed for a support ticket.

![CleanShot 2021-06-08 at 15 37 13@2x](https://user-images.githubusercontent.com/1877073/121196795-11c64c00-c871-11eb-95b4-a57874fa0744.png)
![CleanShot 2021-06-08 at 15 38 43@2x](https://user-images.githubusercontent.com/1877073/121196803-13900f80-c871-11eb-9e89-5fc81f841c91.png)
![CleanShot 2021-06-08 at 15 39 48@2x](https://user-images.githubusercontent.com/1877073/121196805-14c13c80-c871-11eb-875a-7539b07ee61f.png)
