### PR TITLE
feat: add .licrc for licensebat

### DIFF
--- a/.licrc
+++ b/.licrc
@@ -1,0 +1,19 @@
+[licenses]
+# This indicates which are the only licenses that Licensebat will accept.
+# The rest will be flagged as not allowed.
+accepted = ["MIT", "MSC", "BSD"]
+# This will indicate which licenses are not accepted.
+# The rest will be accepted, except for the unknown licenses or dependencies without licenses.
+# unaccepted = ["LGPL"]
+# Note that only one of the previous options can be enabled at once.
+# If both of them are informed, only accepted will be considered.
+
+[dependencies]
+# This will allow users to flag some dependencies so that Licensebat will not check for their license.
+ignored=[]
+
+[behavior]
+# False by default, if true, it will only run the checks when one of the dependency files or the .licrc file has been modified.
+run_only_on_dependency_modification = true
+# False by default, if true, it will never block the build.
+do_not_block_pr = true


### PR DESCRIPTION
#### Summary

The licensebat is installed to the repository. This should enable the tool.