### PR TITLE
feat(i18n): i18n messages from `@commercetools-community-kit/i18n`

### DIFF
--- a/.changeset/purple-shirts-clap.md
+++ b/.changeset/purple-shirts-clap.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/i18n': patch
+---
+
+Optionally load i18n messages from `@commercetools-community-kit/i18n` if the dependency is installed.

--- a/.changeset/purple-shirts-clap.md
+++ b/.changeset/purple-shirts-clap.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-frontend/i18n': patch
+'@commercetools-frontend/i18n': minor
 ---
 
 Optionally load i18n messages from `@commercetools-community-kit/i18n` if the dependency is installed.

--- a/.changeset/purple-shirts-clap.md
+++ b/.changeset/purple-shirts-clap.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/i18n': minor
 ---
 
-Optionally load i18n messages from `@commercetools-community-kit/i18n` if the dependency is installed.
+Include i18n messages from `@commercetools-community-kit/i18n`.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -37,8 +37,9 @@
   "dependencies": {
     "@babel/runtime": "7.14.6",
     "@babel/runtime-corejs3": "7.14.7",
+    "@commercetools-community-kit/i18n": "^0.2.4",
     "@commercetools-frontend/sentry": "20.5.2",
-    "@commercetools-uikit/i18n": "12.0.7",
+    "@commercetools-uikit/i18n": "^12.0.7",
     "@emotion/react": "11.4.0",
     "@types/prop-types": "^15.7.3",
     "@types/react": "^17.0.7",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/runtime": "7.14.6",
     "@babel/runtime-corejs3": "7.14.7",
-    "@commercetools-community-kit/i18n": "^0.2.5",
+    "@commercetools-community-kit/i18n": "^0.2.7",
     "@commercetools-frontend/sentry": "20.5.2",
     "@commercetools-uikit/i18n": "^12.0.7",
     "@emotion/react": "11.4.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -47,11 +47,13 @@
     "prop-types": "15.7.2"
   },
   "devDependencies": {
+    "@commercetools-community-kit/i18n": "^0.2.4",
     "intl-messageformat-parser": "6.4.4",
     "react": "17.0.2",
     "react-intl": "5.20.4"
   },
   "peerDependencies": {
+    "@commercetools-community-kit/i18n": "^0.2.4",
     "react": "17.x",
     "react-intl": "5.x"
   }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/runtime": "7.14.6",
     "@babel/runtime-corejs3": "7.14.7",
-    "@commercetools-community-kit/i18n": "^0.2.4",
+    "@commercetools-community-kit/i18n": "^0.2.5",
     "@commercetools-frontend/sentry": "20.5.2",
     "@commercetools-uikit/i18n": "^12.0.7",
     "@emotion/react": "11.4.0",
@@ -47,13 +47,11 @@
     "prop-types": "15.7.2"
   },
   "devDependencies": {
-    "@commercetools-community-kit/i18n": "^0.2.4",
     "intl-messageformat-parser": "6.4.4",
     "react": "17.0.2",
     "react-intl": "5.20.4"
   },
   "peerDependencies": {
-    "@commercetools-community-kit/i18n": "^0.2.4",
     "react": "17.x",
     "react-intl": "5.x"
   }

--- a/packages/i18n/src/load-i18n.ts
+++ b/packages/i18n/src/load-i18n.ts
@@ -111,49 +111,31 @@ const getCommunityKitChunkImport = async (
   locale: string
 ): Promise<I18NImportData> => {
   const intlLocale = mapLocaleToIntlLocale(locale);
-  try {
-    /* eslint-disable import/no-unresolved */
-    switch (intlLocale) {
-      case 'de':
-        return await import(
-          // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-de" */ '@commercetools-community-kit/i18n/compiled-data/de.json'
-        );
-      case 'es':
-        return await import(
-          // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-es" */ '@commercetools-community-kit/i18n/compiled-data/es.json'
-        );
-      case 'fr-FR':
-        return await import(
-          // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-fr-FR" */ '@commercetools-community-kit/i18n/compiled-data/fr-FR.json'
-        );
-      case 'zh-CN':
-        return await import(
-          // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-zh-CN" */ '@commercetools-community-kit/i18n/compiled-data/zh-CN.json'
-        );
-      case 'ja':
-        return await import(
-          // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-ja" */ '@commercetools-community-kit/i18n/compiled-data/ja.json'
-        );
-      default:
-        return await import(
-          // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-en" */ '@commercetools-community-kit/i18n/compiled-data/en.json'
-        );
-    }
-    /* eslint-enable import/no-unresolved */
-  } catch (error) {
-    switch (error.code) {
-      case 'MODULE_NOT_FOUND':
-        // Ignoring, as the dependency is optional.
-        return { default: {} };
-      default:
-        throw error;
-    }
+  switch (intlLocale) {
+    case 'de':
+      return await import(
+        /* webpackChunkName: "i18n-community-kit-locale-de" */ '@commercetools-community-kit/i18n/compiled-data/de.json'
+      );
+    case 'es':
+      return await import(
+        /* webpackChunkName: "i18n-community-kit-locale-es" */ '@commercetools-community-kit/i18n/compiled-data/es.json'
+      );
+    case 'fr-FR':
+      return await import(
+        /* webpackChunkName: "i18n-community-kit-locale-fr-FR" */ '@commercetools-community-kit/i18n/compiled-data/fr-FR.json'
+      );
+    case 'zh-CN':
+      return await import(
+        /* webpackChunkName: "i18n-community-kit-locale-zh-CN" */ '@commercetools-community-kit/i18n/compiled-data/zh-CN.json'
+      );
+    case 'ja':
+      return await import(
+        /* webpackChunkName: "i18n-community-kit-locale-ja" */ '@commercetools-community-kit/i18n/compiled-data/ja.json'
+      );
+    default:
+      return await import(
+        /* webpackChunkName: "i18n-community-kit-locale-en" */ '@commercetools-community-kit/i18n/compiled-data/en.json'
+      );
   }
 };
 

--- a/packages/i18n/src/load-i18n.ts
+++ b/packages/i18n/src/load-i18n.ts
@@ -107,7 +107,7 @@ const getAppKitChunkImport = (locale: string): Promise<I18NImportData> => {
   }
 };
 
