### PR TITLE
chore: renamed Platform Support to Support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: true
 contact_links:
-  - name: commercetools Platform Support
+  - name: commercetools Support
     url: https://jira.commercetools.com/servicedesk/customer/portal/1
     about: Have an issue or question that contains sensitive or customer information? Ask our support team!


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

According to the rebranding, changing Platform Support to Support.
