### PR TITLE
fix (docs): renamed platform-related terms

### DIFF
--- a/website/src/content/api-reference/application-config.mdx
+++ b/website/src/content/api-reference/application-config.mdx
@@ -580,7 +580,7 @@ To make the application config more reusable across different environments, you 
 
 References are specified with a special expansion-like syntax `${}` together with the prefix key `env:`. For example, to load an environment variable called `APP_URL`, you would use `${env:APP_URL}`.
 
-Imagine developing a Custom Application that can be used in the Composable Commerce Europe Region and North America Region. We can assign the `${env:CLOUD_IDENTIFIER}` reference to the field `cloudIdentifier` and pass the actual value using environment variables.
+Imagine developing a Custom Application that can be used in the same Regions (Europe and North America) as the Composable Commerce APIs. We can assign the `${env:CLOUD_IDENTIFIER}` reference to the field `cloudIdentifier` and pass the actual value using environment variables.
 
 ```json
 {

--- a/website/src/content/api-reference/application-config.mdx
+++ b/website/src/content/api-reference/application-config.mdx
@@ -115,7 +115,7 @@ An optional description of the Custom Application, for information purposes.
 
 ## `entryPointUriPath`
 
-The **unique identifier** of the Custom Application, similarly to the `projectKey` of the commercetools Platform. This value determines the route at which the Custom Application is [served by the Merchant Center Proxy](/concepts/merchant-center-proxy-router).
+The **unique identifier** of the Custom Application, similarly to the `projectKey` of the Composable Commerce APIs. This value determines the route at which the Custom Application is [served by the Merchant Center Proxy](/concepts/merchant-center-proxy-router).
 
 ```
 /:projectKey/:entryPointUriPath
