### PR TITLE
fix: offset calculation of modal pages when notifications are opened

### DIFF
--- a/.changeset/hungry-bulldogs-joke.md
+++ b/.changeset/hungry-bulldogs-joke.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/react-notifications': patch
+'playground': patch
+---
+
+Fix offset calculation for modal pages when notifications are opened.

--- a/cypress/integration/playground/application-shell.js
+++ b/cypress/integration/playground/application-shell.js
@@ -2,7 +2,7 @@ import { encode } from 'qss';
 import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import {
   URL_BASE,
-  URL_STATE_MACHINES,
+  URL_APP_KIT_PLAYGROUND,
   ENTRY_POINT_APP_KIT_PLAYGROUND,
 } from '../../support/urls';
 
@@ -58,7 +58,7 @@ describe('navigation menu', () => {
 describe('failed OIDC authentication', () => {
   describe('when sessionToken is missing', () => {
     it('should show oidc callback error page', () => {
-      cy.visit(`/${URL_STATE_MACHINES}/oidc/callback`);
+      cy.visit(`/${URL_APP_KIT_PLAYGROUND}/oidc/callback`);
       cy.findByText('Authentication error');
       cy.findByText(/missing sessionToken/i);
       cy.percySnapshot();
@@ -66,7 +66,7 @@ describe('failed OIDC authentication', () => {
   });
   describe('when sessionToken is invalid', () => {
     it('should show oidc callback error page', () => {
-      cy.visit(`/${URL_STATE_MACHINES}/oidc/callback#sessionToken=123`);
+      cy.visit(`/${URL_APP_KIT_PLAYGROUND}/oidc/callback#sessionToken=123`);
       cy.findByText('Authentication error');
       cy.findByText(/invalid token specified/i);
       cy.percySnapshot();

--- a/cypress/integration/playground/notifications.js
+++ b/cypress/integration/playground/notifications.js
@@ -1,0 +1,50 @@
+import {
+  URL_APP_KIT_PLAYGROUND_NOTIFICATIONS,
+  ENTRY_POINT_APP_KIT_PLAYGROUND,
+} from '../../support/urls';
+
+describe('Notifications', () => {
+  beforeEach(() => {
+    cy.loginByOidc({
+      entryPointUriPath: ENTRY_POINT_APP_KIT_PLAYGROUND,
+      initialRoute: URL_APP_KIT_PLAYGROUND_NOTIFICATIONS,
+    });
+  });
+  it('should adjust layout when notifications are open', () => {
+    cy.findByLabelText('Open modal 1');
+    cy.findByLabelText('Global notification').click();
+    cy.findByText('hello').should('exist');
+
+    cy.findByLabelText('Page notification').click();
+    cy.findByLabelText('Page notification').click();
+    cy.findAllByText('oops').should('have.length', 2);
+
+    cy.findByLabelText('Side notification').click();
+    cy.findByLabelText('Side notification').click();
+    cy.findAllByText('ok').should('have.length', 2);
+
+    cy.percySnapshot();
+  });
+
+  it('should adjust layout for modals when notifications are open', () => {
+    // Open modal
+    cy.findByLabelText('Open modal 1').click();
+    // Open a second modal
+    cy.findByLabelText('Open modal 2').click();
+
+    cy.findByLabelText('Modal page 2').within(() => {
+      cy.findByLabelText('Global notification').click();
+
+      cy.findByLabelText('Page notification').click();
+      cy.findByLabelText('Page notification').click();
+
+      cy.findByLabelText('Side notification').click();
+      cy.findByLabelText('Side notification').click();
+    });
+
+    cy.findByText('hello').should('exist');
+    cy.findAllByText('oops').should('have.length', 2);
+    cy.findAllByText('ok').should('have.length', 2);
+    cy.percySnapshot();
+  });
+});

--- a/cypress/integration/playground/state-machines.js
+++ b/cypress/integration/playground/state-machines.js
@@ -1,5 +1,5 @@
 import {
-  URL_STATE_MACHINES_ID,
+  URL_APP_KIT_PLAYGROUND_STATE_MACHINES_ID,
   ENTRY_POINT_APP_KIT_PLAYGROUND,
 } from '../../support/urls';
 
@@ -18,7 +18,7 @@ describe('State machines', () => {
   it('should render list view and go to details page', () => {
     // Go to details page
     cy.findAllByText('Initial').first().click();
-    cy.url().should('include', URL_STATE_MACHINES_ID);
+    cy.url().should('include', URL_APP_KIT_PLAYGROUND_STATE_MACHINES_ID);
     cy.findByText('LineItemState').should('exist');
     cy.findByText('Processing...').should('not.exist');
     cy.percySnapshot();

--- a/cypress/support/urls.js
+++ b/cypress/support/urls.js
@@ -3,9 +3,10 @@ export const projectKey = Cypress.env('PROJECT_KEY');
 export const URL_BASE = `/${projectKey}`;
 
 export const ENTRY_POINT_APP_KIT_PLAYGROUND = 'app-kit-playground';
-export const URL_STATE_MACHINES = `${URL_BASE}/${ENTRY_POINT_APP_KIT_PLAYGROUND}`;
-export const URL_STATE_MACHINES_ID = `${URL_STATE_MACHINES}/12ad40eb-b33f-4e0e-ae91-bca373ccfd58`;
+export const URL_APP_KIT_PLAYGROUND = `${URL_BASE}/${ENTRY_POINT_APP_KIT_PLAYGROUND}`;
+export const URL_APP_KIT_PLAYGROUND_NOTIFICATIONS = `${URL_APP_KIT_PLAYGROUND}/notifications`;
+export const URL_APP_KIT_PLAYGROUND_STATE_MACHINES_ID = `${URL_APP_KIT_PLAYGROUND}/12ad40eb-b33f-4e0e-ae91-bca373ccfd58`;
 
 export const ENTRY_POINT_TEMPLATE_STARTER = 'template-starter';
 export const URL_TEMPLATE_STARTER = `${URL_BASE}/${ENTRY_POINT_TEMPLATE_STARTER}`;
-export const URL_TEMPLATE_STARTER_CHANNELS = `${URL_BASE}/${ENTRY_POINT_TEMPLATE_STARTER}/channels`;
+export const URL_TEMPLATE_STARTER_CHANNELS = `${URL_TEMPLATE_STARTER}/channels`;

--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -49,6 +49,7 @@
     "@commercetools-uikit/utils": "^14.0.1",
     "@emotion/react": "11.9.0",
     "@emotion/styled": "11.8.1",
+    "@react-hook/resize-observer": "1.2.5",
     "@types/history": "4.7.11",
     "@types/lodash": "^4.14.181",
     "@types/prop-types": "^15.7.5",

--- a/packages/application-components/src/components/portals-container/portals-container.tsx
+++ b/packages/application-components/src/components/portals-container/portals-container.tsx
@@ -1,6 +1,21 @@
+import {
+  type MutableRefObject,
+  type RefObject,
+  forwardRef,
+  useState,
+} from 'react';
 import { css, Global } from '@emotion/react';
+import useResizeObserver from '@react-hook/resize-observer';
 import { PORTALS_CONTAINER_ID } from '@commercetools-frontend/constants';
 
+type TLayoutRefs = {
+  notificationsGlobalRef: MutableRefObject<HTMLDivElement>;
+  notificationsPageRef: MutableRefObject<HTMLDivElement>;
+};
+type TObservableElementDimensions = {
+  height: number;
+  width: number;
+};
 type TPortalsContainerProps = {
   /**
    * The offset value for positioning the container from the top, when opened.
@@ -36,49 +51,86 @@ const defaultProps: Pick<
   | 'containerSelectorToPreventScrollingOnOpen'
   | 'zIndex'
 > = {
-  offsetTop: '0',
-  offsetLeft: '0',
-  offsetLeftOnExpandedMenu: '0',
+  offsetTop: '0px',
+  offsetLeft: '0px',
+  offsetLeftOnExpandedMenu: '0px',
   containerSelectorToPreventScrollingOnOpen: 'main',
   zIndex: 10000,
 };
 
+const useObserverElementDimensions = (
+  element: RefObject<HTMLDivElement> | null
+): TObservableElementDimensions => {
+  const [dimensions, setDimensions] = useState<TObservableElementDimensions>({
+    height: 0,
+    width: 0,
+  });
+
+  useResizeObserver<HTMLDivElement>(element, (entry) => {
+    setDimensions({
+      height: entry.contentRect.height,
+      width: entry.contentRect.width,
+    });
+  });
+
+  return dimensions;
+};
+
 // All modal components expect to be rendered inside this container.
-const PortalsContainer = (props: TPortalsContainerProps) => (
-  <>
-    <Global
-      // Apply some global styles, based on the `.ReactModal__Body--open` class.
-      styles={css`
-        .ReactModal__Body--open
-          ${props.containerSelectorToPreventScrollingOnOpen} {
-          overflow: hidden;
-        }
+const PortalsContainer = forwardRef<TLayoutRefs, TPortalsContainerProps>(
+  (props, ref) => {
+    const globalNotificationsElementDimensions = useObserverElementDimensions(
+      (ref as MutableRefObject<TLayoutRefs>)?.current?.notificationsGlobalRef
+    );
+    const pageNotificationsElementDimensions = useObserverElementDimensions(
+      (ref as MutableRefObject<TLayoutRefs>)?.current?.notificationsPageRef
+    );
 
-        .ReactModal__Body--open #${PORTALS_CONTAINER_ID} {
-          position: fixed;
-          height: calc(100% - ${props.offsetTop});
-          width: calc(100% - ${props.offsetLeft});
-          top: ${props.offsetTop};
-          right: 0;
-          bottom: 0;
-          z-index: ${props.zIndex};
-        }
+    return (
+      <>
+        <Global
+          // Apply some global styles, based on the `.ReactModal__Body--open` class.
+          styles={css`
+            .ReactModal__Body--open
+              ${props.containerSelectorToPreventScrollingOnOpen} {
+              overflow: hidden;
+            }
 
-        .ReactModal__Body--open.body__menu-open #${PORTALS_CONTAINER_ID} {
-          width: calc(100% - ${props.offsetLeftOnExpandedMenu});
-        }
-      `}
-    />
-    <div
-      id={PORTALS_CONTAINER_ID}
-      // The container needs a height in order to be tabbable: https://reactjs/react-modal#774
-      css={css`
-        display: flex;
-        height: 1px;
-        margin-top: -1px;
-      `}
-    />
-  </>
+            .ReactModal__Body--open #${PORTALS_CONTAINER_ID} {
+              position: fixed;
+              height: calc(
+                100% - ${props.offsetTop} -
+                  ${globalNotificationsElementDimensions.height}px -
+                  ${pageNotificationsElementDimensions.height}px
+              );
+              width: calc(100% - ${props.offsetLeft});
+              top: calc(
+                ${props.offsetTop} +
+                  ${globalNotificationsElementDimensions.height}px +
+                  ${pageNotificationsElementDimensions.height}px
+              );
+              right: 0;
+              bottom: 0;
+              z-index: ${props.zIndex};
+            }
+
+            .ReactModal__Body--open.body__menu-open #${PORTALS_CONTAINER_ID} {
+              width: calc(100% - ${props.offsetLeftOnExpandedMenu});
+            }
+          `}
+        />
+        <div
+          id={PORTALS_CONTAINER_ID}
+          // The container needs a height in order to be tabbable: https://reactjs/react-modal#774
+          css={css`
+            display: flex;
+            height: 1px;
+            margin-top: -1px;
+          `}
+        />
+      </>
+    );
+  }
 );
 PortalsContainer.displayName = 'PortalsContainer';
 PortalsContainer.defaultProps = defaultProps;

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -6,7 +6,13 @@ import type { TApplicationContext } from '@commercetools-frontend/application-sh
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 import type { TrackingList } from '../../utils/gtm';
 
-import { ReactNode, SyntheticEvent, useEffect } from 'react';
+import {
+  type ReactNode,
+  type RefObject,
+  type SyntheticEvent,
+  useEffect,
+  useRef,
+} from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 import { ApolloClient } from '@apollo/client';
 import { Global, css } from '@emotion/react';
@@ -149,6 +155,17 @@ export const RestrictedApplication = <
   // However, every route change will trigger a re-render. This is probably
   // ok-ish but we might want to look into a more performant solution.
   const location = useLocation();
+
+  const notificationsGlobalRef = useRef<HTMLDivElement>(null);
+  const notificationsPageRef = useRef<HTMLDivElement>(null);
+  const layoutRefs = useRef<{
+    notificationsGlobalRef: RefObject<HTMLDivElement>;
+    notificationsPageRef: RefObject<HTMLDivElement>;
+  }>({
+    notificationsGlobalRef,
+    notificationsPageRef,
+  });
+
   return (
     <FetchUser>
       {({ isLoading: isLoadingUser, user, error }) => {
@@ -245,6 +262,7 @@ export const RestrictedApplication = <
                         `}
                       >
                         <div
+                          ref={notificationsGlobalRef}
                           role="global-notifications"
                           css={css`
                             grid-row: 1;
@@ -358,7 +376,7 @@ export const RestrictedApplication = <
                                       // The permissions for the Navbar are resolved separately, within
                                       // a different React context.
                                     >
-                                      <NavBar<AdditionalEnvironmentProperties>
+                                      <NavBar
                                         applicationLocale={locale}
                                         projectKey={projectKeyFromUrl}
                                         project={project}
@@ -379,7 +397,9 @@ export const RestrictedApplication = <
                           </MainContainer>
                         ) : (
                           <MainContainer role="main">
-                            <NotificationsList domain={DOMAINS.PAGE} />
+                            <div ref={notificationsPageRef}>
+                              <NotificationsList domain={DOMAINS.PAGE} />
+                            </div>
                             <NotificationsList domain={DOMAINS.SIDE} />
                             <div
                               css={css`
@@ -404,10 +424,16 @@ export const RestrictedApplication = <
                               `}
                             >
                               <PortalsContainer
+                                // @ts-ignore
+                                ref={layoutRefs}
                                 offsetTop={DIMENSIONS.header}
-                                offsetLeft={DIMENSIONS.navMenu}
+                                offsetLeft={
+                                  projectKeyFromUrl ? DIMENSIONS.navMenu : '0px'
+                                }
                                 offsetLeftOnExpandedMenu={
-                                  DIMENSIONS.navMenuExpanded
+                                  projectKeyFromUrl
+                                    ? DIMENSIONS.navMenuExpanded
+                                    : '0px'
                                 }
                               />
                               <Switch>

--- a/packages/react-notifications/src/components/notifications-list/index.ts
+++ b/packages/react-notifications/src/components/notifications-list/index.ts
@@ -1,2 +1,1 @@
 export { default } from './notifications-list';
-export { selectPageNotifications } from './selectors';

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.styles.ts
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.styles.ts
@@ -13,7 +13,7 @@ const getStyles = (props: StyleProps) => {
     color: ${customProperties.colorSurface};
     position: relative;
     width: 100%;
-    z-index: 10000;
+    z-index: 19999;
   `;
 
   switch (props.domain) {

--- a/packages/react-notifications/src/components/notifications-list/notifications-list.tsx
+++ b/packages/react-notifications/src/components/notifications-list/notifications-list.tsx
@@ -38,7 +38,7 @@ const NotificationsListGlobal = (props: Props) => {
     selectGlobalNotifications
   );
   return (
-    <div css={getStyles(props)}>
+    <div id={`notifications-${props.domain}`} css={getStyles(props)}>
       {notifications.map((notification) => {
         // 1. Check if there is a custom notification component first
         const CustomNotificationComponent =
@@ -107,7 +107,7 @@ const NotificationsListPage = (props: Props) => {
     selectPageNotifications
   );
   return (
-    <div css={getStyles(props)}>
+    <div id={`notifications-${props.domain}`} css={getStyles(props)}>
       {notifications.map((notification) => {
         // 1. Check if there is a custom notification component first
         const CustomNotificationComponent =
@@ -185,7 +185,7 @@ const NotificationsListSide = (props: Props) => {
     selectSideNotifications
   );
   return (
-    <div css={getStyles(props)}>
+    <div id={`notifications-${props.domain}`} css={getStyles(props)}>
       {notifications.map((notification) => {
         // 1. Check if there is a custom notification component first
         const CustomNotificationComponent =

--- a/packages/react-notifications/src/index.ts
+++ b/packages/react-notifications/src/index.ts
@@ -3,9 +3,11 @@ export * from './export-types';
 
 export { default as NotificationProviderForCustomComponent } from './components/map-notification-to-component';
 export { default as Notification } from './components/notification';
+export { default as NotificationsList } from './components/notifications-list';
 export {
-  default as NotificationsList,
+  selectSideNotifications,
+  selectGlobalNotifications,
   selectPageNotifications,
-} from './components/notifications-list';
+} from './components/notifications-list/selectors';
 export { default as Notifier } from './components/notifier';
 export { default as ApiErrorMessage } from './components/notification-kinds/api-error-message';

--- a/playground/custom-application-config.mjs
+++ b/playground/custom-application-config.mjs
@@ -49,6 +49,12 @@ const config = {
   },
   submenuLinks: [
     {
+      uriPath: 'notifications',
+      permissions: [PERMISSIONS.View],
+      defaultLabel: 'Notifications',
+      labelAllLocales: [],
+    },
+    {
       uriPath: 'echo-server',
       permissions: [PERMISSIONS.View],
       defaultLabel: '${intl:en:Menu.EchoServer}',

--- a/playground/src/components/notifications-playground/index.js
+++ b/playground/src/components/notifications-playground/index.js
@@ -1,0 +1,1 @@
+export { default } from './notifications-playground';

--- a/playground/src/components/notifications-playground/notifications-playground.js
+++ b/playground/src/components/notifications-playground/notifications-playground.js
@@ -1,0 +1,92 @@
+import PropTypes from 'prop-types';
+import { useShowNotification } from '@commercetools-frontend/actions-global';
+import {
+  InfoModalPage,
+  useModalState,
+} from '@commercetools-frontend/application-components';
+import FlatButton from '@commercetools-uikit/flat-button';
+import SecondaryButton from '@commercetools-uikit/secondary-button';
+import Spacings from '@commercetools-uikit/spacings';
+
+const NotificationsTriggers = () => {
+  const showNotification = useShowNotification();
+
+  return (
+    <Spacings.Stack scale="s">
+      <Spacings.Inline>
+        <SecondaryButton
+          label="Global notification"
+          onClick={() => {
+            showNotification({
+              domain: 'global',
+              kind: 'info',
+              text: 'hello',
+            });
+          }}
+        />
+      </Spacings.Inline>
+      <Spacings.Inline>
+        <SecondaryButton
+          label="Page notification"
+          onClick={() => {
+            showNotification({
+              domain: 'page',
+              kind: 'error',
+              text: 'oops',
+            });
+          }}
+        />
+      </Spacings.Inline>
+      <Spacings.Inline>
+        <SecondaryButton
+          label="Side notification"
+          onClick={() => {
+            showNotification(
+              {
+                domain: 'side',
+                kind: 'success',
+                text: 'ok',
+              },
+              {
+                dismissAfter: 0,
+              }
+            );
+          }}
+        />
+      </Spacings.Inline>
+    </Spacings.Stack>
+  );
+};
+
+const NotificationsPlayground = (props) => {
+  const modalState = useModalState();
+
+  return (
+    <Spacings.Inset>
+      <Spacings.Stack>
+        <NotificationsTriggers />
+        <FlatButton
+          label={`Open modal ${props.level}`}
+          onClick={modalState.openModal}
+        />
+
+        <InfoModalPage
+          isOpen={modalState.isModalOpen}
+          title={`Modal page ${props.level}`}
+          onClose={modalState.closeModal}
+          level={props.level}
+        >
+          <NotificationsPlayground level={props.level + 1} />
+        </InfoModalPage>
+      </Spacings.Stack>
+    </Spacings.Inset>
+  );
+};
+NotificationsPlayground.propTypes = {
+  level: PropTypes.number.isRequired,
+};
+NotificationsPlayground.defaultProps = {
+  level: 1,
+};
+
+export default NotificationsPlayground;

--- a/playground/src/routes.js
+++ b/playground/src/routes.js
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { Route, Switch, useRouteMatch, useHistory } from 'react-router-dom';
 import StateMachinesList from './components/state-machines-list';
 import StateMachinesDetails from './components/state-machines-details';
+import NotificationsPlayground from './components/notifications-playground';
 import EchoServer from './components/echo-server';
 
 const ApplicationRoutes = () => {
@@ -21,6 +22,9 @@ const ApplicationRoutes = () => {
     <Switch>
       <Route path={`${match.path}/echo-server`}>
         <EchoServer />
+      </Route>
+      <Route path={`${match.path}/notifications`}>
+        <NotificationsPlayground />
       </Route>
       <Route>
         <StateMachinesList goToStateMachineDetail={goToStateMachineDetail}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,6 +2579,7 @@ __metadata:
     "@commercetools-uikit/utils": ^14.0.1
     "@emotion/react": 11.9.0
     "@emotion/styled": 11.8.1
+    "@react-hook/resize-observer": 1.2.5
     "@types/history": 4.7.11
     "@types/lodash": ^4.14.181
     "@types/prop-types": ^15.7.5
@@ -6871,6 +6872,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@juggle/resize-observer@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@juggle/resize-observer@npm:3.3.1"
+  checksum: ddabc4044276a2cb57d469c4917206c7e39f2463aa8e3430e33e4eda554412afe29c22afa40e6708b49dad5d56768dc83acd68a704b1dcd49a0906bb96b991b2
+  languageName: node
+  linkType: hard
+
 "@leichtgewicht/ip-codec@npm:^2.0.1":
   version: 2.0.3
   resolution: "@leichtgewicht/ip-codec@npm:2.0.3"
@@ -8119,6 +8127,39 @@ __metadata:
     pirates: ^4.0.1
     source-map-support: ^0.5.16
   checksum: 5043b0d8a09d370f955b713d350fa01d3f4d9a6f2c8a88019ba239d584981e6610e6eda75fb235aab00839afd23ded6bfcfdc0a492d73e697bd58b3cf2bc534e
+  languageName: node
+  linkType: hard
+
+"@react-hook/latest@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@react-hook/latest@npm:1.0.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 2408c9cd35c5cfa7697b6da3bc5eebef254a932ade70955074c474f23be7dd3e2f81bbba12edcc9208bd0f89c6ed366d6b11d4f6d7b1052877a0bac8f74afad4
+  languageName: node
+  linkType: hard
+
+"@react-hook/passive-layout-effect@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "@react-hook/passive-layout-effect@npm:1.2.1"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 217cb8aa90fb8e677672319a9a466d7752890cf4357c76df000b207696e9cc717cf2ee88080671cc9dae238a82f92093ab4f61ab2f6032d2a8db958fc7d99b5d
+  languageName: node
+  linkType: hard
+
+"@react-hook/resize-observer@npm:1.2.5":
+  version: 1.2.5
+  resolution: "@react-hook/resize-observer@npm:1.2.5"
+  dependencies:
+    "@juggle/resize-observer": ^3.3.1
+    "@react-hook/latest": ^1.0.2
+    "@react-hook/passive-layout-effect": ^1.2.0
+    "@types/raf-schd": ^4.0.0
+    raf-schd: ^4.0.2
+  peerDependencies:
+    react: ">=16.8"
+  checksum: a2f3b333e344adb3d7a4cfd2bc77fd75054b07063fba706d57bef0c497650c3e82038eafb64fa4148c08527e8b0a34f2f70392da1700a7a0d9676ee8ba795c16
   languageName: node
   linkType: hard
 
@@ -9473,6 +9514,13 @@ __metadata:
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
+  languageName: node
+  linkType: hard
+
+"@types/raf-schd@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@types/raf-schd@npm:4.0.1"
+  checksum: 0babaa85541aadc6e5f8aa64ec79cd68bf67ea56abb7610c8daf3ca5f4b1a75d12e4e147a0b5434938a4031650ebddc733021ec4e7db4f11f7955390ec32c917
   languageName: node
   linkType: hard
 
@@ -28029,6 +28077,13 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: a516faa25574be7947969883e6068dbe4aa19e8ef8e8e0fd96cddd6d36485e9106d85c0041a27153286b0770b381328f4072aa40d3b18a19f5f7d2b78b94b5ed
+  languageName: node
+  linkType: hard
+
+"raf-schd@npm:^4.0.2":
+  version: 4.0.3
+  resolution: "raf-schd@npm:4.0.3"
+  checksum: 45514041c5ad31fa96aef3bb3c572a843b92da2f2cd1cb4a47c9ad58e48761d3a4126e18daa32b2bfa0bc2551a42d8f324a0e40e536cb656969929602b4e8b58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow up of #2549 and #2541

Using fixed positioned layout for modal pages had obviously some consequences, for instance how the layout adjusts itself when notifications are rendered on a page.

With the fixed position we now need to adjust the offset/top positions, which are based on the heights of the notifications (global + page).

To calculate the heights we're using now a `ResizeObserver` to update the position whenever the notifications are rendered/removed.

To avoid possible regressions in the future I also added some e2e + percy tests using some new custom pages in the playground app.