### PR TITLE
chore: move exported types from package entry point into a separate file

### DIFF
--- a/.changeset/plenty-zoos-tap.md
+++ b/.changeset/plenty-zoos-tap.md
@@ -1,0 +1,11 @@
+---
+'@commercetools-frontend/actions-global': patch
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/browser-history': patch
+'@commercetools-frontend/i18n': patch
+'@commercetools-frontend/react-notifications': patch
+---
+
+Move exported types into a separate file, to avoid having type imports/exports in the package entry point.
+
+> This change is only useful in development in the merchant-center-application-kit repository.

--- a/packages/actions-global/src/export-types.ts
+++ b/packages/actions-global/src/export-types.ts
@@ -1,0 +1,3 @@
+import type { DispatchActionError } from './actions/handle-action-error';
+
+export type TDispatchActionError = DispatchActionError;

--- a/packages/actions-global/src/index.ts
+++ b/packages/actions-global/src/index.ts
@@ -1,9 +1,5 @@
-import type { DispatchActionError } from './actions/handle-action-error';
-
-export type TDispatchActionError = DispatchActionError;
-
+export { default as version } from './version';
 export * from './actions';
 export * from './hooks';
 export * from './types';
-
-export { default as version } from './version';
+export * from './export-types';

--- a/packages/application-shell-connectors/src/export-types.ts
+++ b/packages/application-shell-connectors/src/export-types.ts
@@ -1,0 +1,18 @@
+import type {
+  TProviderProps as ProviderProps,
+  TApplicationContext as ApplicationContext,
+  TNormalizedMenuVisibilities as NormalizedMenuVisibilities,
+  TNormalizedPermissions as NormalizedPermissions,
+  TNormalizedActionRights as NormalizedActionRights,
+  TNormalizedDataFences as NormalizedDataFences,
+} from './components/application-context';
+
+export type TProviderProps<AdditionalEnvironmentProperties extends {}> =
+  ProviderProps<AdditionalEnvironmentProperties>;
+export type TApplicationContext<AdditionalEnvironmentProperties extends {}> =
+  ApplicationContext<AdditionalEnvironmentProperties>;
+
+export type TNormalizedMenuVisibilities = NormalizedMenuVisibilities;
+export type TNormalizedPermissions = NormalizedPermissions;
+export type TNormalizedActionRights = NormalizedActionRights;
+export type TNormalizedDataFences = NormalizedDataFences;

