### PR TITLE
Create a new React hook to access Projects Images rewrite configuration

### DIFF
--- a/.changeset/angry-days-swim.md
+++ b/.changeset/angry-days-swim.md
@@ -6,23 +6,26 @@ There is a new React hook which you can use to access the Project Images rewrite
 
 You would use it like this:
 
+```js
 function MyComponent() {
-const { isLoading, imageRegex } = useProjectExtensionImageRegex();
+  const { isLoading, imageRegex } = useProjectExtensionImageRegex();
 
-if (isLoading) return <LoadingSpinner />;
+  if (isLoading) return <LoadingSpinner />;
 
-return (
-<div>
-<h1>Project images regex: {imageRegex}</h1>
-</div>
-);
+  return (
+    <div>
+      <h1>Project images regex: {imageRegex}</h1>
+    </div>
+  );
 }
 
 function MyApp() {
-return (
-<ProjectExtensionProviderForImageRegex>
-<MyComponent />
-</ProjectExtensionProviderForImageRegex>
-);
+  return (
+    <ProjectExtensionProviderForImageRegex>
+      <MyComponent />
+    </ProjectExtensionProviderForImageRegex>
+  );
 }
+```
+
 Both GetProjectExtensionImageRegex component and withProjectExtensionImageRegex still exists for backwards compatibility but have been marked as deprecated.

--- a/.changeset/angry-days-swim.md
+++ b/.changeset/angry-days-swim.md
@@ -2,4 +2,27 @@
 '@commercetools-frontend/application-shell-connectors': patch
 ---
 
