### PR TITLE
fix(babel): flaky resolution of emotion babel preset

### DIFF
--- a/.changeset/funny-crabs-applaud.md
+++ b/.changeset/funny-crabs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/babel-preset-mc-app': patch
+---
+
+Fix flaky resolution of `@emotion/babel-preset-css-prop`

--- a/packages/babel-preset-mc-app/create.js
+++ b/packages/babel-preset-mc-app/create.js
@@ -85,7 +85,7 @@ module.exports = function createBabePresetConfigForMcApp(api, opts = {}, env) {
       // use the `@emotion/babel-plugin` plugin.
       // https://emotion.sh/docs/@emotion/babel-preset-css-prop
       options.runtime !== 'automatic' && [
-        '@emotion/babel-preset-css-prop',
+        require('@emotion/babel-preset-css-prop').default,
         {
           sourceMap: isEnvDevelopment,
           autoLabel: 'dev-only',


### PR DESCRIPTION
Sometimes we get an error like `Cannot find module @emotion/babel-preset-css-prop`.

Usually this relates to how dependencies are hoisted in `node_modules`.

I noticed though that we weren't using `require()` to resolve the babel preset. This now should hopefully fix that problem.