### PR TITLE
chore: export `TImageRegexContext` type from `@commercetools-frontend/application-shell-connectors`

### DIFF
--- a/.changeset/silver-cobras-switch.md
+++ b/.changeset/silver-cobras-switch.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+---
+
+Export `TImageRegexContext` type

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/index.ts
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/index.ts
@@ -1,3 +1,7 @@
+import type { TImageRegexContext as ImageRegexContext } from './project-extension-image-regex';
+
+export type TImageRegexContext = ImageRegexContext;
+
 export {
   GetProjectExtensionImageRegex,
   ProjectExtensionProviderForImageRegex,

--- a/packages/application-shell-connectors/src/export-types.ts
+++ b/packages/application-shell-connectors/src/export-types.ts
@@ -6,6 +6,7 @@ import type {
   TNormalizedActionRights as NormalizedActionRights,
   TNormalizedDataFences as NormalizedDataFences,
 } from './components/application-context';
+import type { TImageRegexContext as ImageRegexContext } from './components/project-extension-image-regex';
 
 export type TProviderProps<AdditionalEnvironmentProperties extends {}> =
   ProviderProps<AdditionalEnvironmentProperties>;
@@ -16,3 +17,5 @@ export type TNormalizedMenuVisibilities = NormalizedMenuVisibilities;
 export type TNormalizedPermissions = NormalizedPermissions;
 export type TNormalizedActionRights = NormalizedActionRights;
 export type TNormalizedDataFences = NormalizedDataFences;
+
+export type TImageRegexContext = ImageRegexContext;


### PR DESCRIPTION
This PR solves the issue with importing the `TImageRegexContext` type.

Allows to use:
`import type { TImageRegexContext } from '@commercetools-frontend/application-shell-connectors';`
instead of:
`import type { TImageRegexContext } from '@commercetools-frontend/application-shell-connectors/dist/declarations/src/components/project-extension-image-regex/project-extension-image-regex';`

Noticed while working [on docs](https://appkit-sha-a747a41965c62da2e0904ac906a67c69a185fb99.commercetools.vercel.app/custom-applications/api-reference/commercetools-frontend-application-shell-connectors#withprojectextensionimageregex)