### PR TITLE
refactor(oidc-callback): replace flaky e2e/vrt tests with unit tests

### DIFF
--- a/cypress/integration/playground/application-shell.ts
+++ b/cypress/integration/playground/application-shell.ts
@@ -1,10 +1,6 @@
 import { encode } from 'qss';
 import { LOGOUT_REASONS } from '@commercetools-frontend/constants';
-import {
-  URL_BASE,
-  URL_APP_KIT_PLAYGROUND,
-  ENTRY_POINT_APP_KIT_PLAYGROUND,
-} from '../../support/urls';
+import { URL_BASE, ENTRY_POINT_APP_KIT_PLAYGROUND } from '../../support/urls';
 
 describe('when user is authenticated', () => {
   beforeEach(() => {
@@ -54,24 +50,5 @@ describe('navigation menu', () => {
       expect(win.localStorage.getItem('isForcedMenuOpen')).to.equal('true')
     );
     cy.percySnapshot();
-  });
-});
-
-describe('failed OIDC authentication', () => {
-  describe('when sessionToken is missing', () => {
-    it('should show oidc callback error page', () => {
-      cy.visit(`/${URL_APP_KIT_PLAYGROUND}/oidc/callback`);
-      cy.findByText('Authentication error');
-      cy.findByText(/missing sessionToken/i);
-      cy.percySnapshot();
-    });
-  });
-  describe('when sessionToken is invalid', () => {
-    it('should show oidc callback error page', () => {
-      cy.visit(`/${URL_APP_KIT_PLAYGROUND}/oidc/callback#sessionToken=123`);
-      cy.findByText('Authentication error');
-      cy.findByText(/invalid token specified/i);
-      cy.percySnapshot();
-    });
   });
 });

--- a/packages/application-shell/src/components/authenticated/oidc-callback.spec.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback.spec.tsx
@@ -1,0 +1,27 @@
+import { renderApp, screen } from '../../test-utils';
+import OidcCallback from './oidc-callback';
+
+describe('failed OIDC authentication', () => {
+  describe('when sessionToken is missing', () => {
+    it('should show oidc callback error page', async () => {
+      renderApp(<OidcCallback locale="en" applicationMessages={{}} />, {
+        route: '/project/app/oidc/callback',
+        disableAutomaticEntryPointRoutes: true,
+        disableRoutePermissionCheck: true,
+      });
+      await screen.findByText('Authentication error');
+      screen.getByText('Invalid client session (missing sessionToken)');
+    });
+  });
+  describe('when sessionToken is invalid', () => {
+    it('should show oidc callback error page', async () => {
+      renderApp(<OidcCallback locale="en" applicationMessages={{}} />, {
+        route: '/project/app/oidc/callback#sessionToken=123',
+        disableAutomaticEntryPointRoutes: true,
+        disableRoutePermissionCheck: true,
+      });
+      await screen.findByText('Authentication error');
+      screen.getByText('Invalid token specified');
+    });
+  });
+});


### PR DESCRIPTION
Lately the E2E / Percy tests for the OIDC callback error pages seem to be consistently flaky.

This causes many PRs to fail the snapshot tests.

So instead of snapshot tests, let's just write some simple unit tests.