### PR TITLE
Fix application config file loading in Windows OS

### DIFF
--- a/.changeset/tender-turkeys-relax.md
+++ b/.changeset/tender-turkeys-relax.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Fixed an issue when loading application config file in Windows OS

--- a/packages/application-config/scripts/load-js-module.js
+++ b/packages/application-config/scripts/load-js-module.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * This script file is used to load and parse a JS module in a child process,
  * to isolate the Babel configuration from the main program and avoid causing

--- a/packages/application-config/src/load-config.ts
+++ b/packages/application-config/src/load-config.ts
@@ -30,8 +30,8 @@ const loadJsModule: LoaderSync = (filePath) => {
   // The "required module output" is then written into `stdout` and parsed
   // as JSON.
   const output = execFileSync(
-    path.join(packageRootPath, 'scripts/load-js-module.js'),
-    [filePath],
+    'node',
+    [path.join(packageRootPath, 'scripts/load-js-module.js'), filePath],
     { encoding: 'utf8' }
   );
   return JSON.parse(output);


### PR DESCRIPTION
### Summary

<!-- provide a short summary of your changes -->
Running the `mc-scripts start` in a custom application in a Windows OS machine is raising an error related to loading the application config file.

fixes #2486

### Description

When the scripts tries to load the configuration file, it tries to execute an [executable *nix script file](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-config/scripts/load-js-module.js) which fails to execute in Windows OS.
Since this is actually a javascript file, we can just change it to not execute the file itself but running it using the `node` command.
