### PR TITLE
docs: hide info about login command for now

### DIFF
--- a/.changeset/stupid-kangaroos-film.md
+++ b/.changeset/stupid-kangaroos-film.md
@@ -6,4 +6,4 @@ Add a new CLI command `mc-scripts login`.
 
 This command enables users to log in to their Merchant Center account through the CLI. An interactive prompt will be displayed asking the user to enter the login credentials.
 
-Upon login, the user session token is stored in the user's home directory `$HOME/.commercetools/mc-credentials.json`. The session token will be used by other CLI commands that require a valid session token.
+Upon login, an API token is stored in the user's home directory `$HOME/.commercetools/mc-credentials.json`. The API token will be used by other CLI commands that require a valid API token.

--- a/website/src/content/api-reference/cli.mdx
+++ b/website/src/content/api-reference/cli.mdx
@@ -103,15 +103,15 @@ We recommend to set up the following scripts in your `package.json`:
 
 By default the application starts at `http://localhost:3001`.
 
-## login
+<!-- ## login
 
 This command enables users to log in to their Merchant Center account through the CLI. An interactive prompt will be displayed asking the user to enter the login credentials.
 
-Upon login, the user session token is stored in the user's home directory `$HOME/.commercetools/mc-credentials.json`. The session token will be used by other CLI commands that require a valid session token.
+Upon login, an API token is stored in the user's home directory `$HOME/.commercetools/mc-credentials.json`. The API token will be used by other CLI commands that require a valid API token.
 
 ```console
 mc-scripts login
-```
+``` -->
 
 # Using dotenv files
 


### PR DESCRIPTION
Since we haven't released the new `login` command yet, and that we're still considering other things around that, I think we can keep the docs part hidden for now.