### PR TITLE
refactor(app-shell): redirect to `/login` and `/logout` using a full origin URL

### DIFF
--- a/.changeset/four-ladybugs-smash.md
+++ b/.changeset/four-ladybugs-smash.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Redirect to `/login` and `/logout` pages using a full origin URL.

--- a/packages/application-shell/src/components/application-shell/helpers.spec.ts
+++ b/packages/application-shell/src/components/application-shell/helpers.spec.ts
@@ -1,0 +1,18 @@
+import { getMcOrigin } from './helpers';
+
+describe.each`
+  mcApiUrl                                               | mcUrl                                                   | realMcUrl
+  ${'https://mc-api.europe-west1.gcp.commercetools.com'} | ${'https://mc.europe-west1.gcp.commercetools.com'}      | ${'https://mc.europe-west1.gcp.commercetools.com'}
+  ${'https://mc-api.europe-west1.gcp.commercetools.com'} | ${'https://mc-1234.europe-west1.gcp.commercetools.com'} | ${'https://mc-1234.europe-west1.gcp.commercetools.com'}
+  ${'https://mc-api.europe-west1.gcp.commercetools.com'} | ${'https://avengers.app'}                               | ${'https://mc.europe-west1.gcp.commercetools.com'}
+`('Get real MC origin if URL is $mcUrl', ({ mcApiUrl, mcUrl, realMcUrl }) => {
+  it(`should return real MC URL ${realMcUrl}`, () => {
+    expect(
+      getMcOrigin(
+        mcApiUrl,
+        // @ts-ignore: fake `window`-like object
+        { location: new URL(mcUrl) }
+      )
+    ).toBe(realMcUrl);
+  });
+});

--- a/packages/application-shell/src/components/application-shell/helpers.ts
+++ b/packages/application-shell/src/components/application-shell/helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Get the "real" Merchant Center frontend URL to redirect the user
+ * to the login page.
+ * We use an explicit full URL so that if a user tries to access the
+ * Custom Applications directly to its domain, it will always redirect
+ * the user to the login page.
+ *
+ * To determine the "real" URL, we need to check if the current location
+ * is a Merchant Center domain, or if it's a custom user domain.
+ * For the latter, we can derive the URL from the Merchant Center API URL.
+ *
+ * A Merchant Center hostname is composed by the following parts:
+ *    https://<mc-prefix>.<region>.<provider>.<ct-domain>.<tld>
+ * We neeed to check if at least the first 4 parts (right-to-left) are
+ * the same.
+ */
+export function getMcOrigin(mcApiUrl: string, actualWindow = window) {
+  const mcApiUrlObject = new URL(mcApiUrl);
+
+  const [tldMcApi, ctDomainMcApi, providerMcApi, regionMcApi] =
+    mcApiUrlObject.hostname.split('.').reverse();
+  const [tldMc, ctDomainMc, providerMc, regionMc] =
+    actualWindow.location.hostname.split('.').reverse();
+
+  const isMatching =
+    tldMcApi === tldMc &&
+    ctDomainMcApi === ctDomainMc &&
+    providerMcApi === providerMc &&
+    regionMcApi === regionMc;
+
+  if (isMatching) {
+    return actualWindow.location.origin;
+  }
+
+  return mcApiUrlObject.origin.replace('mc-api', 'mc');
+}

--- a/packages/application-shell/src/components/application-shell/redirect-to-login.tsx
+++ b/packages/application-shell/src/components/application-shell/redirect-to-login.tsx
@@ -3,6 +3,7 @@ import type { AuthorizeSessionState } from '../authenticated/types';
 
 import { v4 as uuidv4 } from 'uuid';
 import { useLocation } from 'react-router-dom';
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   joinPaths,
   trimLeadingAndTrailingSlashes,
@@ -12,6 +13,7 @@ import { buildOidcScope } from '../authenticated/helpers';
 import { OIDC_RESPONSE_TYPES } from '../../constants';
 import * as oidcStorage from '../../utils/oidc-storage';
 import Redirector from '../redirector';
+import { getMcOrigin } from './helpers';
 
 declare let window: ApplicationWindow;
 
