### PR TITLE
Improve regex for Entry Point Uri Path to accept at least 2 characters

### DIFF
--- a/.changeset/polite-jars-fix.md
+++ b/.changeset/polite-jars-fix.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+validating entry point uri path should allow two characters

--- a/packages/application-config/schema.json
+++ b/packages/application-config/schema.json
@@ -30,7 +30,7 @@
       "oneOf": [
         {
           "type": "string",
-          "pattern": "^[^\\-_]([0-9a-z]|[\\-_](?![\\-_])){2,64}[^\\-_]$"
+          "pattern": "^[^\\-_]([0-9a-z]|[\\-_](?![\\-_])){0,62}[^\\-_]$"
         },
         {
           "$ref": "#/definitions/envVariablePlaceholder"

--- a/packages/application-config/schema.json
+++ b/packages/application-config/schema.json
@@ -30,7 +30,7 @@
       "oneOf": [
         {
           "type": "string",
-          "pattern": "^[^\\-_]([0-9a-z]|[\\-_](?![\\-_])){0,62}[^\\-_]$"
+          "pattern": "^[^\\-_#]([0-9a-z]|[\\-_](?![\\-_])){0,62}[^\\-_#]$"
         },
         {
           "$ref": "#/definitions/envVariablePlaceholder"


### PR DESCRIPTION
Improve regex for Entry Path Url to accept at least 2 alphanumeric characters.
Currently, the regex to validate the entryPointUriPath seems to prevent at least 2 characters. Find more information [here](https://jira.commercetools.com/browse/SHIELD-474)