### PR TITLE
fix(create-mc-app): reading user input in Node v14

### DIFF
--- a/.changeset/fair-emus-hammer.md
+++ b/.changeset/fair-emus-hammer.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Fix reading user input to `entryPointUriPath` and `initialProjectKey` variables in case of `create-mc-app` executed in Node v14.

--- a/packages/create-mc-app/src/parse-arguments.js
+++ b/packages/create-mc-app/src/parse-arguments.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 const path = require('path');
-const util = require('util');
 const readline = require('readline');
 const crypto = require('crypto');
 const {
@@ -14,7 +13,9 @@ const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 });
-const question = util.promisify(rl.question).bind(rl);
+
+const question = (query) =>
+  new Promise((resolve) => rl.question(query, resolve));
 
 const getTemplateName = (flags) => flags.template || 'starter';
 const getEntryPointUriPath = async (flags) => {


### PR DESCRIPTION
Fix reading user input to `entryPointUriPath` and `initialProjectKey`
variables in case of `create-mc-app` executed in Node v14.

closes #2484

The way I tested it:
```
cd packages/create-mc-app
npm pack
```
Then installed the package globally and run the script
```
npm i -g path_to_tarball
create-mc-app …
```