@@ -177,7 +177,7 @@ We explain this further in the [help section](/help-needed/#using-a-test-or-stag
 
 ## `cloudIdentifier`
 
-The [identifier of the cloud Region](/concepts/merchant-center-api#cloud-identifiers) that the Custom Application uses to connect to the commercetools Platform. The values map to the actual Merchant Center API URL for that Region.
+The [identifier of the cloud Region](/concepts/merchant-center-api#cloud-identifiers) that the Custom Application uses to connect to Composable Commerce. The values map to the actual Merchant Center API URL for that Region.
 
 Supported values are:
 
@@ -580,7 +580,7 @@ To make the application config more reusable across different environments, you 
 
 References are specified with a special expansion-like syntax `${}` together with the prefix key `env:`. For example, to load an environment variable called `APP_URL`, you would use `${env:APP_URL}`.
 
-Imagine developing a Custom Application that can be used in the commercetools Platform Europe Region and North America Region. We can assign the `${env:CLOUD_IDENTIFIER}` reference to the field `cloudIdentifier` and pass the actual value using environment variables.
+Imagine developing a Custom Application that can be used in the Composable Commerce Europe Region and North America Region. We can assign the `${env:CLOUD_IDENTIFIER}` reference to the field `cloudIdentifier` and pass the actual value using environment variables.
 
 ```json
 {

--- a/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
@@ -187,7 +187,7 @@ export default withApplicationContext((applicationContext) => ({
 
 # Project image settings
 
-Product images can be uploaded to the commercetools Platform or referenced from external sources.
+Product images can be uploaded to Composable Commerce or referenced from external sources.
 
 By default, images referenced from external sources are not displayed in the Merchant Center. This avoids possible performance issues in case the size of those images is big.
 

--- a/website/src/content/concepts/integrate-with-your-own-api.mdx
+++ b/website/src/content/concepts/integrate-with-your-own-api.mdx
@@ -12,7 +12,7 @@ Developing Custom Applications might require you to have your own backend server
 
 If that's the case, you're probably facing a problem: _how do you authenticate requests to your API?_
 
-Previously we learned that Custom Applications must use the [Merchant Center API](/concepts/merchant-center-api) to target any of the commercetools Platform APIs, as the Merchant Center API handles all [authentication and authorization](/concepts/merchant-center-api#authentication) logic to access those APIs. Therefore, Custom Applications don't need to deal with this logic as they can't really safely store any access token on the client/browser.
+Previously we learned that Custom Applications must use the [Merchant Center API](/concepts/merchant-center-api) to target any of the Composable Commerce APIs, as the Merchant Center API handles all [authentication and authorization](/concepts/merchant-center-api#authentication) logic to access those APIs. Therefore, Custom Applications don't need to deal with this logic as they can't really safely store any access token on the client/browser.
 
 However, since your backend server is hosted on a different domain than the Merchant Center, you can't send authenticated requests to your server from your Custom Application. Well, you can but you don't know whether the request comes from an authenticated user or not.
 

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -26,7 +26,7 @@ In case you need advice in which Region your Project should be located, please c
 
 ## Hostnames
 
-The Merchant Center and the Merchant Center API Gateway are available at the same cloud Regions where Composable Commerce runs.
+The Merchant Center and the Merchant Center API Gateway are available in the same cloud Regions where Composable Commerce runs.
 
 All hostnames are subdomains of `commercetools.com` and follow a specific naming format, including the cloud provider, the cloud Region, and the Merchant Center service name.
 

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -2,31 +2,31 @@
 title: Merchant Center API
 ---
 
-Custom Applications need to fetch data from different APIs in the commercetools Platform. Examples are fetching channel information or updating product data.
+Custom Applications need to fetch data from different APIs in Composable Commerce. Examples are fetching channel information or updating product data.
 
 Accessing these API requires some sort of authentication mechanism. For security reasons, client-side applications **cannot be trusted** with sensitive credentials, which makes it difficult to connect to an API directly from the browser.
 
-To solve these issues, the Merchant Center provides an HTTP API that handles authentication and authorization to all commercetools Platform APIs. You can think about it as an **API Gateway**.
+To solve these issues, the Merchant Center provides an HTTP API that handles authentication and authorization to all Composable Commerce APIs. You can think about it as an **API Gateway**.
 
-Therefore, Custom Applications use the Merchant Center API to make requests to one of the commercetools Platform APIs. The way you select the API in your requests depends on the [API Gateway endpoints](#api-gateway-endpoints).
+Therefore, Custom Applications use the Merchant Center API to make requests to one of the Composable Commerce APIs. The way you select the API in your requests depends on the [API Gateway endpoints](#api-gateway-endpoints).
 
 ![Merchant Center API](/images/merchant-center-api.png 'Merchant Center API')
 
 # Cloud Regions
 
-The commercetools Platform is available in [multiple cloud Regions](https://docs.commercetools.com/api/general-concepts#regions).
+Composable Commerce is available in [multiple cloud Regions](https://docs.commercetools.com/api/general-concepts#regions).
 These Regions are completely isolated from each other and no data is transferred between them.
 
 <Info>
 
-Platform accounts created for one Region are not valid for the other Regions. A [signup](https://docs.commercetools.com/tutorials/getting-started) is required for each Region individually.
+Composable Commerce accounts created for one Region are not valid for the other Regions. A [signup](https://docs.commercetools.com/tutorials/getting-started) is required for each Region individually.
 In case you need advice in which Region your Project should be located, please contact [commercetools support](https://support.commercetools.com).
 
 </Info>
 
 ## Hostnames
 
-The Merchant Center and the Merchant Center API Gateway are available at the same cloud Regions where the commercetools Platform runs.
+The Merchant Center and the Merchant Center API Gateway are available at the same cloud Regions where Composable Commerce runs.
 
 All hostnames are subdomains of `commercetools.com` and follow a specific naming format, including the cloud provider, the cloud Region, and the Merchant Center service name.
 
@@ -116,11 +116,11 @@ However, there are multiple target GraphQL APIs that Custom Applications can use
 
 The following targets are available:
 
-* `ctp`: Proxies requests to the [commercetools Platform GraphQL API](https://docs.commercetools.com/api/graphql).
-* `change-history`: Proxies requests to the [commercetools Platform History API](https://docs.commercetools.com/api/history/change-history).
+* `ctp`: Proxies requests to the [Composable Commerce GraphQL API](https://docs.commercetools.com/api/graphql).
+* `change-history`: Proxies requests to the [Composable Commerce History API](https://docs.commercetools.com/api/history/change-history).
 * `mc`: Proxies requests to the Merchant Center GraphQL API.
 
-Normally you would only need to use the official [commercetools Platform GraphQL API](https://docs.commercetools.com/api/graphql) as other APIs are mostly for internal usage and not documented.
+Normally you would only need to use the official [Composable Commerce GraphQL API](https://docs.commercetools.com/api/graphql) as other APIs are mostly for internal usage and not documented.
 
 To learn more how to use the target values, check out the [Data Fetching documentation](/development/data-fetching) for developing Custom Applications.
 
@@ -134,7 +134,7 @@ https://mc-api.<cloud-region>.commercetools.com/proxy/*
 
 The following proxy endpoints are available:
 
-* `/proxy/ctp/*`: Proxies requests to the [commercetools Platform HTTP API](https://docs.commercetools.com/api).
+* `/proxy/ctp/*`: Proxies requests to the [Composable Commerce HTTP API](https://docs.commercetools.com/api).
 * `/proxy/ml/*`: Proxies requests to the [Machine Learning API](https://docs.commercetools.com/api/ml).
 * `/proxy/import/*`: Proxies requests to the [Import Export API](https://docs.commercetools.com/import-export).
 * `/proxy/forward-to`: See [Integrate with your own API](/concepts/integrate-with-your-own-api).

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -120,7 +120,7 @@ The following targets are available:
 * `change-history`: Proxies requests to the [Composable Commerce Change History API](https://docs.commercetools.com/api/history/change-history).
 * `mc`: Proxies requests to the Merchant Center GraphQL API.
 
-Normally you would only need to use the official [Composable Commerce GraphQL API](https://docs.commercetools.com/api/graphql) as other APIs are mostly for internal usage and not documented.
+Normally, you would only need to use the official [Composable Commerce GraphQL API](https://docs.commercetools.com/api/graphql) as other APIs are mostly for internal usage and not documented.
 
 To learn more how to use the target values, check out the [Data Fetching documentation](/development/data-fetching) for developing Custom Applications.
 

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -117,7 +117,7 @@ However, there are multiple target GraphQL APIs that Custom Applications can use
 The following targets are available:
 
 * `ctp`: Proxies requests to the [Composable Commerce GraphQL API](https://docs.commercetools.com/api/graphql).
-* `change-history`: Proxies requests to the [Composable Commerce History API](https://docs.commercetools.com/api/history/change-history).
+* `change-history`: Proxies requests to the [Composable Commerce Change History API](https://docs.commercetools.com/api/history/change-history).
 * `mc`: Proxies requests to the Merchant Center GraphQL API.
 
 Normally you would only need to use the official [Composable Commerce GraphQL API](https://docs.commercetools.com/api/graphql) as other APIs are mostly for internal usage and not documented.

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -8,7 +8,7 @@ Accessing these API requires some sort of authentication mechanism. For security
 
 To solve these issues, the Merchant Center provides an HTTP API that handles authentication and authorization to all Composable Commerce APIs. You can think about it as an **API Gateway**.
 
-Therefore, Custom Applications use the Merchant Center API to make requests to one of the Composable Commerce APIs. The way you select the API in your requests depends on the [API Gateway endpoints](#api-gateway-endpoints).
+Therefore, Custom Applications use the Merchant Center API to make requests to the Composable Commerce APIs. The way you select the API in your requests depends on the [API Gateway endpoints](#api-gateway-endpoints).
 
 ![Merchant Center API](/images/merchant-center-api.png 'Merchant Center API')
 

--- a/website/src/content/concepts/oauth-scopes-and-user-permissions.mdx
+++ b/website/src/content/concepts/oauth-scopes-and-user-permissions.mdx
@@ -4,7 +4,7 @@ title: OAuth Scopes and user permissions
 
 # OAuth Scopes
 
-Custom Applications can potentially use any of the available commercetools Platform APIs. This is very important and one of the reasons for using Custom Applications in the first place: to be able to extend and improve functionalities of the commercetools Platform and Merchant Center.
+Custom Applications can potentially use any of the available Composable Commerce APIs. This is very important and one of the reasons for using Custom Applications in the first place: to be able to extend and improve functionalities of the commercetools Composable Commerce and Merchant Center.
 
 Therefore, Custom Applications **must specify the list of OAuth Scopes** needed by the application.
 

--- a/website/src/content/concepts/oauth-scopes-and-user-permissions.mdx
+++ b/website/src/content/concepts/oauth-scopes-and-user-permissions.mdx
@@ -4,7 +4,7 @@ title: OAuth Scopes and user permissions
 
 # OAuth Scopes
 
-Custom Applications can potentially use any of the available Composable Commerce APIs. This is very important and one of the reasons for using Custom Applications in the first place: to be able to extend and improve functionalities of the commercetools Composable Commerce and Merchant Center.
+Custom Applications can use any of the available Composable Commerce APIs. This allows you to extend the functionality and build custom features for any of the Composable Commerce APIs and the Merchant Center.
 
 Therefore, Custom Applications **must specify the list of OAuth Scopes** needed by the application.
 

--- a/website/src/content/development/data-fetching.mdx
+++ b/website/src/content/development/data-fetching.mdx
@@ -4,7 +4,7 @@ title: Data Fetching
 
 In client-side applications, data fetching is not always easy and it usually involves a lot of boilerplate code around implementation, state management, data normalization, etc.
 
-The Composable Commerce APIs and the Merchant Center have first-class support for GraphQL and we strongly recommend building your Custom Application using GraphQL wherever possible.
+The Composable Commerce APIs and the Merchant Center have first-class support for GraphQL. We strongly recommend building your Custom Application using GraphQL whenever possible.
 
 To handle requests to the [GraphQL APIs](/concepts/merchant-center-api#graphql) we use the built-in [Apollo GraphQL Client](https://www.apollographql.com/docs/react/).
 

--- a/website/src/content/development/data-fetching.mdx
+++ b/website/src/content/development/data-fetching.mdx
@@ -4,7 +4,7 @@ title: Data Fetching
 
 In client-side applications, data fetching is not always easy and it usually involves a lot of boilerplate code around implementation, state management, data normalization, etc.
 
-The commercetools Platform and the Merchant Center have first-class support for GraphQL and we strongly recommend building your Custom Application using GraphQL wherever possible.
+The Composable Commerce APIs and the Merchant Center have first-class support for GraphQL and we strongly recommend building your Custom Application using GraphQL wherever possible.
 
 To handle requests to the [GraphQL APIs](/concepts/merchant-center-api#graphql) we use the built-in [Apollo GraphQL Client](https://www.apollographql.com/docs/react/).
 

--- a/website/src/content/index.mdx
+++ b/website/src/content/index.mdx
@@ -58,7 +58,7 @@ Focus more on implementing the right features instead of configuration. Our open
 
 - [Application Kit](https://github.com/commercetools/merchant-center-application-kit)
 - [UI Kit](https://github.com/commercetools/ui-kit)
-- [commercetools Platform](https://docs.commercetools.com/api)
+- [Composable Commerce API](https://docs.commercetools.com/api)
 
 </>
   </Card>

--- a/website/src/content/index.mdx
+++ b/website/src/content/index.mdx
@@ -58,7 +58,7 @@ Focus more on implementing the right features instead of configuration. Our open
 
 - [Application Kit](https://github.com/commercetools/merchant-center-application-kit)
 - [UI Kit](https://github.com/commercetools/ui-kit)
-- [Composable Commerce API](https://docs.commercetools.com/api)
+- [Composable Commerce APIs](https://docs.commercetools.com/api)
 
 </>
   </Card>

--- a/website/src/content/migrating-from-project-level-custom-applications.mdx
+++ b/website/src/content/migrating-from-project-level-custom-applications.mdx
@@ -45,7 +45,7 @@ Managing Custom Applications is done now on Organization level rather than the P
 
 # OAuth Scopes and user permissions
 
-Project-level Custom Applications weren't able to define which [OAuth Scopes](https://docs.commercetools.com/api/scopes) of the commercetools Composable Commerce API were needed and could only rely on the implicit OAuth Scopes defined for user permissions of the _default_ Merchant Center applications (**Organizations > Teams > Permissions**).
+Project-level Custom Applications weren't able to define which Composable Commerce [OAuth Scopes](https://docs.commercetools.com/api/scopes) were needed. It could only rely on the implicit OAuth Scopes defined for user permissions of the _default_ Merchant Center applications (**Organizations > Teams > Permissions**).
 
 Let us look at an example. The user permission `ViewProducts` maps internally to some OAuth Scopes, like `view_products`, `view_states`, `view_types`. If a Custom Application has to use the [States API](https://docs.commercetools.com/api/projects/states), it would need to use the `ViewProducts` permission to properly authorize the user to perform the API requests.
 Therefore, using the `ViewProducts` permission makes the Custom Application work by chance to be able to interact with the States API.

--- a/website/src/content/migrating-from-project-level-custom-applications.mdx
+++ b/website/src/content/migrating-from-project-level-custom-applications.mdx
@@ -45,13 +45,13 @@ Managing Custom Applications is done now on Organization level rather than the P
 
 # OAuth Scopes and user permissions
 
-Project-level Custom Applications weren't able to define which [OAuth Scopes](https://docs.commercetools.com/api/scopes) of the commercetools Platform were needed and could only rely on the implicit OAuth Scopes defined for user permissions of the _default_ Merchant Center applications (**Organizations > Teams > Permissions**).
+Project-level Custom Applications weren't able to define which [OAuth Scopes](https://docs.commercetools.com/api/scopes) of the commercetools Composable Commerce API were needed and could only rely on the implicit OAuth Scopes defined for user permissions of the _default_ Merchant Center applications (**Organizations > Teams > Permissions**).
 
 Let us look at an example. The user permission `ViewProducts` maps internally to some OAuth Scopes, like `view_products`, `view_states`, `view_types`. If a Custom Application has to use the [States API](https://docs.commercetools.com/api/projects/states), it would need to use the `ViewProducts` permission to properly authorize the user to perform the API requests.
 Therefore, using the `ViewProducts` permission makes the Custom Application work by chance to be able to interact with the States API.
 
 What if this mapping of user permissions and OAuth Scopes would change? Custom Applications relying on this undocumented and implicit behavior would stop working.
-Furthermore, if a Custom Application would require to use a Platform API with OAuth Scopes that are not mapped to any user permissions, it wouldn't be even possible.
+Furthermore, if a Custom Application would require to use a Composable Commerce API with OAuth Scopes that are not mapped to any user permissions, it wouldn't be even possible.
 
 With the introduction of Org-level Custom Applications we intend to change this behavior and empower Custom Applications to take control of their requirements.
 
@@ -139,7 +139,7 @@ See [Custom Application config](/api-reference/application-config) for more info
 
 ## Choose the `entryPointUriPath`
 
-The `entryPointUriPath` is the identifier of the Custom Application similar to the `projectKey` of the commercetools Platform.
+The `entryPointUriPath` is the identifier of the Custom Application similar to the `projectKey` used in Composable Commerce APIs.
 
 <Info>
 

--- a/website/src/content/what-is-a-custom-application.mdx
+++ b/website/src/content/what-is-a-custom-application.mdx
@@ -14,7 +14,7 @@ A Custom Application is developed and managed by merchants.
 
 Using Custom Applications enables merchants to:
 
-* Extend new or existing functionalities of the Composable Commerce APIs and the Merchant Center.
+* Extend the functionality of the Composable Commerce APIs and the Merchant Center
 * Tailor specific business requirements and needs of merchants.
 * Integrate the Composable Commerce APIs and the Merchant Center with external services.
 

--- a/website/src/content/what-is-a-custom-application.mdx
+++ b/website/src/content/what-is-a-custom-application.mdx
@@ -2,7 +2,7 @@
 title: What is a Custom Application?
 ---
 
-A Custom Application is a set of UI tools and components to extend existing functionalities of the [commercetools Platform](https://commercetools.com/commerce-platform) and the [Merchant Center](https://commercetools.com/features/business-tooling).
+A Custom Application is a set of UI tools and components to extend existing functionalities of the [Composable Commerce](https://commercetools.com/commerce-platform) and the [Merchant Center](https://commercetools.com/features/business-tooling).
 
 Merchants can implement specific business requirements in a Custom Application and use it in their Merchant Center Projects by configuring and installing Custom Applications into their commercetools Organizations.
 
@@ -14,9 +14,9 @@ A Custom Application is developed and managed by merchants.
 
 Using Custom Applications enables merchants to:
 
-* Extend new or existing functionalities of the commercetools Platform and the Merchant Center.
+* Extend new or existing functionalities of the Composable Commerce APIs and the Merchant Center.
 * Tailor specific business requirements and needs of merchants.
-* Integrate the commercetools Platform and the Merchant Center with external services.
+* Integrate the Composable Commerce APIs and the Merchant Center with external services.
 
 Developing Custom Applications allows developers to:
 

--- a/website/src/content/what-is-a-custom-application.mdx
+++ b/website/src/content/what-is-a-custom-application.mdx
@@ -2,7 +2,7 @@
 title: What is a Custom Application?
 ---
 
-A Custom Application is a set of UI tools and components to extend existing functionalities of the [Composable Commerce](https://commercetools.com/commerce-platform) and the [Merchant Center](https://commercetools.com/features/business-tooling).
+A Custom Application is a set of UI tools and components to extend the existing functionality of the [Composable Commerce APIs](https://commercetools.com/commerce-platform) and the [Merchant Center](https://commercetools.com/features/business-tooling).
 
 Merchants can implement specific business requirements in a Custom Application and use it in their Merchant Center Projects by configuring and installing Custom Applications into their commercetools Organizations.
 

--- a/website/src/content/what-is-a-custom-application.mdx
+++ b/website/src/content/what-is-a-custom-application.mdx
@@ -15,7 +15,7 @@ A Custom Application is developed and managed by merchants.
 Using Custom Applications enables merchants to:
 
 * Extend the functionality of the Composable Commerce APIs and the Merchant Center
-* Tailor specific business requirements and needs of merchants.
+* Tailor to specific business requirements and use-cases
 * Integrate the Composable Commerce APIs and the Merchant Center with external services.
 
 Developing Custom Applications allows developers to:


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Renamed Platform-related terms following the rebranding.

#### Description

With a new Portfolio strategy for the company, some renaming of the used terms was done. For instance, the term "Platform" was replaced with the term "Composable Commerce".

As a result, all "Platform"-related text was replaced in the Custom Application documentation. The affected sentences were rephrased accordingly. Used the [existing PR](https://github.com/commercetools/commercetools-docs/pull/2007) for the rest of the documentation as a reference.
