### PR TITLE
feat: add new `eslint-config-node` for Node.js projects

### DIFF
--- a/.changeset/ninety-elephants-deliver.md
+++ b/.changeset/ninety-elephants-deliver.md
@@ -1,0 +1,17 @@
+---
+'@commercetools-backend/eslint-config-node': minor
+---
+
+Add new ESLint config for Node.js projects. It includes TypeScript support.
+
+```bash
+$ yarn add eslint @commercetools-backend/eslint-config-node
+```
+
+```js
+// .eslintrc.js
+
+module.exports = {
+  extends: ['@commercetools-backend/eslint-config-node'],
+};
+```

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "!packages/jest-stylelint-runner",
       "!packages/mc-dev-authentication",
       "!packages/mc-html-template",
-      "!packages/mc-scripts"
+      "!packages/mc-scripts",
+      "!packages-backend/eslint-config-node"
     ]
   },
   "dependencies": {

--- a/packages-backend/eslint-config-node/LICENSE
+++ b/packages-backend/eslint-config-node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages-backend/eslint-config-node/README.md
+++ b/packages-backend/eslint-config-node/README.md
@@ -1,0 +1,25 @@
+# @commercetools-backend/eslint-config-node
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@commercetools-backend/eslint-config-node"><img src="https://badgen.net/npm/v/@commercetools-backend/eslint-config-node" alt="Latest release (latest dist-tag)" /></a> <a href="https://www.npmjs.com/package/@commercetools-backend/eslint-config-node"><img src="https://badgen.net/npm/v/@commercetools-backend/eslint-config-node/next" alt="Latest release (next dist-tag)" /></a> <a href="https://bundlephobia.com/result?p=@commercetools-backend/eslint-config-node"><img src="https://badgen.net/bundlephobia/minzip/@commercetools-backend/eslint-config-node" alt="Minified + GZipped size" /></a> <a href="https://github.com/commercetools/merchant-center-application-kit/blob/main/LICENSE"><img src="https://badgen.net/github/license/commercetools/merchant-center-application-kit" alt="GitHub license" /></a>
+</p>
+
+ESLint config for Node.js projects.
+
+## Install
+
+```bash
+$ npm install --save @commercetools-backend/eslint-config-node
+
+$ npx install-peerdeps --dev @commercetools-backend/eslint-config-node
+```
+
+## Usage
+
+```js
+// .eslintrc.js
+
+module.exports = {
+  extends: ['@commercetools-backend/eslint-config-node'],
+};
+```

--- a/packages-backend/eslint-config-node/helpers/eslint.js
+++ b/packages-backend/eslint-config-node/helpers/eslint.js
@@ -1,0 +1,8 @@
+const statusCode = {
+  error: 'error',
+  warn: 'warn',
+  off: 'off',
+};
+const allSupportedExtensions = ['.js', '.mjs', '.cjs', '.ts'];
+
+module.exports = { statusCode, allSupportedExtensions };

--- a/packages-backend/eslint-config-node/index.js
+++ b/packages-backend/eslint-config-node/index.js
@@ -1,0 +1,222 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+const { statusCode, allSupportedExtensions } = require('./helpers/eslint');
+// const { craRules } = require('./helpers/rules-presets');
+
+/**
+ * @type {import("eslint").Linter.Config}
+ */
+module.exports = {
+  root: true,
+
+  parser: '@babel/eslint-parser',
+
+  parserOptions: {
+    sourceType: 'module',
+    requireConfigFile: false,
+    /**
+     * @type {import('@babel/core').TransformOptions}
+     */
+    babelOptions: {
+      presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+    },
+  },
+
+  env: {
+    browser: false,
+    commonjs: true,
+    es6: true,
+    jest: true,
+    node: true,
+  },
+
+  extends: [
+    'eslint:recommended',
+    // https://github.com/mysticatea/eslint-plugin-node
+    'plugin:node/recommended',
+    // https://github.com/benmosher/eslint-plugin-import
+    'plugin:import/errors',
+    'plugin:import/warnings',
+    // https://github.com/jest-community/eslint-plugin-jest
+    'plugin:jest/recommended',
+    // NOTE: this should go last.
+    'prettier',
+  ],
+
+  plugins: [
+    // https://github.com/import-js/eslint-plugin-import
+    'import',
+    // https://github.com/jest-community/eslint-plugin-jest
+    'jest',
+    // https://github.com/prettier/prettier-eslint
+    'prettier',
+  ],
+
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: allSupportedExtensions,
+      },
+    },
+  },
+
+  rules: {
+    // Nodejs
+    'node/no-missing-import': statusCode.off,
+    'node/no-unsupported-features/es-syntax': statusCode.off,
+
+    // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
+    'no-unused-expressions': statusCode.off,
+
+    // Imports
+    'import/extensions': [
+      statusCode.error,
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+        mjs: 'never',
+        json: 'always',
+        svg: 'always',
+        graphql: 'always',
+      },
+    ],
+    'import/default': statusCode.off,
+    'import/first': statusCode.error,
+    // TODO: enable this once there is support for `import type`
+    // 'import/order': statusCode.error,
+    'import/named': statusCode.off,
+    'import/namespace': statusCode.off,
+    'import/no-extraneous-dependencies': statusCode.off,
+    'import/no-named-as-default': statusCode.off,
+    'import/no-named-as-default-member': statusCode.off,
+    'import/no-unresolved': statusCode.error,
+
+    // Jest
+    'jest/expect-expect': statusCode.off,
+    'jest/no-identical-title': statusCode.warn,
+    'jest/no-focused-tests': statusCode.error,
+  },
+
+  overrides: [
+    {
+      files: ['*.{spec,test}.*'],
+      env: {
+        'jest/globals': true,
+      },
+      rules: {
+        'node/no-extraneous-require': [
+          statusCode.error,
+          {
+            allowModules: ['jest-each', 'msw'],
+          },
+        ],
+        // https://github.com/jest-community/eslint-plugin-jest
+        'jest/no-conditional-expect': statusCode.error,
+        'jest/no-identical-title': statusCode.error,
+        'jest/no-interpolation-in-snapshots': statusCode.error,
+        'jest/no-jasmine-globals': statusCode.error,
+        'jest/no-jest-import': statusCode.error,
+        'jest/no-mocks-import': statusCode.error,
+        'jest/valid-describe-callback': statusCode.error,
+        'jest/valid-expect': statusCode.error,
+        'jest/valid-expect-in-promise': statusCode.error,
+        'jest/valid-title': statusCode.warn,
+      },
+    },
+    {
+      files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+        // typescript-eslint specific options
+        warnOnUnsupportedTypeScriptVersion: true,
+        /**
+         * @type {import('@babel/core').TransformOptions}
+         */
+        babelOptions: {
+          presets: [
+            ['@babel/preset-env', { targets: { node: 'current' } }],
+            ['@babel/preset-typescript'],
+          ],
+        },
+      },
+      plugins: ['@typescript-eslint'],
+      rules: {
+        // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
+        'default-case': statusCode.off,
+        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+        'no-dupe-class-members': statusCode.off,
+        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+        'no-undef': statusCode.off,
+
+        // Add TypeScript specific rules (and turn off ESLint equivalents)
+        '@typescript-eslint/consistent-type-assertions': statusCode.warn,
+        'no-array-constructor': statusCode.off,
+        '@typescript-eslint/no-array-constructor': statusCode.warn,
+        'no-redeclare': statusCode.off,
+        '@typescript-eslint/no-redeclare': statusCode.warn,
+        'no-use-before-define': statusCode.off,
+        '@typescript-eslint/no-use-before-define': [
+          statusCode.error,
+          {
+            functions: false,
+            classes: false,
+            variables: false,
+            typedefs: false,
+          },
+        ],
+        'no-unused-expressions': statusCode.off,
+        '@typescript-eslint/no-unused-expressions': [
+          statusCode.error,
+          {
+            allowShortCircuit: true,
+            allowTernary: true,
+            allowTaggedTemplates: true,
+          },
+        ],
+        'no-unused-vars': statusCode.off,
+        '@typescript-eslint/no-unused-vars': [
+          statusCode.warn,
+          {
+            args: 'none',
+            ignoreRestSiblings: true,
+          },
+        ],
+        'no-useless-constructor': statusCode.off,
+        '@typescript-eslint/no-useless-constructor': statusCode.warn,
+
+        // TypeScript
+        '@typescript-eslint/ban-types': statusCode.off,
+        '@typescript-eslint/naming-convention': statusCode.off,
+        '@typescript-eslint/consistent-type-definitions': statusCode.off,
+        '@typescript-eslint/no-explicit-any': statusCode.error,
+        '@typescript-eslint/no-var-requires': statusCode.off,
+        '@typescript-eslint/unbound-method': statusCode.off,
+        '@typescript-eslint/ban-ts-comment': statusCode.off,
+        '@typescript-eslint/explicit-function-return-type': statusCode.off,
+        '@typescript-eslint/explicit-member-accessibility': [
+          statusCode.error,
+          { accessibility: 'no-public' },
+        ],
+        '@typescript-eslint/no-require-imports': statusCode.off,
+        '@typescript-eslint/promise-function-async': statusCode.off,
+      },
+      settings: {
+        'import/parsers': {
+          '@typescript-eslint/parser': allSupportedExtensions,
+        },
+        'import/resolver': {
+          'eslint-import-resolver-typescript': true,
+          typescript: {},
+          node: {
+            extensions: allSupportedExtensions,
+          },
+        },
+      },
+    },
+  ],
+};

