### PR TITLE
🚀 Speed up CI time by splitting up jobs

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -1,0 +1,36 @@
+name: CI
+
+description: Shared action with basic setup for each job
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node (uses version in .nvmrc)
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Get yarn cache
+      id: yarn-cache
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      shell: bash
+
+    - uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-v1-
+
+    - name: Install dependencies
+      run: yarn install --immutable
+      env:
+        # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L14-L18
+        # https://github.com/marketplace/actions/cypress-io#custom-install
+        CYPRESS_INSTALL_BINARY: "0"
+      shell: bash
+
+    - name: Building packages
+      run: yarn build
+      shell: bash

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/ci
+      - name: Install dependencies and build packages
+        uses: ./.github/actions/ci
 
       - name: Building Playground application
         run: yarn playground:build

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,33 @@
+name: Deployment
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy_playground:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/ci
+
+      - name: Building Playground application
+        run: yarn playground:build
+        env:
+          APP_ID: ${{ secrets.APP_ID_PLAYGROUND }}
+          MC_API_URL: ${{ secrets.MC_API_URL }}
+          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
+          HOST_GCP_STAGING: ${{ secrets.HOST_GCP_STAGING }}
+
+      - name: Deploying Playground application to Vercel (production)
+        run: |
+          yarn workspace playground run deploy --prod --token="${{ secrets.VERCEL_TOKEN_PLAYGROUND }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PLAYGROUND }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PLAYGROUND }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
   build_and_deploy_docs:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
     env:
@@ -124,7 +124,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/ci
+      - name: Install dependencies and build packages
+        uses: ./.github/actions/ci
 
       - name: Check for unmet constraints (fix w/ "yarn constraints --fix")
         run: yarn constraints
@@ -53,7 +54,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/ci
+      - name: Install dependencies and build packages
+        uses: ./.github/actions/ci
 
       - name: Building Visual Regression Tests application for UI components
         run: yarn visual-testing-app:build
@@ -79,7 +81,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/ci
+      - name: Install dependencies and build packages
+        uses: ./.github/actions/ci
 
       - name: Testing Starter application development server
         run: yarn start-server-and-test 'yarn template-starter:start' 3001 'exit 0'
@@ -133,7 +136,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/ci
+      - name: Install dependencies and build packages
+        uses: ./.github/actions/ci
 
       - name: Preparing tarballs of packages for testing templates installation
         run: node ./scripts/build-tarballs.js
@@ -160,7 +164,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/ci
+      - name: Install dependencies and build packages
+        uses: ./.github/actions/ci
 
       - name: Building Playground application
         run: yarn playground:build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
   lint_and_test:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
     env:
@@ -48,7 +48,7 @@ jobs:
   test_visual:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -68,7 +68,7 @@ jobs:
   test_starter_template:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
     env:
@@ -130,7 +130,7 @@ jobs:
 
     if: github.ref != 'refs/heads/main'
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -151,7 +151,7 @@ jobs:
   test_playground:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ on:
   pull_request:
 
 jobs:
-  build_lint_and_test:
+  lint_and_test:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 25
+    timeout-minutes: 15
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
     env:
@@ -27,34 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install dependencies
-        run: yarn install --immutable
-        env:
-          # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L14-L18
-          # https://github.com/marketplace/actions/cypress-io#custom-install
-          CYPRESS_INSTALL_BINARY: 0
+      - uses: ./.github/actions/ci
 
       - name: Check for unmet constraints (fix w/ "yarn constraints --fix")
         run: yarn constraints
-
-      - name: Building packages
-        run: yarn build
 
       - name: Running static type checking
         run: yarn typecheck
@@ -68,6 +44,43 @@ jobs:
           CI: true
           RTL_ASYNC_UTIL_TIMEOUT: 5000
 
+  test_visual:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/ci
+
+      - name: Building Visual Regression Tests application for UI components
+        run: yarn visual-testing-app:build
+
+      - name: Running Visual Regression Tests for UI components
+        run: "yarn vrt:components"
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_UI_COMPONENTS }}
+
+  test_starter_template:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+
+    # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/ci
+
       - name: Testing Starter application development server
         run: yarn start-server-and-test 'yarn template-starter:start' 3001 'exit 0'
         env:
@@ -76,14 +89,10 @@ jobs:
           MC_API_URL: ${{ secrets.MC_API_URL }}
           CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
 