--- a/packages/application-shell-connectors/src/index.ts
+++ b/packages/application-shell-connectors/src/index.ts
@@ -1,21 +1,5 @@
-import type {
-  TProviderProps as ProviderProps,
-  TApplicationContext as ApplicationContext,
-  TNormalizedMenuVisibilities as NormalizedMenuVisibilities,
-  TNormalizedPermissions as NormalizedPermissions,
-  TNormalizedActionRights as NormalizedActionRights,
-  TNormalizedDataFences as NormalizedDataFences,
-} from './components/application-context';
-
-export type TProviderProps<AdditionalEnvironmentProperties extends {}> =
-  ProviderProps<AdditionalEnvironmentProperties>;
-export type TApplicationContext<AdditionalEnvironmentProperties extends {}> =
-  ApplicationContext<AdditionalEnvironmentProperties>;
-
-export type TNormalizedMenuVisibilities = NormalizedMenuVisibilities;
-export type TNormalizedPermissions = NormalizedPermissions;
-export type TNormalizedActionRights = NormalizedActionRights;
-export type TNormalizedDataFences = NormalizedDataFences;
+export { default as version } from './version';
+export * from './export-types';
 
 export {
   Context,
@@ -34,5 +18,3 @@ export {
   ProjectExtensionProviderForImageRegex,
   withProjectExtensionImageRegex,
 } from './components/project-extension-image-regex';
-
-export { default as version } from './version';

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -1,3 +1,4 @@
+export { default as version } from './version';
 export { default as ApplicationShell } from './components/application-shell';
 export { default as ApplicationShellProvider } from './components/application-shell-provider';
 export { default as createApolloClient } from './configure-apollo';
@@ -14,7 +15,6 @@ export { GtmContext } from './components/gtm-booter';
 export { default as GtmUserLogoutTracker } from './components/gtm-user-logout-tracker';
 export { default as SetupFlopFlipProvider } from './components/setup-flop-flip-provider';
 export { default as ConfigureIntlProvider } from './components/configure-intl-provider';
-export { default as version } from './version';
 export {
   useMcQuery,
   useMcLazyQuery,

--- a/packages/browser-history/src/export-types.ts
+++ b/packages/browser-history/src/export-types.ts
@@ -1,0 +1,4 @@
+import type { EnhancedLocation } from 'history-query-enhancer';
+
+// Convenience types
+export type TEnhancedLocation<Q extends {}> = EnhancedLocation<Q>;

--- a/packages/browser-history/src/index.ts
+++ b/packages/browser-history/src/index.ts
@@ -1,9 +1,4 @@
-// eslint-disable-next-line import/named
-import type { EnhancedLocation } from 'history-query-enhancer';
-
 export { default as version } from './version';
+export * from './export-types';
 
 export { default, createEnhancedHistory } from './enhanced-history';
-
-// Convenience types
-export type TEnhancedLocation<Q extends {}> = EnhancedLocation<Q>;

--- a/packages/i18n/src/export-types.ts
+++ b/packages/i18n/src/export-types.ts
@@ -1,0 +1,3 @@
+import type { Props } from './async-locale-data/async-locale-data';
+
+export type TAsyncLocaleDataProps = Props;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,8 +1,5 @@
-import type { Props } from './async-locale-data/async-locale-data';
-
-export type TAsyncLocaleDataProps = Props;
-
 export { default as version } from './version';
+export * from './export-types';
 
 export {
   AsyncLocaleData,

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,6 +1,7 @@
 export { default as version } from './version';
+export * from './types';
+
 export { default as middleware } from './middleware';
 export { default as reducer } from './reducer';
 export { addNotification, removeNotification } from './action-creators';
 export { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from './action-types';
-export * from './types';

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -1,4 +1,5 @@
 export { default as version } from './version';
+
 export { default as RestrictedByPermissions } from './components/restricted-by-permissions';
 export { default as branchOnPermissions } from './components/branch-on-permissions';
 export {

--- a/packages/react-notifications/src/export-types.ts
+++ b/packages/react-notifications/src/export-types.ts
@@ -1,0 +1,4 @@
+import type { TProps as MapNotificationToComponentProps } from './components/map-notification-to-component';
+
+// Re-export type for convenience
+export type TMapNotificationToComponentProps = MapNotificationToComponentProps;

--- a/packages/react-notifications/src/index.ts
+++ b/packages/react-notifications/src/index.ts
@@ -1,9 +1,6 @@
-import type { TProps as MapNotificationToComponentProps } from './components/map-notification-to-component';
-
-// Re-export type for convenience
-export type TMapNotificationToComponentProps = MapNotificationToComponentProps;
-
 export { default as version } from './version';
+export * from './export-types';
+
 export { default as NotificationProviderForCustomComponent } from './components/map-notification-to-component';
 export { default as Notification } from './components/notification';
 export {


### PR DESCRIPTION
When developing in this repository, `preconstruct dev` [runs after installing the dependencies](https://preconstruct.tools/guides/using-preconstruct-dev-in-a-monorepo). This results in "placeholder" `dist` files to be generated, which are essentially symlinks to the package entry point.

However, those are not TS files, so if the entry point file has any `type` syntax, the file is kind of invalid and you will see this kind of error in the editor:

```
'import type' declarations can only be used in TypeScript files.ts(8006)
```

Therefore, we should avoid having type declarations in the entry point file and instead re-export them from a "special" file (I went with the name `export-types`). This way, types are still exported and the syntax is still valid.