### PR TITLE
fix(mc-scripts): parsing of CLI options casing

### DIFF
--- a/.changeset/ninety-drinks-relate.md
+++ b/.changeset/ninety-drinks-relate.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix parsing of CLI options casing

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -74,7 +74,8 @@ const run = () => {
     )
     .option(
       '--build-only',
-      '(optional) If defined, the command only creates the production bundles without compiling the "index.html".'
+      '(optional) If defined, the command only creates the production bundles without compiling the "index.html".',
+      { default: false }
     )
     .action(async (options: TCliCommandBuildOptions & TCliGlobalOptions) => {
       // Load dotenv files into the process environment.
@@ -101,11 +102,11 @@ const run = () => {
         : await import('./commands/build');
       await buildCommand.default();
 
-      const shouldAlsoCompile = !options['build-only'];
+      const shouldAlsoCompile = !options.buildOnly;
       if (shouldAlsoCompile) {
         console.log('');
         const compileHtmlCommand = await import('./commands/compile-html');
-        await compileHtmlCommand.default();
+        await compileHtmlCommand.default({ printSecurityHeaders: false });
       }
     });
 
@@ -121,7 +122,8 @@ const run = () => {
     )
     .option(
       '--print-security-headers',
-      '(optional) If defined, the compiled security headers are printed to stdout.'
+      '(optional) If defined, the compiled security headers are printed to stdout.',
+      { default: false }
     )
     .action(
       async (options: TCliCommandCompileHtmlOptions & TCliGlobalOptions) => {
@@ -181,7 +183,8 @@ const run = () => {
     )
     .option(
       '--dry-run',
-      '(optional) Executes the command but does not send any mutation request.'
+      '(optional) Executes the command but does not send any mutation request.',
+      { default: false }
     )
     .action(
       async (options: TCliCommandConfigSyncOptions & TCliGlobalOptions) => {

--- a/packages/mc-scripts/src/commands/compile-html.ts
+++ b/packages/mc-scripts/src/commands/compile-html.ts
@@ -6,7 +6,7 @@ import type { TCliCommandCompileHtmlOptions } from '../types';
 
 const appDirectory = fs.realpathSync(process.cwd());
 
-async function run(options: TCliCommandCompileHtmlOptions = {}) {
+async function run(options: TCliCommandCompileHtmlOptions) {
   console.log('Compiling index.html...');
   const compiled = await compileHtml(paths.appIndexHtmlTemplate);
 
@@ -28,7 +28,7 @@ async function run(options: TCliCommandCompileHtmlOptions = {}) {
         }`
       );
     }
-  } else if (options['print-security-headers']) {
+  } else if (options.printSecurityHeaders) {
     console.log(JSON.stringify(compiled.headers));
   }
 

--- a/packages/mc-scripts/src/commands/config-sync.ts
+++ b/packages/mc-scripts/src/commands/config-sync.ts
@@ -27,7 +27,7 @@ const getMcUrlLink = (
   return customAppLink;
 };
 
-async function run(options: TCliCommandConfigSyncOptions = {}) {
+async function run(options: TCliCommandConfigSyncOptions) {
   const applicationConfig = processConfig();
   const { data: localCustomAppData } = applicationConfig;
   const { mcApiUrl } = applicationConfig.env;
@@ -100,7 +100,7 @@ async function run(options: TCliCommandConfigSyncOptions = {}) {
     }
 
     const data = omit(localCustomAppData, ['id']);
-    if (options['dry-run']) {
+    if (options.dryRun) {
       console.log(chalk.gray('DRY RUN mode'));
       console.log(
         `A new Custom Application would be created for the Organization ${organizationName} with the following payload:`
@@ -170,7 +170,7 @@ async function run(options: TCliCommandConfigSyncOptions = {}) {
   }
 
   const data = omit(localCustomAppData, ['id']);
-  if (options['dry-run']) {
+  if (options.dryRun) {
     console.log(chalk.gray('DRY RUN mode'));
     console.log(
       `The Custom Application ${data.name} would be updated with the following payload:`

--- a/packages/mc-scripts/src/types.ts
+++ b/packages/mc-scripts/src/types.ts
@@ -4,16 +4,16 @@ export type TCliGlobalOptions = {
 };
 
 export type TCliCommandBuildOptions = {
-  'build-only'?: boolean;
+  buildOnly: boolean;
 };
 
 export type TCliCommandCompileHtmlOptions = {
   transformer?: string;
-  'print-security-headers'?: boolean;
+  printSecurityHeaders: boolean;
 };
 
 export type TCliCommandConfigSyncOptions = {
-  'dry-run'?: boolean;
+  dryRun: boolean;
 };
 
 export type TMcCliAuthToken = {


### PR DESCRIPTION
Small regression of #2613 

The CLI options are now parsed as camelCase with the [parsing library we're using now](https://www.npmjs.com/package/cac).

I totally missed that part of the docs:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/1110551/177108442-c5ca8273-2809-4920-ac04-0001da2cb038.png">
