### PR TITLE
refactor(l10n): add translations for included timezones

### DIFF
--- a/packages/l10n/src/time-zone-messages.ts
+++ b/packages/l10n/src/time-zone-messages.ts
@@ -1,0 +1,1419 @@
+// import { defineMessages } from 'react-intl';
+
+export const TIME_ZONE_MESSAGES = {
+  'Pacific/Niue': {
+    id: 'Pacific/Niue',
+    defaultMessage: 'Niue Time',
+    offset: '-11',
+  },
+  'Pacific/Samoa': {
+    id: 'Pacific/Samoa',
+    defaultMessage: 'Samoa Standard Time',
+    offset: '-11',
+  },
+  'Pacific/Rarotonga': {
+    id: 'Pacific/Rarotonga',
+    defaultMessage: 'Cook Island Standard Time - Rarotonga',
+    offset: '-10',
+  },
+  'Pacific/Honolulu': {
+    id: 'Pacific/Honolulu',
+    defaultMessage: 'Hawaii-Aleutian Time - Honolulu',
+    offset: '-10',
+  },
+  'Pacific/Tahiti': {
+    id: 'Pacific/Tahiti',
+    defaultMessage: 'Tahiti Time',
+    offset: '-10',
+  },
+  'Pacific/Marquesas': {
+    id: 'Pacific/Marquesas',
+    defaultMessage: 'Marquesas Time',
+    offset: '-9:30',
+  },
+  'Pacific/Gambier': {
+    id: 'Pacific/Gambier',
+    defaultMessage: 'Gambier Islands',
+    offset: '-9',
+  },
+  'America/Adak': {
+    id: 'America/Adak',
+    defaultMessage: 'Hawaii-Aleutian Time - Adak',
+    offset: false,
+  },
+  'America/Anchorage': {
+    id: 'America/Anchorage',
+    defaultMessage: 'Alaska Time - Anchorage',
+    offset: false,
+  },
+  'Pacific/Pitcairn': {
+    id: 'Pacific/Pitcairn',
+    defaultMesasge: 'Pitcairn Time',
+    offset: '-8',
+  },
+  'America/Dawson_Creek': {
+    id: 'America/Dawson_Creek',
+    defaultMesasge: 'Mountain Standard Time - Dawson Creek',
+    offset: '-7',
+  },
+  'America/Fort_Nelson': {
+    id: 'America/Fort_Nelson',
+    defaultMesasge: 'Mountain Standard Time - Fort Nelson',
+    offset: '-7',
+  },
+  'America/Hermosillo': {
+    id: 'America/Hermosillo',
+    defaultMesasge: 'Mountain Standard Time - Hermosillo',
+    offset: '-7',
+  },
+  'America/Phoenix': {
+    id: 'America/Phoenix',
+    defaultMesasge: 'Mountain Standard Time - Phoenix',
+    offset: '-7',
+  },
+  'America/Los_Angeles': {
+    id: 'America/Los_Angeles',
+    defaultMesasge: 'Pacific Time - Los Angeles',
+    offset: false,
+  },
+  'America/Tijuana': {
+    id: 'America/Tijuana',
+    defaultMesasge: 'Pacific Time - Tijuana',
+    offset: false,
+  },
+  'America/Vancouver': {
+    id: 'America/Vancouver',
+    defaultMesasge: 'Pacific Time - Vancouver',
+    offset: false,
+  },
+  'America/Dawson': {
+    id: 'America/Dawson',
+    defaultMesasge: 'Yukon Time - Dawson',
+    offset: '-7',
+  },
+  'America/Whitehorse': {
+    id: 'America/Whitehorse',
+    defaultMesasge: 'Yukon Time - Whitehorse',
+    offset: '-7',
+  },
+  'Pacific/Easter': {
+    id: 'Pacific/Easter',
+    defaultMesasge: 'Easter Island Time',
+    offset: false,
+  },
+  'America/Belize': {
+    id: 'America/Belize',
+    defaultMesasge: 'Central Standard Time - Belize',
+    offset: '-6',
+  },
+  'America/Costa_Rica': {
+    id: 'America/Costa_Rica',
+    defaultMesasge: 'Central Standard Time - Costa Rica',
+    offset: '-6',
+  },
+  'America/El_Salvador': {
+    id: 'America/El_Salvador',
+    defaultMesasge: 'Central Standard Time - El Salvador',
+    offset: '-6',
+  },
+  'America/Guatemala': {
+    id: 'America/Guatemala',
+    defaultMesasge: 'Central Standard Time - Guatemala',
+    offset: '-6',
+  },
+  'America/Managua': {
+    id: 'America/Managua',
+    defaultMesasge: 'Central Standard Time - Managua',
+    offset: '-6',
+  },
+  'America/Regina': {
+    id: 'America/Regina',
+    defaultMesasge: 'Central Standard Time - Regina',
+    offset: '-6',
+  },
+  'America/Tegucigalpa': {
+    id: 'America/Tegucigalpa',
+    defaultMesasge: 'Central Standard Time - Tegucigalpa',
+    offset: '-6',
+  },
+  'Pacific/Galapagos': {
+    id: 'Pacific/Galapagos',
+    defaultMesasge: 'Galapagos Time',
+    offset: '-6',
+  },
+  'America/Boise': {
+    id: 'America/Boise',
+    defaultMesasge: 'Mountain Time - Boise',
+    offset: false,
+  },
+  'America/Cambridge_Bay': {
+    id: 'America/Cambridge_Bay',
+    defaultMesasge: 'Mountain Time - Cambridge Bay',
+    offset: false,
+  },
+  'America/Chihuahua': {
+    id: 'America/Chihuahua',
+    defaultMesasge: 'Mountain Time - Chihuahua',
+    offset: false,
+  },
+  'America/Denver': {
+    id: 'America/Denver',
+    defaultMesasge: 'Mountain Time - Denver',
+    offset: false,
+  },
+  'America/Edmonton': {
+    id: 'America/Edmonton',
+    defaultMesasge: 'Mountain Time - Edmonton',
+    offset: false,
+  },
+  'America/Inuvik': {
+    id: 'America/Inuvik',
+    defaultMesasge: 'Mountain Time - Inuvik',
+    offset: false,
+  },
+  'America/Mazatlan': {
+    id: 'America/Mazatlan',
+    defaultMesasge: 'Mountain Time - Mazatlan',
+    offset: false,
+  },
+  'America/Ojinaga': {
+    id: 'America/Ojinaga',
+    defaultMesasge: 'Mountain Time - Ojinaga',
+    offset: false,
+  },
+  'America/Yellowknife': {
+    id: 'America/Yellowknife',
+    defaultMesasge: 'Mountain Time - Yellowknife',
+    offset: false,
+  },
+  'America/Eirunepe': {
+    id: 'America/Eirunepe',
+    defaultMesasge: 'Acre Standard Time - Eirunepe',
+    offset: '-5',
+  },
+  'America/Rio_Branco': {
+    id: 'America/Rio_Branco',
+    defaultMesasge: 'Acre Standard Time - Rio Branco',
+    offset: '-5',
+  },
+  'America/Bahia_Banderas': {
+    id: 'America/Bahia_Banderas',
+    defaultMesasge: 'Central Time - Bahia Banderas',
+    offset: false,
+  },
+  'America/North_Dakota/Beulah': {
+    id: 'America/North_Dakota/Beulah',
+    defaultMesasge: 'Central Time - Beulah',
+    offset: false,
+  },
+  'America/Chicago': {
+    id: 'America/Chicago',
+    defaultMesasge: 'Central Time - Chicago',
+    offset: false,
+  },
+  'America/Matamoros': {
+    id: 'America/Matamoros',
+    defaultMesasge: 'Central Time - Matamoros',
+    offset: false,
+  },
+  'America/Menominee': {
+    id: 'America/Menominee',
+    defaultMesasge: 'Central Time - Menominee',
+    offset: false,
+  },
+  'America/Merida': {
+    id: 'America/Merida',
+    defaultMesasge: 'Central Time - Merida',
+    offset: false,
+  },
+  'America/Mexico_City': {
+    id: 'America/Mexico_City',
+    defaultMesasge: 'Central Time - Mexico City',
+    offset: false,
+  },
+  'America/Monterrey': {
+    id: 'America/Monterrey',
+    defaultMesasge: 'Central Time - Monterrey',
+    offset: false,
+  },
+  'America/Rankin_Inlet': {
+    id: 'America/Rankin_Inlet',
+    defaultMesasge: 'Central Time - Rankin Inlet',
+    offset: false,
+  },
+  'America/Indiana/Tell_City': {
+    id: 'America/Indiana/Tell_City',
+    defaultMesasge: 'Central Time - Tell City, Indiana',
+    offset: false,
+  },
+  'America/Winnipeg': {
+    id: 'America/Winnipeg',
+    defaultMesasge: 'Central Time - Winnipeg',
+    offset: false,
+  },
+  'America/Cancun': {
+    id: 'America/Cancun',
+    defaultMesasge: 'Eastern Standard Time - Cancun',
+    offset: '-5',
+  },
+  'America/Jamaica': {
+    id: 'America/Jamaica',
+    defaultMesasge: 'Eastern Standard Time - Jamaica',
+    offset: '-5',
+  },
+  'America/Panama': {
+    id: 'America/Panama',
+    defaultMesasge: 'Eastern Standard Time - Panama',
+    offset: '-5',
+  },
+  'America/Guayaquil': {
+    id: 'America/Guayaquil',
+    defaultMesasge: 'Eastern Standard Time - Guayaquil',
+    offset: '-5',
+  },
+  'America/Lima': {
+    id: 'America/Lima',
+    defaultMesasge: 'Peru Time - Lima',
+    offset: '-5',
+  },
+  'America/Manaus': {
+    id: 'America/Manaus',
+    defaultMesasge: 'Amazon Time - Manaus',
+    offset: '-4',
+  },
+  'America/Barbados': {
+    id: 'America/Barbados',
+    defaultMesasge: 'Atlantic Standard Time - Barbados',
+    offset: '-4',
+  },
+  'America/Martinique': {
+    id: 'America/Martinique',
+    defaultMesasge: 'Atlantic Standard Time - Martinique',
+    offset: '-4',
+  },
+  'America/Puerto_Rico': {
+    id: 'America/Puerto_Rico',
+    defaultMesasge: 'Atlantic Standard Time - Puerto Rico',
+    offset: '-4',
+  },
+  'America/Santo_Domingo': {
+    id: 'America/Santo_Domingo',
+    defaultMesasge: 'Atlantic Standard Time - Santo Domingo',
+    offset: '-4',
+  },
+  'America/Detroit': {
+    id: 'America/Detroit',
+    defaultMesasge: 'Eastern Time - Detroit',
+    offset: false,
+  },
+  'America/Grand_Turk': {
+    id: 'America/Grand_Turk',
+    defaultMesasge: 'Eastern Time - Grand Turk',
+    offset: false,
+  },
+  'America/Indiana/Indianapolis': {
+    id: 'America/Indiana/Indianapolis',
+    defaultMesasge: 'Eastern Time - Indianapolis',
+    offset: false,
+  },
+  'America/Iqaluit': {
+    id: 'America/Iqaluit',
+    defaultMesasge: 'Eastern Time - Iqaluit',
+    offset: false,
+  },
+  'America/Kentucky/Louisville': {
+    id: 'America/Kentucky/Louisville',
+    defaultMesasge: 'Eastern Time - Louisville',
+    offset: false,
+  },
+  'America/New_York': {
+    id: 'America/New_York',
+    defaultMesasge: 'Eastern Time - New York',
+    offset: false,
+  },
+  'America/Port-au-Prince': {
+    id: 'America/Port-au-Prince',
+    defaultMesasge: 'Eastern Time - Port-au-Prince',
+    offset: false,
+  },
+  'America/Thunder_Bay': {
+    id: 'America/Thunder_Bay',
+    defaultMesasge: 'Eastern Time - Thunder Bay',
+    offset: false,
+  },
+  'America/Toronto': {
+    id: 'America/Toronto',
+    defaultMesasge: 'Eastern Time - Toronto',
+    offset: false,
+  },
+  'America/Guyana': {
+    id: 'America/Guyana',
+    defaultMesasge: 'Guyana Time ',
+    offset: '-4',
+  },
+  'America/Asuncion': {
+    id: 'America/Asuncion',
+    defaultMesasge: 'Paraguay Time - Asuncion',
+    offset: false,
+  },
+  'America/Caracas': {
+    id: 'America/Caracas',
+    defaultMesasge: 'Venezuela Time - Caracas',
+    offset: '-4',
+  },
+  'Chile/Continental': {
+    id: 'Chile/Continental',
+    defaultMesasge: 'Chile Time - Santiago',
+    offset: false,
+  },
+  Cuba: {
+    id: 'Cuba',
+    defaultMesasge: 'Cuba Time - Havana',
+    offset: false,
+  },
+  'America/Argentina/Buenos_Aires': {
+    id: 'America/Argentina/Buenos_Aires',
+    defaultMesasge: 'Argentina Time - Buenos Aires',
+    offset: '-3',
+  },
+  'America/Bermuda': {
+    id: 'America/Bermuda',
+    defaultMesasge: 'Atlantic Standard Time - Bermuda',
+    offset: '-3',
+  },
+  'America/Moncton': {
+    id: 'America/Moncton',
+    defaultMesasge: 'Atlantic Time - Moncton',
+    offset: false,
+  },
+  'America/Thule': {
+    id: 'America/Thule',
+    defaultMesasge: 'Atlantic Daylight Time - Thule',
+    offset: false,
+  },
+  'America/Sao_Paulo': {
+    id: 'America/Sao_Paulo',
+    defaultMesasge: 'Brasilia Time',
+    offset: '-3',
+  },
+  'Atlantic/Stanley': {
+    id: 'Atlantic/Stanley',
+    defaultMesasge: 'Falkland Islands Summer Time - Stanley',
+    offset: '-3',
+  },
+  'America/Cayenne': {
+    id: 'America/Cayenne',
+    defaultMesasge: 'French Guiana Time - Cayenne',
+    offset: '-3',
+  },
+  'Antarctica/Palmer': {
+    id: 'Antarctica/Palmer',
+    defaultMesasge: 'Palmer Time - Palmer Station',
+    offset: '-3',
+  },
+  'America/Punta_Arenas': {
+    id: 'America/Punta_Arenas',
+    defaultMesasge: 'Punta Arenas Time - Punta Arenas',
+    offset: '-3',
+  },
+  'Antarctica/Rothera': {
+    id: 'Antarctica/Rothera',
+    defaultMesasge: 'Rothera Time - Rothera',
+    offset: '-3',
+  },
+  'America/Paramaribo': {
+    id: 'America/Paramaribo',
+    defaultMesasge: 'Suriname Time - Paramaribo',
+    offset: '-3',
+  },
+  'America/Montevideo': {
+    id: 'America/Montevideo',
+    defaultMesasge: 'Uruguay Standard Time - Montevideo',
+    offset: '-3',
+  },
+  'Canada/Newfoundland': {
+    id: 'Canada/Newfoundland',
+    defaultMesasge: 'Newfoundland Time',
+    offset: false,
+  },
+  'Brazil/DeNoronha': {
+    id: 'Brazil/DeNoronha',
+    defaultMesasge: 'Fernando de Noronha Time',
+    offset: '-2',
+  },
+  'Atlantic/South_Georgia': {
+    id: 'Atlantic/South_Georgia',
+    defaultMesasge: 'South Georgia Time',
+    offset: '-2',
+  },
+  'Atlantic/Miquelon': {
+    id: 'Atlantic/Miquelon',
+    defaultMesasge: 'St. Pierre & Miquelon Time',
+    offset: false,
+  },
+  'America/Nuuk': {
+    id: 'America/Nuuk',
+    defaultMesasge: 'West Greenland Time - Nuuk',
+    offset: false,
+  },
+  'Atlantic/Cape_Verde': {
+    id: 'Atlantic/Cape_Verde',
+    defaultMesasge: 'Cape Verde Time',
+    offset: '-1',
+  },
+  'Atlantic/Azores': {
+    id: 'Atlantic/Azores',
+    defaultMesasge: 'Azores Time',
+    offset: false,
+  },
+  Universal: {
+    id: 'Universal',
+    defaultMesasge: 'Coordinated Universal Time',
+    offset: '+0',
+  },
+  'Etc/Greenwich': {
+    id: 'Etc/Greenwich',
+    defaultMesasge: 'Greenwich Mean Time',
+    offset: '+0',
+  },
+  'Africa/Abidjan': {
+    id: 'Africa/Abidjan',
+    defaultMesasge: 'Greenwich Mean Time - Abidjan',
+    offset: '+0',
+  },
+  'Africa/Bissau': {
+    id: 'Africa/Bissau',
+    defaultMesasge: 'Greenwich Mean Time - Bissau',
+    offset: '+0',
+  },
+  'Africa/Danmarkshavn': {
+    id: 'Africa/Danmarkshavn',
+    defaultMesasge: 'Greenwich Mean Time - Danmarkshavn',
+    offset: '+0',
+  },
+  'Africa/Monrovia': {
+    id: 'Africa/Monrovia',
+    defaultMesasge: 'Greenwich Mean Time - Monrovia',
+    offset: '+0',
+  },
+  'Atlantic/Reykjavik': {
+    id: 'Atlantic/Reykjavik',
+    defaultMesasge: 'Greenwich Mean Time - Reykjavik',
+    offset: '+0',
+  },
+  'Africa/Sao_Tome': {
+    id: 'Africa/Sao_Tome',
+    defaultMesasge: 'Greenwich Mean Time - Sao Tome',
+    offset: '+0',
+  },
+  'Africa/Casablaca': {
+    id: 'Africa/Casablaca',
+    defaultMesasge: 'Western European Time - Casablanca',
+    offset: false,
+  },
+  'Africa/Algiers': {
+    id: 'Africa/Algiers',
+    defaultMesasge: 'Central European Standard Time - Algiers',
+    offset: '+1',
+  },
+  'Africa/Tunis': {
+    id: 'Africa/Tunis',
+    defaultMesasge: 'Central European Standard Time - Tunis',
+    offset: '+1',
+  },
+  'Europe/Dublin': {
+    id: 'Europe/Dublin',
+    defaultMesasge: 'Ireland Time - Dublin',
+    offset: false,
+  },
+  'Europe/London': {
+    id: 'Europe/London',
+    defaultMesasge: 'United Kingdom Time - London',
+    offset: false,
+  },
+  'Africa/Lagos': {
+    id: 'Africa/Lagos',
+    defaultMesasge: 'West Africa Time - Lagos',
+    offset: '+1',
+  },
+  'Africa/Ndjamena': {
+    id: 'Africa/Ndjamena',
+    defaultMesasge: "West Africa Time - N'Djamena",
+    offset: '+1',
+  },
+  'Atlantic/Canary': {
+    id: 'Atlantic/Canary',
+    defaultMesasge: 'Western European Time - Canary',
+    offset: false,
+  },
+  'Atlantic/Faroe': {
+    id: 'Atlantic/Faroe',
+    defaultMesasge: 'Western European Time - Faroe',
+    offset: false,
+  },
+  'Europe/Lisbon': {
+    id: 'Europe/Lisbon',
+    defaultMesasge: 'Western European Time - Lisbon',
+    offset: false,
+  },
+  'Atlantic/Madiera': {
+    id: 'Atlantic/Madiera',
+    defaultMesasge: 'Western European Time - Madeira',
+    offset: false,
+  },
+  'Africa/Juba': {
+    id: 'Africa/Juba',
+    defaultMesasge: 'Central Africa Time - Juba',
+    offset: '+2',
+  },
+  'Africa/Khartoum': {
+    id: 'Africa/Khartoum',
+    defaultMesasge: 'Central Africa Time - Khartoum',
+    offset: '+2',
+  },
+  'Africa/Maputo': {
+    id: 'Africa/Maputo',
+    defaultMesasge: 'Central Africa Time - Maputo',
+    offset: '+2',
+  },
+  'Africa/Windhoek': {
+    id: 'Africa/Windhoek',
+    defaultMesasge: 'Central Africa Time - Windhoek',
+    offset: '+2',
+  },
+  'Europe/Amsterdam': {
+    id: 'Europe/Amsterdam',
+    defaultMesasge: 'Central European Time - Amsterdam',
+    offset: false,
+  },
+  'Europe/Andorra': {
+    id: 'Europe/Andorra',
+    defaultMesasge: 'Central European Time - Andorra',
+    offset: false,
+  },
+  'Europe/Belgrade': {
+    id: 'Europe/Belgrade',
+    defaultMesasge: 'Central European Time - Belgrade',
+    offset: false,
+  },
+  'Europe/Berlin': {
+    id: 'Europe/Berlin',
+    defaultMesasge: 'Central European Time - Berlin',
+    offset: false,
+  },
+  'Europe/Brussels': {
+    id: 'Europe/Brussels',
+    defaultMesasge: 'Central European Time - Brussels',
+    offset: false,
+  },
+  'Europe/Budapest': {
+    id: 'Europe/Budapest',
+    defaultMesasge: 'Central European Time - Budapest',
+    offset: false,
+  },
+  'Africa/Ceuta': {
+    id: 'Africa/Ceuta',
+    defaultMesasge: 'Central European Time - Ceuta',
+    offset: false,
+  },
+  'Europe/Copenhagen': {
+    id: 'Europe/Copenhagen',
+    defaultMesasge: 'Central European Time - Copenhagen',
+    offset: false,
+  },
+  'Europe/Gibraltar': {
+    id: 'Europe/Gibraltar',
+    defaultMesasge: 'Central European Time - Gibraltar',
+    offset: false,
+  },
+  'Europe/Luxembourg': {
+    id: 'Europe/Luxembourg',
+    defaultMesasge: 'Central European Time - Luxembourg',
+    offset: false,
+  },
+  'Europe/Madrid': {
+    id: 'Europe/Madrid',
+    defaultMesasge: 'Central European Time - Madrid',
+    offset: false,
+  },
+  'Europe/Malta': {
+    id: 'Europe/Malta',
+    defaultMesasge: 'Central European Time - Malta',
+    offset: false,
+  },
+  'Europe/Monaco': {
+    id: 'Europe/Monaco',
+    defaultMesasge: 'Central European Time - Monaco',
+    offset: false,
+  },
+  'Europe/Oslo': {
+    id: 'Europe/Oslo',
+    defaultMesasge: 'Central European Time - Oslo',
+    offset: false,
+  },
+  'Europe/Paris': {
+    id: 'Europe/Paris',
+    defaultMesasge: 'Central European Time - Paris',
+    offset: false,
+  },
+  'Europe/Prague': {
+    id: 'Europe/Prague',
+    defaultMesasge: 'Central European Time - Prague',
+    offset: false,
+  },
+  'Europe/Rome': {
+    id: 'Europe/Rome',
+    defaultMesasge: 'Central European Time - Rome',
+    offset: false,
+  },
+  'Europe/Stockholm': {
+    id: 'Europe/Stockholm',
+    defaultMesasge: 'Central European Time - Stockholm',
+    offset: false,
+  },
+  'Europe/Tirana': {
+    id: 'Europe/Tirana',
+    defaultMesasge: 'Central European Time - Tirane',
+    offset: false,
+  },
+  'Europe/Vienna': {
+    id: 'Europe/Vienna',
+    defaultMesasge: 'Central European Time - Vienna',
+    offset: false,
+  },
+  'Europe/Warsaw': {
+    id: 'Europe/Warsaw',
+    defaultMesasge: 'Central European Time - Warsaw',
+    offset: false,
+  },
+  'Europe/Zurich': {
+    id: 'Europe/Zurich',
+    defaultMesasge: 'Central European Time - Zurich',
+    offset: false,
+  },
+  'Africa/Cairo': {
+    id: 'Africa/Cairo',
+    defaultMesasge: 'Eastern European Time - Cairo',
+    offset: '+2',
+  },
+  'Europe/Kaliningrad': {
+    id: 'Europe/Kaliningrad',
+    defaultMesasge: 'Eastern European Time - Kaliningrad',
+    offset: '+2',
+  },
+  'Africa/Tripoli': {
+    id: 'Africa/Tripoli',
+    defaultMesasge: 'Eastern European Time- Tripoli',
+    offset: '+2',
+  },
+  'Africa/Johannesburg': {
+    id: 'Africa/Johannesburg',
+    defaultMesasge: 'South Africa Standard Time',
+    offset: '+2',
+  },
+  'Antarctica/Troll': {
+    id: 'Antarctica/Troll',
+    defaultMesasge: 'Troll Time - Troll Station',
+    offset: false,
+  },
+  'Asia/Baghdad': {
+    id: 'Asia/Baghdad',
+    defaultMesasge: 'Arabian Standard Time - Baghdad',
+    offset: '+3',
+  },
+  'Asia/Qatar': {
+    id: 'Asia/Qatar',
+    defaultMesasge: 'Arabian Standard Time - Qatar',
+    offset: '+3',
+  },
+  'Asia/Riyadh': {
+    id: 'Asia/Riyadh',
+    defaultMesasge: 'Arabian Standard Time - Riyadh',
+    offset: '+3',
+  },
+  'Asia/Amman': {
+    id: 'Asia/Amman',
+    defaultMesasge: 'Eastern European Time - Amman',
+    offset: false,
+  },
+  'Europe/Athens': {
+    id: 'Europe/Athens',
+    defaultMesasge: 'Eastern European Time - Athens',
+    offset: false,
+  },
+  'Asia/Beirut': {
+    id: 'Asia/Beirut',
+    defaultMesasge: 'Eastern European Time - Beirut',
+    offset: false,
+  },
+  'Europe/Bucharest': {
+    id: 'Europe/Bucharest',
+    defaultMesasge: 'Eastern European Time - Bucharest',
+    offset: false,
+  },
+  'Europe/Chisinau': {
+    id: 'Europe/Chisinau',
+    defaultMesasge: 'Eastern European Time - Chisinau',
+    offset: false,
+  },
+  'Asia/Damascus': {
+    id: 'Asia/Damascus',
+    defaultMesasge: 'Eastern European Time - Damascus',
+    offset: false,
+  },
+  'Asia/Famagusta': {
+    id: 'Asia/Famagusta',
+    defaultMesasge: 'Eastern European Time - Famagusta',
+    offset: false,
+  },
+  'Asia/Gaza': {
+    id: 'Asia/Gaza',
+    defaultMesasge: 'Eastern European Time - Gaza',
+    offset: false,
+  },
+  'Asia/Hebron': {
+    id: 'Asia/Hebron',
+    defaultMesasge: 'Eastern European Time - Hebron',
+    offset: false,
+  },
+  'Europe/Helsinki': {
+    id: 'Europe/Helsinki',
+    defaultMesasge: 'Eastern European Time - Helsinki',
+    offset: false,
+  },
+  'Europe/Kiev': {
+    id: 'Europe/Kiev',
+    defaultMesasge: 'Eastern European Time - Kyiv',
+    offset: false,
+  },
+  'Asia/Nicosia': {
+    id: 'Asia/Nicosia',
+    defaultMesasge: 'Eastern European Time - Nicosia',
+    offset: false,
+  },
+  'Europe/Riga': {
+    id: 'Europe/Riga',
+    defaultMesasge: 'Eastern European Time - Riga',
+    offset: false,
+  },
+  'Europe/Sofia': {
+    id: 'Europe/Sofia',
+    defaultMesasge: 'Eastern European Time - Sofia',
+    offset: false,
+  },
+  'Europe/Tallinn': {
+    id: 'Europe/Tallinn',
+    defaultMesasge: 'Eastern European Time - Tallinn',
+    offset: false,
+  },
+  'Europe/Uzhgorod': {
+    id: 'Europe/Uzhgorod',
+    defaultMesasge: 'Eastern European Time - Uzhgorod',
+    offset: false,
+  },
+  'Europe/Vilnius': {
+    id: 'Europe/Vilnius',
+    defaultMesasge: 'Eastern European Time - Vilnius',
+    offset: false,
+  },
+  'Europe/Zaporozhye': {
+    id: 'Europe/Zaporozhye',
+    defaultMesasge: 'Eastern European Time - Zaporozhskoye',
+    offset: '+3',
+  },
+  Israel: {
+    id: 'Israel',
+    defaultMesasge: 'Israel Time - Tel Aviv',
+    offset: false,
+  },
+  'Europe/Kirov': {
+    id: 'Europe/Kirov',
+    defaultMesasge: 'Moscow Standard Time - Kirov',
+    offset: '+3',
+  },
+  'Europe/Minsk': {
+    id: 'Europe/Minsk',
+    defaultMesasge: 'Moscow Standard Time - Minsk',
+    offset: '+3',
+  },
+  'Europe/Moscow': {
+    id: 'Europe/Moscow',
+    defaultMesasge: 'Moscow Standard Time - Moscow',
+    offset: '+3',
+  },
+  'Europe/Simferopol': {
+    id: 'Europe/Simferopol',
+    defaultMesasge: 'Moscow Standard Time - Simferopol',
+    offset: '+3',
+  },
+  'Europe/Volgograd': {
+    id: 'Europe/Volgograd',
+    defaultMesasge: 'Moscow Standard Time - Volgograd',
+    offset: '+3',
+  },
+  Turkey: {
+    id: 'Turkey',
+    defaultMesasge: 'Turkey Time - Istanbul',
+    offset: '+3',
+  },
+  'Asia/Yerevan': {
+    id: 'Asia/Yerevan',
+    defaultMesasge: 'Armenia Standard Time - Yerevan',
+    offset: '+4',
+  },
+  'Europe/Astrakhan': {
+    id: 'Europe/Astrakhan',
+    defaultMesasge: 'Europe/Astrakhan',
+    offset: '+4',
+  },
+  'Asia/Baku': {
+    id: 'Asia/Baku',
+    defaultMesasge: 'Azerbaijan Time - Baku',
+    offset: '',
+  },
+  'Asia/Tbilisi': {
+    id: 'Asia/Tbilisi',
+    defaultMesasge: 'Georgia Standard Time - Tbilisi',
+    offset: '+4',
+  },
+  'Indian/Mauritius': {
+    id: 'Indian/Mauritius',
+    defaultMesasge: 'Mauritius Time',
+    offset: '+4',
+  },
+  'Indian/Reunion': {
+    id: 'Indian/Reunion',
+    defaultMesasge: 'Réunion Time',
+    offset: '+4',
+  },
+  'Europe/Samara': {
+    id: 'Europe/Samara',
+    defaultMesasge: 'Samara Time',
+    offset: '+4',
+  },
+  'Asia/Saratov': {
+    id: 'Asia/Saratov',
+    defaultMesasge: 'Saratov Time - Saratov',
+    offset: '+4',
+  },
+  'Europe/Ulyanovsk': {
+    id: 'Europe/Ulyanovsk',
+    defaultMesasge: 'Ulyanovsk Time',
+    offset: '+4',
+  },
+  'Indian/Kabul': {
+    id: 'Indian/Kabul',
+    defaultMesasge: 'Afghanistan Time - Kabul',
+    offset: '+4:30',
+  },
+  Iran: {
+    id: 'Iran',
+    defaultMesasge: 'Iran Time',
+    offset: false,
+  },
+  'Indian/Kerguelen': {
+    id: 'Indian/Kerguelen',
+    defaultMesasge: 'French Southern & Antarctic Time - Kerguelen',
+    offset: '+5',
+  },
+  'Indian/Maldives': {
+    id: 'Indian/Maldives',
+    defaultMesasge: 'Maldives Time',
+    offset: '+5',
+  },
+  'Antarctica/Mawson': {
+    id: 'Antarctica/Mawson',
+    defaultMesasge: 'Mawson Time',
+    offset: '+5',
+  },
+  'Asia/Karachi': {
+    id: 'Asia/Karachi',
+    defaultMesasge: 'Pakistan Standard Time - Karachi',
+    offset: '+5',
+  },
+  'Asia/Dushanbe': {
+    id: 'Asia/Dushanbe',
+    defaultMesasge: 'Tajikistan Time - Dushanbe',
+    offset: '+5',
+  },
+  'Asia/Ashgabat': {
+    id: 'Asia/Ashgabat',
+    defaultMesasge: 'Turkmenistan Time - Ashgabat',
+    offset: '+5',
+  },
+  'Asia/Samarkand': {
+    id: 'Asia/Samarkand',
+    defaultMesasge: 'Uzbekistan Time - Samarkand',
+    offset: '+5',
+  },
+  'Asia/Tashkent': {
+    id: 'Asia/Tashkent',
+    defaultMesasge: 'Uzbekistan Time - Tashkent',
+    offset: '+5',
+  },
+  'Asia/Atyrau': {
+    id: 'Asia/Atyrau',
+    defaultMesasge: 'West Kazakhstan Time - Atyrau',
+    offset: '+5',
+  },
+  'Asia/Aqtau': {
+    id: 'Asia/Aqtau',
+    defaultMesasge: 'West Kazakhstan Time - Aqtau',
+    offset: '+5',
+  },
+  'Asia/Aqtobe': {
+    id: 'Asia/Aqtobe',
+    defaultMesasge: 'West Kazakhstan Time - Aqtobe',
+    offset: '+5',
+  },
+  'Asia/Oral': {
+    id: 'Asia/Oral',
+    defaultMesasge: 'West Kazakhstan Time - Oral',
+    offset: '+5',
+  },
+  'Asia/Qyzylorda': {
+    id: 'Asia/Qyzylorda',
+    defaultMesasge: 'West Kazakhstan Time - Qyzylorda',
+    offset: '+5',
+  },
+  'Asia/Yekaterinburg': {
+    id: 'Asia/Yekaterinburg',
+    defaultMesasge: 'Yekaterinburg Time',
+    offset: '+5',
+  },
+  'Asia/Colombo': {
+    id: 'Asia/Colombo',
+    defaultMesasge: 'India Standard Time - Colombo',
+    offset: '+5:30',
+  },
+  'Asia/Kolkata': {
+    id: 'Asia/Kolkata',
+    defaultMesasge: 'India Standard Time - Kolkata',
+    offset: '+5:30',
+  },
+  'Asia/Kathmandu': {
+    id: 'Asia/Kathmandu',
+    defaultMesasge: 'Nepal Time - Kathmandu',
+    offset: '+5:45',
+  },
+  'Asia/Dhaka': {
+    id: 'Asia/Dhaka',
+    defaultMesasge: 'Bangladesh Standard Time - Dhaka',
+    offset: '+6',
+  },
+  'Asia/Thimphu': {
+    id: 'Asia/Thimphu',
+    defaultMesasge: 'Bhutan Time - Thimphu',
+    offset: '+6',
+  },
+  'Asia/Almaty': {
+    id: 'Asia/Almaty',
+    defaultMesasge: 'Alma-Ata Time - Almaty',
+    offset: '+6',
+  },
+  'Asia/Qostanay': {
+    id: 'Asia/Qostanay',
+    defaultMesasge: 'Alma-Ata Time - Kostanay',
+    offset: '+6',
+  },
+  'Indian/Chagos': {
+    id: 'Indian/Chagos',
+    defaultMesasge: 'Indian Ocean Time - Chagos',
+    offset: '+6',
+  },
+  'Asia/Bishkek': {
+    id: 'Asia/Bishkek',
+    defaultMesasge: 'Kyrgyzstan - Bishkek',
+    offset: '+6',
+  },
+  'Asia/Omsk': {
+    id: 'Asia/Omsk',
+    defaultMesasge: 'Omsk Standard Time',
+    offset: '+6',
+  },
+  'Asia/Urumqi': {
+    id: 'Asia/Urumqi',
+    defaultMesasge: 'Urumqi Time',
+    offset: '+6',
+  },
+  'Antarctica/Vostok': {
+    id: 'Antarctica/Vostok',
+    defaultMesasge: 'Vostok Time',
+    offset: '+6',
+  },
+  'Asia/Cocos': {
+    id: 'Asia/Cocos',
+    defaultMesasge: 'Cocos Islands Time',
+    offset: '+6:30',
+  },
+  'Asia/Yangon': {
+    id: 'Asia/Yangon',
+    defaultMesasge: 'Myanmar Time - Yangon',
+    offset: '+7',
+  },
+  'Asia/Barnaul': {
+    id: 'Asia/Barnaul',
+    defaultMesasge: 'Barnaul Time - Barnaul',
+    offset: '+7',
+  },
+  'Indian/Christmas': {
+    id: 'Indian/Christmas',
+    defaultMesasge: 'Christmas Island Time',
+    offset: '+7',
+  },
+  'Antarctica/Davis': {
+    id: 'Antarctica/Davis',
+    defaultMesasge: 'Davis Time',
+    offset: '+7',
+  },
+  'Asia/Hovd': {
+    id: 'Asia/Hovd',
+    defaultMesasge: 'Hovd Time',
+    offset: '+7',
+  },
+  'Asia/Bangkok': {
+    id: 'Asia/Bangkok',
+    defaultMesasge: 'Indochina Time - Bangkok',
+    offset: '+7',
+  },
+  'Asia/Ho_Chi_Minh': {
+    id: 'Asia/Ho_Chi_Minh',
+    defaultMesasge: 'Indochina Time - Ho Chi Minh City',
+    offset: '+7',
+  },
+  'Asia/Krasnoyarsk': {
+    id: 'Asia/Krasnoyarsk',
+    defaultMesasge: 'Krasnoyarsk Time',
+    offset: '+7',
+  },
+  'Asia/Novosibirsk': {
+    id: 'Asia/Novosibirsk',
+    defaultMesasge: 'Novosibirsk Time',
+    offset: '+7',
+  },
+  'Asia/Tomsk': {
+    id: 'Asia/Tomsk',
+    defaultMesasge: 'Tomsk Time',
+    offset: '+7',
+  },
+  'Asia/Jakarta': {
+    id: 'Asia/Jakarta',
+    defaultMesasge: 'Western Indonesian Time - Jakarta',
+    offset: '+7',
+  },
+  'Asia/Pontianak': {
+    id: 'Asia/Pontianak',
+    defaultMesasge: 'Western Indonesian Time - Pontianak',
+    offset: '+7',
+  },
+  'Australia/West': {
+    id: 'Australia/West',
+    defaultMesasge: 'Australian Western Standard Time - Perth',
+    offset: '+8',
+  },
+  'Asia/Brunei': {
+    id: 'Asia/Brunei',
+    defaultMesasge: 'Brunei Darussalam Time',
+    offset: '+8',
+  },
+  'Asia/Makassar': {
+    id: 'Asia/Makassar',
+    defaultMesasge: 'Central Indonesian Time - Makassar',
+    offset: '+8',
+  },
+  'Asia/Macau': {
+    id: 'Asia/Macau',
+    defaultMesasge: 'China Standard Time- Macau',
+    offset: '+8',
+  },
+  'Asia/Shanghai': {
+    id: 'Asia/Shanghai',
+    defaultMesasge: 'China Standard Time - Shanghai',
+    offset: '+8',
+  },
+  'Asia/Choibalsan': {
+    id: 'Asia/Choibalsan',
+    defaultMesasge: 'Choibalsan Time',
+    offset: '+8',
+  },
+  'Asia/Hong_Kong': {
+    id: 'Asia/Hong_Kong',
+    defaultMesasge: 'Hong Kong Time',
+    offset: '+8',
+  },
+  'Asia/Irkutsk': {
+    id: 'Asia/Irkutsk',
+    defaultMesasge: 'Irkutsk Time',
+    offset: '+8',
+  },
+  'Asia/Kuala_Lumpur': {
+    id: 'Asia/Kuala_Lumpur',
+    defaultMesasge: 'Malaysia Time - Kuala Lumpur',
+    offset: '+8',
+  },
+  'Asia/Kuching': {
+    id: 'Asia/Kuching',
+    defaultMesasge: 'Malaysia Time - Kuching',
+    offset: '+8',
+  },
+  'Asia/Manila': {
+    id: 'Asia/Manila',
+    defaultMesasge: 'Philippine Time - Manila',
+    offset: '+8',
+  },
+  'Asia/Singapore': {
+    id: 'Asia/Singapore',
+    defaultMesasge: 'Singapore Time',
+    offset: '+8',
+  },
+  'Asia/Taipei': {
+    id: 'Asia/Taipei',
+    defaultMesasge: 'Taipei Standard Time',
+    offset: '+8',
+  },
+  'Asia/Ulaanbaatar': {
+    id: 'Asia/Ulaanbaatar',
+    defaultMesasge: 'Ulaanbaatar Standard Time',
+    offset: '+8',
+  },
+  'Australia/Eucla': {
+    id: 'Australia/Eucla',
+    defaultMesasge: 'Australian Central Western Standard Time',
+    offset: '+8:45',
+  },
+  'Asia/Jayapura': {
+    id: 'Asia/Jayapura',
+    defaultMesasge: 'Eastern Indonesia Time - Jayapura',
+    offset: '+9',
+  },
+  'Asia/Dili': {
+    id: 'Asia/Dili',
+    defaultMesasge: 'East Timor Time - Dili',
+    offset: '+9',
+  },
+  'Asia/Tokyo': {
+    id: 'Asia/Tokyo',
+    defaultMesasge: 'Japan Standard Time - Tokyo',
+    offset: '+9',
+  },
+  'Asia/Pyongyang': {
+    id: 'Asia/Pyongyang',
+    defaultMesasge: 'Korea Standard Time - Pyongyang',
+    offset: '+9',
+  },
+  'Asia/Seoul': {
+    id: 'Asia/Seoul',
+    defaultMesasge: 'Korea Standard Time - Seoul',
+    offset: '+9',
+  },
+  'Pacific/Palau': {
+    id: 'Pacific/Palau',
+    defaultMesasge: 'Palau Time',
+    offset: '+9',
+  },
+  'Asia/Chita': {
+    id: 'Asia/Chita',
+    defaultMesasge: 'Yakutsk Time - Chita',
+    offset: '+9',
+  },
+  'Asia/Khandyga': {
+    id: 'Asia/Khandyga',
+    defaultMesasge: 'Yakutsk Time - Khandyga',
+    offset: '+9',
+  },
+  'Australia/Adelaide': {
+    id: 'Australia/Adelaide',
+    defaultMesasge: 'Central Australia Time - Adelaide',
+    offset: false,
+  },
+  'Australia/Broken_Hill': {
+    id: 'Australia/Broken_Hill',
+    defaultMesasge: 'Central Australia Time - Broken Hill',
+    offset: false,
+  },
+  'Australia/Brisbane': {
+    id: 'Australia/Brisbane',
+    defaultMesasge: 'Australian Eastern Standard Time - Brisbane',
+    offset: '+10',
+  },
+  'Australia/Lindeman': {
+    id: 'Australia/Lindeman',
+    defaultMesasge: 'Australian Eastern Standard Time - Lindeman',
+    offset: '+10',
+  },
+  'Australia/Hobart': {
+    id: 'Australia/Hobart',
+    defaultMesasge: 'Eastern Australia Time - Hobart',
+    offset: false,
+  },
+  'Australia/NSW': {
+    id: 'Australia/NSW',
+    defaultMesasge: 'Eastern Australia Time - Macquarie',
+    offset: false,
+  },
+  'Australia/Sydney': {
+    id: 'Australia/Sydney',
+    defaultMesasge: 'Eastern Australia Time - Sydney',
+    offset: false,
+  },
+  'Pacific/Guam': {
+    id: 'Pacific/Guam',
+    defaultMesasge: 'Chamorro Standard Time - Guam',
+    offset: '+10',
+  },
+  'Pacific/Chuuk': {
+    id: 'Pacific/Chuuk',
+    defaultMesasge: 'Chuuk Time',
+    offset: '+10',
+  },
+  'Pacific/Port_Moresby': {
+    id: 'Pacific/Port_Moresby',
+    defaultMesasge: 'Papa New Guinea Time - Port Moresby',
+    offset: '+10',
+  },
+  'Antarctica/Ust-Nera': {
+    id: 'Antarctica/Ust-Nera',
+    defaultMesasge: 'Vladivostok Time - Ust-Nera',
+    offset: '+10',
+  },
+  'Australia/Lorde_Howe': {
+    id: 'Australia/Lorde_Howe',
+    defaultMesasge: 'Lorde Howe Time',
+    offset: false,
+  },
+  'Asia/Bougainville': {
+    id: 'Asia/Bougainville',
+    defaultMesasge: 'Bouganville Time - Arawa',
+    offset: '+11',
+  },
+  'Pacific/Kosrae': {
+    id: 'Pacific/Kosrae',
+    defaultMesasge: 'Kosrae Time',
+    offset: '+11',
+  },
+  'Asia/Magadan': {
+    id: 'Asia/Magadan',
+    defaultMesasge: 'Magadan Time',
+    offset: '+11',
+  },
+  'Pacific/Noumea': {
+    id: 'Pacific/Noumea',
+    defaultMesasge: 'New Caledonia Time - Noumea',
+    offset: '+11',
+  },
+  'Pacific/Norfolk': {
+    id: 'Pacific/Norfolk',
+    defaultMesasge: 'Norfolk Time - Kingston',
+    offset: '+11',
+  },
+  'Pacific/Pohnpei': {
+    id: 'Pacific/Pohnpei',
+    defaultMesasge: 'Ponape Time',
+    offset: '+11',
+  },
+  'Asia/Sakhalin': {
+    id: 'Asia/Sakhalin',
+    defaultMesasge: 'Sakhalin Time',
+    offset: '+11',
+  },
+  'Pacific/Guadalcanal': {
+    id: 'Pacific/Guadalcanal',
+    defaultMesasge: 'Solomon Islands Time - Guadalcanal',
+    offset: '+11',
+  },
+  'Asia/Srednekolymsk': {
+    id: 'Asia/Srednekolymsk',
+    defaultMesasge: 'Srednekolymsk Time',
+    offset: '+11',
+  },
+  'Pacific/Efate': {
+    id: 'Pacific/Efate',
+    defaultMesasge: 'Vanuatu Time - Efate',
+    offset: '+11',
+  },
+  'Asia/Anadyr': {
+    id: 'Asia/Anadyr',
+    defaultMesasge: 'Anadyr Time',
+    offset: '+12',
+  },
+  'Pacific/Fiji': {
+    id: 'Pacific/Fiji',
+    defaultMesasge: 'Fiji Time',
+    offset: false,
+  },
+  'Pacific/Tarawa': {
+    id: 'Pacific/Tarawa',
+    defaultMesasge: 'Gilbert Island Time - Tarawa',
+    offset: '+12',
+  },
+  Kwajalein: {
+    id: 'Kwajalein',
+    defaultMesasge: 'Marshall Islands Time - Kwajalein',
+    offset: '+12',
+  },
+  'Pacific/Majuro': {
+    id: 'Pacific/Majuro',
+    defaultMesasge: 'Marshall Islands Time - Majuro',
+    offset: '+12',
+  },
+  'Pacific/Nauru': {
+    id: 'Pacific/Nauru',
+    defaultMesasge: 'Nauru Time',
+    offset: '+12',
+  },
+  'Pacific/Auckland': {
+    id: 'Pacific/Auckland',
+    defaultMesasge: 'New Zealand Time - Auckland',
+    offset: false,
+  },
+  'Asia/Kamchatka': {
+    id: 'Asia/Kamchatka',
+    defaultMesasge: 'Petropavlovsk-Kamchatsky Time - Kamchatka',
+    offset: '+12',
+  },
+  'Pacific/Funafuti': {
+    id: 'Pacific/Funafuti',
+    defaultMesasge: 'Tuvalu Time - Funafuti',
+    offset: '+12',
+  },
+  'Pacific/Wake': {
+    id: 'Pacific/Wake',
+    defaultMesasge: 'Wake Island Time',
+    offset: '+12',
+  },
+  'Pacific/Wallis': {
+    id: 'Pacific/Wallis',
+    defaultMesasge: 'Wallis & Futuna Time - Wallis',
+    offset: '+12',
+  },
+  'Pacific/Chatham': {
+    id: 'Pacific/Chatham',
+    defaultMesasge: 'Chatham Time',
+    offset: false,
+  },
+  'Pacific/Apia': {
+    id: 'Pacific/Apia',
+    defaultMesasge: 'West Samoa Time',
+    offset: '+13',
+  },
+  'Pacific/Enderbury': {
+    id: 'Pacific/Enderbury',
+    defaultMesasge: 'Phoenix Island Time - Enderbury',
+    offset: '+13',
+  },
+  'Pacific/Fakaofo': {
+    id: 'Pacific/Fakaofo',
+    defaultMesasge: 'Tokelau Time - Fakaofo',
+    offset: '+13',
+  },
+  'Pacific/Tongatapu': {
+    id: 'Pacific/Tongatapu',
+    defaultMesasge: 'Tonga Time - Tongatapu',
+    offset: '+13',
+  },
+  'Pacific/Kiritimati': {
+    id: 'Pacific/Kiritimati',
+    defaultMesasge: 'Line Islands Time - Kiritmati',
+    offset: '+14',
+  },
+};


### PR DESCRIPTION
#### Summary

This PR adds a `time-zone-messages.js` file to `l10n/src`.

#### Description

This messages file is meant to be the single source of truth for translations of long-form timezone names.

The objects are keyed by IANA timezone names, and include an `offset` value that is either a number, or `false`.  The reasoning behind this is to include the GMT offset number for timezones that have no daylight/offset times, and `moment-timezone` to return the correct GMT offset for timezones that have daylight/offset time.