@@ -29,6 +31,9 @@ const generateAndCacheNonceWithState = (state: AuthorizeSessionState) => {
 
 const RedirectToLogin = () => {
   const location = useLocation();
+  const servedByProxy = useApplicationContext(
+    (context) => context.environment.servedByProxy
+  );
 
   if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
     // We pick the project key from local storage. This assumes that the value
@@ -81,9 +86,13 @@ const RedirectToLogin = () => {
       />
     );
   }
+
+  const mcOrigin = servedByProxy ? getMcOrigin(window.app.mcApiUrl) : undefined;
+
   return (
     <Redirector
       to="login"
+      origin={mcOrigin}
       location={location}
       queryParams={{
         reason: LOGOUT_REASONS.UNAUTHORIZED,

--- a/packages/application-shell/src/components/application-shell/redirect-to-login.tsx
+++ b/packages/application-shell/src/components/application-shell/redirect-to-login.tsx
@@ -3,13 +3,13 @@ import type { AuthorizeSessionState } from '../authenticated/types';
 
 import { v4 as uuidv4 } from 'uuid';
 import { useLocation } from 'react-router-dom';
-import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
   joinPaths,
   trimLeadingAndTrailingSlashes,
 } from '@commercetools-frontend/url-utils';
 import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import { buildOidcScope } from '../authenticated/helpers';
+import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import { OIDC_RESPONSE_TYPES } from '../../constants';
 import * as oidcStorage from '../../utils/oidc-storage';
 import Redirector from '../redirector';
@@ -31,9 +31,7 @@ const generateAndCacheNonceWithState = (state: AuthorizeSessionState) => {
 
 const RedirectToLogin = () => {
   const location = useLocation();
-  const servedByProxy = useApplicationContext(
-    (context) => context.environment.servedByProxy
-  );
+  const servedByProxy = useIsServedByProxy();
 
   if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
     // We pick the project key from local storage. This assumes that the value

--- a/packages/application-shell/src/components/application-shell/redirect-to-logout.tsx
+++ b/packages/application-shell/src/components/application-shell/redirect-to-logout.tsx
@@ -6,6 +6,7 @@ import { useApplicationContext } from '@commercetools-frontend/application-shell
 import * as oidcStorage from '../../utils/oidc-storage';
 import Redirector from '../redirector';
 import RedirectToLogin from './redirect-to-login';
+import { getMcOrigin } from './helpers';
 
 declare let window: ApplicationWindow;
 
@@ -29,9 +30,12 @@ const RedirectToLogout = (props: Props) => {
     return <RedirectToLogin />;
   }
 
+  const mcOrigin = servedByProxy ? getMcOrigin(window.app.mcApiUrl) : undefined;
+
   return (
     <Redirector
       to="logout"
+      origin={mcOrigin}
       location={location}
       queryParams={{
         reason: props.reason ?? LOGOUT_REASONS.USER,

--- a/packages/application-shell/src/components/application-shell/redirect-to-logout.tsx
+++ b/packages/application-shell/src/components/application-shell/redirect-to-logout.tsx
@@ -2,7 +2,7 @@ import type { ApplicationWindow } from '@commercetools-frontend/constants';
 
 import { useLocation } from 'react-router-dom';
 import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
-import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import * as oidcStorage from '../../utils/oidc-storage';
 import Redirector from '../redirector';
 import RedirectToLogin from './redirect-to-login';
@@ -18,9 +18,7 @@ type Props = {
 // to the logout route of the authentication service.
 const RedirectToLogout = (props: Props) => {
   const location = useLocation();
-  const servedByProxy = useApplicationContext(
-    (context) => context.environment.servedByProxy
-  );
+  const servedByProxy = useIsServedByProxy();
 
   if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
     // Remove the `sessionToken` from storage, so that the AppShell can initiate

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.tsx
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.tsx
@@ -4,13 +4,11 @@ import { ContentNotification } from '@commercetools-uikit/notifications';
 import Text from '@commercetools-uikit/text';
 import Card from '@commercetools-uikit/card';
 import { customProperties } from '@commercetools-uikit/design-system';
-import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import { location } from '../../utils/location';
 
 export const RedirectToProjectCreate = () => {
-  const servedByProxy = useApplicationContext(
-    (context) => context.environment.servedByProxy
-  );
+  const servedByProxy = useIsServedByProxy();
   /**
    * NOTE:
    *   This looks a bit unusual: redirecting in render.

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.tsx
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Route } from 'react-router-dom';
-import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { PageNotFound } from '@commercetools-frontend/application-components';
+import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import { location } from '../../utils/location';
 
 const ForcePageReload = () => {
@@ -13,9 +13,7 @@ const ForcePageReload = () => {
 
 const RouteCatchAll = () => {
   // NOTE: it's important that the return value is a `Route` component!
-  const servedByProxy = useApplicationContext(
-    (context) => context.environment.servedByProxy
-  );
+  const servedByProxy = useIsServedByProxy();
   // In case the application is served by a proxy server, we assume that
   // the reverse proxy router handles requests forwarding to the specified
   // service.

--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
@@ -6,6 +6,7 @@ import type {
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { useMcQuery } from '../../hooks/apollo-hooks';
+import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import { FetchAllMenuFeatureToggles } from './fetch-all-menu-feature-toggles.proxy.graphql';
 
 const defaultApiUrl = window.location.origin;
@@ -19,9 +20,7 @@ const getDefaultedFeatureToggles = (allFeatureToggles: string[]) =>
     {}
   );
 const useAllMenuFeatureToggles = () => {
-  const servedByProxy = useApplicationContext(
-    (applicationContext) => applicationContext.environment.servedByProxy
-  );
+  const servedByProxy = useIsServedByProxy();
   const mcProxyApiUrl = useApplicationContext(
     (applicationContext) => applicationContext.environment.mcProxyApiUrl
   );

--- a/packages/application-shell/src/hooks/use-is-served-by-proxy/index.ts
+++ b/packages/application-shell/src/hooks/use-is-served-by-proxy/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-is-served-by-proxy';

--- a/packages/application-shell/src/hooks/use-is-served-by-proxy/use-is-served-by-proxy.ts
+++ b/packages/application-shell/src/hooks/use-is-served-by-proxy/use-is-served-by-proxy.ts
@@ -1,0 +1,10 @@
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+
+const useIsServedByProxy = () => {
+  const servedByProxy = useApplicationContext(
+    (context) => context.environment.servedByProxy
+  );
+  return servedByProxy;
+};
+
+export default useIsServedByProxy;


### PR DESCRIPTION
Closes #2406 

Currently when you try to access a Custom Application directly to its URL, the application tries to reload itself to go to the `/login` route.

This ends up in an "infinite" loop as the Custom Application is not being served within the Merchant Center Proxy Router and thus there is no way to handle the `/login` request.

One way to avoid this is to manually configure a route handler for `/login` (and `/logout`) in your cloud provider and for example render a message.

To help simplifying the deployment setup, we can redirect to the `/login` and `/logout` pages using a full origin URL redirect.
For Custom Applications, this means that if you try to access the application directly, it will redirect to the login page of the configured MC environment, so there is no need to handle the routes to avoid the infinite loop.