### PR TITLE
ci: add separate workflow for content check, with reviewdog support

### DIFF
--- a/.github/workflows/docs-content-check.yaml
+++ b/.github/workflows/docs-content-check.yaml
@@ -1,0 +1,42 @@
+name: Documentation content check
+
+# The `vale` GitHub action does not work on PR events so this is triggered on all pushes.
+on: [pull_request]
+
+jobs:
+  writing_style:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node (uses version in .nvmrc)
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download .vale.ini from @commercetools-docs/writing-style
+        run: |
+          package_version=$(node -e "console.log(require('./package.json').dependencies['$INSTALL_PACKAGE'])")
+          echo "Removing package.json and yarn.lock to avoid installation issues"
+          rm package.json yarn.lock
+          echo "Installing $INSTALL_PACKAGE@$package_version"
+          npm install --no-save "$INSTALL_PACKAGE@$package_version"
+        env:
+          SKIP_POSTINSTALL_DEV_SETUP: true
+          INSTALL_PACKAGE: '@commercetools-docs/writing-style'
+
+      - name: Check content (generates GitHub comments via `reviewdog`)
+        uses: errata-ai/vale-action@reviewdog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: '["website"]'
+          reporter: github-pr-review
+          filter_mode: diff_context
+          fail_on_error: true
+          vale_flags: '--config=node_modules/@commercetools-docs/writing-style/.vale.ini'
+          debug: true

--- a/.github/workflows/docs-content-check.yaml
+++ b/.github/workflows/docs-content-check.yaml
@@ -18,16 +18,17 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Download .vale.ini from @commercetools-docs/writing-style
+      - name: Download .vale.ini and style rules from @commercetools-docs/writing-style
         run: |
-          package_version=$(node -e "console.log(require('./package.json').dependencies['$INSTALL_PACKAGE'])")
+          package_version=$(node -e "console.log(require('./package.json').dependencies['$PACKAGE_NAME'])")
+
           echo "Removing package.json and yarn.lock to avoid installation issues"
           rm package.json yarn.lock
-          echo "Installing $INSTALL_PACKAGE@$package_version"
-          npm install --no-save "$INSTALL_PACKAGE@$package_version"
+
+          echo "Installing $PACKAGE_NAME@$package_version"
+          npm install --no-save "$PACKAGE_NAME@$package_version"
         env:
-          SKIP_POSTINSTALL_DEV_SETUP: true
-          INSTALL_PACKAGE: '@commercetools-docs/writing-style'
+          PACKAGE_NAME: '@commercetools-docs/writing-style'
 
       - name: Check content (generates GitHub comments via `reviewdog`)
         uses: errata-ai/vale-action@reviewdog

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn typecheck:starter
 
       - name: Running linters and tests
-        run: yarn jest --projects jest.{eslint,stylelint,test,text}.config.js --reporters jest-silent-reporter
+        run: yarn jest --projects jest.{eslint,stylelint,test}.config.js --reporters jest-silent-reporter
         env:
           CI: true
           RTL_ASYNC_UTIL_TIMEOUT: 5000

--- a/website/src/content/getting-started.mdx
+++ b/website/src/content/getting-started.mdx
@@ -14,7 +14,7 @@ Before you start development, make sure to have the following:
 
 # Installing a starter template
 
-The easiest way to get started is to use one of the [_starter templates_](https://github.com/commercetools/merchant-center-application-kit/tree/main/application-templates).
+So, The easiest way to get started is to use one of the [_starter templates_](https://github.com/commercetools/merchant-center-application-kit/tree/main/application-templates).
 
 We recommend creating a new Custom Application using [`create-mc-app`](/api-reference/create-mc-app), which automatically sets up one of the starter templates for you.
 

--- a/website/src/content/getting-started.mdx
+++ b/website/src/content/getting-started.mdx
@@ -14,7 +14,7 @@ Before you start development, make sure to have the following:
 
 # Installing a starter template
 
-So, The easiest way to get started is to use one of the [_starter templates_](https://github.com/commercetools/merchant-center-application-kit/tree/main/application-templates).
+The easiest way to get started is to use one of the [_starter templates_](https://github.com/commercetools/merchant-center-application-kit/tree/main/application-templates).
 
 We recommend creating a new Custom Application using [`create-mc-app`](/api-reference/create-mc-app), which automatically sets up one of the starter templates for you.
 


### PR DESCRIPTION
See https://github.com/errata-ai/vale-action

TL;DR: We will get github inline comments whenever there are writing style errors.