### PR TITLE
refactor: refine notification types

### DIFF
--- a/.changeset/odd-rivers-impress.md
+++ b/.changeset/odd-rivers-impress.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/actions-global': patch
+'@commercetools-frontend/notifications': patch
+'@commercetools-frontend/react-notifications': patch
+---
+
+Refine notification types.

--- a/packages/actions-global/src/actions/show-notification.ts
+++ b/packages/actions-global/src/actions/show-notification.ts
@@ -1,4 +1,7 @@
-import type { TNotificationMetaOptions } from '@commercetools-frontend/notifications';
+import type {
+  TNotificationMetaOptions,
+  TNotification,
+} from '@commercetools-frontend/notifications';
 import type { TShowNotification } from '../types';
 
 import isNumber from 'lodash/isNumber';
@@ -28,7 +31,7 @@ export default function showNotification<
     dismissAfter =
       notification.kind === NOTIFICATION_KINDS_SIDE.success ? 5000 : 0;
 
-  return addNotification<Pick<Notification, 'id'>>(notification, {
+  return addNotification<Notification & TNotification>(notification, {
     ...meta,
     dismissAfter,
   });

--- a/packages/actions-global/src/hooks/use-show-api-error-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-api-error-notification.ts
@@ -4,10 +4,13 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { showApiErrorNotification } from '../actions';
 
-// Returns a function that dispatches an API error notification.
-// Example:
-//   const showApiErrorNotification = useShowApiErrorNotification();
-//   showApiErrorNotification({ errors });
+/**
+ * Dispatch an API error notification.
+ *
+ * @example
+ * const showApiErrorNotification = useShowApiErrorNotification();
+ * showApiErrorNotification({ errors });
+ */
 export default function useShowApiErrorNotification() {
   const dispatch = useDispatch();
   return useCallback(

--- a/packages/actions-global/src/hooks/use-show-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-notification.ts
@@ -1,25 +1,67 @@
-import type { TNotificationMetaOptions } from '@commercetools-frontend/notifications';
+import type {
+  TNotificationMetaOptions,
+  TAddNotificationAction,
+  TNotification,
+} from '@commercetools-frontend/notifications';
 import type { TShowNotification } from '../types';
 
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { showNotification } from '../actions';
 
-// Returns a function that dispatches a notification, pre-configured to
-// a speficic notification.
-// Example:
-//   const showSuccessNotification = useShowNotification({
-//     domain: NOTIFICATION_DOMAINS.SIDE,
-//     kind: NOTIFICATION_KINDS_SIDE.success,
-//   });
-//   showSuccessNotification({ text: "All good!" });
-export default function useShowNotification<
+type TNotificationHook<Notification extends TShowNotification> = (
+  content: Notification,
+  meta?: TNotificationMetaOptions
+) => TAddNotificationAction<Notification & TNotification>;
+
+/**
+ * Dispatch a notification.
+ *
+ * @example
+ * const showSuccessNotification = useShowNotification();
+ * showSuccessNotification({
+ *   domain: NOTIFICATION_DOMAINS.SIDE,
+ *   kind: NOTIFICATION_KINDS_SIDE.success,
+ *   text: "All good!",
+ * });
+ */
+function useShowNotification<
   Notification extends TShowNotification
-  // FIXME: remove the `notificationFragment`, it makes the typing unnecessarily complex
->(notificationFragment?: Partial<Notification>) {
+>(): TNotificationHook<Notification>;
+/**
+ * Dispatch a notification.
+ *
+ * @deprecated: Avoid passing the notification options here.
+ * Instead define them in the notification function itself.
+ *
+ * @example
+ * Bad:
+ * const showSuccessNotification = useShowNotification({
+ *   domain: NOTIFICATION_DOMAINS.SIDE,
+ *   kind: NOTIFICATION_KINDS_SIDE.success,
+ * });
+ * showSuccessNotification({
+ *   text: "All good!",
+ * });
+ *
+ * Good:
+ * const showSuccessNotification = useShowNotification();
+ * showSuccessNotification({
+ *   domain: NOTIFICATION_DOMAINS.SIDE,
+ *   kind: NOTIFICATION_KINDS_SIDE.success,
+ *   text: "All good!",
+ * });
+ */
+function useShowNotification<Notification extends TShowNotification>(
+  notificationFragment: Partial<Notification>
+): TNotificationHook<Notification>;
+
+function useShowNotification<Notification extends TShowNotification>(
+  notificationFragment?: Partial<Notification>
+): TNotificationHook<Notification> {
   const dispatch = useDispatch();
   return useCallback(
-    (content: Notification, meta?: TNotificationMetaOptions) => {
+    (content, meta) => {
       const notification = showNotification<Notification>(
         { ...notificationFragment, ...content },
         meta
@@ -29,3 +71,5 @@ export default function useShowNotification<
     [dispatch, notificationFragment]
   );
 }
+
+export default useShowNotification;

--- a/packages/actions-global/src/hooks/use-show-unexpected-error-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-unexpected-error-notification.ts
@@ -4,10 +4,13 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { showUnexpectedErrorNotification } from '../actions';
 
-// Returns a function that dispatches an unexpected error notification.
-// Example:
-//   const showUnexpectedErrorNotification = useShowUnexpectedErrorNotification();
-//   showUnexpectedErrorNotification({ error });
+/**
+ * Dispatch an unexpected error notification.
+ *
+ * @example
+ * const showUnexpectedErrorNotification = useShowUnexpectedErrorNotification();
+ * showUnexpectedErrorNotification({ errors });
+ */
 export default function useShowUnexpectedErrorNotification() {
   const dispatch = useDispatch();
   return useCallback(

--- a/packages/actions-global/src/types.ts
+++ b/packages/actions-global/src/types.ts
@@ -1,4 +1,3 @@
-import type { TNotification } from '@commercetools-frontend/notifications';
 import type {
   TAppNotification,
   TAppNotificationDomain,
@@ -8,25 +7,23 @@ import type {
   TAppNotificationValuesUnexpectedError,
 } from '@commercetools-frontend/constants';
 
-export type TShowNotification = TNotification & {
+export type TShowNotification = {
   domain: TAppNotificationDomain;
   kind: TAppNotificationKind;
   text?: string;
 };
 
-export type TApiErrorNotification = TNotification &
-  TAppNotification<{
-    domain: 'page';
-    kind: 'api-error';
-    values: TAppNotificationValuesApiError;
-  }>;
+export type TApiErrorNotification = TAppNotification<{
+  domain: 'page';
+  kind: 'api-error';
+  values: TAppNotificationValuesApiError;
+}>;
 
-export type TUnexpectedErrorNotification = TNotification &
-  TAppNotification<{
-    domain: 'page';
-    kind: 'unexpected-error';
-    values: TAppNotificationValuesUnexpectedError;
-  }>;
+export type TUnexpectedErrorNotification = TAppNotification<{
+  domain: 'page';
+  kind: 'unexpected-error';
+  values: TAppNotificationValuesUnexpectedError;
+}>;
 
 export type TApiErrorNotificationOptions = {
   errors: TAppNotificationApiError | TAppNotificationApiError[];

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -3,7 +3,7 @@ import type { Action } from 'redux';
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from './action-types';
 
 export type TNotification = {
-  id: number;
+  id?: number;
 };
 
 export type TNotificationOnDismiss = (id: TNotification['id']) => void;

--- a/packages/react-notifications/src/components/notifier/notifier.spec.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.spec.tsx
@@ -1,4 +1,7 @@
-import type { TAddNotificationAction } from '@commercetools-frontend/notifications';
+import type {
+  TAddNotificationAction,
+  TNotification,
+} from '@commercetools-frontend/notifications';
 import type { TShowNotification } from '@commercetools-frontend/actions-global';
 
 import { mocked } from 'jest-mock';
@@ -41,12 +44,12 @@ describe('rendering', () => {
   let dismiss: () => void;
   let showNotification: (
     notification: TShowNotification
-  ) => TAddNotificationAction<Pick<TShowNotification, 'id'>>;
+  ) => TAddNotificationAction<TShowNotification & TNotification>;
   beforeEach(() => {
     dismiss = jest.fn();
     showNotification = jest.fn(() => ({
       type: ADD_NOTIFICATION,
-      payload: { id: 1 },
+      payload: { id: 1, domain: 'side', kind: 'success' },
       dismiss,
     }));
     mocked(useShowNotification).mockClear();

--- a/packages/react-notifications/src/components/notifier/notifier.tsx
+++ b/packages/react-notifications/src/components/notifier/notifier.tsx
@@ -24,12 +24,11 @@ const defaultProps: Pick<Props, 'domain' | 'kind'> = {
 };
 
 const Notifier = (props: Props) => {
-  const showNotification = useShowNotification<Props & { id: number }>();
+  const showNotification = useShowNotification<Props>();
 
   useEffect(() => {
     const notification = showNotification(
       {
-        id: 0,
         domain: props.domain,
         kind: props.kind,
         text: props.text,


### PR DESCRIPTION
Some of the types around notifications are currently slightly inaccurate, causing unnecessary type errors.

For example, the notification `id` is internally generated, the user does not need to provide one.

<img width="700" alt="image" src="https://user-images.githubusercontent.com/1110551/157537122-2067be95-b63f-441f-a7ac-d27a2d04502d.png">

This PR tries to refine these small inaccuracies.