### PR TITLE
Fix ApplicationShell component aria roles issues

### DIFF
--- a/.changeset/quick-plums-wonder.md
+++ b/.changeset/quick-plums-wonder.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fixed aria role names.
+
+We were using invalid role names in some of the component's elements.
+
+Special mention to the element wrapping the notifications as it now uses the aria-live [attribute](https://www.w3.org/TR/wai-aria/#aria-live) (with **polite** value).

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -253,7 +253,6 @@ export const RestrictedApplication = <
                         userBusinessRole={user?.businessRole ?? undefined}
                       />
                       <div
-                        role="application-layout"
                         css={css`
                           height: 100vh;
                           display: grid;
@@ -263,7 +262,8 @@ export const RestrictedApplication = <
                       >
                         <div
                           ref={notificationsGlobalRef}
-                          role="global-notifications"
+                          role="region"
+                          aria-live="polite"
                           css={css`
                             grid-row: 1;
                             grid-column: 1/3;
@@ -321,7 +321,6 @@ export const RestrictedApplication = <
                         </Route>
 
                         <header
-                          role="header"
                           css={css`
                             grid-row: 2;
                             grid-column: 1/3;
@@ -334,7 +333,6 @@ export const RestrictedApplication = <
                         </header>
 
                         <aside
-                          role="aside"
                           css={css`
                             position: relative;
                             grid-row: 3;


### PR DESCRIPTION
### Summary

There are some invalid accessibility aria roles being used in the `ApplicationShell` component.

### Description

* We are using a role named **application-layout** which does not exist. The most similar actual role id **application** but I don't think it applies to this use case as it is suitable for elements ["that do not follow a standard interaction pattern"](https://www.w3.org/TR/wai-aria/#application) which I don't think it is the case. So I think we should remove this role altogether.
* We are using a role named **header** (which does not exist) in a **header** element. We must remove that role.
* We are using a role named **aside** (which does not exist) in a **aside** element. We must remove that role.
* We are using a role named **global-notifications** which does not exist. Since the element using this role is supposed to contain dynamic notifications that can be shown to the user, I think we should update the role to be **region** and to add the **aria-live** attribute ([reference](https://www.w3.org/TR/wai-aria/#aria-live)). For the value of this attribute, I would use **polite** as we can't know for sure what type of notifications will be shown but it does not seem we need to break the speech of a screen reader.

