### PR TITLE
fix(components): tab page itself should not scroll

### DIFF
--- a/.changeset/warm-actors-taste.md
+++ b/.changeset/warm-actors-taste.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Page components with tabs should only let the content be scrollable

--- a/packages/application-components/src/components/internals/page.styles.ts
+++ b/packages/application-components/src/components/internals/page.styles.ts
@@ -3,6 +3,7 @@ import { customProperties } from '@commercetools-uikit/design-system';
 
 export const ContentWrapper = styled.div`
   flex: 1;
+  flex-basis: 0;
   padding: ${customProperties.spacingM};
   overflow: auto;
 `;


### PR DESCRIPTION
Follow up of #2517 

![2022-04-05 18 28 59](https://user-images.githubusercontent.com/1110551/161801932-5fad6ab9-159b-4877-ba8d-9e0f40f3f768.gif)
