### PR TITLE
fix(create-mc-app): fix compatibility with Node < v14.18 for reading user input

### DIFF
--- a/.changeset/old-ravens-wait.md
+++ b/.changeset/old-ravens-wait.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Fix compatibility with Node `< v14.18` for reading user input.

--- a/packages/create-mc-app/src/parse-arguments.js
+++ b/packages/create-mc-app/src/parse-arguments.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 const path = require('path');
-const util = require('util');
 const readline = require('readline');
 const crypto = require('crypto');
 const {
@@ -14,7 +13,9 @@ const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 });
-const question = util.promisify(rl.question).bind(rl);
+
+const question = (query) =>
+  new Promise((resolve) => rl.question(query, resolve));
 
 const getTemplateName = (flags) => flags.template || 'starter';
 const getEntryPointUriPath = async (flags) => {


### PR DESCRIPTION
Fix compatibility with Node `< v14.18` for reading user input.

closes #2484
