### PR TITLE
fix(navbar): keep custom aria role attributes

### DIFF
--- a/.changeset/eighty-maps-explode.md
+++ b/.changeset/eighty-maps-explode.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Keep custom aria `role` attributes for navbar.

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -180,7 +180,7 @@ const MenuGroup = (props: MenuGroupProps) => {
     <ul
       id={`${props.id}-group`}
       data-testid={`${props.id}-group`}
-      role="link"
+      role="menu"
       aria-expanded={
         isSublistActiveWhileIsMenuExpanded ||
         isSublistActiveWhileIsMenuCollapsed
@@ -221,7 +221,7 @@ type MenuItemProps = {
 };
 const MenuItem = (props: MenuItemProps) => (
   <li
-    role="link"
+    role="menu-item"
     className={classnames(styles['list-item'], {
       [styles.item__active]: props.isActive,
       [styles['item_menu-collapsed']]: !props.isMenuOpen,


### PR DESCRIPTION
Small regression caused by #2281 

I forgot that we use the roles for testing. It's also fine apparently to have custom roles, so the eslint warning can be "ignored".