### PR TITLE
Update viewport meta in main html template for applications

### DIFF
--- a/.changeset/slimy-apples-grab.md
+++ b/.changeset/slimy-apples-grab.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Removed _user-scalable=no_ property from `viewport` meta tag as it is a problem from the [accessibility point of view](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics).

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="referrer" content="no-referrer">
 
     <meta http-equiv="Content-Security-Policy" content="__CSP__">


### PR DESCRIPTION
### Summary

Remove *user-scalable=no* property from `viewport` meta tag as it is a problem from the accessibility point of view.

### Description

One of the findings of the accessibility report is about having a meta tag with *viewport* name that contains a value of *no* for *user-scalable* property.

(_This property only affects zooming in touch screen devices_).

As stated [in the documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics), this is an accessibility issue we should take care of.
