### PR TITLE
feat(app-shell): enforce 'view' permission check for main application route

### DIFF
--- a/.changeset/thin-cows-develop.md
+++ b/.changeset/thin-cows-develop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Enforce that the Custom Application route is protected by the application "View" permission.

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -77,6 +77,7 @@ type Props<AdditionalEnvironmentProperties extends {}> = {
     event: SyntheticEvent<HTMLAnchorElement>,
     track: TrackFn
   ) => void;
+  disableRoutePermissionCheck?: boolean;
   render?: () => JSX.Element;
   children?: ReactNode;
 };
@@ -460,6 +461,9 @@ export const RestrictedApplication = <
                                       match={routerProps.match}
                                       location={routerProps.location}
                                       environment={applicationEnvironment}
+                                      disableRoutePermissionCheck={
+                                        props.disableRoutePermissionCheck
+                                      }
                                       // This effectively renders the
                                       // children, which is the application
                                       // specific part
@@ -530,6 +534,9 @@ const ApplicationShell = <AdditionalEnvironmentProperties extends {}>(
                     render={props.render}
                     applicationMessages={props.applicationMessages}
                     onMenuItemClick={props.onMenuItemClick}
+                    disableRoutePermissionCheck={
+                      props.disableRoutePermissionCheck
+                    }
                   >
                     {props.children}
                   </RestrictedApplication>

--- a/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
+++ b/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
@@ -41,7 +41,9 @@ describe('rendering', () => {
     it('should call render with `isAuthenticated` set to true', async () => {
       mocked(window.localStorage.getItem).mockReturnValue('true');
       const props = createTestProps();
-      renderApp(<Authenticated {...props} />);
+      renderApp(<Authenticated {...props} />, {
+        disableRoutePermissionCheck: true,
+      });
       await waitFor(() => {
         expect(props.render).toHaveBeenCalledWith({ isAuthenticated: true });
       });
@@ -52,7 +54,9 @@ describe('rendering', () => {
       it('should call render with `isAuthenticated` set to true', async () => {
         mocked(window.localStorage.getItem).mockReturnValue(null);
         const props = createTestProps();
-        renderApp(<Authenticated {...props} />);
+        renderApp(<Authenticated {...props} />, {
+          disableRoutePermissionCheck: true,
+        });
         await waitFor(() => {
           expect(props.render).toHaveBeenCalledWith({ isAuthenticated: true });
         });
@@ -74,7 +78,9 @@ describe('rendering', () => {
         console.error = jest.fn();
         mocked(window.localStorage.getItem).mockReturnValue(null);
         const props = createTestProps();
-        renderApp(<Authenticated {...props} />);
+        renderApp(<Authenticated {...props} />, {
+          disableRoutePermissionCheck: true,
+        });
         await waitFor(() => {
           expect(props.render).toHaveBeenCalledWith({ isAuthenticated: false });
         });

--- a/packages/application-shell/src/components/back-to-project/back-to-project.spec.tsx
+++ b/packages/application-shell/src/components/back-to-project/back-to-project.spec.tsx
@@ -7,7 +7,9 @@ jest.mock('../../utils/location');
 
 describe('with `projectKey`', () => {
   it('should redirect to the project with the key', async () => {
-    renderApp(<BackToProject projectKey="test-project-key" />);
+    renderApp(<BackToProject projectKey="test-project-key" />, {
+      disableRoutePermissionCheck: true,
+    });
     fireEvent.click(screen.getByText('Back to project'));
     await waitFor(() => {
       expect(mocked(location.replace)).toHaveBeenCalledWith(
@@ -18,7 +20,9 @@ describe('with `projectKey`', () => {
 });
 describe('without `projectKey`', () => {
   it('should redirect to the root', async () => {
-    renderApp(<BackToProject />);
+    renderApp(<BackToProject />, {
+      disableRoutePermissionCheck: true,
+    });
     fireEvent.click(screen.getByText('Back to project'));
     await waitFor(() => {
       expect(mocked(location.replace)).toHaveBeenCalledWith('/');

--- a/packages/application-shell/src/components/fetch-project/fetch-project.spec.tsx
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.spec.tsx
@@ -35,7 +35,10 @@ const renderProject = () =>
         if (project) return <div>{`Project: ${project.name}`}</div>;
         return null;
       }}
-    </FetchProject>
+    </FetchProject>,
+    {
+      disableRoutePermissionCheck: true,
+    }
   );
 
 describe('rendering', () => {

--- a/packages/application-shell/src/components/fetch-user/fetch-user.spec.tsx
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.spec.tsx
@@ -33,7 +33,10 @@ const renderUser = () =>
         if (user) return <div>{`User: ${user.firstName}`}</div>;
         return null;
       }}
-    </FetchUser>
+    </FetchUser>,
+    {
+      disableRoutePermissionCheck: true,
+    }
   );
 
 describe('rendering', () => {

--- a/packages/application-shell/src/components/inject-reducers/inject-reducers.spec.js
+++ b/packages/application-shell/src/components/inject-reducers/inject-reducers.spec.js
@@ -39,7 +39,10 @@ describe('injecting reducers', () => {
     renderAppWithRedux(
       <InjectReducers id="test" reducers={reducers}>
         <ConnectedCounter />
-      </InjectReducers>
+      </InjectReducers>,
+      {
+        disableRoutePermissionCheck: true,
+      }
     );
 
     await screen.findByText(/The count is 0/i);

--- a/packages/application-shell/src/components/project-container/project-container.tsx
+++ b/packages/application-shell/src/components/project-container/project-container.tsx
@@ -33,6 +33,7 @@ type Props<AdditionalEnvironmentProperties extends {}> = Pick<
 > & {
   user: TFetchLoggedInUserQuery['user'];
   environment: TProviderProps<AdditionalEnvironmentProperties>['environment'];
+  disableRoutePermissionCheck?: boolean;
   render?: () => JSX.Element;
   children?: ReactNode;
 };
@@ -176,6 +177,9 @@ const ProjectContainer = <AdditionalEnvironmentProperties extends {}>(
                        */}
                       <ApplicationEntryPoint<AdditionalEnvironmentProperties>
                         environment={props.environment}
+                        disableRoutePermissionCheck={
+                          props.disableRoutePermissionCheck
+                        }
                         render={props.render}
                       >
                         {props.children}

--- a/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
@@ -33,7 +33,10 @@ describe('rendering', () => {
         path="/:projectKey"
         render={() => <ProjectSuspended isTemporary={true} />}
       />,
-      { route: '/my-project' }
+      {
+        disableRoutePermissionCheck: true,
+        route: '/my-project',
+      }
     );
     await screen.findByText(
       /Your Project is temporarily suspended due to maintenance/

--- a/packages/application-shell/src/components/project-switcher/project-switcher.spec.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.spec.tsx
@@ -19,6 +19,7 @@ const render = () => {
       <ProjectSwitcher projectKey="key-0" />
     </>,
     {
+      disableRoutePermissionCheck: true,
       mocks: mockedRequest,
       enableApolloMocks: true,
     }

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.spec.tsx
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.spec.tsx
@@ -12,6 +12,7 @@ beforeEach(() => {
 describe('given `servedByProxy`', () => {
   it('should redirect to `projects/new`', async () => {
     renderApp(<RedirectToProjectCreate />, {
+      disableRoutePermissionCheck: true,
       environment: {
         servedByProxy: true,
       },
@@ -26,14 +27,18 @@ describe('given `servedByProxy`', () => {
 
 describe('given not `servedByProxy`', () => {
   it('should not redirect to `projects/new`', async () => {
-    renderApp(<RedirectToProjectCreate />);
+    renderApp(<RedirectToProjectCreate />, {
+      disableRoutePermissionCheck: true,
+    });
     await waitFor(() => {
       expect(mocked(location.replace)).not.toHaveBeenCalled();
     });
   });
 
   it('should show development mode message', async () => {
-    renderApp(<RedirectToProjectCreate />);
+    renderApp(<RedirectToProjectCreate />, {
+      disableRoutePermissionCheck: true,
+    });
     await screen.findByText('Please create a project!');
     expect(mocked(location.replace)).not.toHaveBeenCalled();
   });

--- a/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.spec.tsx
+++ b/packages/application-shell/src/components/requests-in-flight-loader/requests-in-flight-loader.spec.tsx
@@ -5,6 +5,7 @@ describe('rendering', () => {
   describe('when there are no requests in flight', () => {
     it('should not render loading spinner', async () => {
       renderAppWithRedux(<RequestsInFlightLoader />, {
+        disableRoutePermissionCheck: true,
         storeState: { requestsInFlight: [] },
       });
       await waitFor(() => {
@@ -15,6 +16,7 @@ describe('rendering', () => {
   describe('when there are requests in flight', () => {
     it('should render loading spinner', async () => {
       renderAppWithRedux(<RequestsInFlightLoader />, {
+        disableRoutePermissionCheck: true,
         storeState: { requestsInFlight: ['one', 'two'] },
       });
 

--- a/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
+++ b/packages/application-shell/src/components/route-catch-all/route-catch-all.spec.js
@@ -12,6 +12,7 @@ describe('rendering', () => {
   describe('when "servedByProxy" is "true"', () => {
     it('should force a page reload', async () => {
       renderApp(<RouteCatchAll />, {
+        disableRoutePermissionCheck: true,
         environment: {
           servedByProxy: true,
         },
@@ -24,6 +25,7 @@ describe('rendering', () => {
   describe('when "servedByProxy" is "false"', () => {
     it('should render 404 page', async () => {
       renderApp(<RouteCatchAll />, {
+        disableRoutePermissionCheck: true,
         environment: {
           servedByProxy: false,
         },

--- a/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
+++ b/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
@@ -9,6 +9,7 @@ describe('rendering', () => {
       const { container } = renderApp(
         <Route path={`/:projectKey`} component={ServicePageProjectSwitcher} />,
         {
+          disableRoutePermissionCheck: true,
           route: '/test-1',
           user: {
             projects: {
@@ -36,6 +37,7 @@ describe('rendering', () => {
       const { container } = renderApp(
         <Route path={`/:projectKey`} component={ServicePageProjectSwitcher} />,
         {
+          disableRoutePermissionCheck: true,
           route: '/test-1',
           user: {
             projects: {

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -40,6 +40,7 @@ describe('rendering', () => {
     it('should open the menu and inspect the links', async () => {
       const props = createTestProps();
       renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
         environment: {
           servedByProxy: 'true',
         },
@@ -83,6 +84,7 @@ describe('rendering', () => {
     it('should open the menu and inspect the links', async () => {
       const props = createTestProps();
       renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
         environment: {
           __DEVELOPMENT__: {
             // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.
@@ -119,6 +121,7 @@ describe('rendering', () => {
     it('should navigate to projects route and close the user menu', async () => {
       const props = createTestProps();
       const { history } = renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
         environment: {
           __DEVELOPMENT__: {
             // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.
@@ -152,6 +155,7 @@ describe('rendering', () => {
     it('should close the user menu', async () => {
       const props = createTestProps();
       renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
         environment: {
           __DEVELOPMENT__: {
             // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.
@@ -182,6 +186,7 @@ describe('rendering', () => {
     it('should close the user menu', async () => {
       const props = createTestProps();
       renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
         environment: {
           __DEVELOPMENT__: {
             // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.

--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.spec.js
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.spec.js
@@ -55,6 +55,7 @@ const mockRequests = {
 
 const render = ({ mocks, environment } = { mocks: [] }) =>
   renderApp(<TestComponent />, {
+    disableRoutePermissionCheck: true,
     mocks,
     environment,
     enableApolloMocks: true,

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
@@ -187,6 +187,7 @@ describe('for production usage', () => {
   describe('when the query succeeds', () => {
     it('should render menu key', async () => {
       renderApp(<NavBarTest environment={environment} />, {
+        disableRoutePermissionCheck: true,
         mocks: [
           {
             request: {
@@ -219,6 +220,7 @@ describe('for production usage', () => {
           }}
         />,
         {
+          disableRoutePermissionCheck: true,
           mocks: [
             {
               request: {
@@ -246,7 +248,9 @@ describe('for local development', () => {
             menuLinks: createTestNavBarMenuLinksConfig(),
           },
         });
-        renderApp(<NavBarTest environment={environment} />);
+        renderApp(<NavBarTest environment={environment} />, {
+          disableRoutePermissionCheck: true,
+        });
         await screen.findByText('Avengers');
         expect(screen.getByText('Add avenger')).toBeInTheDocument();
         expect(screen.getByText('Path: avengers')).toBeInTheDocument();
@@ -264,7 +268,9 @@ describe('for local development', () => {
             accountLinks: createTestAppBarMenuLinksConfig(),
           },
         });
-        renderApp(<AppBarTest environment={environment} />);
+        renderApp(<AppBarTest environment={environment} />, {
+          disableRoutePermissionCheck: true,
+        });
         await screen.findByText('Profile');
         expect(screen.getByText('Path: profile')).toBeInTheDocument();
         expect(screen.getByText('Organizations')).toBeInTheDocument();

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -266,6 +266,7 @@ export type TRenderAppOptions<AdditionalEnvironmentProperties = {}> = {
   apolloClient?: ApolloClient<NormalizedCacheObject>;
   enableApolloMocks: boolean;
   route: string;
+  disableRoutePermissionCheck: boolean;
   disableAutomaticEntryPointRoutes: boolean;
   history: ReturnType<typeof createEnhancedHistory>;
   flags: TFlags;
@@ -286,6 +287,9 @@ type TApplicationProvidersProps = {
 };
 
 function createApplicationProviders<AdditionalEnvironmentProperties = {}>({
+  // application
+  disableAutomaticEntryPointRoutes = false,
+  disableRoutePermissionCheck = false,
   // react-intl
   locale = 'en',
   // Apollo
@@ -294,7 +298,6 @@ function createApplicationProviders<AdditionalEnvironmentProperties = {}>({
   enableApolloMocks = false,
   // react-router
   route,
-  disableAutomaticEntryPointRoutes = false,
   history,
   // flopflip
   flags = {},
@@ -340,6 +343,7 @@ function createApplicationProviders<AdditionalEnvironmentProperties = {}>({
               <Suspense fallback={<LoadingFallback />}>
                 <ApplicationEntryPoint
                   environment={mergedEnvironment}
+                  disableRoutePermissionCheck={disableRoutePermissionCheck}
                   render={
                     disableAutomaticEntryPointRoutes
                       ? // eslint-disable-next-line testing-library/no-node-access

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -417,7 +417,7 @@ function renderApp<AdditionalEnvironmentProperties = {}>(
   };
 }
 
-type TRenderAppWithReduxOptions<
+export type TRenderAppWithReduxOptions<
   AdditionalEnvironmentProperties = {},
   StoreState = {}
 > = {


### PR DESCRIPTION
Main branch: #2430 

With the new Custom Application permissions, users can assign permissions to Teams to grant or not to grant access to the application.

If a user is a member of a Team without permissions assigned to this Custom Application, the application should be not accessible to that user.

Usually it's up to the developer to enforce the check on the route level. However, people might forget to do so, resulting in the Custom Application (route) to be available to users even though they shouldn't have permissions to do so.

To enforce that as a default, this check is now performed within the AppShell.

NOTE: if a user does not have permissions, the API requests will fail anyway. This is more of a UX improvement to simply prevent the user to access the application in the first place.