-Create a new React hook to access Projects Images rewrite configuration. At the moment, most components are not functional, moving away from HOC, we want to have a react hook that can get context.
+There is a new React hook which you can use to access the Project Images rewrite configuration [see documentation](https://docs.commercetools.com/custom-applications/api-reference/commercetools-frontend-application-shell-connectors#project-image-settings).
+
+You would use it like this:
+
+function MyComponent() {
+const { isLoading, imageRegex } = useProjectExtensionImageRegex();
+
+if (isLoading) return <LoadingSpinner />;
+
+return (
+<div>
+<h1>Project images regex: {imageRegex}</h1>
+</div>
+);
+}
+
+function MyApp() {
+return (
+<ProjectExtensionProviderForImageRegex>
+<MyComponent />
+</ProjectExtensionProviderForImageRegex>
+);
+}
+Both GetProjectExtensionImageRegex component and withProjectExtensionImageRegex still exists for backwards compatibility but have been marked as deprecated.

--- a/.changeset/angry-days-swim.md
+++ b/.changeset/angry-days-swim.md
@@ -28,4 +28,4 @@ function MyApp() {
 }
 ```
 
-Both GetProjectExtensionImageRegex component and withProjectExtensionImageRegex still exists for backwards compatibility but have been marked as deprecated.
+Both `GetProjectExtensionImageRegex` component and `withProjectExtensionImageRegex` still exists for backwards compatibility but have been marked as deprecated.

--- a/.changeset/angry-days-swim.md
+++ b/.changeset/angry-days-swim.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+---
+
+Create a new React hook to access Projects Images rewrite configuration. At the moment, most components are not functional, moving away from HOC, we want to have a react hook that can get context.

--- a/packages/application-shell-connectors/package.json
+++ b/packages/application-shell-connectors/package.json
@@ -33,7 +33,7 @@
     "lodash": "4.17.21",
     "moment-timezone": "^0.5.34",
     "prop-types": "15.8.1",
-    "tiny-warning": "^1.0.3"
+    "tiny-warning": "1.0.3"
   },
   "devDependencies": {
     "@apollo/client": "3.6.2",

--- a/packages/application-shell-connectors/package.json
+++ b/packages/application-shell-connectors/package.json
@@ -32,7 +32,8 @@
     "graphql": "15.8.0",
     "lodash": "4.17.21",
     "moment-timezone": "^0.5.34",
-    "prop-types": "15.8.1"
+    "prop-types": "15.8.1",
+    "tiny-warning": "^1.0.3"
   },
   "devDependencies": {
     "@apollo/client": "3.6.2",

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/index.ts
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/index.ts
@@ -2,4 +2,5 @@ export {
   GetProjectExtensionImageRegex,
   ProjectExtensionProviderForImageRegex,
   withProjectExtensionImageRegex,
+  useProjectExtensionImageRegex,
 } from './project-extension-image-regex';

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -1,4 +1,3 @@
-//@ts-nocheck
 import type { MockedResponse } from '@apollo/client/testing';
 
 import {
@@ -46,9 +45,9 @@ const HookTestComponent = () => {
 };
 
 const WrappedTestComponent =
-  withProjectExtensionImageRegex<TBasicTestComponentProps>('imageRegexData')(
+  withProjectExtensionImageRegex<TBasicTestComponentProps>()(
     BasicTestComponent
-  );
+  ) as ComponentType<unknown>;
 
 const RenderPropTestComponent = () => {
   return (

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -18,6 +18,7 @@ import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import type { ComponentType } from 'react';
 
 jest.mock('@commercetools-frontend/sentry');
+jest.mock('tiny-warning');
 
 type TBasicTestComponentProps = {
   imageRegexData: TImageRegexContext;
@@ -81,10 +82,6 @@ const renderTestComponent = ({
     </ApolloMockProvider>
   );
 };
-
-beforeEach(() => {
-  jest.spyOn(console, 'warn').mockImplementation(() => {});
-});
 
 describe.each([
   [HookTestComponent],

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -84,9 +84,9 @@ const renderTestComponent = ({
 };
 
 describe.each([
-  [HookTestComponent],
-  [WrappedTestComponent],
-  [RenderPropTestComponent],
+  HookTestComponent,
+  WrappedTestComponent,
+  RenderPropTestComponent,
 ])('rendering #%#', (Component) => {
   describe('when image regex is defined', () => {
     it('should render regex info', async () => {

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -1,3 +1,4 @@
+//@ts-nocheck
 import type { MockedResponse } from '@apollo/client/testing';
 
 import {
@@ -10,14 +11,27 @@ import {
   ProjectExtensionProviderForImageRegex,
   GetProjectExtensionImageRegex,
   useProjectExtensionImageRegex,
+  withProjectExtensionImageRegex,
+  TImageRegexContext,
 } from './project-extension-image-regex';
 import FetchProjectExtensionImageRegex from './fetch-project-extension-image-regex.settings.graphql';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
+import type { ComponentType } from 'react';
 
 jest.mock('@commercetools-frontend/sentry');
 
-const TestComponent = () => {
+type TBasicTestComponentProps = {
+  imageRegexData: TImageRegexContext;
+};
+
+const BasicTestComponent = (props: TBasicTestComponentProps) => {
   const { imageRegex } = useProjectExtensionImageRegex();
+  if (props.imageRegexData.isLoading) {
+    return <div>{'Loading...'}</div>;
+  }
+  if (!props.imageRegexData.imageRegex) {
+    return <div>{'Not found'}</div>;
+  }
   return (
     <>
       <div>{imageRegex?.small?.replace}</div>
@@ -26,115 +40,128 @@ const TestComponent = () => {
   );
 };
 
-const renderComponent = (
-  mocks: ReadonlyArray<MockedResponse>,
-  skipQuery?: boolean
-) =>
-  render(
+const HookTestComponent = () => {
+  const imageRegexData = useProjectExtensionImageRegex();
+  return <BasicTestComponent imageRegexData={imageRegexData} />;
+};
+
+const WrappedTestComponent =
+  withProjectExtensionImageRegex<TBasicTestComponentProps>('imageRegexData')(
+    BasicTestComponent
+  );
+
+const RenderPropTestComponent = () => {
+  return (
+    <GetProjectExtensionImageRegex
+      render={(imageRegexData) => (
+        <BasicTestComponent imageRegexData={imageRegexData} />
+      )}
+    />
+  );
+};
+
+const renderTestComponent = ({
+  Component,
+  mocks,
+  skipQuery = false,
+  includeProvider = true,
+}: {
+  Component: ComponentType<unknown>;
+  mocks: ReadonlyArray<MockedResponse>;
+  skipQuery?: boolean;
+  includeProvider?: boolean;
+}) => {
+  if (!includeProvider) {
+    return render(<Component />);
+  }
+  return render(
     <ApolloMockProvider mocks={mocks} addTypename={true}>
       <ProjectExtensionProviderForImageRegex skip={skipQuery}>
-        <div>
-          <GetProjectExtensionImageRegex
-            render={(imageRegexContext) => {
-              if (imageRegexContext.isLoading) {
-                return <div>{'Loading...'}</div>;
-              }
-              if (!imageRegexContext.imageRegex) {
-                return <div>{'Not found'}</div>;
-              }
-              return <TestComponent />;
-            }}
-          />
-        </div>
+        <Component />
       </ProjectExtensionProviderForImageRegex>
     </ApolloMockProvider>
   );
-const renderComponentWithoutProvider = () =>
-  render(
-    <div>
-      <GetProjectExtensionImageRegex
-        render={(imageRegexContext) => {
-          if (imageRegexContext.isLoading) {
-            return <div>{'Loading...'}</div>;
-          }
-          if (!imageRegexContext.imageRegex) {
-            return <div>{'Not found'}</div>;
-          }
-          return <TestComponent />;
-        }}
-      />
-    </div>
-  );
+};
 
-describe('rendering', () => {
+describe.each([
+  [HookTestComponent],
+  [WrappedTestComponent],
+  [RenderPropTestComponent],
+])('rendering #%#', (Component) => {
   describe('when image regex is defined', () => {
     it('should render regex info', async () => {
-      renderComponent([
-        {
-          request: {
-            query: FetchProjectExtensionImageRegex,
-            context: {
-              target: GRAPHQL_TARGETS.SETTINGS_SERVICE,
+      renderTestComponent({
+        Component,
+        mocks: [
+          {
+            request: {
+              query: FetchProjectExtensionImageRegex,
+              context: {
+                target: GRAPHQL_TARGETS.SETTINGS_SERVICE,
+              },
             },
-          },
-          result: {
-            data: {
-              projectExtension: {
-                __typename: 'ProjectExtension',
-                id: 'p1',
-                imageRegex: {
-                  __typename: 'ImageRegex',
-                  thumb: {
-                    __typename: 'ImageRegexOptions',
-                    flag: 'gi',
-                    replace: '-thumb.jpg',
-                    search: '.[^.]+$',
+            result: {
+              data: {
+                projectExtension: {
+                  __typename: 'ProjectExtension',
+                  id: 'p1',
+                  imageRegex: {
+                    __typename: 'ImageRegex',
+                    thumb: {
+                      __typename: 'ImageRegexOptions',
+                      flag: 'gi',
+                      replace: '-thumb.jpg',
+                      search: '.[^.]+$',
+                    },
+                    small: null,
                   },
-                  small: null,
                 },
               },
             },
           },
-        },
-      ]);
+        ],
+      });
       await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
       expect(screen.getByText('-thumb.jpg')).toBeInTheDocument();
     });
   });
   describe('when image regex is not defined', () => {
     it('should not render regex info', async () => {
-      renderComponent([
-        {
-          request: {
-            query: FetchProjectExtensionImageRegex,
-            context: {
-              target: GRAPHQL_TARGETS.SETTINGS_SERVICE,
+      renderTestComponent({
+        Component,
+        mocks: [
+          {
+            request: {
+              query: FetchProjectExtensionImageRegex,
+              context: {
+                target: GRAPHQL_TARGETS.SETTINGS_SERVICE,
+              },
             },
-          },
-          result: {
-            data: {
-              projectExtension: {
-                __typename: 'ProjectExtension',
-                id: 'p1',
-                imageRegex: null,
+            result: {
+              data: {
+                projectExtension: {
+                  __typename: 'ProjectExtension',
+                  id: 'p1',
+                  imageRegex: null,
+                },
               },
             },
           },
-        },
-      ]);
+        ],
+      });
       await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
       expect(screen.getByText('Not found')).toBeInTheDocument();
     });
   });
   describe('when fetching regex settings is skipped', () => {
     it('should not render regex info', () => {
-      renderComponent([], true);
+      renderTestComponent({ Component, mocks: [], skipQuery: true });
       expect(screen.getByText('Not found')).toBeInTheDocument();
     });
   });
   describe('when context provider is not defined', () => {
     it('should not render regex info', () => {
-      renderComponentWithoutProvider();
+      renderTestComponent({ Component, mocks: [], includeProvider: false });
       expect(screen.getByText('Not found')).toBeInTheDocument();
     });
   });

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -82,6 +82,10 @@ const renderTestComponent = ({
   );
 };
 
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
 describe.each([
   [HookTestComponent],
   [WrappedTestComponent],

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.spec.tsx
@@ -1,5 +1,4 @@
 import type { MockedResponse } from '@apollo/client/testing';
-import type { TImageRegexContext } from './project-extension-image-regex';
 
 import {
   screen,
@@ -10,29 +9,22 @@ import { MockedProvider as ApolloMockProvider } from '@apollo/client/testing';
 import {
   ProjectExtensionProviderForImageRegex,
   GetProjectExtensionImageRegex,
+  useProjectExtensionImageRegex,
 } from './project-extension-image-regex';
 import FetchProjectExtensionImageRegex from './fetch-project-extension-image-regex.settings.graphql';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 
 jest.mock('@commercetools-frontend/sentry');
 
-type TestProps = {
-  imageRegex: TImageRegexContext['imageRegex'];
+const TestComponent = () => {
+  const { imageRegex } = useProjectExtensionImageRegex();
+  return (
+    <>
+      <div>{imageRegex?.small?.replace}</div>
+      <div>{imageRegex?.thumb?.replace}</div>
+    </>
+  );
 };
-const TestComponent = (props: TestProps) => (
-  <>
-    <div>
-      {props.imageRegex &&
-        props.imageRegex.small &&
-        props.imageRegex.small.replace}
-    </div>
-    <div>
-      {props.imageRegex &&
-        props.imageRegex.thumb &&
-        props.imageRegex.thumb.replace}
-    </div>
-  </>
-);
 
 const renderComponent = (
   mocks: ReadonlyArray<MockedResponse>,
@@ -50,9 +42,7 @@ const renderComponent = (
               if (!imageRegexContext.imageRegex) {
                 return <div>{'Not found'}</div>;
               }
-              return (
-                <TestComponent imageRegex={imageRegexContext.imageRegex} />
-              );
+              return <TestComponent />;
             }}
           />
         </div>
@@ -70,7 +60,7 @@ const renderComponentWithoutProvider = () =>
           if (!imageRegexContext.imageRegex) {
             return <div>{'Not found'}</div>;
           }
-          return <TestComponent imageRegex={imageRegexContext.imageRegex} />;
+          return <TestComponent />;
         }}
       />
     </div>

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
@@ -4,7 +4,7 @@ import type {
   TImageRegexOptions,
 } from '../../types/generated/settings';
 
-import { ComponentType, createContext, ReactNode } from 'react';
+import { ComponentType, createContext, ReactNode, useContext } from 'react';
 import { useQuery } from '@apollo/client/react';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
@@ -61,16 +61,10 @@ const GetProjectExtensionImageRegex = (props: ConsumerProps) => (
 );
 GetProjectExtensionImageRegex.displayName = 'GetProjectExtensionImageRegex';
 
-function withProjectExtensionImageRegex<Props extends {}>(
-  propKey = 'imageRegexData'
-) {
+function withProjectExtensionImageRegex<Props extends {}>() {
   return (Component: ComponentType<Props>) => {
     const WrappedComponent = (props: Props) => (
-      <GetProjectExtensionImageRegex
-        render={(imageRegexData) => (
-          <Component {...props} {...{ [propKey]: imageRegexData }} />
-        )}
-      />
+      <GetProjectExtensionImageRegex render={() => <Component {...props} />} />
     );
     WrappedComponent.displayName = `withProjectExtensionImageRegex(${getDisplayName<Props>(
       Component
@@ -79,9 +73,15 @@ function withProjectExtensionImageRegex<Props extends {}>(
   };
 }
 
+const useProjectExtensionImageRegex = () => {
+  const { isLoading, imageRegex } = useContext(Context);
+  return { isLoading, imageRegex };
+};
+
 // Exports
 export {
   GetProjectExtensionImageRegex,
   ProjectExtensionProviderForImageRegex,
   withProjectExtensionImageRegex,
+  useProjectExtensionImageRegex,
 };

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
@@ -74,10 +74,9 @@ ProjectExtensionProviderForImageRegex.displayName =
   'ProjectExtensionProviderForImageRegex';
 
 const GetProjectExtensionImageRegex = (props: ConsumerProps) => {
-  //TODO: add a descriptive possible deprecation warning for moving from HOC to Hooks in the future
   useWarning(
     false,
-    `@commercetools-frontend/application-shell-connectors: ...`
+    `@commercetools-frontend/application-shell-connectors: It is not recommended to use the 'GetProjectExtensionImageRegex' anymore. Please use the 'useProjectExtensionImageRegex' hook instead.`
   );
 
   return (
@@ -89,10 +88,14 @@ const GetProjectExtensionImageRegex = (props: ConsumerProps) => {
 GetProjectExtensionImageRegex.displayName = 'GetProjectExtensionImageRegex';
 
 function withProjectExtensionImageRegex<Props extends {}>(
-  propKey: 'imageRegexData'
+  propKey = 'imageRegexData'
 ) {
   return (Component: ComponentType<Props>) => {
     const WrappedComponent = (props: Props) => {
+      useWarning(
+        false,
+        `@commercetools-frontend/application-shell-connectors: It is not recommended to use the 'withProjectExtensionImageRegex' high order component anymore. Please use the 'useProjectExtensionImageRegex' hook instead.`
+      );
       const imageregexContext = useProjectExtensionImageRegex();
       return (
         <GetProjectExtensionImageRegex

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
@@ -6,9 +6,9 @@ import type {
 import warning from 'tiny-warning';
 
 import {
-  ComponentType,
+  type ComponentType,
+  type ReactNode,
   createContext,
-  ReactNode,
   useContext,
   useEffect,
 } from 'react';

--- a/packages/application-shell-connectors/src/index.ts
+++ b/packages/application-shell-connectors/src/index.ts
@@ -17,4 +17,5 @@ export {
   GetProjectExtensionImageRegex,
   ProjectExtensionProviderForImageRegex,
   withProjectExtensionImageRegex,
+  useProjectExtensionImageRegex,
 } from './components/project-extension-image-regex';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,6 +2735,7 @@ __metadata:
     moment-timezone: ^0.5.34
     prop-types: 15.8.1
     react: 17.0.2
+    tiny-warning: ^1.0.3
   peerDependencies:
     "@apollo/client": 3.x
     react: 17.x

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,7 +2735,7 @@ __metadata:
     moment-timezone: ^0.5.34
     prop-types: 15.8.1
     react: 17.0.2
-    tiny-warning: ^1.0.3
+    tiny-warning: 1.0.3
   peerDependencies:
     "@apollo/client": 3.x
     react: 17.x


### PR DESCRIPTION
Create react hook to access Project's images URLs rewrite rules configurations  information from context.
See more on ticket here: https://github.com/commercetools/merchant-center-application-kit/issues/2571