-const getCommunityKitChunkImport = (
+const getCommunityKitChunkImport = async (
   locale: string
 ): Promise<I18NImportData> => {
   const intlLocale = mapLocaleToIntlLocale(locale);
@@ -115,42 +115,42 @@ const getCommunityKitChunkImport = (
     /* eslint-disable import/no-unresolved */
     switch (intlLocale) {
       case 'de':
-        return import(
+        return await import(
           // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-de" */ '@commercetools-community-kit/i18n/i18n/compiled-data/de.json'
+          /* webpackChunkName: "i18n-community-kit-locale-de" */ '@commercetools-community-kit/i18n/compiled-data/de.json'
         );
       case 'es':
-        return import(
+        return await import(
           // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-es" */ '@commercetools-community-kit/i18n/i18n/compiled-data/es.json'
+          /* webpackChunkName: "i18n-community-kit-locale-es" */ '@commercetools-community-kit/i18n/compiled-data/es.json'
         );
       case 'fr-FR':
-        return import(
+        return await import(
           // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-fr-FR" */ '@commercetools-community-kit/i18n/i18n/compiled-data/fr-FR.json'
+          /* webpackChunkName: "i18n-community-kit-locale-fr-FR" */ '@commercetools-community-kit/i18n/compiled-data/fr-FR.json'
         );
       case 'zh-CN':
-        return import(
+        return await import(
           // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-zh-CN" */ '@commercetools-community-kit/i18n/i18n/compiled-data/zh-CN.json'
+          /* webpackChunkName: "i18n-community-kit-locale-zh-CN" */ '@commercetools-community-kit/i18n/compiled-data/zh-CN.json'
         );
       case 'ja':
-        return import(
+        return await import(
           // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-ja" */ '@commercetools-community-kit/i18n/i18n/compiled-data/ja.json'
+          /* webpackChunkName: "i18n-community-kit-locale-ja" */ '@commercetools-community-kit/i18n/compiled-data/ja.json'
         );
       default:
-        return import(
+        return await import(
           // @ts-expect-error: it's an optional dependency.
-          /* webpackChunkName: "i18n-community-kit-locale-en" */ '@commercetools-community-kit/i18n/i18n/compiled-data/en.json'
+          /* webpackChunkName: "i18n-community-kit-locale-en" */ '@commercetools-community-kit/i18n/compiled-data/en.json'
         );
     }
     /* eslint-enable import/no-unresolved */
   } catch (error) {
     switch (error.code) {
-      case 'ERR_MODULE_NOT_FOUND':
+      case 'MODULE_NOT_FOUND':
         // Ignoring, as the dependency is optional.
-        return Promise.resolve({ default: {} });
+        return { default: {} };
       default:
         throw error;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,6 +1532,14 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime-corejs3@7.13.17":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.17.tgz#9baf45f03d4d013f021760b992d6349a9d27deaf"
+  integrity sha512-RGXINY1YvduBlGrP+vHjJqd/nK7JVpfM4rmZLGMx77WoL3sMrhheA0qxii9VNn1VHnxJLEyxmvCB+Wqc+x/FMw==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@7.14.0", "@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.12.5", "@babel/runtime-corejs3@^7.13.10":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz#6bf5fbc0b961f8e3202888cb2cd0fb7a0a9a3f66"
@@ -1560,6 +1568,13 @@
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@7.13.17":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1886,6 +1901,14 @@
     fs-extra "^7.0.1"
     human-id "^1.0.2"
     prettier "^1.19.1"
+
+"@commercetools-community-kit/i18n@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@commercetools-community-kit/i18n/-/i18n-0.2.4.tgz#ddac50b2eff961ebcd0031c8a9d607cb474877da"
+  integrity sha512-Kd5DyVYIPXta17LvTvtaEoK+XUuZfa2NiYpWYvCcx911j9v2MPFROg+gWVtVe2wPdn/rSOERrp56nE0WTkEeBA==
+  dependencies:
+    "@babel/runtime" "7.13.17"
+    "@babel/runtime-corejs3" "7.13.17"
 
 "@commercetools-docs/gatsby-theme-docs@16.3.1":
   version "16.3.1"
@@ -2260,7 +2283,7 @@
     "@commercetools-uikit/utils" "12.0.0"
     lodash "4.17.20"
 
-"@commercetools-uikit/i18n@12.0.7":
+"@commercetools-uikit/i18n@^12.0.7":
   version "12.0.7"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/i18n/-/i18n-12.0.7.tgz#dac4b38a2da14f24401a055d0701f39f2b09d6ea"
   integrity sha512-ccVu0OcInl9WFymayuBpfJogmAufzVqSGx8IU0LYQ+DKY+uXsUvyJV39I/o8mHXbQi1jotlvWtgzkOfloUCO0w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,10 +1887,10 @@
     human-id "^1.0.2"
     prettier "^1.19.1"
 
-"@commercetools-community-kit/i18n@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@commercetools-community-kit/i18n/-/i18n-0.2.5.tgz#468d5c0be4a4dd5ecd2bfca7c9bf381d75b55d6a"
-  integrity sha512-u37AwuRo8S0rk086wrX/+dGZYgX22sWaFWXjKDoh/el/A7Sp/VxVxiBIyCzd1r69Q+YW+ZRilWMnapwkmFsRJw==
+"@commercetools-community-kit/i18n@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@commercetools-community-kit/i18n/-/i18n-0.2.7.tgz#23c03bf77a99e64fb3d21ce89146964c486f9f07"
+  integrity sha512-1TIyewG1HwAQnwqHft2R6DJFFaLGV4Pw6G1MORyKwHba3Zsu09t79eXNAQ93cLw2iZT25o7wbHhtPlFwShlw8g==
   dependencies:
     "@babel/runtime" "7.14.6"
     "@babel/runtime-corejs3" "7.14.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,14 +1532,6 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime-corejs3@7.13.17":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.17.tgz#9baf45f03d4d013f021760b992d6349a9d27deaf"
-  integrity sha512-RGXINY1YvduBlGrP+vHjJqd/nK7JVpfM4rmZLGMx77WoL3sMrhheA0qxii9VNn1VHnxJLEyxmvCB+Wqc+x/FMw==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime-corejs3@7.14.0", "@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.12.5", "@babel/runtime-corejs3@^7.13.10":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz#6bf5fbc0b961f8e3202888cb2cd0fb7a0a9a3f66"
@@ -1568,13 +1560,6 @@
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@7.13.17":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
-  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1902,13 +1887,13 @@
     human-id "^1.0.2"
     prettier "^1.19.1"
 
-"@commercetools-community-kit/i18n@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@commercetools-community-kit/i18n/-/i18n-0.2.4.tgz#ddac50b2eff961ebcd0031c8a9d607cb474877da"
-  integrity sha512-Kd5DyVYIPXta17LvTvtaEoK+XUuZfa2NiYpWYvCcx911j9v2MPFROg+gWVtVe2wPdn/rSOERrp56nE0WTkEeBA==
+"@commercetools-community-kit/i18n@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@commercetools-community-kit/i18n/-/i18n-0.2.5.tgz#468d5c0be4a4dd5ecd2bfca7c9bf381d75b55d6a"
+  integrity sha512-u37AwuRo8S0rk086wrX/+dGZYgX22sWaFWXjKDoh/el/A7Sp/VxVxiBIyCzd1r69Q+YW+ZRilWMnapwkmFsRJw==
   dependencies:
-    "@babel/runtime" "7.13.17"
-    "@babel/runtime-corejs3" "7.13.17"
+    "@babel/runtime" "7.14.6"
+    "@babel/runtime-corejs3" "7.14.7"
 
 "@commercetools-docs/gatsby-theme-docs@16.3.1":
   version "16.3.1"


### PR DESCRIPTION
Note (**tech debt**): we might want/need to rethink how to ship and consume i18n messages from packages/repositories. At the moment, they are all loaded from the i18n package in appkit, but it's not really scalable. Ideally, packages should ship they own messages instead of relying on a single i18n package that aggregates all messages. See also https://formatjs.io/docs/getting-started/message-distribution