-      - name: Building Visual Regression Tests application for UI components
-        run: yarn visual-testing-app:build
-
-      - name: Running Visual Regression Tests for UI components
-        run: "yarn vrt:components"
-        timeout-minutes: 20
+      - name: Building Starter template application
+        run: yarn template-starter:build
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_UI_COMPONENTS }}
+          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
 
       # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L23-L30
       # https://github.com/marketplace/actions/cypress-io#custom-install
@@ -99,41 +108,6 @@ jobs:
       - name: Installing Cypress binary
         run: yarn cypress install && yarn cypress cache list
 
-      - name: Building Playground application
-        run: yarn playground:build
-        env:
-          APP_ID: ${{ secrets.APP_ID_PLAYGROUND }}
-          MC_API_URL: ${{ secrets.MC_API_URL }}
-          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
-          HOST_GCP_STAGING: ${{ secrets.HOST_GCP_STAGING }}
-
-      - name: Running End-to-End tests for Playground application
-        run: yarn start-server-and-test 'yarn playground:start:prod:local' 3001 'yarn percy exec -- yarn test:e2e:playground'
-        env:
-          NODE_ENV: test
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E_PLAYGROUND }}
-          CYPRESS_CI: "true"
-          CYPRESS_LOGIN_USER: ${{ secrets.CYPRESS_LOGIN_USER }}
-          CYPRESS_LOGIN_PASSWORD: ${{ secrets.CYPRESS_LOGIN_PASSWORD }}
-          CYPRESS_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
-          HOST_GCP_STAGING: ${{ secrets.HOST_GCP_STAGING }}
-          APP_ID: ${{ secrets.APP_ID_PLAYGROUND }}
-          MC_API_URL: ${{ secrets.MC_API_URL }}
-          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
-
-      - name: Deploying Playground application to Vercel (production)
-        if: github.ref == 'refs/heads/main'
-        run: |
-          yarn workspace playground run deploy --prod --token="${{ secrets.VERCEL_TOKEN_PLAYGROUND }}"
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PLAYGROUND }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PLAYGROUND }}
-
-      - name: Building Starter template application
-        run: yarn template-starter:build
-        env:
-          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
-
       - name: Running End-to-End tests for Starter template application
         run: yarn start-server-and-test 'yarn template-starter:start:prod:local' 3001 'yarn percy exec -- yarn test:e2e:template-starter'
         env:
@@ -148,87 +122,78 @@ jobs:
           MC_API_URL: ${{ secrets.MC_API_URL }}
           CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
 
-      - name: Uploading Cypress artifacts
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-videos
-          path: cypress/videos
+  test_starter_template_installation:
+    runs-on: ubuntu-latest
+
+    if: github.ref != 'refs/heads/main'
+
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/ci
 
       - name: Preparing tarballs of packages for testing templates installation
-        if: github.ref != 'refs/heads/main'
         run: node ./scripts/build-tarballs.js
 
-      # TODO: in the future we want to extract this step into a separate job to be able
-      # to test this in multiple environments (macOS, Window) and with different node
-      # versions (13, 14). This can be done using the action strategy matrix.
-      # However, in order to do that, we need to be able to persist the tarballs between
-      # jobs. This can be done by using the upload/download artifacts actions.
-      # However, at this time there is no option to clean up the artifacts automatically
-      # after the workflow ends, and the artifacts will stay for 90 days.
-      # Some related issues:
-      # - https://github.com/actions/upload-artifact/issues/5
-      # - https://github.com/actions/upload-artifact/issues/45
       - name: Installing and building template starter
-        if: github.ref != 'refs/heads/main'
         run: node ./scripts/install-template.js
         env:
           TEMPLATE_NAME: starter
           CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
