### PR TITLE
fix(config): compute submenu link `uriPath` when parsing local config

### DIFF
--- a/.changeset/stupid-gorillas-attend.md
+++ b/.changeset/stupid-gorillas-attend.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-config': patch
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix computing submenu link `uriPath` when parsing local Custom Application config.

--- a/packages/application-config/src/transformers.ts
+++ b/packages/application-config/src/transformers.ts
@@ -2,6 +2,21 @@ import type { JSONSchemaForCustomApplicationConfigurationFiles } from './schema'
 import type { CustomApplicationData } from './types';
 import { entryPointUriPathToResourceAccesses } from './formatters';
 
+// The `uriPath` of each submenu link is supposed to be defined relative
+// to the `entryPointUriPath`. Computing the full path is done internally to keep
+// the configuration simple.
+const computeUriPath = (uriPath: string, entryPointUriPath: string) => {
+  // In case the `uriPath` is only `/`, it means that the link is supposed to be
+  // treated the same as the main application path. In this case, the return value
+  // should not contain any unnecessary trailing slash and therefore we use the `entryPointUriPath`.
+  if (uriPath === '/') return entryPointUriPath;
+  // In case the `uriPath` is already configured including the `entryPointUriPath`,
+  // we return the `uriPath` as-is.
+  if (uriPath.startsWith(`${entryPointUriPath}/`)) return uriPath;
+  // Return the full path including the `entryPointUriPath` as a prefix.
+  return `${entryPointUriPath}/${uriPath}`;
+};
+
 function transformCustomApplicationConfigToData(
   appConfig: JSONSchemaForCustomApplicationConfigurationFiles
 ): CustomApplicationData {
@@ -27,7 +42,10 @@ function transformCustomApplicationConfigToData(
     ],
     icon: appConfig.icon,
     mainMenuLink: appConfig.mainMenuLink,
-    submenuLinks: appConfig.submenuLinks,
+    submenuLinks: appConfig.submenuLinks.map((submenuLink) => ({
+      ...submenuLink,
+      uriPath: computeUriPath(submenuLink.uriPath, appConfig.entryPointUriPath),
+    })),
   };
 }
 

--- a/packages/application-config/test/process-config.spec.js
+++ b/packages/application-config/test/process-config.spec.js
@@ -938,7 +938,7 @@ describe('processing a config with intl variable placeholders', () => {
             defaultLabel: 'Add avenger',
             labelAllLocales: [],
             permissions: ['ManageAvengers'],
-            uriPath: 'new',
+            uriPath: 'avengers/new',
           },
         ],
       },
@@ -971,7 +971,7 @@ describe('processing a config with intl variable placeholders', () => {
             permissions: ['ViewAvengers'],
             submenuLinks: [
               {
-                uriPath: 'new',
+                uriPath: 'avengers/new',
                 defaultLabel: 'Add avenger',
                 labelAllLocales: [],
                 permissions: ['ManageAvengers'],

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
@@ -141,7 +141,7 @@ const createTestNavBarMenuLinksConfig = (
   permissions: [],
   submenuLinks: [
     {
-      uriPath: 'new',
+      uriPath: 'avengers/new',
       defaultLabel: 'Add avenger',
       labelAllLocales: [{ locale: 'en', value: 'Add avenger' }],
       permissions: [],

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
@@ -100,17 +100,7 @@ const mapApplicationMenuConfigToGraqhQLQueryResult = (
               submenu: menuLinks.submenuLinks.map((submenuLink) => ({
                 __typename: 'BaseMenu',
                 key: `${entryPointUriPath}-${submenuLink.uriPath}`,
-                // The `uriPath` of each submenu link is supposed to be defined relative
-                // to the entry point URI path.
-                // However, when rendering the link, we need to provide the full uri path.
-                // Special case when the value is `/`: it means that the link is supposed to be
-                // treated the same as the entry point uri path. In this case, the return value
-                // should not contain any unnecessary trailing slash and therefore we return the
-                // main value `entryPointUriPath`.
-                uriPath:
-                  submenuLink.uriPath === '/'
-                    ? entryPointUriPath
-                    : `${entryPointUriPath}/${submenuLink.uriPath}`,
+                uriPath: submenuLink.uriPath,
                 labelAllLocales: mapLabelAllLocalesWithDefaults(
                   submenuLink.labelAllLocales,
                   submenuLink.defaultLabel


### PR DESCRIPTION
I was testing the CLI `config:sync` and noticed an inconsistency.

Currently, the API expects the submenu link `uriPath` to contain the full uri path (including the `entryPointUriPath`). For example, if the `entryPointUriPath` is `avengers`, a submenu link can be `avengers/new`.

However, for simplicity in both the MC UI and in the local Custom Application config, the user only needs to provide the value relative to the `entryPointUriPath`. This avoids having to re-enter the `entryPointUriPath` for every submenu link and to avoid possible typos.

This logic of computing the full uri path is already defined in the MC UI form and in the app shell, when rendering the navigation menu.

However, it was not defined in the application config, which is also used for the `config:sync` command.

This PR "moves" the logic of computing the value into the parsing of the config, so that things are consistent again.