### PR TITLE
chore: try increasing networkIdleTimeout for more stable tests

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -2,4 +2,6 @@ version: 2
 snapshot:
   widths:
     - 1024
-  min-height: 1024
+  minHeight: 1024
+discovery:
+  networkIdleTimeout: 750


### PR DESCRIPTION
Trying to see if it helps with the flaky snapshot