### PR TITLE
docs: prefer using formik `handleReset` instead of `resetForm`

### DIFF
--- a/.changeset/old-otters-arrive.md
+++ b/.changeset/old-otters-arrive.md
@@ -68,7 +68,7 @@ const AccountPage = () => {
       title="Manage your account"
       onPreviousPathClick={() => history.push('/starting-page')}
       isPrimaryButtonDisabled={formik.isSubmitting}
-      onSecondaryButtonClick={formik.resetForm}
+      onSecondaryButtonClick={formik.handleReset}
       onPrimaryButtonClick={formik.handleSubmit}
     >
       <TextField
@@ -122,7 +122,7 @@ const AccountPage = () => {
       formControls={
         <>
           <CustomFormDetailPage.FormSecondaryButton
-            onClick={formik.resetForm}
+            onClick={formik.handleReset}
           />
           <CustomFormDetailPage.FormPrimaryButton
             onClick={formik.handleSubmit}

--- a/application-templates/starter/src/components/channel-details/channel-details-form.jsx
+++ b/application-templates/starter/src/components/channel-details/channel-details-form.jsx
@@ -80,7 +80,7 @@ const ChannelDetailsForm = (props) => {
     isDirty: formik.dirty,
     isSubmitting: formik.isSubmitting,
     submitForm: formik.handleSubmit,
-    resetForm: formik.resetForm,
+    handleReset: formik.handleReset,
   });
 };
 ChannelDetailsForm.displayName = 'ChannelDetailsForm';

--- a/application-templates/starter/src/components/channel-details/channel-details.jsx
+++ b/application-templates/starter/src/components/channel-details/channel-details.jsx
@@ -109,7 +109,7 @@ const ChannelDetails = (props) => {
               formProps.isSubmitting || !formProps.isDirty || !canManage
             }
             isSecondaryButtonDisabled={!formProps.isDirty}
-            onSecondaryButtonClick={formProps.resetForm}
+            onSecondaryButtonClick={formProps.handleReset}
             onPrimaryButtonClick={formProps.submitForm}
             labelPrimaryButton={FormModalPage.Intl.save}
             labelSecondaryButton={FormModalPage.Intl.revert}

--- a/website-components-playground/src/pages/custom-form-detail-page.js
+++ b/website-components-playground/src/pages/custom-form-detail-page.js
@@ -123,9 +123,7 @@ const CustomFormDetailPageExample = (props) => {
                 formControls={
                   <>
                     <CustomFormDetailPage.FormSecondaryButton
-                      onClick={() => {
-                        formikProps.resetForm();
-                      }}
+                      onClick={formikProps.handleReset}
                     />
                     <CustomFormDetailPage.FormPrimaryButton
                       onClick={formikProps.handleSubmit}

--- a/website-components-playground/src/pages/custom-form-modal-page.js
+++ b/website-components-playground/src/pages/custom-form-modal-page.js
@@ -66,10 +66,7 @@ const CustomFormModalPageExample = () => (
                   formControls={
                     <>
                       <CustomFormModalPage.FormSecondaryButton
-                        onClick={() => {
-                          formikProps.resetForm();
-                          setIsOpen(false);
-                        }}
+                        onClick={formikProps.handleReset}
                       />
                       <CustomFormModalPage.FormPrimaryButton
                         onClick={formikProps.handleSubmit}

--- a/website-components-playground/src/pages/form-detail-page.js
+++ b/website-components-playground/src/pages/form-detail-page.js
@@ -135,9 +135,7 @@ const FormDetailPageExample = (props) => {
                 isSecondaryButtonDisabled={formikProps.isSubmitting}
                 labelSecondaryButton={values.labelSecondaryButton}
                 labelPrimaryButton={values.labelPrimaryButton}
-                onSecondaryButtonClick={() => {
-                  formikProps.resetForm();
-                }}
+                onSecondaryButtonClick={formikProps.handleReset}
                 onPrimaryButtonClick={formikProps.handleSubmit}
                 hideControls={values.hideControls}
               >

--- a/website-components-playground/src/pages/form-dialog.js
+++ b/website-components-playground/src/pages/form-dialog.js
@@ -61,10 +61,7 @@ const FormDialogExample = (props) => (
                   onClose={() => setIsOpen(false)}
                   size={values.size}
                   isPrimaryButtonDisabled={formikProps.isSubmitting}
-                  onSecondaryButtonClick={() => {
-                    formikProps.resetForm();
-                    setIsOpen(false);
-                  }}
+                  onSecondaryButtonClick={formikProps.handleReset}
                   onPrimaryButtonClick={formikProps.handleSubmit}
                   getParentSelector={() =>
                     document.querySelector(`#${containerId}`)

--- a/website-components-playground/src/pages/form-modal-page.js
+++ b/website-components-playground/src/pages/form-modal-page.js
@@ -81,10 +81,7 @@ const FormModalPageExample = (props) => (
                   isSecondaryButtonDisabled={formikProps.isSubmitting}
                   labelSecondaryButton={values.labelSecondaryButton}
                   labelPrimaryButton={values.labelPrimaryButton}
-                  onSecondaryButtonClick={() => {
-                    formikProps.resetForm();
-                    setIsOpen(false);
-                  }}
+                  onSecondaryButtonClick={formikProps.handleReset}
                   onPrimaryButtonClick={formikProps.handleSubmit}
                   getParentSelector={() =>
                     document.querySelector(`#${containerId}`)

--- a/website/src/content/api-reference/commercetools-frontend-application-components.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-components.mdx
@@ -193,10 +193,7 @@ const EmailForm = () => {
       isOpen={formModalState.isModalOpen}
       onClose={formModalState.closeModal}
       isPrimaryButtonDisabled={formik.isSubmitting}
-      onSecondaryButtonClick={() => {
-        formik.resetForm();
-        formModalState.closeModal()
-      }}
+      onSecondaryButtonClick={formik.handleReset}
       onPrimaryButtonClick={formik.handleSubmit}
     >
       <TextField
@@ -330,10 +327,7 @@ const AccountPage = () => {
       isOpen={formModalState.isModalOpen}
       onClose={formModalState.closeModal}
       isPrimaryButtonDisabled={formik.isSubmitting}
-      onSecondaryButtonClick={() => {
-        formik.resetForm();
-        formModalState.closeModal()
-      }}
+      onSecondaryButtonClick={formik.handleReset}
       onPrimaryButtonClick={formik.handleSubmit}
     >
       <TextField
@@ -428,20 +422,9 @@ const AccountPage = () => {
       title="Manage your account"
       isOpen={formModalState.isModalOpen}
       onClose={formModalState.closeModal}
-      isPrimaryButtonDisabled={formik.isSubmitting}
-      onSecondaryButtonClick={() => {
-        formik.resetForm();
-        formModalState.closeModal()
-      }}
-      onPrimaryButtonClick={formik.handleSubmit}
       formControls={
         <>
-          <CustomFormModalPage.FormSecondaryButton
-            onClick={() => {
-              formik.resetForm();
-              formModalState.closeModal()
-            }}
-          />
+          <CustomFormModalPage.FormSecondaryButton onClick={formik.handleReset} />
           <CustomFormModalPage.FormPrimaryButton onClick={formik.handleSubmit} />
           <CustomFormModalPage.FormDeleteButton onClick={handleDelete} />
         </>
@@ -602,9 +585,7 @@ const AccountPage = () => {
       title="Manage your account"
       onPreviousPathClick={() => history.push('/starting-page')}
       isPrimaryButtonDisabled={formik.isSubmitting}
-      onSecondaryButtonClick={() => {
-        formik.resetForm();
-      }}
+      onSecondaryButtonClick={formik.handleReset}
       onPrimaryButtonClick={formik.handleSubmit}
     >
       <TextField
@@ -640,7 +621,7 @@ const AccountPage = () => {
 | `isSecondaryButtonDisabled`     | `boolean`                       |    -     | `false`                            | Indicates whether the secondary button is deactivated or not.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `dataAttributesSecondaryButton` | `object`                        |    -     | -                                  | Use this prop to pass `data-` attributes to the secondary button.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `dataAttributesPrimaryButton`   | `object`                        |    -     | -                                  | Use this prop to pass `data-` attributes to the primary button.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `hideControls`                  | `boolean`                       |    -     | `false`                            | Hides the form controls.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 
+| `hideControls`                  | `boolean`                       |    -     | `false`                            | Hides the form controls.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ### Static properties
 
@@ -680,8 +661,8 @@ import { useHistory } from 'react-router-dom'
 import { useFormik } from "formik";
 import TextField from "@commercetools-uikit/text-field";
 import TextInput from "@commercetools-uikit/text-input";
-import { 
-  CustomFormDetailPage 
+import {
+  CustomFormDetailPage
 } from "@commercetools-frontend/application-components";
 
 const AccountPage = () => {
@@ -708,14 +689,8 @@ const AccountPage = () => {
       onPreviousPathClick={() => history.push('/starting-page')}
       formControls={
         <>
-          <CustomFormDetailPage.FormSecondaryButton
-            onClick={() => {
-              formik.resetForm();
-            }}
-          />
-          <CustomFormDetailPage.FormPrimaryButton
-            onClick={formik.handleSubmit}
-          />
+          <CustomFormDetailPage.FormSecondaryButton onClick={formik.handleReset} />
+          <CustomFormDetailPage.FormPrimaryButton onClick={formik.handleSubmit} />
           <CustomFormDetailPage.FormDeleteButton onClick={handleDelete} />
         </>
       }


### PR DESCRIPTION
I've seen multiple times using `resetForm` passed as a callback function to some click handlers. For example

```js
<button onClick={formik.resetForm}>Click</button>
```

The `resetForm` method from Formik accepts an argument as the `nextState` and that could lead to unexpected issues if the function is called with the event `resetForm(event)`, like in the example above `onClick={formik.resetForm}`.

https://formik.org/docs/api/formik#resetform-nextstate-partialformikstatevalues--void

However, Formik also exposes a `handleReset` function (https://formik.org/docs/api/formik#handlereset---void) that does not accept any arguments.
This should be the preferred method to use as callback handlers like `onClick={formik.handleReset}`.