### PR TITLE
Align children and legal message of PublicPageLayout component

### DIFF
--- a/.changeset/bright-numbers-check.md
+++ b/.changeset/bright-numbers-check.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/application-components": patch
+"@commercetools-local/visual-testing-app": patch
+---
+
+Fix alignment of public page footer element.

--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -87,15 +87,17 @@ const PublicPageLayout: FC<TProps> = (props) => {
         <Spacings.Stack scale="s">
           <PublicPageLayoutContent {...props} />
 
-          <Spacings.Stack
-            scale="xs"
-            alignItems={props.contentScale === 'wide' ? 'center' : 'stretch'}
-          >
-            {props.legalMessage && (
-              <Text.Body tone="inverted">{props.legalMessage}</Text.Body>
-            )}
-            <Text.Body tone="inverted">{`${year} © commercetools`}</Text.Body>
-          </Spacings.Stack>
+          <PublicPageLayoutContent contentScale={props.contentScale}>
+            <Spacings.Stack
+              scale="xs"
+              alignItems={props.contentScale === 'wide' ? 'center' : 'stretch'}
+            >
+              {props.legalMessage && (
+                <Text.Body tone="inverted">{props.legalMessage}</Text.Body>
+              )}
+              <Text.Body tone="inverted">{`${year} © commercetools`}</Text.Body>
+            </Spacings.Stack>
+          </PublicPageLayoutContent>
         </Spacings.Stack>
       </Spacings.Stack>
     </Container>

--- a/visual-testing-app/package.json
+++ b/visual-testing-app/package.json
@@ -14,6 +14,7 @@
     "@commercetools-frontend/constants": "21.3.4",
     "@commercetools-frontend/react-notifications": "21.6.0",
     "@commercetools-uikit/accessible-button": "^15.0.0",
+    "@commercetools-uikit/card": "^15.0.0",
     "@commercetools-uikit/design-system": "^15.0.0",
     "@commercetools-uikit/grid": "^15.0.0",
     "@commercetools-uikit/icon-button": "^15.0.0",

--- a/visual-testing-app/src/components/public-page-layout/public-page-layout.visualroute.tsx
+++ b/visual-testing-app/src/components/public-page-layout/public-page-layout.visualroute.tsx
@@ -1,0 +1,29 @@
+import { PublicPageLayout } from '@commercetools-frontend/application-components';
+import Card from '@commercetools-uikit/card';
+import { Suite, Spec } from '../../test-utils';
+
+export const routePath = '/public-page-layout';
+
+export const Component = () => (
+  <Suite>
+    <Spec label="PublicPageLayout">
+      <PublicPageLayout>
+        <Card>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu
+          dictum varius duis at consectetur lorem donec.
+        </Card>
+      </PublicPageLayout>
+    </Spec>
+
+    <Spec label="PublicPageLayout with long legal message">
+      <PublicPageLayout legalMessage="Lea nuestra Política de privacidad y nuestros Términos del servicio.">
+        <Card>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu
+          dictum varius duis at consectetur lorem donec.
+        </Card>
+      </PublicPageLayout>
+    </Spec>
+  </Suite>
+);

--- a/visual-testing-app/src/components/public-page-layout/public-page-layout.visualspec.ts
+++ b/visual-testing-app/src/components/public-page-layout/public-page-layout.visualspec.ts
@@ -1,0 +1,13 @@
+import percySnapshot from '@percy/puppeteer';
+import { HOST } from '../../constants';
+
+describe('PublicPageLayout', () => {
+  beforeAll(async () => {
+    await page.goto(`${HOST}/public-page-layout`);
+  });
+
+  it('Default', async () => {
+    await expect(page).toMatch('PublicPageLayout');
+    await percySnapshot(page, 'PublicPageLayout');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3319,6 +3319,7 @@ __metadata:
     "@commercetools-frontend/constants": 21.3.4
     "@commercetools-frontend/react-notifications": 21.6.0
     "@commercetools-uikit/accessible-button": ^15.0.0
+    "@commercetools-uikit/card": ^15.0.0
     "@commercetools-uikit/design-system": ^15.0.0
     "@commercetools-uikit/grid": ^15.0.0
     "@commercetools-uikit/icon-button": ^15.0.0


### PR DESCRIPTION
#### Summary
Children in PublicPageLayout component are not correctly aligned when using a long legal message.

#### Description
Provided children to PublicPageLayout component have a container with a fixed width but the legal message that can be rendered below does not. So if that message is too long, both contents do not align well.

Example:
![image](https://user-images.githubusercontent.com/97907068/171425507-0f70037a-cb29-400f-a42a-8da2ba875fd2.png)

We used the same with for the legal message to avoid this problem.

An alternative could be to allow different widths and use a center alignment between the children and the legal message.


