### PR TITLE
Use a native link for top bar logo

### DIFF
--- a/.changeset/flat-hounds-switch.md
+++ b/.changeset/flat-hounds-switch.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Update the link for the main logo in the topbar (top left corner) to be a native one

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Initialize GitHub Deployment
         if: ${{ env.DEPLOY_DOCS_ENV == 'Preview' }}
-        uses: bobheadxi/deployments@v1.1.0
+        uses: bobheadxi/deployments@v1.2.0
         id: start-deployment
         with:
           step: start
@@ -103,10 +103,12 @@ jobs:
 
       - name: Update GitHub Deployment Status
         if: ${{ env.DEPLOY_DOCS_ENV == 'Preview' }}
-        uses: bobheadxi/deployments@v1.1.0
+        uses: bobheadxi/deployments@v1.2.0
         id: finish_deployment
         with:
           step: finish
+          override: false
+          auto_inactive: false
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.start-deployment.outputs.env }}

--- a/packages/application-shell/src/components/app-bar/app-bar.tsx
+++ b/packages/application-shell/src/components/app-bar/app-bar.tsx
@@ -1,6 +1,5 @@
 import type { TFetchLoggedInUserQuery } from '../../types/generated/mc';
 
-import { Link } from 'react-router-dom';
 import { css } from '@emotion/react';
 import Spacings from '@commercetools-uikit/spacings';
 import { customProperties } from '@commercetools-uikit/design-system';
@@ -51,9 +50,9 @@ const AppBar = (props: Props) => {
           {!props.user ? (
             <img src={LogoSVG} width="100%" alt="Logo" />
           ) : (
-            <Link to={`/${previousProjectKey || ''}`}>
+            <a href={`/${previousProjectKey || ''}`}>
               <img src={LogoSVG} width="100%" alt="Logo" />
-            </Link>
+            </a>
           )}
         </div>
 


### PR DESCRIPTION
#### Summary
Update the link for the logo in the topbar (top left corner) to be a native one

#### Description
The link currently does a client-side redirect, which eventually ends up in a full page redirect anyway.
Also, it will help with some errors we've seen in Sentry.

closes #1832


