### PR TITLE
refactor(changesets): use fixed mode

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
     }
   ],
   "commit": false,
-  "linked": [
+  "fixed": [
     [
       "@commercetools-backend/*",
       "@commercetools-frontend/*",


### PR DESCRIPTION
We want to have all packages following the same version. This should also simplify documenting new releases.
