### PR TITLE
Add workflow to handle staled issues

### DIFF
--- a/.github-labelsrc.json
+++ b/.github-labelsrc.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 4294819708,
-    "name": "⌛ Status: Waiting for Customer",
+    "name": "⌛ Status: Awaiting for feedback",
     "color": "000000",
     "description": "Waiting for the answer from customer"
   },

--- a/.github-labelsrc.json
+++ b/.github-labelsrc.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": 4294819708,
+    "name": "⌛ Status: Waiting for Customer",
+    "color": "000000",
+    "description": "Waiting for the answer from customer"
+  },
+  {
     "id": 1083802571,
     "name": "⛑ Type: Refactoring",
     "color": "58ce3d",

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          any-of-labels: "⌛ Status: Waiting for Customer"
+          any-of-labels: "⌛ Status: Awaiting for feedback"
           start-date: "2022-05-01 00:00:00.000"
           days-before-issue-stale: 14
           days-before-issue-close: 14

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,24 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          any-of-labels: "⌛ Status: Waiting for Customer"
+          start-date: "2022-05-01 00:00:00.000"
+          days-before-issue-stale: 14
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been marked as 'stale' due to its inactivity for the last 14 days. Please, add a new comment to keep the conversation going; otherwise, the issue will be closed in two weeks."
+          close-issue-message: "This issue has been closed due to its inactivity for the last month. Please, feel free to reopen it and add a new comment in case you think the problem has not been resolved."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 50
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Summary

Add a new GitHub workflow so we can automatically handle those opened issues which we already replied to but the author do not reply back for a long time.

#### Description

Configuration:
* Requires the issue to have a specific label
* 14 days to mark it as stale
* another 14 days (on top of the previous ones) to close it
