### PR TITLE
test: disable core-js in test environment

### DIFF
--- a/.changeset/tender-eggs-joke.md
+++ b/.changeset/tender-eggs-joke.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/babel-preset-mc-app': minor
+---
+
+Do not use `core-js` in test environment.
+
+After upgrading `jest` to v27 we found out that some of `core-js` polyfills conflict with new underlying implementation of `jest`'s fake timers. Turned out it's just safe not to use it in tests all together.

--- a/.changeset/tender-eggs-joke.md
+++ b/.changeset/tender-eggs-joke.md
@@ -2,6 +2,6 @@
 '@commercetools-frontend/babel-preset-mc-app': minor
 ---
 
-Do not use `core-js` in test environment.
+Removes usage of `core-js` when `process.env` is test. The update of `jest` to v27 comes with changes to how timers and timer mocks work. Some of `core-js` polyfills conflict or interfere with the new implementation of `jest`'s fake timers
 
-After upgrading `jest` to v27 we found out that some of `core-js` polyfills conflict with new underlying implementation of `jest`'s fake timers. Turned out it's just safe not to use it in tests all together.
+As test environments do not require `core-js` it can be removed. This allows `jest` to work as expected and removed bloat from the test environment. 

--- a/.changeset/tender-eggs-joke.md
+++ b/.changeset/tender-eggs-joke.md
@@ -2,6 +2,6 @@
 '@commercetools-frontend/babel-preset-mc-app': minor
 ---
 
-Removes usage of `core-js` when `process.env` is test. The update of `jest` to v27 comes with changes to how timers and timer mocks work. Some of `core-js` polyfills conflict or interfere with the new implementation of `jest`'s fake timers
+Removes usage of `core-js` when `process.env` is test. 
 
-As test environments do not require `core-js` it can be removed. This allows `jest` to work as expected and removed bloat from the test environment. 
+The update of `jest` to v27 comes with changes to how timers and timer mocks work. Some of `core-js` polyfills conflict or interfere with the new implementation of `jest`'s fake timers. As test environments do not require `core-js` it can be removed. This allows `jest` to work as expected and removed bloat from the test environment. 

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -141,7 +141,9 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
       [
         require('@babel/plugin-transform-runtime').default,
         {
-          corejs: 3,
+          // corejs messes with jest@27 in tests, due to some
+          // Promise/Date related polyfills it provides.
+          corejs: !isEnvTest && 3,
           // To be able to use `runtime` in Rollup babel plugin
           helpers: true,
           regenerator: true,


### PR DESCRIPTION
`core-js` causes troubles it tests when running together with `jest@27`. 

Beacuse `core-js` adds polyfills for `Promises` (and maybe `Date`, I'm not sure), that breaks some assumptions under the hood of resent version of `jest`. Which in turn leads to all tests relying on jest's fake timers to break.

I ran both app-kit and MC tests with this new setup and it seems to work fine.