### PR TITLE
refactor(jest): use babel-jest instead of ts-jest

### DIFF
--- a/.changeset/shy-donuts-sin.md
+++ b/.changeset/shy-donuts-sin.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/jest-preset-mc-app': patch
+---
+
+Use `babel-jest` also for TypeScript files instead of `ts-jest`.

--- a/packages/jest-preset-mc-app/jest-preset-for-typescript.js
+++ b/packages/jest-preset-mc-app/jest-preset-for-typescript.js
@@ -4,19 +4,4 @@ module.exports = {
   ...defaultPreset,
   moduleFileExtensions: ['ts', 'tsx', ...defaultPreset.moduleFileExtensions],
   testRegex: '\\.spec\\.[j|t]sx?$',
-  transform: {
-    ...defaultPreset.transform,
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  // Without this option, somehow CI fails to run the tests with the following error:
-  //   TypeError: Unable to require `.d.ts` file.
-  //   This is usually the result of a faulty configuration or import. Make sure there is a `.js`, `.json` or another executable extension available alongside `core.ts`.
-  // Fix is based on this comment:
-  // - https://github.com/kulshekhar/ts-jest/issues/805#issuecomment-456055213
-  // - https://github.com/kulshekhar/ts-jest/blob/master/docs/user/config/isolatedModules.md
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
 };

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -36,7 +36,7 @@ module.exports = {
   testPathIgnorePatterns: ['node_modules', 'cypress'],
   testRegex: '\\.spec\\.jsx?$',
   transform: {
-    '^.+\\.(js|mjs)$': defaultTransformBabelJest,
+    '^.+\\.(js|jsx|mjs|ts|tsx)$': defaultTransformBabelJest,
     '^.+\\.graphql$': 'jest-transform-graphql',
   },
   watchPlugins: ['jest-watch-typeahead/filename'],


### PR DESCRIPTION
It seems that using `ts-jest` causes issues with Emotion whenever we use [selectors as styled components](https://emotion.sh/docs/styled#targeting-another-emotion-component).

The error we get is

```
Component selectors can only be used in conjunction with @emotion/babel-plugin
```

Apparently we can just "go back" to use `babel-jest`.