-  #     - name: Uploading tarball artifacts
-  #       uses: actions/upload-artifact@v1
-  #       with:
-  #         name: dist-tarballs
-  #         path: dist-tarballs
-  # install_template_starter:
-  #   needs: build_lint_and_test
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [macos-latest, windows-latest]
-  #       node: [13, 14]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: dist-tarballs
-  #         path: dist-tarballs
-  #     - name: Setup node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node }}
-  #     - name: Installing shelljs globally
-  #       run: yarn add global shelljs
-  #     - name: Installing and building template starter
-  #       run: node ./scripts/install-template.js
-  #       env:
-  #         TEMPLATE_NAME: starter
-  #     - name: Fetching workflow artifacts
-  #       uses: octokit/request-action@v2.x
-  #       if: always()
-  #       id: get_workflow_artifacts
-  #       with:
-  #         route: GET /repos/:owner/:repository/actions/runs/:run_id/artifacts
-  #         owner: commercetools
-  #         repository: ${{ github.repository }}
-  #         run_id: ${{ github.run_id }}
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Parsing result to get the artifact_id
-  #       uses: gr2m/get-json-paths-action@v1.x
-  #       if: always()
-  #       id: get_artifact_id
-  #       with:
-  #         json: ${{ steps.get_workflow_artifacts.outputs.data }}
-  #         artifact_id: "artifacts[0].id"
-  #     - name: Deleting workflow artifact
-  #       uses: octokit/request-action@v2.x
-  #       if: always()
-  #       with:
-  #         route: DELETE /repos/:owner/:repository/actions/artifacts/:artifact_id
-  #         owner: commercetools
-  #         repository: ${{ github.repository }}
-  #         artifact_id: ${{ steps.get_artifact_id.outputs.artifact_id }}
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test_playground:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+
+    # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L8-L11
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/ci
+
+      - name: Building Playground application
+        run: yarn playground:build
+        env:
+          APP_ID: ${{ secrets.APP_ID_PLAYGROUND }}
+          MC_API_URL: ${{ secrets.MC_API_URL }}
+          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
+          HOST_GCP_STAGING: ${{ secrets.HOST_GCP_STAGING }}
+
+      # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L23-L30
+      # https://github.com/marketplace/actions/cypress-io#custom-install
+      - name: Restoring Cypress cache
+        # restore / cache the binary ourselves on Linux
+        # see https://github.com/actions/cache
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+
+      - name: Installing Cypress binary
+        run: yarn cypress install && yarn cypress cache list
+
+      - name: Running End-to-End tests for Playground application
+        run: yarn start-server-and-test 'yarn playground:start:prod:local' 3001 'yarn percy exec -- yarn test:e2e:playground'
+        env:
+          NODE_ENV: test
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E_PLAYGROUND }}
+          CYPRESS_CI: "true"
+          CYPRESS_LOGIN_USER: ${{ secrets.CYPRESS_LOGIN_USER }}
+          CYPRESS_LOGIN_PASSWORD: ${{ secrets.CYPRESS_LOGIN_PASSWORD }}
+          CYPRESS_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
+          HOST_GCP_STAGING: ${{ secrets.HOST_GCP_STAGING }}
+          APP_ID: ${{ secrets.APP_ID_PLAYGROUND }}
+          MC_API_URL: ${{ secrets.MC_API_URL }}
+          CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
As our CI pipeline is growing with many different things that we need to build and test, having one single workflow takes longer and longer. For example, having a second starter template (#2615 ) will increase the time even more.

As of now, a CI run takes between 15 and 20 minutes.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/1110551/175540245-4fa67499-9368-4685-acb3-aab2fa82d927.png">

Using one workflow has some benefits, like installing dependencies and building packages once. However, it's highly sequential even though many steps don't relate with each other.

To speed things up and make our CI more resilient and useful, I experimented a bit with using multiple smaller jobs:
* `lint_and_test`: runs the main typechecking on the repo as well as all linters and tests
* `test_visual`: runs only the VRTs of the UI components
* `test_starter_template`: runs only the build and tests of the starter template application
* `test_starter_template_installation`: runs the installation workflow of the starter template application
* `test_playground`: runs only the build and tests of the playground application

As you can see, the grouping is done based on the different applications or use cases.

All these jobs share a common CI setup (installing dependencies and building packages) which has been extracted into a so-called [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).

One drawback is that every job now installs the dependencies and builds the packages on their own. However, it seems that the time it takes is less than 3 minutes (considering the cache) so it's overall acceptable considering that these jobs now take between 5 and 10 minutes.

Compared to the previous setup with a single workflow, it appears that by splitting up the jobs a CI run now takes less than a half of the time it took before 🚀

Additionally, all jobs now have a reduced timeout to 10 minutes.

NOTE: I split one more job into a separate workflow for deploying the playground app to Vercel. This workflow only runs on the main branch.