### PR TITLE
refactor(eslint-mc-app): merge CRA config to avoid possible ESLint merge errors

### DIFF
--- a/.changeset/beige-bags-refuse.md
+++ b/.changeset/beige-bags-refuse.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/eslint-config-mc-app': patch
+---
+
+Merge `eslint-config-react-app` into our `@commercetools-frontend/eslint-config-mc-app`. This should avoid any ESLint error related to merging different configs.

--- a/packages/eslint-config-mc-app/helpers/rules-presets.js
+++ b/packages/eslint-config-mc-app/helpers/rules-presets.js
@@ -1,0 +1,293 @@
+/**
+ * This file contains rules copied from other libraries, to make it easier to differentiate with
+ * our own rules and to better maintain them.
+ */
+
+// The ESLint browser environment defines all browser globals as valid,
+// even though most people don't know some of them exist (e.g. `name` or `status`).
+// This is dangerous as it hides accidentally undefined variables.
+// We deny the globals that we deem potentially confusing.
+// To use them, explicitly reference them, e.g. `window.name` or `window.status`.
+const restrictedGlobals = require('confusing-browser-globals');
+
+const { statusCode } = require('./eslint');
+
+// NOTE: When adding rules here, you need to make sure they are compatible with
+// `typescript-eslint`, as some rules such as `no-array-constructor` aren't compatible.
+// https://github.com/facebook/create-react-app/blob/main/packages/eslint-config-react-app/index.js
+const craRules = {
+  base: {
+    // http://eslint.org/docs/rules/
+    'array-callback-return': statusCode.warn,
+    'default-case': [statusCode.warn, { commentPattern: '^no default$' }],
+    'dot-location': [statusCode.warn, 'property'],
+    eqeqeq: [statusCode.warn, 'smart'],
+    'new-parens': statusCode.warn,
+    'no-array-constructor': statusCode.warn,
+    'no-caller': statusCode.warn,
+    'no-cond-assign': [statusCode.warn, 'except-parens'],
+    'no-const-assign': statusCode.warn,
+    'no-control-regex': statusCode.warn,
+    'no-delete-var': statusCode.warn,
+    'no-dupe-args': statusCode.warn,
+    'no-dupe-class-members': statusCode.warn,
+    'no-dupe-keys': statusCode.warn,
+    'no-duplicate-case': statusCode.warn,
+    'no-empty-character-class': statusCode.warn,
+    'no-empty-pattern': statusCode.warn,
+    'no-eval': statusCode.warn,
+    'no-ex-assign': statusCode.warn,
+    'no-extend-native': statusCode.warn,
+    'no-extra-bind': statusCode.warn,
+    'no-extra-label': statusCode.warn,
+    'no-fallthrough': statusCode.warn,
+    'no-func-assign': statusCode.warn,
+    'no-implied-eval': statusCode.warn,
+    'no-invalid-regexp': statusCode.warn,
+    'no-iterator': statusCode.warn,
+    'no-label-var': statusCode.warn,
+    'no-labels': [statusCode.warn, { allowLoop: true, allowSwitch: false }],
+    'no-lone-blocks': statusCode.warn,
+    'no-loop-func': statusCode.warn,
+    'no-mixed-operators': [
+      statusCode.warn,
+      {
+        groups: [
+          ['&', '|', '^', '~', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+          ['&&', '||'],
+          ['in', 'instanceof'],
+        ],
+        allowSamePrecedence: false,
+      },
+    ],
+    'no-multi-str': statusCode.warn,
+    'no-global-assign': statusCode.warn,
+    'no-unsafe-negation': statusCode.warn,
+    'no-new-func': statusCode.warn,
+    'no-new-object': statusCode.warn,
+    'no-new-symbol': statusCode.warn,
+    'no-new-wrappers': statusCode.warn,
+    'no-obj-calls': statusCode.warn,
+    'no-octal': statusCode.warn,
+    'no-octal-escape': statusCode.warn,
+    'no-redeclare': statusCode.warn,
+    'no-regex-spaces': statusCode.warn,
+    'no-restricted-syntax': [statusCode.warn, 'WithStatement'],
+    'no-script-url': statusCode.warn,
+    'no-self-assign': statusCode.warn,
+    'no-self-compare': statusCode.warn,
+    'no-sequences': statusCode.warn,
+    'no-shadow-restricted-names': statusCode.warn,
+    'no-sparse-arrays': statusCode.warn,
+    'no-template-curly-in-string': statusCode.warn,
+    'no-this-before-super': statusCode.warn,
+    'no-throw-literal': statusCode.warn,
+    'no-undef': statusCode.error,
+    'no-restricted-globals': [statusCode.error].concat(restrictedGlobals),
+    'no-unreachable': statusCode.warn,
+    'no-unused-expressions': [
+      statusCode.error,
+      {
+        allowShortCircuit: true,
+        allowTernary: true,
+        allowTaggedTemplates: true,
+      },
+    ],
+    'no-unused-labels': statusCode.warn,
+    'no-unused-vars': [
+      statusCode.warn,
+      {
+        args: 'none',
+        ignoreRestSiblings: true,
+      },
+    ],
+    'no-use-before-define': [
+      statusCode.warn,
+      {
+        functions: false,
+        classes: false,
+        variables: false,
+      },
+    ],
+    'no-useless-computed-key': statusCode.warn,
+    'no-useless-concat': statusCode.warn,
+    'no-useless-constructor': statusCode.warn,
+    'no-useless-escape': statusCode.warn,
+    'no-useless-rename': [
+      statusCode.warn,
+      {
+        ignoreDestructuring: false,
+        ignoreImport: false,
+        ignoreExport: false,
+      },
+    ],
+    'no-with': statusCode.warn,
+    'no-whitespace-before-property': statusCode.warn,
+    'react-hooks/exhaustive-deps': statusCode.warn,
+    'require-yield': statusCode.warn,
+    'rest-spread-spacing': [statusCode.warn, 'never'],
+    strict: [statusCode.warn, 'never'],
+    'unicode-bom': [statusCode.warn, 'never'],
+    'use-isnan': statusCode.warn,
+    'valid-typeof': statusCode.warn,
+    'no-restricted-properties': [
+      statusCode.error,
+      {
+        object: 'require',
+        property: 'ensure',
+        message:
+          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+      },
+      {
+        object: 'System',
+        property: 'import',
+        message:
+          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+      },
+    ],
+    'getter-return': statusCode.warn,
+
+    // https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules
+    'import/first': statusCode.error,
+    'import/no-amd': statusCode.error,
+    'import/no-anonymous-default-export': statusCode.warn,
+    'import/no-webpack-loader-syntax': statusCode.error,
+
+    // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
+    'react/forbid-foreign-prop-types': [
+      statusCode.warn,
+      { allowInPropTypes: true },
+    ],
+    'react/jsx-no-comment-textnodes': statusCode.warn,
+    'react/jsx-no-duplicate-props': statusCode.warn,
+    'react/jsx-no-target-blank': statusCode.warn,
+    'react/jsx-no-undef': statusCode.error,
+    'react/jsx-pascal-case': [
+      statusCode.warn,
+      {
+        allowAllCaps: true,
+        ignore: [],
+      },
+    ],
+    'react/no-danger-with-children': statusCode.warn,
+    // Disabled because of undesirable warnings
+    // See https://github.com/facebook/create-react-app/issues/5204 for
+    // blockers until its re-enabled
+    // 'react/no-deprecated': statusCode.warn,
+    'react/no-direct-mutation-state': statusCode.warn,
+    'react/no-is-mounted': statusCode.warn,
+    'react/no-typos': statusCode.error,
+    'react/require-render-return': statusCode.error,
+    'react/style-prop-object': statusCode.warn,
+
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
+    'jsx-a11y/alt-text': statusCode.warn,
+    'jsx-a11y/anchor-has-content': statusCode.warn,
+    'jsx-a11y/anchor-is-valid': [
+      statusCode.warn,
+      {
+        aspects: ['noHref', 'invalidHref'],
+      },
+    ],
+    'jsx-a11y/aria-activedescendant-has-tabindex': statusCode.warn,
+    'jsx-a11y/aria-props': statusCode.warn,
+    'jsx-a11y/aria-proptypes': statusCode.warn,
+    'jsx-a11y/aria-role': [statusCode.warn, { ignoreNonDOM: true }],
+    'jsx-a11y/aria-unsupported-elements': statusCode.warn,
+    'jsx-a11y/heading-has-content': statusCode.warn,
+    'jsx-a11y/iframe-has-title': statusCode.warn,
+    'jsx-a11y/img-redundant-alt': statusCode.warn,
+    'jsx-a11y/no-access-key': statusCode.warn,
+    'jsx-a11y/no-distracting-elements': statusCode.warn,
+    'jsx-a11y/no-redundant-roles': statusCode.warn,
+    'jsx-a11y/role-has-required-aria-props': statusCode.warn,
+    'jsx-a11y/role-supports-aria-props': statusCode.warn,
+    'jsx-a11y/scope': statusCode.warn,
+
+    // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+    'react-hooks/rules-of-hooks': statusCode.error,
+  },
+
+  typescript: {
+    // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
+    'default-case': statusCode.off,
+    // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+    'no-dupe-class-members': statusCode.off,
+    // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+    'no-undef': statusCode.off,
+
+    // Add TypeScript specific rules (and turn off ESLint equivalents)
+    '@typescript-eslint/consistent-type-assertions': statusCode.warn,
+    'no-array-constructor': statusCode.off,
+    '@typescript-eslint/no-array-constructor': statusCode.warn,
+    'no-redeclare': statusCode.off,
+    '@typescript-eslint/no-redeclare': statusCode.warn,
+    'no-use-before-define': statusCode.off,
+    '@typescript-eslint/no-use-before-define': [
+      statusCode.warn,
+      {
+        functions: false,
+        classes: false,
+        variables: false,
+        typedefs: false,
+      },
+    ],
+    'no-unused-expressions': statusCode.off,
+    '@typescript-eslint/no-unused-expressions': [
+      statusCode.error,
+      {
+        allowShortCircuit: true,
+        allowTernary: true,
+        allowTaggedTemplates: true,
+      },
+    ],
+    'no-unused-vars': statusCode.off,
+    '@typescript-eslint/no-unused-vars': [
+      statusCode.warn,
+      {
+        args: 'none',
+        ignoreRestSiblings: true,
+      },
+    ],
+    'no-useless-constructor': statusCode.off,
+    '@typescript-eslint/no-useless-constructor': statusCode.warn,
+  },
+
+  jest: {
+    // https://github.com/jest-community/eslint-plugin-jest
+    'jest/no-conditional-expect': statusCode.error,
+    'jest/no-identical-title': statusCode.error,
+    'jest/no-interpolation-in-snapshots': statusCode.error,
+    'jest/no-jasmine-globals': statusCode.error,
+    'jest/no-jest-import': statusCode.error,
+    'jest/no-mocks-import': statusCode.error,
+    'jest/valid-describe-callback': statusCode.error,
+    'jest/valid-expect': statusCode.error,
+    'jest/valid-expect-in-promise': statusCode.error,
+    'jest/valid-title': statusCode.warn,
+
+    // https://github.com/testing-library/eslint-plugin-testing-library
+    'testing-library/await-async-query': statusCode.error,
+    'testing-library/await-async-utils': statusCode.error,
+    'testing-library/no-await-sync-query': statusCode.error,
+    'testing-library/no-container': statusCode.error,
+    'testing-library/no-debugging-utils': statusCode.error,
+    'testing-library/no-dom-import': [statusCode.error, 'react'],
+    'testing-library/no-node-access': statusCode.error,
+    'testing-library/no-promise-in-fire-event': statusCode.error,
+    'testing-library/no-render-in-setup': statusCode.error,
+    'testing-library/no-unnecessary-act': statusCode.error,
+    'testing-library/no-wait-for-empty-callback': statusCode.error,
+    'testing-library/no-wait-for-multiple-assertions': statusCode.error,
+    'testing-library/no-wait-for-side-effects': statusCode.error,
+    'testing-library/no-wait-for-snapshot': statusCode.error,
+    'testing-library/prefer-find-by': statusCode.error,
+    'testing-library/prefer-presence-queries': statusCode.error,
+    'testing-library/prefer-query-by-disappearance': statusCode.error,
+    'testing-library/prefer-screen-queries': statusCode.error,
+    'testing-library/render-result-naming-convention': statusCode.error,
+  },
+};
+
+exports.craRules = craRules;

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -5,12 +5,19 @@ require('@rushstack/eslint-patch/modern-module-resolution');
 
 const { statusCode, allSupportedExtensions } = require('./helpers/eslint');
 const hasJsxRuntime = require('./helpers/has-jsx-runtime');
+const { craRules } = require('./helpers/rules-presets');
 
 /**
  * @type {import("eslint").Linter.Config}
  */
 module.exports = {
+  root: true,
+
+  parser: '@babel/eslint-parser',
+
   parserOptions: {
+    sourceType: 'module',
+    requireConfigFile: false,
     babelOptions: {
       presets: [
         require.resolve(
@@ -19,13 +26,19 @@ module.exports = {
       ],
     },
   },
+
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true,
+    jest: true,
+    node: true,
+  },
+
   extends: [
-    // https://github.com/facebook/create-react-app/tree/master/packages/eslint-config-react-app
-    'react-app',
-    'react-app/jest',
     // https://github.com/cypress-io/eslint-plugin-cypress
     'plugin:cypress/recommended',
-    // https://github.com/benmosher/eslint-plugin-import
+    // https://github.com/import-js/eslint-plugin-import
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript',
@@ -39,13 +52,37 @@ module.exports = {
     // NOTE: this should go last.
     'prettier',
   ],
+
   plugins: [
+    // https://github.com/import-js/eslint-plugin-import
+    'import',
+    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
+    'jsx-a11y',
+    // https://github.com/yannickcr/eslint-plugin-react
+    'react',
+    // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+    'react-hooks',
+    // https://github.com/testing-library/eslint-plugin-testing-library
+    'testing-library',
+    // https://github.com/jest-community/eslint-plugin-jest
+    'jest',
     // https://github.com/testing-library/eslint-plugin-jest-dom
     'jest-dom',
     // https://github.com/prettier/prettier-eslint
     'prettier',
   ],
+
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: allSupportedExtensions,
+      },
+    },
+  },
+
   rules: {
+    ...craRules.base,
+
     // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
     'no-unused-expressions': statusCode.off,
 
@@ -95,24 +132,36 @@ module.exports = {
       'react/react-in-jsx-scope': statusCode.off,
     }),
   },
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: allSupportedExtensions,
-      },
-    },
-  },
+
   overrides: [
     {
       files: ['*.{spec,test}.*'],
+      env: {
+        'jest/globals': true,
+      },
       rules: {
         'react/display-name': statusCode.off,
+
+        ...craRules.jest,
       },
     },
     {
       files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+        // typescript-eslint specific options
+        warnOnUnsupportedTypeScriptVersion: true,
+      },
+      plugins: ['@typescript-eslint'],
       extends: ['prettier'],
       rules: {
+        ...craRules.typescript,
+
         // TypeScript
         '@typescript-eslint/ban-types': statusCode.off,
         '@typescript-eslint/naming-convention': statusCode.off,

--- a/packages/eslint-config-mc-app/package.json
+++ b/packages/eslint-config-mc-app/package.json
@@ -15,15 +15,16 @@
     "access": "public"
   },
   "dependencies": {
+    "@babel/core": "^7.17.8",
+    "@babel/eslint-parser": "^7.17.0",
     "@commercetools-frontend/babel-preset-mc-app": "^21.0.0",
     "@rushstack/eslint-patch": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
+    "confusing-browser-globals": "^1.0.11",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-config-react-app": "^7.0.0",
     "eslint-import-resolver-typescript": "^2.7.0",
     "eslint-plugin-cypress": "^2.12.1",
-    "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^25.7.0",
     "eslint-plugin-jest-dom": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,7 +167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.14.0, @babel/core@npm:^7.15.5, @babel/core@npm:^7.16.0, @babel/core@npm:^7.7.2, @babel/core@npm:^7.7.7, @babel/core@npm:^7.8.0":
+"@babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.14.0, @babel/core@npm:^7.15.5, @babel/core@npm:^7.7.2, @babel/core@npm:^7.7.7, @babel/core@npm:^7.8.0":
   version: 7.16.12
   resolution: "@babel/core@npm:7.16.12"
   dependencies:
@@ -213,7 +213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/eslint-parser@npm:^7.15.4, @babel/eslint-parser@npm:^7.16.3":
+"@babel/eslint-parser@npm:^7.15.4":
   version: 7.16.5
   resolution: "@babel/eslint-parser@npm:7.16.5"
   dependencies:
@@ -224,6 +224,20 @@ __metadata:
     "@babel/core": ">=7.11.0"
     eslint: ^7.5.0 || ^8.0.0
   checksum: 7d4fe169b371bdce3caab64d6434f251c661cef86e01e320f4e2f81bed159d1f366138e18abb7386d40032cd4972fce723ec9af8b9895d5559fa7caff52efbab
+  languageName: node
+  linkType: hard
+
+"@babel/eslint-parser@npm:^7.17.0":
+  version: 7.17.0
+  resolution: "@babel/eslint-parser@npm:7.17.0"
+  dependencies:
+    eslint-scope: ^5.1.1
+    eslint-visitor-keys: ^2.1.0
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ">=7.11.0"
+    eslint: ^7.5.0 || ^8.0.0
+  checksum: 1cedd9998dd89f779bbc5496531e3ef1b43d6f4fb7209ed5088938292b81287302cb47c0923ce074e84e83aa41b236b09bfecacdf20770f4cbfade2de9519c10
   languageName: node
   linkType: hard
 
@@ -637,7 +651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:^7.0.0, @babel/plugin-proposal-class-properties@npm:^7.14.0, @babel/plugin-proposal-class-properties@npm:^7.16.0, @babel/plugin-proposal-class-properties@npm:^7.16.7":
+"@babel/plugin-proposal-class-properties@npm:^7.0.0, @babel/plugin-proposal-class-properties@npm:^7.14.0, @babel/plugin-proposal-class-properties@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-proposal-class-properties@npm:7.16.7"
   dependencies:
@@ -659,19 +673,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.12.0
   checksum: 3b95b5137e089f0be17de667299ea2e28867b6310ab94219a5a89ac7675824e69f316d31930586142b9f432122ef3b98eb05fffdffae01b5587019ce9aab4ef3
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-proposal-decorators@npm:^7.16.4":
-  version: 7.16.7
-  resolution: "@babel/plugin-proposal-decorators@npm:7.16.7"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.16.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    "@babel/plugin-syntax-decorators": ^7.16.7
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 1c1a658ad70f71c542f2b770849eaebaff0a12e1f12b9b4a994a2d26440cb44b7bd8b88987bc0252ea669d1cbf253d2da134975607e362cf14d5e3f2d11c966a
   languageName: node
   linkType: hard
 
@@ -747,7 +748,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.14.5, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.16.0, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.16.7":
+"@babel/plugin-proposal-nullish-coalescing-operator@npm:^7.14.5, @babel/plugin-proposal-nullish-coalescing-operator@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-proposal-nullish-coalescing-operator@npm:7.16.7"
   dependencies:
@@ -759,7 +760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-numeric-separator@npm:^7.14.5, @babel/plugin-proposal-numeric-separator@npm:^7.16.0, @babel/plugin-proposal-numeric-separator@npm:^7.16.7":
+"@babel/plugin-proposal-numeric-separator@npm:^7.14.5, @babel/plugin-proposal-numeric-separator@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-proposal-numeric-separator@npm:7.16.7"
   dependencies:
@@ -826,7 +827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-optional-chaining@npm:^7.14.5, @babel/plugin-proposal-optional-chaining@npm:^7.16.0, @babel/plugin-proposal-optional-chaining@npm:^7.16.7":
+"@babel/plugin-proposal-optional-chaining@npm:^7.14.5, @babel/plugin-proposal-optional-chaining@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-proposal-optional-chaining@npm:7.16.7"
   dependencies:
@@ -839,7 +840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-private-methods@npm:^7.16.0, @babel/plugin-proposal-private-methods@npm:^7.16.11":
+"@babel/plugin-proposal-private-methods@npm:^7.16.11":
   version: 7.16.11
   resolution: "@babel/plugin-proposal-private-methods@npm:7.16.11"
   dependencies:
@@ -851,7 +852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-private-property-in-object@npm:^7.16.0, @babel/plugin-proposal-private-property-in-object@npm:^7.16.7":
+"@babel/plugin-proposal-private-property-in-object@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.16.7"
   dependencies:
@@ -918,17 +919,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3e80814b5b6d4fe17826093918680a351c2d34398a914ce6e55d8083d72a9bdde4fbaf6a2dcea0e23a03de26dc2917ae3efd603d27099e2b98380345703bf948
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-decorators@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/plugin-syntax-decorators@npm:7.16.7"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.16.7
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 4c8dacd8b612d24638394bc86df7f89f92f8a21e5c450be983f754003ffe72d70aebdb81456232df5ec2fc7ff4f7415489bc1f577a28c072c336fc4f9114b82a
   languageName: node
   linkType: hard
 
@@ -1262,7 +1252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-flow-strip-types@npm:^7.0.0, @babel/plugin-transform-flow-strip-types@npm:^7.16.0":
+"@babel/plugin-transform-flow-strip-types@npm:^7.0.0":
   version: 7.16.7
   resolution: "@babel/plugin-transform-flow-strip-types@npm:7.16.7"
   dependencies:
@@ -1441,7 +1431,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-display-name@npm:^7.0.0, @babel/plugin-transform-react-display-name@npm:^7.16.0, @babel/plugin-transform-react-display-name@npm:^7.16.7":
+"@babel/plugin-transform-react-display-name@npm:^7.0.0, @babel/plugin-transform-react-display-name@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-transform-react-display-name@npm:7.16.7"
   dependencies:
@@ -1512,7 +1502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.15.0, @babel/plugin-transform-runtime@npm:^7.16.4":
+"@babel/plugin-transform-runtime@npm:^7.15.0":
   version: 7.16.10
   resolution: "@babel/plugin-transform-runtime@npm:7.16.10"
   dependencies:
@@ -1735,7 +1725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-react@npm:^7.14.0, @babel/preset-react@npm:^7.14.5, @babel/preset-react@npm:^7.16.0, @babel/preset-react@npm:^7.16.7":
+"@babel/preset-react@npm:^7.14.0, @babel/preset-react@npm:^7.14.5, @babel/preset-react@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/preset-react@npm:7.16.7"
   dependencies:
@@ -1751,7 +1741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.15.0, @babel/preset-typescript@npm:^7.16.0, @babel/preset-typescript@npm:^7.16.7":
+"@babel/preset-typescript@npm:^7.15.0, @babel/preset-typescript@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/preset-typescript@npm:7.16.7"
   dependencies:
@@ -2676,16 +2666,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@commercetools-frontend/eslint-config-mc-app@workspace:packages/eslint-config-mc-app"
   dependencies:
+    "@babel/core": ^7.17.8
+    "@babel/eslint-parser": ^7.17.0
     "@commercetools-frontend/babel-preset-mc-app": ^21.0.0
     "@rushstack/eslint-patch": ^1.1.1
     "@typescript-eslint/eslint-plugin": ^5.16.0
     "@typescript-eslint/parser": ^5.16.0
+    confusing-browser-globals: ^1.0.11
     eslint: 8.11.0
     eslint-config-prettier: ^8.5.0
-    eslint-config-react-app: ^7.0.0
     eslint-import-resolver-typescript: ^2.7.0
     eslint-plugin-cypress: ^2.12.1
-    eslint-plugin-flowtype: ^8.0.3
     eslint-plugin-import: ^2.25.4
     eslint-plugin-jest: ^25.7.0
     eslint-plugin-jest-dom: ^4.0.1
@@ -7794,13 +7785,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rushstack/eslint-patch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@rushstack/eslint-patch@npm:1.1.0"
-  checksum: 4602c23454c8bb03502da12398cb5c4c0bfb3b1772535b418ec94ab8c47824f70e6ff32206a35fe7086042d9516959edea439e2371147b1de7eee50ef03ace65
-  languageName: node
-  linkType: hard
-
 "@rushstack/eslint-patch@npm:^1.1.1":
   version: 1.1.1
   resolution: "@rushstack/eslint-patch@npm:1.1.1"
@@ -11300,30 +11284,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 251bcea11c18fd9672fec104eadb45b43f117ceeb326fa7345ced778d4c1feab29343cd7a87a1dcfae4997d6c851a8b386d7f7213792da6e23b74f4443a8976d
-  languageName: node
-  linkType: hard
-
-"babel-preset-react-app@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "babel-preset-react-app@npm:10.0.1"
-  dependencies:
-    "@babel/core": ^7.16.0
-    "@babel/plugin-proposal-class-properties": ^7.16.0
-    "@babel/plugin-proposal-decorators": ^7.16.4
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.16.0
-    "@babel/plugin-proposal-numeric-separator": ^7.16.0
-    "@babel/plugin-proposal-optional-chaining": ^7.16.0
-    "@babel/plugin-proposal-private-methods": ^7.16.0
-    "@babel/plugin-transform-flow-strip-types": ^7.16.0
-    "@babel/plugin-transform-react-display-name": ^7.16.0
-    "@babel/plugin-transform-runtime": ^7.16.4
-    "@babel/preset-env": ^7.16.4
-    "@babel/preset-react": ^7.16.0
-    "@babel/preset-typescript": ^7.16.0
-    "@babel/runtime": ^7.16.3
-    babel-plugin-macros: ^3.1.0
-    babel-plugin-transform-react-remove-prop-types: ^0.4.24
-  checksum: ee66043484e67b8aef2541976388299691478ea00834f3bb14b6b3d5edcd316a5ac95351f6ec084b41ee555cad820d4194280ad38ce51884fedc7e8946a57b74
   languageName: node
   linkType: hard
 
@@ -15274,30 +15234,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-react-app@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "eslint-config-react-app@npm:7.0.0"
-  dependencies:
-    "@babel/core": ^7.16.0
-    "@babel/eslint-parser": ^7.16.3
-    "@rushstack/eslint-patch": ^1.1.0
-    "@typescript-eslint/eslint-plugin": ^5.5.0
-    "@typescript-eslint/parser": ^5.5.0
-    babel-preset-react-app: ^10.0.1
-    confusing-browser-globals: ^1.0.11
-    eslint-plugin-flowtype: ^8.0.3
-    eslint-plugin-import: ^2.25.3
-    eslint-plugin-jest: ^25.3.0
-    eslint-plugin-jsx-a11y: ^6.5.1
-    eslint-plugin-react: ^7.27.1
-    eslint-plugin-react-hooks: ^4.3.0
-    eslint-plugin-testing-library: ^5.0.1
-  peerDependencies:
-    eslint: ^8.0.0
-  checksum: dac130cfcb9689596ce3495692fecb25d913ba81de0e0c3e4b078ae79f0f0d20a77751f30823c5b3c09d66981c1df7f2836aa193f5c6c542faeb17761cd62019
-  languageName: node
-  linkType: hard
-
 "eslint-formatter-pretty@npm:4.1.0":
   version: 4.1.0
   resolution: "eslint-formatter-pretty@npm:4.1.0"
@@ -15373,20 +15309,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-flowtype@npm:^8.0.3":
-  version: 8.0.3
-  resolution: "eslint-plugin-flowtype@npm:8.0.3"
-  dependencies:
-    lodash: ^4.17.21
-    string-natural-compare: ^3.0.1
-  peerDependencies:
-    "@babel/plugin-syntax-flow": ^7.14.5
-    "@babel/plugin-transform-react-jsx": ^7.14.9
-    eslint: ^8.1.0
-  checksum: 30e63c5357b0b5571f39afed51e59c140084f4aa53c106b1fd04f26da42b268908466daa6020b92943e71409bdaee1c67202515ed9012404d027cc92cb03cefa
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-graphql@npm:4.0.0, eslint-plugin-graphql@npm:^4.0.0":
   version: 4.0.0
   resolution: "eslint-plugin-graphql@npm:4.0.0"
@@ -15401,7 +15323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.25.3, eslint-plugin-import@npm:^2.25.4":
+"eslint-plugin-import@npm:^2.25.4":
   version: 2.25.4
   resolution: "eslint-plugin-import@npm:2.25.4"
   dependencies:
@@ -15437,7 +15359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:^25.3.0, eslint-plugin-jest@npm:^25.7.0":
+"eslint-plugin-jest@npm:^25.7.0":
   version: 25.7.0
   resolution: "eslint-plugin-jest@npm:25.7.0"
   dependencies:
@@ -15500,7 +15422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:^7.27.1, eslint-plugin-react@npm:^7.29.2, eslint-plugin-react@npm:^7.29.4":
+"eslint-plugin-react@npm:^7.29.2, eslint-plugin-react@npm:^7.29.4":
   version: 7.29.4
   resolution: "eslint-plugin-react@npm:7.29.4"
   dependencies:
@@ -15524,7 +15446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:^5.0.1, eslint-plugin-testing-library@npm:^5.1.0":
+"eslint-plugin-testing-library@npm:^5.1.0":
   version: 5.1.0
   resolution: "eslint-plugin-testing-library@npm:5.1.0"
   dependencies:


### PR DESCRIPTION
Recently we've been seeing this kind of errors when we had to update dependencies.

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/1110551/160107094-b7a3d23e-82aa-4ad7-b3b8-99412c1dfa4b.png">

To try avoiding this as much as possible, I thought it would make sense to remove the `eslint-config-react-app` dependency and include most of its configuration into our own config.

So most of the things are copied over.