### PR TITLE
fix(api-errors): migrate to `error.extensions.code` for notifications

### DIFF
--- a/.changeset/twelve-rabbits-look.md
+++ b/.changeset/twelve-rabbits-look.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/constants': patch
+'@commercetools-frontend/react-notifications': patch
+---
+
+Support GraphQL `error.extensions.code` and deprecate `error.code`.

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -66,6 +66,8 @@ export type TAppNotificationOfKind<T extends TAppNotificationOfDomain> =
   };
 export type TAppNotificationApiError<ExtraFields extends {} = {}> = {
   message: string;
+  /** @deprecated Use `extensions.code` */
+  code?: string;
   extensions?: {
     code?: string;
   };

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -66,7 +66,9 @@ export type TAppNotificationOfKind<T extends TAppNotificationOfDomain> =
   };
 export type TAppNotificationApiError<ExtraFields extends {} = {}> = {
   message: string;
-  code?: string;
+  extensions?: {
+    code?: string;
+  };
 } & ExtraFields;
 export type TAppNotificationValuesApiError<ExtraFields extends {} = {}> = {
   errors: TAppNotificationApiError<ExtraFields>[];

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
@@ -12,7 +12,10 @@ const renderMessage = (ui: ReactElement) =>
 
 describe('render', () => {
   it('should show message for InvalidInput', () => {
-    const error = { code: 'InvalidInput', message: 'message-content' };
+    const error = {
+      extensions: { code: 'InvalidInput' },
+      message: 'message-content',
+    };
     renderMessage(<ApiErrorMessage error={error} />);
     expect(
       screen.getByText(/Sorry, but there seems to be something wrong/i)
@@ -20,7 +23,7 @@ describe('render', () => {
   });
   it('should show message for OverlappingPrices', () => {
     const error = {
-      code: 'unnecessary code',
+      extensions: { code: 'unnecessary code' },
       message: 'message-content',
       invalidValue: { overlappingPrices: 'overlappingPricesContent' },
     };
@@ -31,7 +34,7 @@ describe('render', () => {
   });
   it('should show message for InvalidOperation', () => {
     const error = {
-      code: 'InvalidOperation',
+      extensions: { code: 'InvalidOperation' },
       message: "Required attribute 'foo' cannot be removed",
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -39,7 +42,7 @@ describe('render', () => {
   });
   it('should show message for InvalidDateRange', () => {
     const error = {
-      code: 'InvalidField',
+      extensions: { code: 'InvalidField' },
       message: 'message-content',
       field: 'price',
       invalidValue: {
@@ -55,7 +58,7 @@ describe('render', () => {
   it('should show message for unmapped error and report to sentry', async () => {
     mocked(reportErrorToSentry).mockReset();
     const error = {
-      code: 'unmapped error message foo 123',
+      extensions: { code: 'unmapped error message foo 123' },
       message: 'message-content',
       detailedErrorMessage: 'detailed-error-message-content',
     };
@@ -70,7 +73,7 @@ describe('render', () => {
   it('should show message for unmapped error and not report to sentry for project expired', async () => {
     mocked(reportErrorToSentry).mockReset();
     const error = {
-      code: 'invalid_scope',
+      extensions: { code: 'invalid_scope' },
       message: 'has expired',
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -81,7 +84,7 @@ describe('render', () => {
   });
   it('should show message for DuplicateSlug', () => {
     const error = {
-      code: 'DuplicateField',
+      extensions: { code: 'DuplicateField' },
       message: 'message-content',
       field: 'slug',
       duplicateValue: 'duplicateValueContent',
@@ -93,7 +96,7 @@ describe('render', () => {
   });
   it('should show message for DuplicateAttributeValue', () => {
     const error = {
-      code: 'DuplicateAttributeValue',
+      extensions: { code: 'DuplicateAttributeValue' },
       message: 'message-content',
       attribute: {
         name: 'attribute-name',
@@ -108,7 +111,7 @@ describe('render', () => {
   });
   it('should show message for Unauthorized', () => {
     const error = {
-      code: 'Unauthorized',
+      extensions: { code: 'Unauthorized' },
       message: 'message-content',
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -120,7 +123,7 @@ describe('render', () => {
   });
   it('should show message for Forbidden', () => {
     const error = {
-      code: 'insufficient_scope',
+      extensions: { code: 'insufficient_scope' },
       message: 'message-content',
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -132,7 +135,7 @@ describe('render', () => {
   });
   it('should show translated message for API Error extensions', () => {
     const error = {
-      code: 'InvalidField',
+      extensions: { code: 'InvalidField' },
       message: 'Default message',
       errorByExtension: {
         id: 'some-id',
@@ -147,7 +150,7 @@ describe('render', () => {
   });
   it('should show "untranslated" message for API Error extensions', () => {
     const error = {
-      code: 'InvalidField',
+      extensions: { code: 'InvalidField' },
       message: 'Default message',
       errorByExtension: {
         id: 'some-id',
@@ -161,7 +164,7 @@ describe('render', () => {
   });
   it('should show message for ExtensionNoResponse', () => {
     const error = {
-      code: 'ExtensionNoResponse',
+      extensions: { code: 'ExtensionNoResponse' },
       message: 'message-content',
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -173,7 +176,7 @@ describe('render', () => {
   });
   it('should show message for ExtensionBadResponse', () => {
     const error = {
-      code: 'ExtensionBadResponse',
+      extensions: { code: 'ExtensionBadResponse' },
       message: 'message-content',
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -185,7 +188,7 @@ describe('render', () => {
   });
   it('should show message for ExtensionUpdateActionsFailed', () => {
     const error = {
-      code: 'ExtensionUpdateActionsFailed',
+      extensions: { code: 'ExtensionUpdateActionsFailed' },
       message: 'message-content',
     };
     renderMessage(<ApiErrorMessage error={error} />);
@@ -197,7 +200,7 @@ describe('render', () => {
   });
   it('should show message for MaxResourceLimitExceeded', () => {
     const error = {
-      code: 'MaxResourceLimitExceeded',
+      extensions: { code: 'MaxResourceLimitExceeded' },
       message: 'message-content',
     };
     renderMessage(<ApiErrorMessage error={error} />);

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
@@ -53,9 +53,11 @@ const hasErrorCodeAMatchingMessage = (
 const FormattedErrorMessage = (props: Props) => {
   const intl = useIntl();
   // Attempt to map the error by code
+  const extensionErrorCode = props.error.extensions?.code;
+
   const messageCode =
-    props.error.code && hasErrorCodeAMatchingMessage(props.error.code)
-      ? messages[props.error.code]
+    extensionErrorCode && hasErrorCodeAMatchingMessage(extensionErrorCode)
+      ? messages[extensionErrorCode]
       : undefined;
 
   useEffect(() => {
@@ -64,7 +66,7 @@ const FormattedErrorMessage = (props: Props) => {
       // we log, report it to sentry and show the original error, unless `error.code` is `invalid_scope`
       // which an error code emitted for expired project(s)
       if (
-        props.error.code !== 'invalid_scope' &&
+        props.error.extensions?.code !== 'invalid_scope' &&
         !props.error.message.includes('has expired')
       ) {
         reportErrorToSentry(new Error('Unmapped error'), {
@@ -130,14 +132,14 @@ function getSpecialFormattedMessageByErrorCode(
     return extensionMessage || error.message;
   }
 
-  if (!error.code || error.code === 'InvalidInput')
+  if (!error.extensions?.code || error.extensions?.code === 'InvalidInput')
     return intl.formatMessage(messages.General);
 
   // TODO: this is a temporary solution until we have proper pages about 403
-  if (error.code === 'insufficient_scope')
+  if (error.extensions?.code === 'insufficient_scope')
     return intl.formatMessage(messages.Forbidden);
 
-  if (error.code === 'DuplicateField' && error.field === 'slug')
+  if (error.extensions?.code === 'DuplicateField' && error.field === 'slug')
     return intl.formatMessage(messages.DuplicateSlug, {
       slugValue: error.duplicateValue,
     });
@@ -150,7 +152,7 @@ function getSpecialFormattedMessageByErrorCode(
     return intl.formatMessage(messages.OverlappingPrices);
 
   if (
-    error.code === 'InvalidOperation' &&
+    error.extensions?.code === 'InvalidOperation' &&
     error.message.includes('validFrom') &&
     error.message.includes('validUntil')
   ) {
@@ -160,14 +162,14 @@ function getSpecialFormattedMessageByErrorCode(
   }
 
   if (
-    error.code === 'InvalidOperation' &&
+    error.extensions?.code === 'InvalidOperation' &&
     error.message.includes('Duplicate tax rate for')
   ) {
     return intl.formatMessage(messages.TaxCategoryDuplicateCountry);
   }
 
   if (
-    error.code === 'InvalidOperation' &&
+    error.extensions?.code === 'InvalidOperation' &&
     regexInvalidOperationRequiredAttribute.test(error.message)
   ) {
     const attrName = error.message.replace(
@@ -182,7 +184,7 @@ function getSpecialFormattedMessageByErrorCode(
   // this error (invalid start / end dates with prices) from other price
   // errors. We should investigate this further.
   if (
-    error.code === 'InvalidField' &&
+    error.extensions?.code === 'InvalidField' &&
     error.field === 'price' &&
     has(error, 'invalidValue') &&
     has(error.invalidValue, 'validFrom') &&
@@ -192,13 +194,13 @@ function getSpecialFormattedMessageByErrorCode(
       field: error.field,
     });
 
-  if (error.code === 'DuplicateAttributeValue' && error.attribute) {
+  if (error.extensions?.code === 'DuplicateAttributeValue' && error.attribute) {
     return intl.formatMessage(messages.DuplicateAttributeValue, {
       name: error.attribute.name,
     });
   }
 
-  if (error.code === 'MaxResourceLimitExceeded') {
+  if (error.extensions?.code === 'MaxResourceLimitExceeded') {
     return intl.formatMessage(messages.MaxResourceLimitExceeded);
   }
 

--- a/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
@@ -29,8 +29,9 @@ const ApiErrorNotification = (props: Props) => (
     <ul>
       {props.notification.values &&
         props.notification.values.errors.map((error, idx) => {
+          const extensionErrorCode = error.extensions?.code ?? error.code;
           const shouldLogErrorToConsole =
-            !error.extensions?.code && process.env.NODE_ENV === 'development';
+            !extensionErrorCode && process.env.NODE_ENV === 'development';
           if (shouldLogErrorToConsole) {
             /**
              * NOTE: This is an API error which usually contains

--- a/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error/api-error.tsx
@@ -30,7 +30,7 @@ const ApiErrorNotification = (props: Props) => (
       {props.notification.values &&
         props.notification.values.errors.map((error, idx) => {
           const shouldLogErrorToConsole =
-            !error.code && process.env.NODE_ENV === 'development';
+            !error.extensions?.code && process.env.NODE_ENV === 'development';
           if (shouldLogErrorToConsole) {
             /**
              * NOTE: This is an API error which usually contains

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.spec.tsx
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.spec.tsx
@@ -87,7 +87,9 @@ describe('rendering', () => {
             values: {
               errors: [
                 {
-                  code: 'ConcurrentModification',
+                  extensions: {
+                    code: 'ConcurrentModification',
+                  },
                   message: 'Concurrent modification',
                 },
               ],


### PR DESCRIPTION
Closes #168 

#### Summary

This PR extends support for the the GraphQL API error object shape, `error.extensions.code`.

#### Description

While migrating Discounts, I noticed that migrating all test cases did not pass cleanly. @ByronDWall and I discovered that the `useShowApiErrorNotification` hook's return value created an action (that we pass `errors` to) that `<ApplicationShell />`'s Redux context consumes, and it is here where `error.code` is expected.

This PR changes the `TAppNotificationApiError` type and all tests that rely on it.

#### Considerations
I'm unsure if there are backwards compatibility issues / side effects for other projects given the changes here - should we extend the type as needed as a safeguard?