### PR TITLE
chore: update Sentry dependencies to `v7`

### DIFF
--- a/.changeset/strong-windows-hammer.md
+++ b/.changeset/strong-windows-hammer.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-backend/loggers': patch
+'@commercetools-frontend/sentry': patch
+---
+
+Update Sentry dependencies to v7"

--- a/packages-backend/loggers/package.json
+++ b/packages-backend/loggers/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@babel/runtime-corejs3": "^7.18.6",
-    "@sentry/node": "6.19.7",
+    "@sentry/node": "7.6.0",
     "@types/triple-beam": "1.3.2",
     "express-winston": "4.2.0",
     "fast-safe-stringify": "2.1.1",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -21,14 +21,14 @@
     "@babel/runtime": "^7.18.6",
     "@babel/runtime-corejs3": "^7.18.6",
     "@commercetools-frontend/constants": "21.8.1",
-    "@sentry/browser": "6.19.7",
+    "@sentry/browser": "7.6.0",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.47",
     "prop-types": "15.8.1"
   },
   "devDependencies": {
     "react": "17.0.2",
-    "sentry-testkit": "3.3.7",
+    "sentry-testkit": "4.0.1",
     "wait-for-expect": "3.0.2"
   },
   "peerDependencies": {

--- a/packages/sentry/src/sentry.spec.ts
+++ b/packages/sentry/src/sentry.spec.ts
@@ -36,7 +36,7 @@ describe('reporting to sentry', () => {
     Sentry.init({
       dsn: DUMMY_DSN,
       release: 'test',
-      transport: sentryTransport,
+      transport: () => new sentryTransport(),
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,7 +3225,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.18.6
     "@babel/runtime-corejs3": ^7.18.6
-    "@sentry/node": 6.19.7
+    "@sentry/node": 7.6.0
     "@tsconfig/node16": ^1.0.3
     "@types/triple-beam": 1.3.2
     express: 4.18.1
@@ -4064,12 +4064,12 @@ __metadata:
     "@babel/runtime": ^7.18.6
     "@babel/runtime-corejs3": ^7.18.6
     "@commercetools-frontend/constants": 21.8.1
-    "@sentry/browser": 6.19.7
+    "@sentry/browser": 7.6.0
     "@types/prop-types": ^15.7.5
     "@types/react": ^17.0.47
     prop-types: 15.8.1
     react: 17.0.2
-    sentry-testkit: 3.3.7
+    sentry-testkit: 4.0.1
     wait-for-expect: 3.0.2
   peerDependencies:
     react: 17.x
@@ -9684,18 +9684,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/browser@npm:6.19.7"
-  dependencies:
-    "@sentry/core": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: 071d00c76c2d0384580474c634c58c6196bbd1a3cf510da1309bd1565c57df7422fca8ceb717db189fa557f2c711a21664ee1ab935dfd9869faf416d388e6f78
-  languageName: node
-  linkType: hard
-
 "@sentry/browser@npm:7.1.1":
   version: 7.1.1
   resolution: "@sentry/browser@npm:7.1.1"
@@ -9708,16 +9696,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/core@npm:6.19.7"
+"@sentry/browser@npm:7.6.0":
+  version: 7.6.0
+  resolution: "@sentry/browser@npm:7.6.0"
   dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/minimal": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
+    "@sentry/core": 7.6.0
+    "@sentry/types": 7.6.0
+    "@sentry/utils": 7.6.0
     tslib: ^1.9.3
-  checksum: d212e8ef07114549de4a93b81f8bfa217ca1550ca7a5eeaa611e5629faef78ff72663ce561ffa2cff48f3dc556745ef65177044f9965cdd3cbccf617cf3bf675
+  checksum: baf0ee62cb5bbfa0abd6e15e53a8a7072c26a2a456a873ca12991b8f33fdba3abede9fc55034679b07282346de3b1fd74651d5c99e1ce88f470132f960445333
   languageName: node
   linkType: hard
 
@@ -9733,14 +9720,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/hub@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/hub@npm:6.19.7"
+"@sentry/core@npm:7.6.0":
+  version: 7.6.0
+  resolution: "@sentry/core@npm:7.6.0"
   dependencies:
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
+    "@sentry/hub": 7.6.0
+    "@sentry/types": 7.6.0
+    "@sentry/utils": 7.6.0
     tslib: ^1.9.3
-  checksum: 10bb1c5cba1b0f1e27a3dd0a186c22f94aeaf11c4662890ab07b2774f46f46af78d61e3ba71d76edc750a7b45af86edd032f35efecdb4efa2eaf551080ccdcb1
+  checksum: bef8f89599c3849e2f24273d2c0045d4095c4297a6b9b2e9d4d6e409f2ad1584b88b1ac0b958339d9bcdbf47bc33a807cfad2442dae4c021e13d90f7a223a66d
   languageName: node
   linkType: hard
 
@@ -9755,37 +9743,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/minimal@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/minimal@npm:6.19.7"
+"@sentry/hub@npm:7.6.0":
+  version: 7.6.0
+  resolution: "@sentry/hub@npm:7.6.0"
   dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/types": 6.19.7
+    "@sentry/types": 7.6.0
+    "@sentry/utils": 7.6.0
     tslib: ^1.9.3
-  checksum: 9153ac426ee056fc34c5be898f83d74ec08f559d69f544c5944ec05e584b62ed356b92d1a9b08993a7022ad42b5661c3d72881221adc19bee5fc1af3ad3864a8
+  checksum: 436c546ac0418efdbd8e07e65feac2bb9965fdd4c44dbb7a033eb1211b2a8ccb7c01f5db7e8b80032da81d3af23a807a66a9e1490133dbed3c9b90c0a378ccf3
   languageName: node
   linkType: hard
 
-"@sentry/node@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/node@npm:6.19.7"
+"@sentry/node@npm:7.6.0":
+  version: 7.6.0
+  resolution: "@sentry/node@npm:7.6.0"
   dependencies:
-    "@sentry/core": 6.19.7
-    "@sentry/hub": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
+    "@sentry/core": 7.6.0
+    "@sentry/hub": 7.6.0
+    "@sentry/types": 7.6.0
+    "@sentry/utils": 7.6.0
     cookie: ^0.4.1
     https-proxy-agent: ^5.0.0
     lru_map: ^0.3.3
     tslib: ^1.9.3
-  checksum: 2293b0d1d1f9fac3a451eb94f820bc27721c8edddd1f373064666ddd6272f0a4c70dbe58c6c4b3d3ccaf4578aab8f466d71ee69f6f6ff93521bbb02dfe829ce5
-  languageName: node
-  linkType: hard
-
-"@sentry/types@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/types@npm:6.19.7"
-  checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
+  checksum: aa359da32bfeb298dd7b3da8ef66d5adc32b2d229ad834026d9646bbb373282089f4367713efb3ed067c8eed1c7cadc2a28843a59acbcb932e1aac873bed3833
   languageName: node
   linkType: hard
 
@@ -9796,13 +9777,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/utils@npm:6.19.7"
-  dependencies:
-    "@sentry/types": 6.19.7
-    tslib: ^1.9.3
-  checksum: a000223b9c646c64e3565e79cace1eeb75114342b768367c4dddd646476c215eb1bddfb70c63f05e2352d3bce2d7d415344e4757a001605d0e01ac74da5dd306
+"@sentry/types@npm:7.6.0":
+  version: 7.6.0
+  resolution: "@sentry/types@npm:7.6.0"
+  checksum: 679f786e34af1ef395c0539ed1530b4825931d77e228f30527a82291d4d62bf7d5841660b76a5f0c42531b0d70ed2900ed1b8f64359964c33fa299a44f7af007
   languageName: node
   linkType: hard
 
@@ -9813,6 +9791,16 @@ __metadata:
     "@sentry/types": 7.1.1
     tslib: ^1.9.3
   checksum: b36d0e03b007229cad81dc8db517c4bf58c8e7636aa80a575dc91fb605028c1a0b61e5f090704e04b5e9021fd8ec95b1a6f1465449f2a1a6c657b283295add71
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.6.0":
+  version: 7.6.0
+  resolution: "@sentry/utils@npm:7.6.0"
+  dependencies:
+    "@sentry/types": 7.6.0
+    tslib: ^1.9.3
+  checksum: 6c5a20ca67883b5c5900005d26ad0599ee13ea367fbf9ec9fa9415efaf2df75c578d04f784773943cff03a44dff59c3fcc8cf712690b093707bb8d33aec5543c
   languageName: node
   linkType: hard
 
@@ -33227,13 +33215,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sentry-testkit@npm:3.3.7":
-  version: 3.3.7
-  resolution: "sentry-testkit@npm:3.3.7"
+"sentry-testkit@npm:4.0.1":
+  version: 4.0.1
+  resolution: "sentry-testkit@npm:4.0.1"
   dependencies:
     body-parser: ^1.19.0
     express: ^4.17.1
-  checksum: d6645dc2c78092541693ed1d6533bfa045a35ff2da16708feb887e3d6f97b9405bf72d50a661587bd43edb505d3db78271cd99e3bfd50ef0c794b03e8ac7688f
+  checksum: 808dd013a15b2bae84de40e6ee02b86c279e88b5815690861dd4170c680243029fab0081b08c6654f8e93e2aa83def6e3157eb1270abaf92e9fbf8761a3afbdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Extracted from #2623

There are no breaking changes that affect us.