### PR TITLE
fix (docs): change domain for example emails

### DIFF
--- a/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
@@ -58,7 +58,7 @@ The information about the logged in user.
 {
   "user": {
     "id": "3mj76c04-f910-4223-84e1-f97b0fe291c2",
-    "email": "john.doe@domain.com",
+    "email": "john.doe@example.com",
     "firstName": "John",
     "lastName": "Doe",
     "businessRole": "Consultant",


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

#### Description
The docs team has decided to change example email addresses in our docs to ensure that they use a domain that is suited for documentation purposes ([Issue](https://github.com/commercetools/commercetools-docs/issues/1998), [PR](https://github.com/commercetools/commercetools-docs/pull/2000)).

The goal was to amend any cases of example emails within the Custom Applications docs to fit the initiative.
 
In most cases, the example email should be [email@example.com](mailto:email@example.com), but anything on the [example.com](http://example.com/) domain would be acceptable.

**The regex used** to search for the email addresses: `[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+`
