### PR TITLE
fix: to use native checkout action nvmrc support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,14 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup Node (uses version in .nvmrc)
         uses: actions/setup-node@v2
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version-file: '.nvmrc'
 
       - name: Get yarn cache
         id: yarn-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,10 @@ jobs:
           # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
           token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup Node (uses version in .nvmrc)
         uses: actions/setup-node@v2
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version-file: '.nvmrc'
 
       - name: Get yarn cache
         id: yarn-cache


### PR DESCRIPTION
#### Summary

This refactors using the native `setup-node` action support for `.nvmrc` files.

#### Description

Prior to a recent release [here](https://github.com/actions/setup-node/releases/tag/v2.5.0) the `setuo-node` action didn't support `.nvmrc` files natively. As a result of the above we used an intermediate step. I cats out the `.nvmrc` file's content and makes it accessible to subsequent steps through its `nvm` step id as an output.

All of the above is not needed anymore as we can simply do `node-version-file: '.nvmrc'` on the `setup-node` job (see release notes above).

I quickly refactored private projects [here](https://github.com/tdeekens/flopflip/pull/1560) and it seems to work. I think removing the indirection of the additional step is nice. 

I just wanted to quickly propose this before I forget again. Writing this PR almost felt more time consuming than the change 😄 . We can do the same on ui-kit too.

Have a nice weekend!