### PR TITLE
docs(playground): fix reset styles

### DIFF
--- a/.changeset/few-timers-poke.md
+++ b/.changeset/few-timers-poke.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Update `@pmmmwh/react-refresh-webpack-plugin` to `0.5.0-rc.2`

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   "resolutions": {
     "@babel/core": "7.14.6",
     "@babel/preset-env": "7.14.7",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.1",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.2",
     "@types/puppeteer": "5.4.4",
     "@types/react-router": "5.1.16",
     "@typescript-eslint/eslint-plugin": "4.28.2",

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -37,7 +37,7 @@
     "@commercetools-frontend/babel-preset-mc-app": "20.7.0",
     "@commercetools-frontend/mc-dev-authentication": "19.0.0",
     "@commercetools-frontend/mc-html-template": "20.7.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.1",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.2",
     "@svgr/webpack": "5.5.0",
     "autoprefixer": "10.3.0",
     "babel-loader": "8.2.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -14,7 +14,7 @@
     "extract-intl": "formatjs extract --format=$(pwd)/intl-formatter.js --out-file=$(pwd)/src/i18n/data/core.json 'src/**/!(*.spec).js'"
   },
   "dependencies": {
-    "@commercetools-docs/ui-kit": "16.3.1",
+    "@commercetools-docs/ui-kit": "17.0.2",
     "@commercetools-frontend/actions-global": "20.7.0",
     "@commercetools-frontend/application-components": "20.7.0",
     "@commercetools-frontend/application-shell": "20.7.0",

--- a/website-components-playground/gatsby-config.js
+++ b/website-components-playground/gatsby-config.js
@@ -7,7 +7,6 @@ module.exports = {
     DEV_SSR: true,
     FAST_DEV: true,
     PRESERVE_FILE_DOWNLOAD_CACHE: true,
-    PRESERVE_WEBPACK_CACHE: true,
   },
   pathPrefix: '/custom-applications/playground',
   siteMetadata: {

--- a/website-components-playground/src/layouts/layout-app.js
+++ b/website-components-playground/src/layouts/layout-app.js
@@ -17,6 +17,12 @@ const LayoutApp = (props) => {
     <>
       <Global
         styles={css`
+          *,
+          *::before,
+          *::after {
+            box-sizing: inherit;
+          }
+
           html,
           body {
             padding: 0;

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -4,10 +4,9 @@ module.exports = {
   // https://www.gatsbyjs.com/docs/reference/release-notes/v2.28/#feature-flags-in-gatsby-configjs
   // https://www.gatsbyjs.com/docs/reference/release-notes/v2.30
   flags: {
-    DEV_SSR: true,
+    DEV_SSR: false, // good for catching bugs when developing, but too slow for productive content authoring
     FAST_DEV: true,
     PRESERVE_FILE_DOWNLOAD_CACHE: true,
-    PRESERVE_WEBPACK_CACHE: true,
   },
   pathPrefix: '/custom-applications',
   siteMetadata: {

--- a/website/package.json
+++ b/website/package.json
@@ -12,8 +12,8 @@
     "generate-icons": "svgr -d src/icons/generated src/icons/svg && prettier --write '**/generated/*.js'"
   },
   "dependencies": {
-    "@commercetools-docs/gatsby-theme-docs": "16.3.1",
-    "@commercetools-docs/ui-kit": "16.3.1",
+    "@commercetools-docs/gatsby-theme-docs": "17.0.2",
+    "@commercetools-docs/ui-kit": "17.0.2",
     "@commercetools-uikit/card": "^12.2.0",
     "@commercetools-uikit/spacings-inline": "^12.2.0",
     "@commercetools-uikit/spacings-stack": "^12.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,14 +1114,6 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime-corejs3@7.14.6":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.6.tgz#066b966eda40481740180cb3caab861a3f208cd3"
-  integrity sha512-Xl8SPYtdjcMoCsIM4teyVRg7jIcgl8F2kRtoCcXuHzXswt9UxZCS6BzRo8fcnCuP6u2XtPgvyonmEPF57Kxo9Q==
-  dependencies:
-    core-js-pure "^3.14.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime-corejs3@7.14.7", "@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.12.5", "@babel/runtime-corejs3@^7.13.10":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz#0ef292bbce40ca00f874c9724ef175a12476465c"
@@ -1137,7 +1129,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.14.6", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@7.14.6", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.6", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -1424,53 +1416,53 @@
     "@babel/runtime" "7.14.6"
     "@babel/runtime-corejs3" "7.14.7"
 
-"@commercetools-docs/gatsby-theme-docs@16.3.1":
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/@commercetools-docs/gatsby-theme-docs/-/gatsby-theme-docs-16.3.1.tgz#7324503533529b34814716826df34c6dd8465e8e"
-  integrity sha512-t36DrPCDVRM7hHPtjONaG2oXKgJphCJCsv9U/0mun0KLI77HxWemf+bJHzAM47hwAxMx5QdI4AS1fQFBQeNq9Q==
+"@commercetools-docs/gatsby-theme-docs@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@commercetools-docs/gatsby-theme-docs/-/gatsby-theme-docs-17.0.2.tgz#9c5e905196e73968758ee8ec6b5fd69cfc6531d4"
+  integrity sha512-JimadPDslZrTc/4Gic8VvoYWE/XoROfrdfSUv686ND37lXWZ7OL36t0zeme2GKCC12XGZKL8q5JMAjg0F+KiUw==
   dependencies:
-    "@commercetools-docs/ui-kit" "16.3.1"
-    "@commercetools-uikit/card" "^12.0.0"
-    "@commercetools-uikit/checkbox-input" "^12.0.0"
-    "@commercetools-uikit/date-input" "^12.0.0"
-    "@commercetools-uikit/design-system" "^12.0.0"
-    "@commercetools-uikit/icon-button" "^12.0.0"
-    "@commercetools-uikit/icons" "^12.0.0"
-    "@commercetools-uikit/secondary-icon-button" "^12.0.0"
-    "@commercetools-uikit/spacings-inline" "^12.0.0"
-    "@commercetools-uikit/spacings-stack" "^12.0.0"
-    "@commercetools-uikit/stamp" "^12.0.0"
+    "@commercetools-docs/ui-kit" "17.0.2"
+    "@commercetools-uikit/card" "^12.2.0"
+    "@commercetools-uikit/checkbox-input" "^12.2.1"
+    "@commercetools-uikit/date-input" "^12.2.1"
+    "@commercetools-uikit/design-system" "^12.1.0"
+    "@commercetools-uikit/icon-button" "^12.2.0"
+    "@commercetools-uikit/icons" "^12.2.1"
+    "@commercetools-uikit/secondary-icon-button" "^12.2.1"
+    "@commercetools-uikit/spacings-inline" "^12.2.0"
+    "@commercetools-uikit/spacings-stack" "^12.2.0"
+    "@commercetools-uikit/stamp" "^12.1.0"
     "@emotion/cache" "^11.0.0"
     "@emotion/react" "^11.1.1"
     "@emotion/server" "^11.0.0"
     "@emotion/styled" "^11.0.0"
-    "@fontsource/roboto" "4.4.5"
-    "@fontsource/roboto-mono" "4.4.5"
+    "@fontsource/roboto" "4.5.0"
+    "@fontsource/roboto-mono" "4.5.0"
     "@mdx-js/mdx" "1.6.22"
     "@mdx-js/react" "1.6.22"
-    "@sentry/browser" "6.7.1"
+    "@sentry/browser" "6.8.0"
     "@svgr/webpack" "5.5.0"
     cosmiconfig "^7.0.0"
     docsearch.js "2.6.3"
-    gatsby-plugin-emotion "6.7.1"
-    gatsby-plugin-feed "3.7.1"
-    gatsby-plugin-google-analytics "3.7.1"
+    gatsby-plugin-emotion "6.9.0"
+    gatsby-plugin-feed "3.9.0"
+    gatsby-plugin-google-analytics "3.9.0"
     gatsby-plugin-hubspot "1.3.5"
-    gatsby-plugin-image "1.7.1"
-    gatsby-plugin-manifest "3.7.1"
-    gatsby-plugin-mdx "2.7.1"
+    gatsby-plugin-image "1.9.0"
+    gatsby-plugin-manifest "3.9.0"
+    gatsby-plugin-mdx "2.9.0"
     gatsby-plugin-meta-redirect "1.1.1"
-    gatsby-plugin-react-helmet "4.7.1"
+    gatsby-plugin-react-helmet "4.9.0"
     gatsby-plugin-react-helmet-canonical-urls "1.4.0"
-    gatsby-plugin-remove-trailing-slashes "3.7.1"
-    gatsby-plugin-sharp "3.7.1"
-    gatsby-plugin-webpack-bundle-analyser-v2 "1.1.22"
-    gatsby-remark-copy-linked-files "4.4.1"
-    gatsby-remark-images "5.4.1"
+    gatsby-plugin-remove-trailing-slashes "3.9.0"
+    gatsby-plugin-sharp "3.9.0"
+    gatsby-plugin-webpack-bundle-analyser-v2 "1.1.24"
+    gatsby-remark-copy-linked-files "4.6.0"
+    gatsby-remark-images "5.6.0"
     gatsby-remark-relative-images "0.2.3"
-    gatsby-source-filesystem "3.7.1"
-    gatsby-transformer-sharp "3.7.1"
-    gatsby-transformer-yaml "3.7.1"
+    gatsby-source-filesystem "3.9.0"
+    gatsby-transformer-sharp "3.9.0"
+    gatsby-transformer-yaml "3.9.0"
     github-slugger "1.3.0"
     hast-util-heading "1.0.5"
     intersection-observer "0.12.0"
@@ -1494,18 +1486,18 @@
     unified "9.2.1"
     unist-util-filter "3.0.0"
 
-"@commercetools-docs/ui-kit@16.3.1":
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/@commercetools-docs/ui-kit/-/ui-kit-16.3.1.tgz#6a81fae867ee67e3702939838825a05fd98d16f6"
-  integrity sha512-+W1dgor/qOOnFW+Umc6OJXuD7+oA8irg86I5bpqIiL0XpCDsIVmdJikTan4SLqvdK7fFaS5OUbsFNoqgOT5Q7Q==
+"@commercetools-docs/ui-kit@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@commercetools-docs/ui-kit/-/ui-kit-17.0.2.tgz#8324589f1204463002c4abd5666254b11bed2cc6"
+  integrity sha512-kXHr80wy+E1GaNJec5T+5g5Jg4k1yK1Tr5T6ry+8iy8ao89B9jL5UAE4cEIlDZEyk++6acicikWJAsQH1DKJbQ==
   dependencies:
     "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.6"
-    "@commercetools-uikit/design-system" "^12.0.0"
-    "@commercetools-uikit/icons" "^12.0.0"
-    "@commercetools-uikit/loading-spinner" "^12.0.0"
-    "@commercetools-uikit/spacings-inline" "^12.0.0"
-    "@commercetools-uikit/tooltip" "^12.0.0"
+    "@babel/runtime-corejs3" "7.14.7"
+    "@commercetools-uikit/design-system" "^12.1.0"
+    "@commercetools-uikit/icons" "^12.2.1"
+    "@commercetools-uikit/loading-spinner" "^12.2.0"
+    "@commercetools-uikit/spacings-inline" "^12.2.0"
+    "@commercetools-uikit/tooltip" "^12.2.0"
     "@emotion/react" "^11.1.1"
     "@emotion/styled" "^11.0.0"
     lodash.escape "4.0.1"
@@ -1588,19 +1580,19 @@
     "@emotion/styled" "^11.3.0"
     prop-types "15.7.2"
 
-"@commercetools-uikit/calendar-utils@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/calendar-utils/-/calendar-utils-12.2.0.tgz#28d1113cf5a6e9d06de97b1b70ed5b207c6da146"
-  integrity sha512-eOvfuvMKFIc6xLEasx38PTlHFpALfYmkSdClgZQJibG2hoDSpgAAMVEwMQmwzStNJS/7/MhVhk0lvM3zBGRkeg==
+"@commercetools-uikit/calendar-utils@12.2.1":
+  version "12.2.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/calendar-utils/-/calendar-utils-12.2.1.tgz#9f3b66fe30d5a899ca9fb7b9a6d8a1bfc05dcf17"
+  integrity sha512-dYgBvwDnJT7yWHAd8x31z3o0ND709OItNEuhK39J+OJ0DSuV7ic2yAtWNr+yHlsQIyuiNOKHxzBwzS+DBiaZog==
   dependencies:
     "@babel/runtime" "7.14.6"
     "@babel/runtime-corejs3" "7.14.7"
     "@commercetools-uikit/accessible-button" "12.2.0"
     "@commercetools-uikit/design-system" "12.1.0"
     "@commercetools-uikit/hooks" "12.2.0"
-    "@commercetools-uikit/icons" "12.2.0"
-    "@commercetools-uikit/input-utils" "12.2.0"
-    "@commercetools-uikit/secondary-icon-button" "12.2.0"
+    "@commercetools-uikit/icons" "12.2.1"
+    "@commercetools-uikit/input-utils" "12.2.1"
+    "@commercetools-uikit/secondary-icon-button" "12.2.1"
     "@commercetools-uikit/spacings-inline" "12.2.0"
     "@commercetools-uikit/text" "12.2.0"
     "@commercetools-uikit/tooltip" "12.2.0"
@@ -1610,7 +1602,7 @@
     prop-types "15.7.2"
     react-select "4.3.1"
 
-"@commercetools-uikit/card@^12.0.0", "@commercetools-uikit/card@^12.2.0":
+"@commercetools-uikit/card@^12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/card/-/card-12.2.0.tgz#9d33d495168f61b1a728cb4fef863f4716269e15"
   integrity sha512-AqGYyEoUtTRaUvWPeO6sqCuJzrUZIIS9LQFRYXjjRgkVicEd8OPig1YpGKbrteqQfd7jFFwfV8jfi5NnroAJnw==
@@ -1620,23 +1612,6 @@
     "@commercetools-uikit/design-system" "12.1.0"
     "@commercetools-uikit/spacings-inset" "12.2.0"
     "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/checkbox-input@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/checkbox-input/-/checkbox-input-12.1.0.tgz#191f310815af36483ad64df8dc373696b4f2a2f2"
-  integrity sha512-XY9m0Y1HU8YWT5OLD666LYqvx/1Q07UxuyYq3/IWcTk6Z6zJ684YOyPNS//w7tw8Y1VxkTeV0GRqyZgg8Oh81Q==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/icons" "12.1.0"
-    "@commercetools-uikit/input-utils" "12.1.0"
-    "@commercetools-uikit/select-utils" "12.1.0"
-    "@commercetools-uikit/text" "12.1.0"
-    "@commercetools-uikit/utils" "12.0.7"
     "@emotion/react" "^11.4.0"
     "@emotion/styled" "^11.3.0"
     prop-types "15.7.2"
@@ -1690,21 +1665,21 @@
     prop-types "15.7.2"
     react-required-if "1.0.3"
 
-"@commercetools-uikit/date-input@^12.0.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/date-input/-/date-input-12.2.0.tgz#7b193ecaefdb381a88a3c3ee9ad120550db9a327"
-  integrity sha512-KH1oWtNQ5bEYUXkImrfSdbcLNuq5RTi5PsC1zJuyyiHKp7tLqRuFuHspWZ9sB+esBHPXT/wYpe/lBi7xZ4SCQQ==
+"@commercetools-uikit/date-input@^12.2.1":
+  version "12.2.1"
+  resolved "https://registry.yarnpkg.com/@commercetools-uikit/date-input/-/date-input-12.2.1.tgz#8e56dbf18c3103061126271117fe8fe2e9e8314a"
+  integrity sha512-hpNn45QyI33lvrtSZWnl+VV+0HQa6vGJz4bnsuLvtPTErcU+ThCJJXCIOlzZMsFRBCLOp49x+DEV83lCKYVSdQ==
   dependencies:
     "@babel/runtime" "7.14.6"
     "@babel/runtime-corejs3" "7.14.7"
     "@commercetools-uikit/accessible-button" "12.2.0"
-    "@commercetools-uikit/calendar-utils" "12.2.0"
+    "@commercetools-uikit/calendar-utils" "12.2.1"
     "@commercetools-uikit/constraints" "12.2.0"
     "@commercetools-uikit/design-system" "12.1.0"
     "@commercetools-uikit/hooks" "12.2.0"
-    "@commercetools-uikit/icons" "12.2.0"
-    "@commercetools-uikit/secondary-icon-button" "12.2.0"
-    "@commercetools-uikit/select-utils" "12.2.0"
+    "@commercetools-uikit/icons" "12.2.1"
+    "@commercetools-uikit/secondary-icon-button" "12.2.1"
+    "@commercetools-uikit/select-utils" "12.2.1"
     "@commercetools-uikit/spacings-inline" "12.2.0"
     "@commercetools-uikit/text" "12.2.0"
     "@commercetools-uikit/tooltip" "12.2.0"
@@ -1718,7 +1693,7 @@
     react-required-if "1.0.3"
     warning "4.0.3"
 
-"@commercetools-uikit/design-system@12.1.0", "@commercetools-uikit/design-system@^12.0.0", "@commercetools-uikit/design-system@^12.1.0":
+"@commercetools-uikit/design-system@12.1.0", "@commercetools-uikit/design-system@^12.1.0":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-12.1.0.tgz#335208f9cff400ef896fc01fc21132a2631118a3"
   integrity sha512-2oeMiZO9U8udXqKrD8BcVma5q3aLklyH3562dVEGX51TaTfBEPGBJoDg0qMb4RmrdXIoPnHINPt53A9fUv3G/g==
@@ -1823,40 +1798,6 @@
     lodash "4.17.21"
     prop-types "15.7.2"
 
-"@commercetools-uikit/icon-button@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icon-button/-/icon-button-12.1.0.tgz#9a3c476bfbbb78d2f0d48417ec020613b5a687df"
-  integrity sha512-TvGv/8CeowurnKZJlAevsa1c28s/shmSfX9EXIImKqi27E6JPOzD2frGr2tDOp9HtNx/2DpEWJ31DZ7BEL6+/w==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/accessible-button" "12.1.0"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/spacings" "12.1.0"
-    "@commercetools-uikit/text" "12.1.0"
-    "@commercetools-uikit/utils" "12.0.7"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    common-tags "1.8.0"
-    lodash "4.17.21"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/icons@12.2.0", "@commercetools-uikit/icons@^12.0.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-12.2.0.tgz#8a3f8d8653aecba1bdd30b812adb6ea97eaec238"
-  integrity sha512-56WvSTAqjhdkhhKheV0d+/eS/y7LMcGYE4qXNmxU6NsrYL4GuCi/xWc1U35DLIWQRJbZHpP9RE0B065TgzTjAQ==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    "@types/dompurify" "^2.2.3"
-    dompurify "2.3.0"
-    prop-types "15.7.2"
-    react-from-dom "0.6.1"
-
 "@commercetools-uikit/icons@12.2.1", "@commercetools-uikit/icons@^12.2.1":
   version "12.2.1"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-12.2.1.tgz#6dba36f904ee7ab13f72d082cdcb03e163b3c6c7"
@@ -1872,22 +1813,6 @@
     dompurify "2.3.0"
     prop-types "15.7.2"
     react-from-dom "0.6.1"
-
-"@commercetools-uikit/input-utils@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/input-utils/-/input-utils-12.2.0.tgz#c27ede17d0ad24c387dd1085f45af2e062747cf5"
-  integrity sha512-M+AL0tHkj6wAygvU7rF6ZDB9TIp5uMyDRCXX0g1mBqyKwTpyoBItNpdIqcvxWWJlM2Rg6zKG6meZo3GCz71koA==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/flat-button" "12.2.0"
-    "@commercetools-uikit/icons" "12.2.0"
-    "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    prop-types "15.7.2"
-    react-required-if "1.0.3"
-    react-textarea-autosize "8.3.3"
 
 "@commercetools-uikit/input-utils@12.2.1":
   version "12.2.1"
@@ -1948,20 +1873,6 @@
     "@commercetools-uikit/spacings-inline" "12.2.0"
     "@commercetools-uikit/text" "12.2.0"
     "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/loading-spinner@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/loading-spinner/-/loading-spinner-12.1.0.tgz#194e65f9d46a03fb1e42a64daee1a1fb8d91e3c9"
-  integrity sha512-dDiXr3yMC985wtWG1DTZLCN+me9ySuRwu94PPRKecp+v6xZLf2t0ofjibcYaZzEeegKJXbt5YnhQdFRmuVt+4g==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/spacings-inline" "12.1.0"
-    "@commercetools-uikit/text" "12.1.0"
-    "@commercetools-uikit/utils" "12.0.7"
     "@emotion/react" "^11.4.0"
     prop-types "15.7.2"
 
@@ -2072,24 +1983,6 @@
     lodash "4.17.21"
     prop-types "15.7.2"
 
-"@commercetools-uikit/secondary-icon-button@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-12.2.0.tgz#6c53303dde6d5b139935d627b14f2a58161f1d09"
-  integrity sha512-r3pPLCk+V0mcfuMtHyFf/1bKAGjO/P121k8A3NGnj5bviaPvh/M6g472JMfrmG+JzDM4zSe+UdG5dd2mmBhpqw==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/accessible-button" "12.2.0"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/spacings" "12.2.0"
-    "@commercetools-uikit/text" "12.2.0"
-    "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    common-tags "1.8.0"
-    lodash "4.17.21"
-    prop-types "15.7.2"
-
 "@commercetools-uikit/secondary-icon-button@12.2.1", "@commercetools-uikit/secondary-icon-button@^12.2.1":
   version "12.2.1"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-12.2.1.tgz#cedce3958ef9da298e1a9368eea7c9fa04f3d8d8"
@@ -2102,24 +1995,6 @@
     "@commercetools-uikit/spacings" "12.2.0"
     "@commercetools-uikit/text" "12.2.0"
     "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    common-tags "1.8.0"
-    lodash "4.17.21"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/secondary-icon-button@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/secondary-icon-button/-/secondary-icon-button-12.1.0.tgz#13a7ba5e396944c9eb7a376d35fd6545b0560c09"
-  integrity sha512-w3qTNx7+FHnNmof4qfJOlIrU3BSaoI/FgHZuK3tHNeWVzITa2fuTlmEBeSRcuJEXiIuK8clOU2VJTF4CL+Nu8Q==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/accessible-button" "12.1.0"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/spacings" "12.1.0"
-    "@commercetools-uikit/text" "12.1.0"
-    "@commercetools-uikit/utils" "12.0.7"
     "@emotion/react" "^11.4.0"
     "@emotion/styled" "^11.3.0"
     common-tags "1.8.0"
@@ -2164,25 +2039,6 @@
     prop-types "15.7.2"
     react-select "4.3.1"
 
-"@commercetools-uikit/select-utils@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-12.2.0.tgz#032f4c02e7d2fca83bac7472ac3692d2e43b615e"
-  integrity sha512-IuA4V5+HrbMUBzL9yheaDsPYkcVttt1Lx39y0k0X2zQPYg864Jz7c1GTKei1BwNes54MhcfqYmG5DlCShTnecg==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/accessible-button" "12.2.0"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/icons" "12.2.0"
-    "@commercetools-uikit/spacings" "12.2.0"
-    "@commercetools-uikit/text" "12.2.0"
-    "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    lodash "4.17.21"
-    prop-types "15.7.2"
-    react-select "4.3.1"
-
 "@commercetools-uikit/select-utils@12.2.1":
   version "12.2.1"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-12.2.1.tgz#cb2015396696b1baa74abcc2368fc3ef09af9211"
@@ -2211,18 +2067,6 @@
     "@babel/runtime-corejs3" "7.14.7"
     "@commercetools-uikit/design-system" "12.1.0"
     "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/spacings-inline@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-inline/-/spacings-inline-12.1.0.tgz#b113420c12342f93a11407b6798d276f77e2d618"
-  integrity sha512-aCuWv1bthuh3hXWHlWeB5cCsGnVfrJU/XiVOB8yjR84Oq6udOUXcSnrgjHl/Z2z7/P1FyN0Q5HGIZ1xZvS77gQ==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/utils" "12.0.7"
     "@emotion/react" "^11.4.0"
     prop-types "15.7.2"
 
@@ -2262,18 +2106,6 @@
     "@emotion/react" "^11.4.0"
     prop-types "15.7.2"
 
-"@commercetools-uikit/spacings-stack@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings-stack/-/spacings-stack-12.1.0.tgz#84e8e2236f322408cc308b4771225e61eb118272"
-  integrity sha512-tlIDPqzHhSLLguMdSUSPXt9DQQqm+w5adIBmEVP0HkMrrg/2La2avL9TaBPjl8k557UAEXsejPGt8hMash30mA==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/utils" "12.0.7"
-    "@emotion/react" "^11.4.0"
-    prop-types "15.7.2"
-
 "@commercetools-uikit/spacings@12.2.0", "@commercetools-uikit/spacings@^12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/spacings/-/spacings-12.2.0.tgz#a89778b6db9883d117366a0b612527a24a6d5ad0"
@@ -2286,7 +2118,7 @@
     "@commercetools-uikit/spacings-inset-squish" "12.2.0"
     "@commercetools-uikit/spacings-stack" "12.2.0"
 
-"@commercetools-uikit/stamp@^12.0.0":
+"@commercetools-uikit/stamp@^12.1.0":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/stamp/-/stamp-12.1.0.tgz#2b99f209821c474abc854568305e4a8c9a34d12b"
   integrity sha512-Tob/8uJmuEXonZQevaUpL9dk9eb37HMgCw3PBzP4dgVuxiXb437C/hpOzZLAIgaVY/G9DwyRUy3hMm+QDq6FsA==
@@ -2346,7 +2178,7 @@
     react-required-if "1.0.3"
     warning "4.0.3"
 
-"@commercetools-uikit/tooltip@12.2.0":
+"@commercetools-uikit/tooltip@12.2.0", "@commercetools-uikit/tooltip@^12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/tooltip/-/tooltip-12.2.0.tgz#51f8b90fe1b5936796715a8cc4caa7473a4fd7d5"
   integrity sha512-dha7p4+qam4lr7eBTf/LWz2vHh/VKipmlJHNLOs4H6qU0TpZKusuhlLMbeaX8ky61Q9C1kUXLFazMY01e2xqiA==
@@ -2357,24 +2189,6 @@
     "@commercetools-uikit/design-system" "12.1.0"
     "@commercetools-uikit/hooks" "12.2.0"
     "@commercetools-uikit/utils" "12.2.0"
-    "@emotion/react" "^11.4.0"
-    "@emotion/styled" "^11.3.0"
-    lodash "4.17.21"
-    prop-types "15.7.2"
-    react-is "17.0.2"
-    use-popper "1.1.6"
-
-"@commercetools-uikit/tooltip@^12.0.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/tooltip/-/tooltip-12.1.0.tgz#169d6b240377043fc93f338b6306c26a372206ca"
-  integrity sha512-iXHu9qWeu4Ytdb9NT4IRnGD81ek2Y8KG2CaiOZ0YPYXDOZGCrXLQZkIZ3KOacjZIazU9XL7Pj5nQODn0FXHjCw==
-  dependencies:
-    "@babel/runtime" "7.14.6"
-    "@babel/runtime-corejs3" "7.14.7"
-    "@commercetools-uikit/constraints" "12.1.0"
-    "@commercetools-uikit/design-system" "12.1.0"
-    "@commercetools-uikit/hooks" "12.0.7"
-    "@commercetools-uikit/utils" "12.0.7"
     "@emotion/react" "^11.4.0"
     "@emotion/styled" "^11.3.0"
     lodash "4.17.21"
@@ -2870,15 +2684,15 @@
   resolved "https://registry.yarnpkg.com/@fontsource/open-sans/-/open-sans-4.5.0.tgz#e6d05dfdfe74580001010302f9c418067b45a6a9"
   integrity sha512-49+A0IkTTv3cpS1YecrZNCqvlVTThUt/qioiAIZsXfgC3TqavgRqwXXvroXmhVeP/f0sqZw5CRDMS1Hj4aSTbQ==
 
-"@fontsource/roboto-mono@4.4.5":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@fontsource/roboto-mono/-/roboto-mono-4.4.5.tgz#63c54719a8d592d793632501a56d570572c17065"
-  integrity sha512-y9fbKH1eCCkcqtRGhevFlmR5schCRz1GiTT/VYz6z8Ij0WHW0tS26BhMyXhmSgEIiFt+254yS8teqP+cc7Xq0w==
+"@fontsource/roboto-mono@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto-mono/-/roboto-mono-4.5.0.tgz#27e44fbb1d86a9ef14501493a37eef1d73e60d02"
+  integrity sha512-/6Gm6fJjBHZiFNyvzIKGJkVuyifoc1aoTel+pkzdhxNh7yNhFyokCoChdbbqZEpGKpqs5uld74G5TJthUVFyjw==
 
-"@fontsource/roboto@4.4.5":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.4.5.tgz#9ef1b9288ac4a97b97906da920c63c08dba97c89"
-  integrity sha512-e3s7BF8MDBLpkA2r6lnl5PMnllF0McVvpolK9h2zzvVJw2WPexP1GTgMKHISlglYZRij2lKg/ZjQcIUUYDsAXg==
+"@fontsource/roboto@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.0.tgz#d6f925668ba6af46707f1040c43aff498ba204bb"
+  integrity sha512-ja4XYw/9kNRFM5Ndk9vwzHWsdBMXczyBazFkTXJQ74QQBnT0BbSsHn0pF60AU0Iznig1Wt9x3rADfG8LANvMpw==
 
 "@formatjs/cli@4.2.27":
   version "4.2.27"
@@ -4598,10 +4412,10 @@
   dependencies:
     "@percy/logger" "^1.0.0-beta.58"
 
-"@pmmmwh/react-refresh-webpack-plugin@0.5.0-rc.1", "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
-  version "0.5.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.0-rc.1.tgz#3b51d5a3a1818afc20b7c887631db8698d68d00e"
-  integrity sha512-zwuSpdEr1PVfPntc+0+D2nacSXDJuYsx2Ie8twOyjjiJObxlGjc52ez7U/8p0/e3IkgzdqKrvmo2jmMKOFGI6Q==
+"@pmmmwh/react-refresh-webpack-plugin@0.5.0-rc.2", "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
+  version "0.5.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.0-rc.2.tgz#7f1049150d8474cd8bfe21ae0efec581238dc924"
+  integrity sha512-LTZK5rAAiog7FvsDKX7mJBifV9yyzhIXHqlHA8E978Z0iFLsW40j6OVJFZ/AzV3wBIvN3+iPVYvhVGckkoy8OQ==
   dependencies:
     ansi-html "^0.0.7"
     core-js-pure "^3.8.1"
@@ -4732,16 +4546,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/browser@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.7.1.tgz#e01144a08984a486ecc91d7922cc457e9c9bd6b7"
-  integrity sha512-R5PYx4TTvifcU790XkK6JVGwavKaXwycDU0MaAwfc4Vf7BLm5KCNJCsDySu1RPAap/017MVYf54p6dWvKiRviA==
-  dependencies:
-    "@sentry/core" "6.7.1"
-    "@sentry/types" "6.7.1"
-    "@sentry/utils" "6.7.1"
-    tslib "^1.9.3"
-
 "@sentry/browser@6.8.0":
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.8.0.tgz#023707cd2302f6818014e9a7e124856b2d064178"
@@ -4750,17 +4554,6 @@
     "@sentry/core" "6.8.0"
     "@sentry/types" "6.8.0"
     "@sentry/utils" "6.8.0"
-    tslib "^1.9.3"
-
-"@sentry/core@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.7.1.tgz#c3aaa6415d06bec65ac446b13b84f073805633e3"
-  integrity sha512-VAv8OR/7INn2JfiLcuop4hfDcyC7mfL9fdPndQEhlacjmw8gRrgXjR7qyhnCTgzFLkHI7V5bcdIzA83TRPYQpA==
-  dependencies:
-    "@sentry/hub" "6.7.1"
-    "@sentry/minimal" "6.7.1"
-    "@sentry/types" "6.7.1"
-    "@sentry/utils" "6.7.1"
     tslib "^1.9.3"
 
 "@sentry/core@6.8.0":
@@ -4774,15 +4567,6 @@
     "@sentry/utils" "6.8.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.7.1.tgz#d46d24deec67f0731a808ca16796e6765b371bc1"
-  integrity sha512-eVCTWvvcp6xa0A5GGNHMQEWslmKPlisE5rGmsV/kjvSUv3zSrI0eIDfb51ikdnCiBjHpK2NBWP8Vy8cZOEJegg==
-  dependencies:
-    "@sentry/types" "6.7.1"
-    "@sentry/utils" "6.7.1"
-    tslib "^1.9.3"
-
 "@sentry/hub@6.8.0":
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.8.0.tgz#cb0f8509093919ed3c1ef98ef8cf63dc102a6524"
@@ -4790,15 +4574,6 @@
   dependencies:
     "@sentry/types" "6.8.0"
     "@sentry/utils" "6.8.0"
-    tslib "^1.9.3"
-
-"@sentry/minimal@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.7.1.tgz#babf85ee2f167e9dcf150d750d7a0b250c98449c"
-  integrity sha512-HDDPEnQRD6hC0qaHdqqKDStcdE1KhkFh0RCtJNMCDn0zpav8Dj9AteF70x6kLSlliAJ/JFwi6AmQrLz+FxPexw==
-  dependencies:
-    "@sentry/hub" "6.7.1"
-    "@sentry/types" "6.7.1"
     tslib "^1.9.3"
 
 "@sentry/minimal@6.8.0":
@@ -4836,23 +4611,10 @@
     "@sentry/utils" "6.8.0"
     tslib "^1.9.3"
 
-"@sentry/types@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.7.1.tgz#c8263e1886df5e815570c4668eb40a1cfaa1c88b"
-  integrity sha512-9AO7HKoip2MBMNQJEd6+AKtjj2+q9Ze4ooWUdEvdOVSt5drg7BGpK221/p9JEOyJAZwEPEXdcMd3VAIMiOb4MA==
-
 "@sentry/types@6.8.0":
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.8.0.tgz#97fd531a0ed1e75e65b4a24b26509fb7c15eb7b8"
   integrity sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA==
-
-"@sentry/utils@6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.7.1.tgz#909184ad580f0f6375e1e4d4a6ffd33dfe64a4d1"
-  integrity sha512-Tq2otdbWlHAkctD+EWTYKkEx6BL1Qn3Z/imkO06/PvzpWvVhJWQ5qHAzz5XnwwqNHyV03KVzYB6znq1Bea9HuA==
-  dependencies:
-    "@sentry/types" "6.7.1"
-    tslib "^1.9.3"
 
 "@sentry/utils@6.8.0":
   version "6.8.0"
@@ -6968,7 +6730,7 @@ babel-plugin-preval@5.0.0:
     babel-plugin-macros "^2.8.0"
     require-from-string "^2.0.2"
 
-babel-plugin-remove-graphql-queries@^3.7.1, babel-plugin-remove-graphql-queries@^3.9.0:
+babel-plugin-remove-graphql-queries@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-3.9.0.tgz#73732b5632a944ad4d623a30b8dca69c529ffceb"
   integrity sha512-gr7n6Ytoyp6Ix7XX071oVPynC+jfesYH05fzg8Ih8yKQsBxmqWiMxAUIHuD70ieZJ94TxlXQQbHYi6oibmlx7w==
@@ -8685,7 +8447,7 @@ core-js-compat@^3.14.0, core-js-compat@^3.15.0:
     browserslist "^4.16.6"
     semver "7.0.0"
 
-core-js-pure@^3.0.0, core-js-pure@^3.14.0, core-js-pure@^3.15.0, core-js-pure@^3.8.1:
+core-js-pure@^3.0.0, core-js-pure@^3.15.0, core-js-pure@^3.8.1:
   version "3.15.2"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.2.tgz#c8e0874822705f3385d3197af9348f7c9ae2e3ce"
   integrity sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==
@@ -11781,7 +11543,7 @@ gatsby-cli@3.9.0, gatsby-cli@^3.9.0:
     yoga-layout-prebuilt "^1.9.6"
     yurnalist "^2.1.0"
 
-gatsby-core-utils@^2.7.1, gatsby-core-utils@^2.9.0:
+gatsby-core-utils@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-2.9.0.tgz#f1ba30dfa687bdd2c1c5106d29e6491e5376e8c5"
   integrity sha512-LKmkk4B/VnSEYKR9W/C8Lp9lwk/l/qY5jbsoiChc43F67VM667gITWH0noSUdcGzbEsN8xi0Wuc8dMA6BvKkvg==
@@ -11832,14 +11594,6 @@ gatsby-page-utils@^1.9.0:
     lodash "^4.17.21"
     micromatch "^4.0.2"
 
-gatsby-plugin-emotion@6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-emotion/-/gatsby-plugin-emotion-6.7.1.tgz#f25156e7fbf8e7f6f9dd42fcd2708cb50742e18e"
-  integrity sha512-tbgehb9VexyAvxyOIsrg9KUHrvYi3f8tmpGaKg3qb5GWsH0tssGiHlBDl6+84Bo6nJO14jSoIxwerUS0AzSVAw==
-  dependencies:
-    "@babel/runtime" "^7.14.0"
-    "@emotion/babel-preset-css-prop" "^11.2.0"
-
 gatsby-plugin-emotion@6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-emotion/-/gatsby-plugin-emotion-6.9.0.tgz#38381b98c7599eb42cfe5e51add93093c52a39c9"
@@ -11848,26 +11602,27 @@ gatsby-plugin-emotion@6.9.0:
     "@babel/runtime" "^7.14.0"
     "@emotion/babel-preset-css-prop" "^11.2.0"
 
-gatsby-plugin-feed@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-3.7.1.tgz#5ec1348ed8221439584c4eb91fa590a35f27e2a6"
-  integrity sha512-MG4q/PWcA79xdKep+CKp32v8n4b1pVZLQ/bQJzLqZ/gx5mbMzzjlbUPzzmxa3nj5Zyghf40gBKgG+x84LumPzQ==
+gatsby-plugin-feed@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-3.9.0.tgz#f2724843635456a737a2ca23fc3f9c6d466e64ac"
+  integrity sha512-9anpntXFlv7rQdqWKZoHqybUZIL3ne0rHgynvnLE+jLpJy0HoWGHg/yu8hvzxSH1+L1QDrDHJEtxivs58cBKkg==
   dependencies:
     "@babel/runtime" "^7.14.0"
     "@hapi/joi" "^15.1.1"
     common-tags "^1.8.0"
     fs-extra "^9.1.0"
-    gatsby-plugin-utils "^1.7.1"
+    gatsby-plugin-utils "^1.9.0"
     lodash.merge "^4.6.2"
     rss "^1.2.2"
 
-gatsby-plugin-google-analytics@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-3.7.1.tgz#c54821e609d10ca6f4843b60054bf0b243302cb4"
-  integrity sha512-50NT0Fvv/f+pSxohheVixYxrRHf2mE/XtGOyGMVl9Qxbry8evaqSLMYaoLP6JCcm/pzEoHQk04Cyrlo173JBMQ==
+gatsby-plugin-google-analytics@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-3.9.0.tgz#550cf9a31d05c8f627d7a963df0acaafef416849"
+  integrity sha512-vK/NEl4uJI6QdlhK+CwCsMdEw5Ikl0bKi/TYjoCn0mjN/45qlxlOL2Yz7r813dD742hdz75HQhxedWG9MRH2Cg==
   dependencies:
     "@babel/runtime" "^7.14.0"
     minimatch "3.0.4"
+    web-vitals "^1.1.2"
 
 gatsby-plugin-hubspot@1.3.5:
   version "1.3.5"
@@ -11876,39 +11631,39 @@ gatsby-plugin-hubspot@1.3.5:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-gatsby-plugin-image@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-1.7.1.tgz#07d8f14b9c37b294a38d4151dbf80e21cfaabaff"
-  integrity sha512-1wUgNNc4e1ySNaDgH3yEs6HYZ8W4s0IAFU945SQtASknrR9o69WpeWPBllQwDrlq/1jlzetMTCiMISHvc7aqqQ==
+gatsby-plugin-image@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-1.9.0.tgz#2728a166ac541933754828ee1a4fcd8a24e1c796"
+  integrity sha512-MxqXsgMpAfzm2HhySlv1enojy15BkAhm96tiVPkSO7BMiufm6eS9VvIu+eJ4cthCdJztOcYlzTlWNCI+whEUPg==
   dependencies:
     "@babel/code-frame" "^7.14.0"
     "@babel/parser" "^7.14.0"
     "@babel/traverse" "^7.14.0"
     babel-jsx-utils "^1.1.0"
-    babel-plugin-remove-graphql-queries "^3.7.1"
+    babel-plugin-remove-graphql-queries "^3.9.0"
     camelcase "^5.3.1"
     chokidar "^3.5.1"
     common-tags "^1.8.0"
     fs-extra "^8.1.0"
-    gatsby-core-utils "^2.7.1"
+    gatsby-core-utils "^2.9.0"
     objectFitPolyfill "^2.3.0"
     prop-types "^15.7.2"
 
-gatsby-plugin-manifest@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-3.7.1.tgz#c3c721d951390800c58dff69e05eb4566e403140"
-  integrity sha512-STYtL7QZlKmGcXza+qxtIr8A5HS+0TzBy+qRDlOCFIYnxVTWKgg4m45/G7rQrUc1Ws4C5Km+J0zZFrGlpN5b7Q==
+gatsby-plugin-manifest@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-3.9.0.tgz#28e84611382b3d068c03417337ffee6438925a5c"
+  integrity sha512-cRGsgvwtYLWLJUvbrl6uAWwv4ragPKGjPF7w9m5uRlpXh5zLguMqcgUVL9SfLMH2LJUyM7P5YyyiE/6tigOHqA==
   dependencies:
     "@babel/runtime" "^7.14.0"
-    gatsby-core-utils "^2.7.1"
-    gatsby-plugin-utils "^1.7.1"
+    gatsby-core-utils "^2.9.0"
+    gatsby-plugin-utils "^1.9.0"
     semver "^7.3.5"
     sharp "^0.28.1"
 
-gatsby-plugin-mdx@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.7.1.tgz#425b965e85c1efc89b69efc8bf3846a5565cb017"
-  integrity sha512-DEOdcmMKI1Ae5blGkRTZbxPtfZ8HVi9atS9NNXGLHx9LMy7USeruWkdKsoiAXOMBG6uXytSaVtnKlcALkkkczw==
+gatsby-plugin-mdx@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.9.0.tgz#fd31138e73ea65559afaaa4e7b41b4470b9ef170"
+  integrity sha512-umq/MeujCFU9FfG1sYmsyg/ByzTkU2rUd+hzgCa0rFbXcaPqskAhE5UJdDojlvwMI2+9caMYJFZ+7b5daBwR5A==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
@@ -11925,7 +11680,7 @@ gatsby-plugin-mdx@2.7.1:
     escape-string-regexp "^1.0.5"
     eval "^0.1.4"
     fs-extra "^8.1.0"
-    gatsby-core-utils "^2.7.1"
+    gatsby-core-utils "^2.9.0"
     gray-matter "^4.0.2"
     json5 "^2.1.3"
     loader-utils "^1.4.0"
@@ -11976,32 +11731,33 @@ gatsby-plugin-react-helmet-canonical-urls@1.4.0:
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-gatsby-plugin-react-helmet@4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-4.7.1.tgz#0603b1fb9194b421162e2a92d56114dbbbb99946"
-  integrity sha512-lu+Fgs8pWfYvqKdaSgAkbeE9wgVTnAS8sKgykcqaEgK+STpmhFtzpuJqmhBK3wJwP7yK5BePK5Dte+aRbtkpJQ==
+gatsby-plugin-react-helmet@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-4.9.0.tgz#b4ac100a33db68a2a55b85d954f4e23b5c210b03"
+  integrity sha512-x0M2LbY0tkO/EjtgpJwwVv0NHRQV1znoap6tfBOXxhSGCdZHc4zY4/v6fpEXwM4r5YGdT+6MpUQJyy75BWb9Hg==
   dependencies:
     "@babel/runtime" "^7.14.0"
 
-gatsby-plugin-remove-trailing-slashes@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-3.7.1.tgz#02fda176315b33f6ed070a5e7d0f0a59b0a6dc18"
-  integrity sha512-j88WMNEBqqEi+Q/nVAKnENPIHeShS3OEd1mF2grRM9e4HtTyxuDxi7GSqW2fUdDqRreH3rAR7n640nr+sdBL8w==
+gatsby-plugin-remove-trailing-slashes@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-3.9.0.tgz#5f682fbee54173279967c1b8a9bcc6c92ee2ee44"
+  integrity sha512-4wJNgBz7FzwmlNk+Pe3FZdVmc9hT9aPoUKf6d7FZIr0vAftCj02aQn1M94kR4IWvVcdbC0t3p+JCLtTbSD2MhQ==
   dependencies:
     "@babel/runtime" "^7.14.0"
 
-gatsby-plugin-sharp@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-3.7.1.tgz#4ed5aab484f2eeb8115923127a363e1ab56ff32e"
-  integrity sha512-rwtXrGIZ/Tsf8JgxHcEa82lTYMMZL4KUgbEgQ/OMXuMWcvyTeh4pJAwTNk/rxOS8yyVlCY1TiWO0/I65W4osJA==
+gatsby-plugin-sharp@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-3.9.0.tgz#4dfa61be3907f6e5abc262e41d55be265e0a225f"
+  integrity sha512-DHaX390FyPVCVzVy+ALrzbMf7hjMHsIhaQu98bzsodOJ+0bispyh/Qohxq+i8Qeexy8+sy2mRrlDR3ahM5Yb6w==
   dependencies:
     "@babel/runtime" "^7.14.0"
     async "^3.2.0"
     bluebird "^3.7.2"
     filenamify "^4.2.0"
     fs-extra "^9.1.0"
-    gatsby-core-utils "^2.7.1"
-    gatsby-telemetry "^2.7.1"
+    gatsby-core-utils "^2.9.0"
+    gatsby-plugin-utils "^1.9.0"
+    gatsby-telemetry "^2.9.0"
     got "^10.7.0"
     imagemin "^7.0.1"
     imagemin-mozjpeg "^9.0.0"
@@ -12029,20 +11785,20 @@ gatsby-plugin-typescript@^3.9.0:
     "@babel/runtime" "^7.14.0"
     babel-plugin-remove-graphql-queries "^3.9.0"
 
-gatsby-plugin-utils@^1.7.1, gatsby-plugin-utils@^1.9.0:
+gatsby-plugin-utils@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-1.9.0.tgz#c7b124525486f56d4ccc5f78047f5b0fcb4521a7"
   integrity sha512-jBx4GRGfsVw57wrqLZ5AkgMHFxcXfFCdwFOC11bDvM9Ls5LokNu2UYNXU0bCbl8agLPYZwEHYwZgaCgk3iQYGQ==
   dependencies:
     joi "^17.2.1"
 
-gatsby-plugin-webpack-bundle-analyser-v2@1.1.22:
-  version "1.1.22"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-webpack-bundle-analyser-v2/-/gatsby-plugin-webpack-bundle-analyser-v2-1.1.22.tgz#472887ea94a7934d8b609beb9b1cba46b86eab28"
-  integrity sha512-ZhUBv+7GnunHoYzAUQKxD2TEOwtqE1fiu1UX9d1a4+GgYbQEtXDhduJHmeqJxCGyRPKmJPItGtExpoFVEPdMwA==
+gatsby-plugin-webpack-bundle-analyser-v2@1.1.24:
+  version "1.1.24"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-webpack-bundle-analyser-v2/-/gatsby-plugin-webpack-bundle-analyser-v2-1.1.24.tgz#25d0d1d66b7ee70bc46ac4fbb45cb37601a8baea"
+  integrity sha512-ASj5vM5XpWEKVgYE3miS0aCMkd5/RcHHFMkze46EsGMTRbdQ904iyKMjlfP6ruO7v5dX8ZJpl6K2wC37g+rlsA==
   dependencies:
-    "@babel/runtime" "^7.13.10"
-    webpack-bundle-analyzer "^4.4.1"
+    "@babel/runtime" "^7.14.6"
+    webpack-bundle-analyzer "^4.4.2"
 
 gatsby-react-router-scroll@^4.9.0:
   version "4.9.0"
@@ -12115,10 +11871,10 @@ gatsby-recipes@^0.20.0:
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
 
-gatsby-remark-copy-linked-files@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-4.4.1.tgz#6339926b7746792c7b765096343951fd49875f0d"
-  integrity sha512-w8jUHvKmz0g6EPtMpy5jha2SyKKPzUb7PWm+PEr4K1uEpuSI2T/JRMdwP4W+DmIM7AuRjZRLPT/wqQVxKWYlvw==
+gatsby-remark-copy-linked-files@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-4.6.0.tgz#3a55025e94f68239e232fa7ab76b641719f7caca"
+  integrity sha512-QXf44POPTsbVoEc6faLeSeQ+Ypsq40f0EwhVQunwa0v2CY32sSufqOb0KbSGLeMRtUDhloAWDBndY2Mstigkcw==
   dependencies:
     "@babel/runtime" "^7.14.0"
     cheerio "^1.0.0-rc.9"
@@ -12129,15 +11885,15 @@ gatsby-remark-copy-linked-files@4.4.1:
     probe-image-size "^6.0.0"
     unist-util-visit "^2.0.3"
 
-gatsby-remark-images@5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-5.4.1.tgz#4593e7c61dfe1a5c267ca052f9e3bc7487f9819d"
-  integrity sha512-mdiQN7IuJ9cf9XtYsb9jDFJPhXRkE7q3bs0uSZtB9ySXsl/wmrj+LmjgqBTQXMTsuN8vhTbESZgbm5LJgaXyGQ==
+gatsby-remark-images@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-5.6.0.tgz#9831ce1f5f10bd6a77e7304857defa63d186038c"
+  integrity sha512-j6H7Tg2kWxuXIFPcdlkyoFBtE6SDRUnPP0cXID+qYHXz7mCptAf4BAD977nmDJ+8YFF+t3OwUQc4cksKikQOJQ==
   dependencies:
     "@babel/runtime" "^7.14.0"
     chalk "^4.1.0"
     cheerio "^1.0.0-rc.9"
-    gatsby-core-utils "^2.7.1"
+    gatsby-core-utils "^2.9.0"
     is-relative-url "^3.0.0"
     lodash "^4.17.21"
     mdast-util-definitions "^4.0.0"
@@ -12159,25 +11915,6 @@ gatsby-remark-relative-images@0.2.3:
     slash "^2.0.0"
     unist-util-select "^1.5.0"
 
-gatsby-source-filesystem@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-3.7.1.tgz#11b22ea0ae699163a4372bf95604412a49b4fcc1"
-  integrity sha512-JLMFJxvGnmVFW0UDr6r3XlqCp9GJ5Eqz4baWe9cVSdn61rz6YuV+BrtZIRBkqaWbnhv14+z7J+59OxpLG/kXHg==
-  dependencies:
-    "@babel/runtime" "^7.14.0"
-    better-queue "^3.8.10"
-    chokidar "^3.4.3"
-    file-type "^16.0.0"
-    fs-extra "^8.1.0"
-    gatsby-core-utils "^2.7.1"
-    got "^9.6.0"
-    md5-file "^5.0.0"
-    mime "^2.4.6"
-    pretty-bytes "^5.4.1"
-    progress "^2.0.3"
-    valid-url "^1.0.9"
-    xstate "^4.14.0"
-
 gatsby-source-filesystem@3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-3.9.0.tgz#3ed00f8139f14eff9e56568731aa7e8b77891c8a"
@@ -12197,7 +11934,7 @@ gatsby-source-filesystem@3.9.0:
     valid-url "^1.0.9"
     xstate "^4.14.0"
 
-gatsby-telemetry@^2.7.1, gatsby-telemetry@^2.9.0:
+gatsby-telemetry@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-2.9.0.tgz#d6763b278bee601dd007a84427bac52e57a28d79"
   integrity sha512-Ji40by9qHm9Zz2vKIBACT77awt0FpqKES9uT9nLmaqyiOZ/7Hs1dKwMrZ2yCkHNBh6S9RplcgfUQLq2LE4oeaA==
@@ -12217,10 +11954,10 @@ gatsby-telemetry@^2.7.1, gatsby-telemetry@^2.9.0:
     node-fetch "^2.6.1"
     uuid "3.4.0"
 
-gatsby-transformer-sharp@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-sharp/-/gatsby-transformer-sharp-3.7.1.tgz#c1458a056dc9a8e27a556f29a176b8cb422e2282"
-  integrity sha512-Q+/X8sbVpabJz4G+V4aMt0f7XlB5lsPfM3zYUkb9ns4c+soN+qPMqZRiaKqoLb7hXG9Bs48EV8mJXeWc4w+xOA==
+gatsby-transformer-sharp@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-sharp/-/gatsby-transformer-sharp-3.9.0.tgz#341f4e41e5289100ef358ede368a867486d0a01c"
+  integrity sha512-rGayeiDWslbvmEXzm10Cx0X1ahf6XtNa4Wsrp5h+wjgjYiq9NDig8Osw2UsjXrQxS+m2PJvilA0rfaOFq/wOHw==
   dependencies:
     "@babel/runtime" "^7.14.0"
     bluebird "^3.7.2"
@@ -12231,10 +11968,10 @@ gatsby-transformer-sharp@3.7.1:
     semver "^7.3.4"
     sharp "^0.28.0"
 
-gatsby-transformer-yaml@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-yaml/-/gatsby-transformer-yaml-3.7.1.tgz#d20923071e4a6db252b85322072492ade1bed2a4"
-  integrity sha512-LwuoTLUvc8vIlqxQzcK6lE/9ShC2hJp9e1BXqgGhvljTmxT5EUp3qEE/Vnb+gZ37SH20cgDsMfrRfil6AgGdaA==
+gatsby-transformer-yaml@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-yaml/-/gatsby-transformer-yaml-3.9.0.tgz#313819d185ab31c20465068297d94b5f403327c3"
+  integrity sha512-m0+rB8jF8nAmSGWhO8CGyI0fjqaQikgwpY6TZ2GvWX7m5hhs45vyx6fTyJsbiJfAJ5FA3I03T6a2r4JM6PJvcg==
   dependencies:
     "@babel/runtime" "^7.14.0"
     js-yaml "^3.14.1"
@@ -24319,6 +24056,11 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+web-vitals@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.2.tgz#06535308168986096239aa84716e68b4c6ae6d1c"
+  integrity sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -24329,7 +24071,7 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-bundle-analyzer@4.4.2, webpack-bundle-analyzer@^4.4.1:
+webpack-bundle-analyzer@4.4.2, webpack-bundle-analyzer@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz#39898cf6200178240910d629705f0f3493f7d666"
   integrity sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==


### PR DESCRIPTION
Somehow the dialogs buttons are wrongly positioned.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/1110551/125790338-f718ebf9-c0c7-4c2e-8a22-abb001250c20.png">

Apparently this is due to missing "reset" styles (which are included in the appshell). After applying those styles, it works as it should:

<img width="772" alt="image" src="https://user-images.githubusercontent.com/1110551/125790651-7a06ab41-40e5-4431-98a8-c0d0fad4ed84.png">
