### PR TITLE
New documentation page for application shell connectors

### DIFF
--- a/website/src/content/api-reference/application-config.mdx
+++ b/website/src/content/api-reference/application-config.mdx
@@ -694,7 +694,8 @@ const MyComponent = () => {
 
 <Info>
 
-All the properties defined in the `additionalEnv` object are made available to the `context.environment` object.
+All the properties defined in the `additionalEnv` object are made available to the `context.environment` object.<br/>
+You can get more information [here](/api-reference/commercetools-frontend-application-shell-connectors#custom-configuration).
 
 </Info>
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
@@ -1,0 +1,319 @@
+---
+title: "@/application-shell-connectors"
+---
+
+<Subtitle>
+
+Components to work with the `@commercetools-frontend/application-shell` package to access and subscribe to specific data within the AppShell.
+
+</Subtitle>
+
+# Installation
+
+```
+yarn add @commercetools-frontend/application-shell-connectors
+
+# or
+
+npm --save install @commercetools-frontend/application-shell-connectors
+```
+
+Additionally install the peer dependencies (if not present)
+
+```
+yarn add react @apollo/client
+
+# or
+
+npm --save install react @apollo/client
+```
+
+# Context
+
+In this section we describe the type of information you will find in the main application context and how to access it.
+
+## ApplicationContext
+
+This is the main React context for the application and it holds global information regarding user, permissions, project, etc.
+
+To read more about the data in the context, read the following;
+
+### environment
+
+An object holding environment installation information for the Custom Application such its [ID](/custom-applications/api-reference/application-config#envproductionapplicationid))]
+or its [entry point](/custom-applications/api-reference/application-config#entrypointuripath).
+
+```json
+{
+  "environment": {
+    "applicationId": "ckw3vt1hv034901uzio4bkzc3:my-custom-application",
+    "applicationName": "My Custom Application",
+    "entryPointUriPath": "my-custom-application"
+  }
+}
+```
+
+### custom configuration
+
+It is important to note that your custom application configuration is also exposed within the `context.environment` property.<br/>
+Any property you add to your application configuration file under the prop [`additionalEnv`](/custom-applications/api-reference/application-config#additionalenv) will also be available in the `context.environment` object.
+
+Let's say you have something like this `custom-application-config.mjs` file in your project:
+
+```json
+{
+  "name": "My Custom Application",
+  "entryPointUriPath": "my-custom-application",
+  "cloudIdentifier": "gcp-eu",
+  "additionalEnv": {
+    "trackingSentry": "https://000@sentry.io/000",
+  },
+  ... // rest of your configuration
+}
+```
+
+Your `context.environment` object will look like this:
+
+```json
+{
+  "environment": {
+    "applicationId": "ckw3vt1hv034901uzio4bkzc3:my-custom-application",
+    "applicationName": "My Custom Application",
+    "entryPointUriPath": "my-custom-application",
+    "trackingSentry": "https://000@sentry.io/000",
+  }
+}
+```
+
+<Info>
+
+More information about accessing your custom configuration can found [here](/custom-applications/api-reference/application-config#runtime-application-environment)
+
+</Info>
+
+### user
+
+Logged in user information.
+
+```json
+{
+  "user": {
+    "id": "3mj76c04-f910-4223-84e1-f97b0fe291c2",
+    "email": "john.doe@domain.com",
+    "firstName": "John",
+    "lastName": "Doe",
+    "businessRole": "Consultant",
+    "locale": "en-GB",
+    "timeZone": "Europe/Berlin",
+    "projects": [
+      { "key": "my-project-A", "name": "My Project A" },
+      { "key": "my-project-B", "name": "My Project B" }
+    ]
+  }
+}
+```
+
+
+### project
+
+Current selected project information.
+
+```json
+{
+  "project": {
+    "countries": ["DE", "US"],
+    "currencies": ["EUR", "USD"],
+    "key": "project-a",
+    "languages": ["de-DE", "en-US"],
+    "name": "Project A",
+    "ownerId": "3mj76c04-f910-4223-84e1-f97b0fe291c2",
+    "ownerName": "My Organization"
+  }
+}
+```
+
+### dataLocale
+
+This property holds the information about the selected locale that is used to render localized data in your application.
+You should use it as the selected language in components like [LocalizedTextField](https://uikit.commercetools.com/?path=/story/components-fields--localizedtextfield).
+
+```json
+{
+  "dataLocale": "de"
+}
+```
+
+
+## useApplicationContext (hook)
+
+This is a custom hook which allows to access the `ApplicationContext` from any component (or other hooks).
+
+### Usage
+
+```jsx
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+
+const DisplayLocale = () => {
+  const { locale } = useApplicationContext((context) => ({
+    locale: applicationContext.dataLocale
+  }));
+  render() {
+    return (
+      <div>
+        <h2>Current locale: {locale}</h1>
+      </div>
+    );
+  }
+}
+
+export default DisplayLocale;
+```
+
+
+## withApplicationContext (HOC)
+
+This is a High Order Component which allows to access the `ApplicationContext` from any component.
+It is meant to be used if you have a class based component where you need to read context data.
+
+### Usage
+
+```jsx
+import { withApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+
+const DisplayLocale = () => {
+  render() {
+    return (
+      <div>
+        <h2>Current locale: {this.props.locale}</h1>
+      </div>
+    );
+  }
+}
+
+export default withApplicationContext((applicationContext) => ({
+  locale: applicationContext.dataLocale
+}))(DisplayLocale);
+```
+
+# Project Images
+
+When using your images for your projects you are expected to upload them to our platform. However, you can also choose to host your images in another service.<br/>
+If this is the case, we don't show them by default to prevent for huge images to be loaded in the browser that could impact Merchat Center performance.
+
+To enable the rendering of those images you need to set up a project-level configuration where you specify rewrite rules for different images sizes.<br/>
+You can find this configuration in the settings section of your projects in the Merchant Center (**Settings > Project Settings > Miscellaneous**).
+
+
+## ProjectExtensionProviderForImageRegex
+
+If you need to access the rewrite rules for your project images, you need to use this provider in your component's tree.<br/>
+The provider will load the configuration and make it available with the components listes below.
+
+### Properties
+
+| Props                           | Type                       | Required | Values            | Default   | Description                                                              |
+| ------------------------------- | -------------------------- | :------: | ----------------- | --------- | -------------------------------------------------------------------------|
+| `children`                      | `ReactNode`                |    ✅    | -                 | -         | Components that should be rendered within the scope of this provider.    |
+| `skip`                          | `boolean`                  |    -     | -                 | false     | Disable loading images configuration.                                   |
+
+
+## GetProjectExtensionImageRegex
+
+Use this component to access the project images configuration provider.<br/>
+It exposes a render prop function which will return the project images configuration.
+
+### Usage
+
+```jsx
+function MyComponent() {
+  return (
+    <GetProjectExtensionImageRegex
+      render={({ isLoading, imageRegex }) => {
+        if (isLoading) return <LoadingSpinner />;
+
+        return (
+          <div>
+            <h2>Project images regex: {imageRegex}</h2>
+          </div>
+        );
+      }}
+    />
+  );
+}
+
+function MyApp() {
+  return (
+    <ProjectExtensionProviderForImageRegex>
+      <MyComponent />
+    </ProjectExtensionProviderForImageRegex>
+  );
+}
+```
+
+### Properties
+
+| Props                           | Type                                                 | Required | Values            | Default   | Description                                                               |
+| ------------------------------- | ---------------------------------------------------- | :------: | ----------------- | --------- | --------------------------------------------------------------------------|
+| `render`                        | `Function`<br/>[See signature.](#signature-render)   |    ✅    | -                 | -         | Function to render children component with the image regex configuration. |
+
+### Signature `render`
+
+```ts
+(
+  render: (imageRegexContextData: TImageRegexContext) => ReactNode
+) => void
+```
+
+This is the shape of the param provided in the render prop:
+
+```ts
+type TImageRegexContext = {
+  isLoading: boolean;
+  imageRegex?: {
+    small?: {
+      flag: string;
+      replace: string;
+      search: string;
+    } | null;
+    thumb?: {
+      flag: string;
+      replace: string;
+      search: string;
+    } | null;
+  } | null;
+}
+```
+
+
+## withProjectExtensionImageRegex (HOC)
+
+In case you are using a class based component, you can use this HOC to access the project images configuration.
+
+### Usage
+
+```jsx
+function MyComponent({ imageRegexData }) {
+  return (
+    <div>
+      <h2>Project images regex is loading?: {imageRegexData.isLoading}</h2>
+      <h2>Project images regex: {imageRegexData.imageRegex}</h2>
+    </div>
+  );
+}
+
+const WrappedComponent = withProjectExtensionImageRegex()(MyComponent);
+
+function MyApp() {
+  return (
+    <ProjectExtensionProviderForImageRegex>
+      <MyComponent />
+    </ProjectExtensionProviderForImageRegex>
+  );
+}
+```
+
+### Properties
+
+| Props                           | Type                               | Required | Values            | Default                  | Description                                                                                    |
+| ------------------------------- | ---------------------------------- | :------: | ----------------- | ------------------------ | -----------------------------------------------------------------------------------------------|
+| `propKey`                       | `string`                           |    -     | -                 | 'imageRegexData'         | Name of the prop where the image regex context data will be provided to the wrapped component. |

--- a/website/src/data/navigation.yaml
+++ b/website/src/data/navigation.yaml
@@ -79,8 +79,8 @@
 
     - title: '@/application-shell'
       path: /api-reference/commercetools-frontend-application-shell
-    # - title: '@/application-shell-connectors'
-    #   path: /api-reference/commercetools-frontend-application-shell-connectors
+    - title: '@/application-shell-connectors'
+      path: /api-reference/commercetools-frontend-application-shell-connectors
     - title: '@/application-components'
       path: /api-reference/commercetools-frontend-application-components
     - title: '@/constants'


### PR DESCRIPTION
#### Summary

Creates a new page in the public documentation site to provide information about the [application shell connectors](https://github.com/commercetools/merchant-center-application-kit/tree/main/packages/application-shell-connectors).

