### PR TITLE
fix(navbar): keep main menu item a link even when submenu group is expanded

### DIFF
--- a/.changeset/selfish-kangaroos-cry.md
+++ b/.changeset/selfish-kangaroos-cry.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Previously when a menu item had sub-links, clicking on the item would only expand the group of sub-links, making the main menu link not usable.
+
+Now when the item group is collapsed, clicking on the main item the first time expands the group of sub-links. **At this point the main menu item becomes a normal link** and can be used as expected.

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -180,7 +180,7 @@ const MenuGroup = (props: MenuGroupProps) => {
     <ul
       id={`${props.id}-group`}
       data-testid={`${props.id}-group`}
-      role="menu"
+      role="link"
       aria-expanded={
         isSublistActiveWhileIsMenuExpanded ||
         isSublistActiveWhileIsMenuCollapsed
@@ -221,7 +221,7 @@ type MenuItemProps = {
 };
 const MenuItem = (props: MenuItemProps) => (
   <li
-    role="menu-item"
+    role="link"
     className={classnames(styles['list-item'], {
       [styles.item__active]: props.isActive,
       [styles['item_menu-collapsed']]: !props.isMenuOpen,
@@ -428,6 +428,14 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
     return Boolean(match);
   };
 
+  const isMainMenuItemALink =
+    // 1. When the navbar is collapsed
+    !props.isMenuOpen ||
+    // 2. When there is no submenu
+    !hasSubmenu ||
+    // 3. When the submenu group is active/visible
+    props.isActive;
+
   return (
     <>
       {props.menu.shouldRenderDivider && <MenuItemDivider />}
@@ -453,7 +461,7 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
         >
           <MenuItemLink
             linkTo={
-              !props.isMenuOpen || !hasSubmenu
+              isMainMenuItemALink
                 ? `/${props.projectKey}/${props.menu.uriPath}`
                 : undefined
             }


### PR DESCRIPTION
Fixes #2164 