### PR TITLE
feat(jest-preset-mc-app): add babelConfig to jest config

### DIFF
--- a/.changeset/dirty-beans-yawn.md
+++ b/.changeset/dirty-beans-yawn.md
@@ -1,0 +1,15 @@
+---
+"@commercetools-frontend/jest-preset-mc-app": minor
+---
+
+Add a `babelConfig` to the `jest-preset-mc-app` `cosmiconfig`.
+
+To use it create a `jest-preset-mc-app.config.js` in the root of your project and e.g. add a:
+
+```js
+module.exports = {
+  babelConfig: {
+    disableCoreJs: true,
+  },
+};
+```

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -5,6 +5,15 @@ const rootPath = process.cwd();
 const resolveRelativePath = (relativePath) =>
   path.resolve(__dirname, relativePath);
 
+const defaultTransformFile = resolveRelativePath('./transform-file.js');
+const defaultSetupTests = resolveRelativePath('./setup-tests.js');
+const defaultSetupTestFramework = resolveRelativePath(
+  './setup-test-framework.js'
+);
+const defaultTransformBabelJest = resolveRelativePath(
+  './transform-babel-jest.js'
+);
+
 module.exports = {
   displayName: 'test',
   globals: {
@@ -16,22 +25,18 @@ module.exports = {
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      resolveRelativePath('./transform-file.js'),
+      defaultTransformFile,
     '\\.css$': 'identity-obj-proxy',
   },
   rootDir: rootPath,
-  setupFiles: [
-    'raf/polyfill',
-    resolveRelativePath('./setup-tests.js'),
-    'jest-localstorage-mock',
-  ],
-  setupFilesAfterEnv: [resolveRelativePath('./setup-test-framework.js')],
+  setupFiles: ['raf/polyfill', defaultSetupTests, 'jest-localstorage-mock'],
+  setupFilesAfterEnv: [defaultSetupTestFramework],
   testEnvironment: 'jsdom',
   testURL: 'https://mc.europe-west1.gcp.commercetools.com/',
   testPathIgnorePatterns: ['node_modules', 'cypress'],
   testRegex: '\\.spec\\.jsx?$',
   transform: {
-    '^.+\\.(js|mjs)$': resolveRelativePath('./transform-babel-jest.js'),
+    '^.+\\.(js|mjs)$': defaultTransformBabelJest,
     '^.+\\.graphql$': 'jest-transform-graphql',
   },
   watchPlugins: ['jest-watch-typeahead/filename'],

--- a/packages/jest-preset-mc-app/load-config.js
+++ b/packages/jest-preset-mc-app/load-config.js
@@ -19,6 +19,13 @@ const defaultConfig = {
     /.*@commercetools-frontend\/permissions.*/,
     /.*Warning: React.createFactory() is deprecated.*/,
   ],
+  babelConfig: {
+    // Some environemnts do not require `core-js` and can hence disable
+    // it explicitely. This will disable `core-js` for `preset-env` and the
+    // `plugin-transform-runtime`.
+    disableCoreJs: false,
+  },
+  rtlConfig: {},
 };
 
 const mergeSilenceConsoleWarnings = createListMergerWithDefaults(

--- a/packages/jest-preset-mc-app/transform-babel-jest.js
+++ b/packages/jest-preset-mc-app/transform-babel-jest.js
@@ -2,9 +2,13 @@ const getBabePresetConfigForMcApp = require('@commercetools-frontend/babel-prese
 const getJestBabelPreset = require('babel-preset-jest');
 const babelJest = require('babel-jest');
 const hasJsxRuntime = require('./has-jsx-runtime');
+const loadConfig = require('./load-config');
+
+const jestConfig = loadConfig();
 
 const mcAppBabelConfig = getBabePresetConfigForMcApp(null, {
   runtime: hasJsxRuntime() ? 'automatic' : 'classic',
+  disableCoreJs: jestConfig.babelConfig.disableCoreJs,
 });
 
 const jestBabelConfig = {


### PR DESCRIPTION
#### Summary

Adds support for a `babelConfig` in the cosmiconfig for jest (so the `jest-preset-mc-app.config.js in a project's root).

#### Description

The babel config (babel-preset-mc-app) has various configuration options. At times it can make sense to pass down values to the config (e.g. to `disableCoreJs`).
