### PR TITLE
`TabHeader` component accessibility improvements

### DIFF
--- a/.changeset/dry-planes-fry.md
+++ b/.changeset/dry-planes-fry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Accessibility improvements of the `TabHeader` component.

--- a/packages/application-components/src/components/tab-header/tab-header.tsx
+++ b/packages/application-components/src/components/tab-header/tab-header.tsx
@@ -19,10 +19,6 @@ const warnIfMissingContent = (props: TTabHeaderProps) => {
   );
 };
 
-const getDisabledTabHeaderAriaAttributes = (
-  isDisabled: TTabHeaderProps['isDisabled']
-) => (isDisabled ? { 'aria-disabled': true } : {});
-
 const getDisabledLinkAtributes = (isDisabled: TTabHeaderProps['isDisabled']) =>
   isDisabled ? { tabIndex: -1, 'aria-disabled': true } : {};
 
@@ -84,20 +80,16 @@ export const TabHeader = (props: TTabHeaderProps) => {
 
   return (
     <Link
+      role="tab"
+      aria-selected={isActive}
       to={props.to}
       css={getLinkStyles(isActive, isDisabled)}
       {...getDisabledLinkAtributes(isDisabled)}
       {...dataAttributeProps}
     >
-      <div
-        role="tab"
-        aria-selected={isActive}
-        {...getDisabledTabHeaderAriaAttributes(isDisabled)}
-      >
-        <Text.Subheadline as="h4" truncate={true}>
-          {label}
-        </Text.Subheadline>
-      </div>
+      <Text.Subheadline as="h4" truncate={true}>
+        {label}
+      </Text.Subheadline>
     </Link>
   );
 };

--- a/packages/application-components/src/components/tab-header/tab.styles.ts
+++ b/packages/application-components/src/components/tab-header/tab.styles.ts
@@ -42,7 +42,7 @@ export const getLinkStyles = (
   isActive &&
     css`
       ${getBottomBorderStyles(customProperties.colorPrimary)}
-      > * {
+      & h4 {
         color: ${customProperties.colorPrimary} !important;
       }
     `,
@@ -63,7 +63,7 @@ export const getLinkStyles = (
       :hover,
       :focus,
       :active {
-        > * {
+        & h4 {
           color: ${customProperties.colorPrimary} !important;
         }
       }

--- a/packages/application-components/src/components/tab-header/tab.styles.ts
+++ b/packages/application-components/src/components/tab-header/tab.styles.ts
@@ -42,7 +42,7 @@ export const getLinkStyles = (
   isActive &&
     css`
       ${getBottomBorderStyles(customProperties.colorPrimary)}
-      > * > * {
+      > * {
         color: ${customProperties.colorPrimary} !important;
       }
     `,
@@ -63,7 +63,7 @@ export const getLinkStyles = (
       :hover,
       :focus,
       :active {
-        > * > * {
+        > * {
           color: ${customProperties.colorPrimary} !important;
         }
       }


### PR DESCRIPTION
#### Summary

Accessibility improvements of the `TabHeader` component.
> Every tab must have a tab aria role and all of them must be direct children of another element with tablist role.

`Lighthouse` benchmark changes (measured for the `visual-testing-app` at `/tabular-main-page`)
Before: 
![screencapture-googlechrome-github-io-lighthouse-viewer-2022-06-23-14_46_28](https://user-images.githubusercontent.com/49066275/175303978-a75eb825-d3a8-4d44-b42f-a912b0a3fcde.png)
After:
![screencapture-googlechrome-github-io-lighthouse-viewer-2022-06-23-14_48_58](https://user-images.githubusercontent.com/49066275/175303962-601d3e01-4ba3-4080-b1a9-d00e6d721c6d.png)
