### PR TITLE
Add information covering session expiration period

### DIFF
--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -80,8 +80,6 @@ In local development the authentication is handled a bit differently using a Ope
 
 The session token `mcAccessToken` is granted upon user login and is stored in a secure cookie in the browser.
 
-The current expiration period for the session token is 30 days.
-
 The Merchant Center API provides two endpoints for authenticating a user:
 
 - `/tokens`: for normal login using `email` and `password`.

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -62,7 +62,7 @@ To make it easier to reference the Merchant Center API URL, for example in the [
 
 The Merchant Center API is protected by a session token via the HTTP `Cookie` header, which is set only for `<cloud-region>.commercetools.com` domains.
 
-In the browser, the session token is stored in a secure cookie named `mcAccessToken`.
+In the browser, the session token is stored in a secure cookie named `mcAccessToken` and is valid for 30 days.
 
 ```
 Cookie: mcAccessToken=<jwt>

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -80,6 +80,8 @@ In local development the authentication is handled a bit differently using a Ope
 
 The session token `mcAccessToken` is granted upon user login and is stored in a secure cookie in the browser.
 
+The current expiration period for the session token is 30 days.
+
 The Merchant Center API provides two endpoints for authenticating a user:
 
 - `/tokens`: for normal login using `email` and `password`.

--- a/website/src/content/help-needed.mdx
+++ b/website/src/content/help-needed.mdx
@@ -126,6 +126,10 @@ export const PERMISSIONS = entryPointUriPathToPermissionKeys(entryPointUriPath);
 ```
 </Info>
 
+# Session token expiration
+
+In the browser, the session token is stored in a secure cookie named `mcAccessToken` and is valid for 30 days.
+
 
 # Limitations
 


### PR DESCRIPTION
Currently, the documentation doesn't convey any information regarding the expiration period for the token issued by the MC. This question is being asked quite often by customers and various departments internally.

We need to document that the current expiration period for the token issued by the Merchant Center is  30 days. 