--- a/packages-backend/eslint-config-node/index.js
+++ b/packages-backend/eslint-config-node/index.js
@@ -2,7 +2,6 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 const { statusCode, allSupportedExtensions } = require('./helpers/eslint');
-// const { craRules } = require('./helpers/rules-presets');
 
 /**
  * @type {import("eslint").Linter.Config}

--- a/packages-backend/eslint-config-node/package.json
+++ b/packages-backend/eslint-config-node/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/merchant-center-application-kit.git",
-    "directory": "packages/eslint-config-node"
+    "directory": "packages-backend/eslint-config-node"
   },
   "homepage": "https://docs.commercetools.com/custom-applications",
   "keywords": ["javascript", "nodejs", "toolkit", "eslint"],

--- a/packages-backend/eslint-config-node/package.json
+++ b/packages-backend/eslint-config-node/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@commercetools-backend/eslint-config-node",
+  "version": "1.0.0",
+  "description": "ESLint config for Node.js projects.",
+  "bugs": "https://github.com/commercetools/merchant-center-application-kit/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/merchant-center-application-kit.git",
+    "directory": "packages/eslint-config-node"
+  },
+  "homepage": "https://docs.commercetools.com/custom-applications",
+  "keywords": ["javascript", "nodejs", "toolkit", "eslint"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@babel/core": "^7.17.8",
+    "@babel/eslint-parser": "^7.17.0",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-typescript": "^7.16.7",
+    "@rushstack/eslint-patch": "^1.1.1",
+    "@typescript-eslint/eslint-plugin": "^5.16.0",
+    "@typescript-eslint/parser": "^5.16.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^2.7.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-jest": "^25.7.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^4.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "8.x"
+  },
+  "devDependencies": {
+    "eslint": "8.11.0"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@commercetools-backend/eslint-config-node@workspace:packages-backend/eslint-config-node":
+  version: 0.0.0-use.local
+  resolution: "@commercetools-backend/eslint-config-node@workspace:packages-backend/eslint-config-node"
+  dependencies:
+    "@babel/core": ^7.17.8
+    "@babel/eslint-parser": ^7.17.0
+    "@babel/preset-env": ^7.16.11
+    "@babel/preset-typescript": ^7.16.7
+    "@rushstack/eslint-patch": ^1.1.1
+    "@typescript-eslint/eslint-plugin": ^5.16.0
+    "@typescript-eslint/parser": ^5.16.0
+    eslint: 8.11.0
+    eslint-config-prettier: ^8.5.0
+    eslint-import-resolver-typescript: ^2.7.0
+    eslint-plugin-import: ^2.25.4
+    eslint-plugin-jest: ^25.7.0
+    eslint-plugin-node: ^11.1.0
+    eslint-plugin-prettier: ^4.0.0
+  peerDependencies:
+    eslint: 8.x
+  languageName: unknown
+  linkType: soft
+
 "@commercetools-backend/express@21.2.1, @commercetools-backend/express@workspace:packages-backend/express":
   version: 0.0.0-use.local
   resolution: "@commercetools-backend/express@workspace:packages-backend/express"
@@ -15534,6 +15557,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-es@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "eslint-plugin-es@npm:3.0.1"
+  dependencies:
+    eslint-utils: ^2.0.0
+    regexpp: ^3.0.0
+  peerDependencies:
+    eslint: ">=4.19.1"
+  checksum: e57592c52301ee8ddc296ae44216df007f3a870bcb3be8d1fbdb909a1d3a3efe3fa3785de02066f9eba1d6466b722d3eb3cc3f8b75b3cf6a1cbded31ac6298e4
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-flowtype@npm:^5.10.0":
   version: 5.10.0
   resolution: "eslint-plugin-flowtype@npm:5.10.0"
@@ -15635,6 +15670,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-node@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "eslint-plugin-node@npm:11.1.0"
+  dependencies:
+    eslint-plugin-es: ^3.0.0
+    eslint-utils: ^2.0.0
+    ignore: ^5.1.1
+    minimatch: ^3.0.4
+    resolve: ^1.10.1
+    semver: ^6.1.0
+  peerDependencies:
+    eslint: ">=5.16.0"
+  checksum: 5804c4f8a6e721f183ef31d46fbe3b4e1265832f352810060e0502aeac7de034df83352fc88643b19641bb2163f2587f1bd4119aff0fd21e8d98c57c450e013b
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-prettier@npm:^4.0.0":
   version: 4.0.0
   resolution: "eslint-plugin-prettier@npm:4.0.0"
@@ -15721,7 +15772,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-utils@npm:^2.1.0":
+"eslint-utils@npm:^2.0.0, eslint-utils@npm:^2.1.0":
   version: 2.1.0
   resolution: "eslint-utils@npm:2.1.0"
   dependencies:
@@ -19656,7 +19707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.4, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
+"ignore@npm:^5.1.1, ignore@npm:^5.1.4, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
@@ -28252,7 +28303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpp@npm:^3.1.0, regexpp@npm:^3.2.0":
+"regexpp@npm:^3.0.0, regexpp@npm:^3.1.0, regexpp@npm:^3.2.0":
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
   checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
@@ -28815,7 +28866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.12.0, resolve@npm:^1.14.2, resolve@npm:^1.15.1, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.3.2":
+"resolve@npm:^1.1.6, resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.12.0, resolve@npm:^1.14.2, resolve@npm:^1.15.1, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.3.2":
   version: 1.22.0
   resolution: "resolve@npm:1.22.0"
   dependencies:
@@ -28838,7 +28889,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.22.0
   resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
   dependencies:
@@ -29248,7 +29299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.2.0, semver@npm:^6.3.0":
+"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.2.0, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
   bin:


### PR DESCRIPTION
This is a slightly simpler/different ESLint config for Node.js projects. We can use this in our backend services.