### PR TITLE
fix(create-mc-app): formatting of patched constants file

### DIFF
--- a/.changeset/ten-dogs-tickle.md
+++ b/.changeset/ten-dogs-tickle.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Fix file formatting when patching constants file

--- a/packages/create-mc-app/src/tasks/update-application-constants.js
+++ b/packages/create-mc-app/src/tasks/update-application-constants.js
@@ -1,6 +1,8 @@
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
+const rcfile = require('rcfile');
+const prettier = require('prettier');
 const babel = require('@babel/core');
 const { resolveFilePathByExtension } = require('../utils');
 
@@ -24,7 +26,11 @@ function replaceEntryPointUriPathInConstants(filePath, options) {
     retainLines: true,
   });
 
-  fs.writeFileSync(filePath, result.code + os.EOL, {
+  const prettierConfig = rcfile('prettier', {
+    cwd: options.projectDirectoryPath,
+  });
+  const formattedData = prettier.format(result.code + os.EOL, prettierConfig);
+  fs.writeFileSync(filePath, formattedData, {
     encoding: 'utf8',
   });
 }


### PR DESCRIPTION
To prevent lint errors when installing the template.