### PR TITLE
fix(eslint): provide default BABEL_ENV variable to allow VSCode to parse the Babel config

### DIFF
--- a/.changeset/pink-steaks-lick.md
+++ b/.changeset/pink-steaks-lick.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/eslint-config-mc-app': patch
+---
+
+Define the `BABEL_ENV` variable in the ESLint config, to ensure VSCode is able to parse the Babel config.

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -1,3 +1,5 @@
+process.env.BABEL_ENV = 'production';
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('@rushstack/eslint-patch/modern-module-resolution');
 


### PR DESCRIPTION
I noticed that VSCode has difficulties understanding that ESLint uses our Babel preset, even though the Babel preset is referenced to the production config (notice the `/production` import).

https://github.com/commercetools/merchant-center-application-kit/blob/90d5a2308942e232c2f671be182dbb4fbf07a718/packages/eslint-config-mc-app/index.js#L11-L19

This results in VSCode showing this ESLint error:

<img width="1370" alt="image" src="https://user-images.githubusercontent.com/1110551/159437096-443eade2-4690-4500-82ac-0cdc3acf03aa.png">

To amend this, we can explicitly define the `BABEL_ENV` variable within the ESLint config, so that VSCode can correctly parse the Babel preset.