### PR TITLE
fix(api-error): log api errors to console only in development env

### DIFF
--- a/.changeset/modern-cheetahs-cry.md
+++ b/.changeset/modern-cheetahs-cry.md
@@ -2,6 +2,6 @@
 '@commercetools-frontend/react-notifications': patch
 ---
 
-fix(api-error): log api errors to console only in development env
+Removing logging API errors to `console.error` in test environments. Now loggin only in development.
 
 Prevent <ApiErrorNotification /> component from polluting console with the `console.error` messages in both `test` and `production` environments.

--- a/.changeset/modern-cheetahs-cry.md
+++ b/.changeset/modern-cheetahs-cry.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/react-notifications': patch
+---
+
+fix(api-error): log api errors to console only in development env
+
+Prevent <ApiErrorNotification /> component from polluting console with the `console.error` messages in both `test` and `production` environments.

--- a/.changeset/modern-cheetahs-cry.md
+++ b/.changeset/modern-cheetahs-cry.md
@@ -2,6 +2,6 @@
 '@commercetools-frontend/react-notifications': patch
 ---
 
-Removing logging API errors to `console.error` in test environments. Now loggin only in development.
+Removing logging API errors to `console.error` in test environments. Now logging only in development.
 
 Prevent <ApiErrorNotification /> component from polluting console with the `console.error` messages in both `test` and `production` environments.

--- a/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
@@ -29,7 +29,9 @@ const ApiErrorNotification = (props: Props) => (
     <ul>
       {props.notification.values &&
         props.notification.values.errors.map((error, idx) => {
-          if (!error.code && process.env.NODE_ENV !== 'production') {
+          const shouldLogErrorToConsole =
+            !error.code && process.env.NODE_ENV === 'development';
+          if (shouldLogErrorToConsole) {
             /**
              * NOTE: This is an API error which usually contains
              * a `code` property such as `DuplicateField` or `InvalidOperation`.


### PR DESCRIPTION
`<ApiErrorNotification />` component, by design, logs reported error to the `console.error`. At the moment, that only happens in non `production` environment. That's find and good to ease figuring out what's going on in development, but leads to polluted terminal messages when this situation happens under test. 

I suggest we log these errors to console only if `NODE_ENV === 'development'`, silencing both `test` and `production` environments.