### PR TITLE
Added missing changeset and update documentation

### DIFF
--- a/.changeset/witty-scissors-talk.md
+++ b/.changeset/witty-scissors-talk.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Update `engines.node` attribute in `package.json` to explicitly state supported versions (not 15)

--- a/website/src/content/getting-started.mdx
+++ b/website/src/content/getting-started.mdx
@@ -9,7 +9,7 @@ Get up and running in a few steps and start developing Custom Applications for t
 Before you start development, make sure to have the following:
 
 - A [commercetools](https://docs.commercetools.com/tutorials/getting-started) account and a Project.
-- [Node.js](https://nodejs.org/en/) installed (version `>=14`, recommended `>=16`). Either [`yarn`](https://yarnpkg.com/) or [`npm`](https://www.npmjs.com/get-npm) as a package manager.
+- [Node.js](https://nodejs.org/en/) installed (version `14.x`, `16.x` or `17.x`; recommended `>=16`). Either [`yarn`](https://yarnpkg.com/) or [`npm`](https://www.npmjs.com/get-npm) as a package manager.
 - Basic knowledge of [React](https://reactjs.org/) as well as some experience working with web applications.
 
 # Installing a starter template


### PR DESCRIPTION
### Summary

This is a follow up from this PR where I missed adding the changeset for the `create-mc-app` package.

Also, I updated public documentation so we state nodejs versions we support in the prerequisites section of Custom Applications.
