### PR TITLE
CKT-781: to make taxe rate type cached correctly

### DIFF
--- a/packages/application-shell/src/configure-apollo.ts
+++ b/packages/application-shell/src/configure-apollo.ts
@@ -100,6 +100,10 @@ const createApolloClient = (
         Store: {
           keyFields: ['key'],
         },
+        // CTP types with optional id
+        TaxRate: {
+          keyFields: ['name', 'amount']
+        },
         // Internal apps menu links representations
         ApplicationsMenu: {
           fields: {


### PR DESCRIPTION
#### Summary

To make TaxeRate type cached correctly in MC

#### Description

Right now the `TaxRate` type has the field `id` but it is [optional](https://docs.commercetools.com/api/projects/taxCategories#taxrate) and can be `null` (if it's external tax rate) which leads to Apollo not being able to cache it properly and thus to a [bug](https://jira.commercetools.com/browse/CKT-781) in MC.

This PR attempts to fix this issue by specifying other fields than `id` to be used as identifiers, namely `name` and `amount`.
