### PR TITLE
fix(constants): add order-search to graphql proxy targets

### DIFF
--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -124,6 +124,7 @@ export const GRAPHQL_TARGETS = {
   CHANGE_HISTORY_SERVICE: 'change-history',
   PIM_INDEXER: 'pim-indexer',
   ORDER_INDEXER: 'order-indexer',
+  ORDER_SEARCH: 'order-search',
   SETTINGS_SERVICE: 'settings',
   ADMINISTRATION_SERVICE: 'administration',
 } as const;


### PR DESCRIPTION
#### Summary

Adds the `order-search` as a constants of the `GRAPHQL_TARGETS`. Could be a feature but I'd rather mark it as a fix cause I assume it was more forgotten than not added purposefully before.