### PR TITLE
fix(babel-preset-mc-app): to set node.js version to current

### DIFF
--- a/.changeset/proud-cows-own.md
+++ b/.changeset/proud-cows-own.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/babel-preset-mc-app": patch
+---
+
+Set Node.js version to `current` in the `babel-preset-mc-app` for `babel-preset-env`
+
+The previous version was hard-coded to `8` while `current` whill always use the version of the running process.

--- a/packages/babel-preset-mc-app/index.js
+++ b/packages/babel-preset-mc-app/index.js
@@ -44,7 +44,7 @@ module.exports = function getBabePresetConfigForMcApp(api, opts = {}) {
         {
           targets: {
             browsers: ['last 2 versions'],
-            node: '8',
+            node: 'current',
           },
         },
       ],


### PR DESCRIPTION
#### Summary

This sets the Node.js version to `current` instead of hard-coding it to `8`.

#### Description

Current implies the the version of the hosting system will be used which under test is often exactly what you want given everything runs in the version prescribed by the `.nvmrc` if you ask me.

<img width="801" alt="CleanShot 2021-06-10 at 08 02 22@2x" src="https://user-images.githubusercontent.com/1877073/121472945-341baf00-c9c2-11eb-8813-9a9cac2548ce.png">

