### PR TITLE
PCM-2389: Overlapping portal container and notification bar

### DIFF
--- a/.changeset/dry-cherries-whisper.md
+++ b/.changeset/dry-cherries-whisper.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/application-shell': patch
 ---
 
-Change the DOM structure for portal container
+Page notifications (like errors) now correctly push the page content below them, even for modal pages.

--- a/.changeset/dry-cherries-whisper.md
+++ b/.changeset/dry-cherries-whisper.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Change the DOM structure for portal container

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -404,7 +404,7 @@ export const RestrictedApplication = <
                                 and let it do the layout, so we can avoid laying our from the outside as we
                                 do here.
                               */
-                                > *:not(:first-child) {
+                                > *:not(:first-of-type) {
                                   flex-grow: 1;
                                   display: flex;
                                   flex-direction: column;

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -387,7 +387,6 @@ export const RestrictedApplication = <
                           </MainContainer>
                         ) : (
                           <MainContainer role="main">
-                            <PortalsContainer />
                             <NotificationsList domain={DOMAINS.PAGE} />
                             <NotificationsList domain={DOMAINS.SIDE} />
                             <div
@@ -395,6 +394,7 @@ export const RestrictedApplication = <
                                 flex-grow: 1;
                                 display: flex;
                                 flex-direction: column;
+                                position: relative;
 
                                 /*
                                 This is only necessary because we have an intermediary <div> wrapping the
@@ -404,13 +404,14 @@ export const RestrictedApplication = <
                                 and let it do the layout, so we can avoid laying our from the outside as we
                                 do here.
                               */
-                                > * {
+                                > *:not(:first-child) {
                                   flex-grow: 1;
                                   display: flex;
                                   flex-direction: column;
                                 }
                               `}
                             >
+                              <PortalsContainer />
                               <Switch>
                                 <Redirect
                                   from="/profile"


### PR DESCRIPTION
#### Summary

The error notification overlaps with the modal container but the components in the background adjust itself whenever notification appears.

### Fix

Moving the Portal container inside the same common parent div fixes the problem of overlapping.

#### Before

<img width="1187" alt="Screenshot 2021-09-29 at 10 04 12" src="https://user-images.githubusercontent.com/83634106/135228644-044917b7-ee34-4bef-a152-69d4a30f213e.png">

#### After

<img width="1309" alt="Screenshot 2021-09-29 at 10 03 39" src="https://user-images.githubusercontent.com/83634106/135228704-67e5267e-0a8d-4935-91ce-43bf9e697df3.png">
