### PR TITLE
docs: add example of Azure deployment with Static Web Apps

### DIFF
--- a/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
+++ b/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
@@ -29,6 +29,21 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<site>.cloudfront.net"
+    }
+  }
+}
+```
+
 # Set up S3 and CloudFront
 
 To host the production bundles of your Custom Application you need to create some resources in AWS, like an S3 bucket, configure a CloudFront distribution, etc.
@@ -46,21 +61,6 @@ A Custom Application is set up in a very similar way as a Create React App. Ther
 
 The main command to create the production bundles is `mc-scripts build`. The output folder is `public`.<br />
 See [Going to production](/development/going-to-production) for more information.
-
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<site>.cloudfront.net"
-    }
-  }
-}
-```
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
+++ b/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
@@ -29,21 +29,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<site>.cloudfront.net"
-    }
-  }
-}
-```
-
 # Set up S3 and CloudFront
 
 To host the production bundles of your Custom Application you need to create some resources in AWS, like an S3 bucket, configure a CloudFront distribution, etc.
@@ -61,6 +46,21 @@ A Custom Application is set up in a very similar way as a Create React App. Ther
 
 The main command to create the production bundles is `mc-scripts build`. The output folder is `public`.<br />
 See [Going to production](/development/going-to-production) for more information.
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<site>.cloudfront.net"
+    }
+  }
+}
+```
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
+++ b/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
@@ -14,9 +14,9 @@ Before you get started, you need to have:
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your CloudFront site. You can keep the standard CloudFront URL `https://<site>.cloudfront.net` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your CloudFront site. You can keep the standard CloudFront URL `https://<site>.cloudfront.net` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {

--- a/website/src/content/deployment-examples/azure-static-web-apps.mdx
+++ b/website/src/content/deployment-examples/azure-static-web-apps.mdx
@@ -68,21 +68,21 @@ In the Static Web App setup process you need to configure the following things:
 
 <Info>
 
-If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them to your GitHub repository secrets and update the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) accordingly.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables). You can define the environment variables either as plain text or using [GitHub encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
 
-For instance, when using `APPLICATION_ID` environment variable in your Custom Application, add `APPLICATION_ID` repository secret in GitHub settings and edit the GitHub Action workflow file:
+See example below for defining environment variables for the GitHub action:
 
-```yaml highlightLines="9-10"
-...
-
-with:
-  ...
-  action: "upload"
-  app_location: "/"
-  api_location: ""
-  output_location: "public"
-env:
-  APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+```yaml title="deployment.yml" highlightLines="9-10"
+- name: Build And Deploy
+  uses: Azure/static-web-apps-deploy@v1
+  with:
+    action: "upload"
+    app_location: "/"
+    api_location: ""
+    output_location: "public"
+  env:
+    APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+    CLOUD_IDENTIFIER: gcp-eu
 ```
 
 </Info>

--- a/website/src/content/deployment-examples/azure-static-web-apps.mdx
+++ b/website/src/content/deployment-examples/azure-static-web-apps.mdx
@@ -1,22 +1,22 @@
 ---
-title: Deploying to Microsoft Azure with Static Web Apps
+title: Deploying to Azure with Static Web Apps
 ---
 
-This deployment example refers to [Microsoft Azure](https://azure.microsoft.com/).
+This deployment example refers to [Azure Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/#overview).
 
 # Prerequisites
 
 Before you get started, you need to have:
 
-- A [Microsoft Azure](https://azure.microsoft.com/free/) account.
+- An [Azure](https://azure.microsoft.com/free/) account.
 - A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
 - A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Microsoft Azure project. You can keep the standard Azure URL `https://<project>.1.azurestaticapps.net` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Azure project. You can keep the standard Azure URL `https://<project>.1.azurestaticapps.net` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {
@@ -44,15 +44,15 @@ In case you want to avoid hardcoding certain values, for example the Application
 }
 ```
 
-# Connect Microsoft Azure with GitHub Actions
+# Connect Azure with GitHub Actions
 
-The easiest way to deploy to Microsoft Azure is to use [Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/#overview) deployment service. This service enables first-class GitHub integration.
+The easiest way to deploy to Azure is to use [Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/#overview) deployment service. This service enables first-class GitHub integration.
 
-Follow the steps in the [Microsoft Azure Static Web App creator](https://portal.azure.com/#create/Microsoft.StaticApp) to create a new project and select `GitHub` as the deployment source.
+Follow the steps in the [Azure Static Web App creator](https://portal.azure.com/#create/Microsoft.StaticApp) to create a new project and select `GitHub` as the deployment source.
 
 <Info>
 
-Make sure to grant Microsoft Azure access to your repository in the following step.
+Make sure to grant Azure access to your repository in the following step.
 
 </Info>
 
@@ -68,15 +68,28 @@ In the Static Web App setup process you need to configure the following things:
 
 <Info>
 
-If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in your **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them to your GitHub repository secrets and update the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) accordingly.
 
-Alternatively, when using the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) you need to provide the environment variables there.
+For instance, when using `APPLICATION_ID` environment variable in your Custom Application, add `APPLICATION_ID` repository secret in GitHub settings and edit the GitHub Action workflow file:
+
+```yaml highlightLines="9-10"
+...
+
+with:
+  ...
+  action: "upload"
+  app_location: "/"
+  api_location: ""
+  output_location: "public"
+env:
+  APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+```
 
 </Info>
 
 ## Configuring rewrite rules
 
-A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Microsoft Azure](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#defining-routes) to rewrite all requests to serve the `index.html`.
+A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Azure](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#defining-routes) to rewrite all requests to serve the `index.html`.
 For this purpose, create `staticwebapp.config.json` file in the root directory of your project with the following content:
 
 ```json title="staticwebapp.config.json"

--- a/website/src/content/deployment-examples/azure.mdx
+++ b/website/src/content/deployment-examples/azure.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying to Microsoft Azure
+title: Deploying to Microsoft Azure with Static Web Apps
 ---
 
 This deployment example refers to [Microsoft Azure](https://azure.microsoft.com/).
@@ -44,7 +44,7 @@ In case you want to avoid hardcoding certain values, for example the Application
 }
 ```
 
-# Connect Microsoft Azure with GitHub
+# Connect Microsoft Azure with GitHub Actions
 
 The easiest way to deploy to Microsoft Azure is to use [Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/#overview) deployment service. This service enables first-class GitHub integration.
 

--- a/website/src/content/deployment-examples/azure.mdx
+++ b/website/src/content/deployment-examples/azure.mdx
@@ -29,6 +29,21 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.1.azurestaticapps.net"
+    }
+  }
+}
+```
+
 # Connect Microsoft Azure with GitHub
 
 The easiest way to deploy to Microsoft Azure is to use [Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/#overview) deployment service. This service enables first-class GitHub integration.
@@ -51,6 +66,14 @@ In the Static Web App setup process you need to configure the following things:
     * App location: `/` 
     * Output location: `public`
 
+<Info>
+
+In case you decide to use environment variables, create them in the Microsoft Azure application settings: **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
+
+Make sure then to provide the created environment variables in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) provisioned by the Microsoft Azure in your GitHub repository.
+
+</Info>
+
 ## Configuring rewrite rules
 
 A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Microsoft Azure](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#defining-routes) to rewrite all requests to serve the `index.html`.
@@ -66,25 +89,6 @@ For this purpose, create `staticwebapp.config.json` file in the root directory o
   }
 }
 ```
-
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.1.azurestaticapps.net"
-    }
-  }
-}
-```
-
-Create the environment variables in the Microsoft Azure application settings: **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
-
-Make sure then to provide the created environment variables in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) provisioned by the Microsoft Azure in your GitHub repository.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/azure.mdx
+++ b/website/src/content/deployment-examples/azure.mdx
@@ -1,0 +1,99 @@
+---
+title: Deploying to Microsoft Azure
+---
+
+This deployment example refers to [Microsoft Azure](https://azure.microsoft.com/).
+
+# Prerequisites
+
+Before you get started, you need to have:
+
+- A [Microsoft Azure](https://azure.microsoft.com/free/) account.
+- A [Github](https://github.com/join) account.
+- A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
+- A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
+
+# Configuration
+
+In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Microsoft Azure project. You can keep the standard Azure URL `https://<project>.1.azurestaticapps.net` or provide your own custom domain.
+
+```json title="custom-application-config.json"
+{
+  "env": {
+    "production": {
+      "applicationId": "ckvtahxl90097sys6har1e6n3",
+      "url": "https://<project>.1.azurestaticapps.net"
+    }
+  }
+}
+```
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.1.azurestaticapps.net"
+    }
+  }
+}
+```
+
+Create the environment variables in the Microsoft Azure application settings: **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
+
+Make sure then to provide the created environment variables in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) provisioned by the Microsoft Azure in your GitHub repository.
+
+# Connect Microsoft Azure with GitHub
+
+The easiest way to deploy to Microsoft Azure is to use [Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/#overview) deployment service. This service enables first-class GitHub integration.
+
+Follow the steps in the [Microsoft Azure Static Web App creator](https://portal.azure.com/#create/Microsoft.StaticApp) to create a new project and select `GitHub` as the deployment source.
+
+<Info>
+
+Make sure to grant Microsoft Azure access to your repository in the following step.
+
+</Info>
+
+## Configuring build settings
+
+In the Static Web App setup process you need to configure the following things:
+
+* Select your organization, repository and branch.
+* In the **Build details** section select `Custom` as the build preset.
+* Provide the following build settings: 
+    * App location: `/` 
+    * Output location: `public`
+
+## Configuring rewrite rules
+
+A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Microsoft Azure](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#defining-routes) to rewrite all requests to serve the `index.html`.
+
+```json title="staticwebapp.config.json"
+{
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/index.html",
+      "statusCode": 200
+    }
+  }
+}
+```
+
+# Test your deployment
+
+In the Merchant Center you can now [follow the steps to install the Custom Application](https://docs.commercetools.com/merchant-center/managing-custom-applications) and access it in your Projects.
+
+<Warning>
+
+The Custom Application won't render if you try to access it directly via the deployment URL, as it needs to be served within the [Merchant Center Proxy Router](/concepts/merchant-center-proxy-router).
+
+Therefore, Preview deployments are not really useful. If you are interested in this functionality, let us know and open a [support issue](https://github.com/commercetools/merchant-center-application-kit/issues/new/choose).
+
+</Warning>

--- a/website/src/content/deployment-examples/azure.mdx
+++ b/website/src/content/deployment-examples/azure.mdx
@@ -9,7 +9,6 @@ This deployment example refers to [Microsoft Azure](https://azure.microsoft.com/
 Before you get started, you need to have:
 
 - A [Microsoft Azure](https://azure.microsoft.com/free/) account.
-- A [Github](https://github.com/join) account.
 - A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
 - A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
 
@@ -29,25 +28,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
   }
 }
 ```
-
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.1.azurestaticapps.net"
-    }
-  }
-}
-```
-
-Create the environment variables in the Microsoft Azure application settings: **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
-
-Make sure then to provide the created environment variables in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) provisioned by the Microsoft Azure in your GitHub repository.
 
 # Connect Microsoft Azure with GitHub
 
@@ -74,6 +54,7 @@ In the Static Web App setup process you need to configure the following things:
 ## Configuring rewrite rules
 
 A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Microsoft Azure](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#defining-routes) to rewrite all requests to serve the `index.html`.
+For this purpose, create `staticwebapp.config.json` file in the root directory of your project with the following content:
 
 ```json title="staticwebapp.config.json"
 {
@@ -85,6 +66,25 @@ A Custom Application is a Single-Page Application that uses client-side routing.
   }
 }
 ```
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.1.azurestaticapps.net"
+    }
+  }
+}
+```
+
+Create the environment variables in the Microsoft Azure application settings: **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
+
+Make sure then to provide the created environment variables in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) provisioned by the Microsoft Azure in your GitHub repository.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/azure.mdx
+++ b/website/src/content/deployment-examples/azure.mdx
@@ -62,15 +62,15 @@ In the Static Web App setup process you need to configure the following things:
 
 * Select your organization, repository and branch.
 * In the **Build details** section select `Custom` as the build preset.
-* Provide the following build settings: 
-    * App location: `/` 
+* Provide the following build settings:
+    * App location: `/`
     * Output location: `public`
 
 <Info>
 
-In case you decide to use environment variables, create them in the Microsoft Azure application settings: **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in your **Home > Static Web Apps > Your project name > Configuration > Application Settings**.
 
-Make sure then to provide the created environment variables in the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) provisioned by the Microsoft Azure in your GitHub repository.
+Alternatively, when using the [GitHub Action workflow file](https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#environment-variables) you need to provide the environment variables there.
 
 </Info>
 

--- a/website/src/content/deployment-examples/cloudflare.mdx
+++ b/website/src/content/deployment-examples/cloudflare.mdx
@@ -14,9 +14,9 @@ Before you get started, you need to have:
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Cloudflare Pages project. You can keep the standard Cloudflare Pages URL `https://<project>.pages.dev` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Cloudflare Pages project. You can keep the standard Cloudflare Pages URL `https://<project>.pages.dev` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {

--- a/website/src/content/deployment-examples/cloudflare.mdx
+++ b/website/src/content/deployment-examples/cloudflare.mdx
@@ -29,6 +29,21 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.pages.dev"
+    }
+  }
+}
+```
+
 # Connect Cloudflare with GitHub
 
 The easiest way to deploy to Cloudflare is to use the [GitHub integration](https://developers.cloudflare.com/pages/platform/git-integration).
@@ -65,22 +80,11 @@ In the Cloudflare Pages setup process you need to configure the following things
 * Override the *Output directory* with: `public`.
 * If possible, select or specify the *Node.js Version*. Recommended version is `>= v14`.
 
-## Using environment variables
+<Info>
 
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+In case you decide to use environment variables, make sure then to provide them in your **Account Home > Pages > Pages project > Settings > Environment variables**.
 
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.pages.dev"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Account Home > Pages > Pages project > Settings > Environment variables**.
+</Info>
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/cloudflare.mdx
+++ b/website/src/content/deployment-examples/cloudflare.mdx
@@ -29,23 +29,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.pages.dev"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Account Home > Pages > Pages project > Settings > Environment variables**.
-
 # Connect Cloudflare with GitHub
 
 The easiest way to deploy to Cloudflare is to use the [GitHub integration](https://developers.cloudflare.com/pages/platform/git-integration).
@@ -81,6 +64,23 @@ In the Cloudflare Pages setup process you need to configure the following things
 
 * Override the *Output directory* with: `public`.
 * If possible, select or specify the *Node.js Version*. Recommended version is `>= v14`.
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.pages.dev"
+    }
+  }
+}
+```
+
+Make sure then to provide the environment variables in your **Account Home > Pages > Pages project > Settings > Environment variables**.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/cloudflare.mdx
+++ b/website/src/content/deployment-examples/cloudflare.mdx
@@ -82,7 +82,7 @@ In the Cloudflare Pages setup process you need to configure the following things
 
 <Info>
 
-In case you decide to use environment variables, make sure then to provide them in your **Account Home > Pages > Pages project > Settings > Environment variables**.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in your **Account Home > Pages > Pages project > Settings > Environment variables**.
 
 </Info>
 

--- a/website/src/content/deployment-examples/index.mdx
+++ b/website/src/content/deployment-examples/index.mdx
@@ -30,10 +30,10 @@ This page outlines some of the common platforms and services Custom Applications
     Learn more about deploying to AWS with S3 and CloudFront.
   </Card>
   <Card
-    title="Microsoft Azure"
-    href="/deployment-examples/azure"
+    title="Azure with Static Web Apps"
+    href="/deployment-examples/azure-static-web-apps"
   >
-    Learn more about deploying to Microsoft Azure.
+    Learn more about deploying to Azure Static Web Apps.
   </Card>
   <Card
     title="Surge"

--- a/website/src/content/deployment-examples/index.mdx
+++ b/website/src/content/deployment-examples/index.mdx
@@ -30,6 +30,12 @@ This page outlines some of the common platforms and services Custom Applications
     Learn more about deploying to AWS with S3 and CloudFront.
   </Card>
   <Card
+    title="Microsoft Azure"
+    href="/deployment-examples/azure"
+  >
+    Learn more about deploying to Microsoft Azure.
+  </Card>
+  <Card
     title="Surge"
     href="/deployment-examples/surge"
   >

--- a/website/src/content/deployment-examples/netlify.mdx
+++ b/website/src/content/deployment-examples/netlify.mdx
@@ -29,6 +29,21 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<site>.netlify.app"
+    }
+  }
+}
+```
+
 # Connect Netlify with GitHub
 
 The easiest way to deploy to Netlify is to use the [GitHub integration](https://docs.netlify.com/configure-builds/overview/).
@@ -64,6 +79,12 @@ In the Netlify setup process you need to configure the following things:
 * Override the *Output directory* with: `public`.
 * If possible, select or specify the *Node.js Version*. Recommended version is `>= v14`.
 
+<Info>
+
+In case you decide to use environment variables, make sure then to provide them in your **Netlify site > Settings > Build & deploy > Environment**.
+
+</Info>
+
 ## Configuring rewrite rules
 
 A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Netlify](https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps) to rewrite all requests to serve the `index.html`.
@@ -75,23 +96,6 @@ For this purpose, create `netlify.toml` file in the root directory of your proje
   to = "/index.html"
   status = 200
 ```
-
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<site>.netlify.app"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Netlify site > Settings > Build & deploy > Environment**.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/netlify.mdx
+++ b/website/src/content/deployment-examples/netlify.mdx
@@ -81,7 +81,7 @@ In the Netlify setup process you need to configure the following things:
 
 <Info>
 
-In case you decide to use environment variables, make sure then to provide them in your **Netlify site > Settings > Build & deploy > Environment**.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in your **Netlify site > Settings > Build & deploy > Environment**.
 
 </Info>
 

--- a/website/src/content/deployment-examples/netlify.mdx
+++ b/website/src/content/deployment-examples/netlify.mdx
@@ -29,23 +29,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<site>.netlify.app"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Netlify site > Settings > Build & deploy > Environment**.
-
 # Connect Netlify with GitHub
 
 The easiest way to deploy to Netlify is to use the [GitHub integration](https://docs.netlify.com/configure-builds/overview/).
@@ -84,6 +67,7 @@ In the Netlify setup process you need to configure the following things:
 ## Configuring rewrite rules
 
 A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Netlify](https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps) to rewrite all requests to serve the `index.html`.
+For this purpose, create `netlify.toml` file in the root directory of your project with the following content:
 
 ```toml title="netlify.toml"
 [[redirects]]
@@ -91,6 +75,23 @@ A Custom Application is a Single-Page Application that uses client-side routing.
   to = "/index.html"
   status = 200
 ```
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<site>.netlify.app"
+    }
+  }
+}
+```
+
+Make sure then to provide the environment variables in your **Netlify site > Settings > Build & deploy > Environment**.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/netlify.mdx
+++ b/website/src/content/deployment-examples/netlify.mdx
@@ -14,9 +14,9 @@ Before you get started, you need to have:
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Netlify site. You can keep the standard Netlify URL `https://<site>.netlify.app` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Netlify site. You can keep the standard Netlify URL `https://<site>.netlify.app` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {

--- a/website/src/content/deployment-examples/render.mdx
+++ b/website/src/content/deployment-examples/render.mdx
@@ -14,9 +14,9 @@ Before you get started, you need to have:
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Render site. You can keep the standard Render URL `https://<site>.onrender.com` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Render site. You can keep the standard Render URL `https://<site>.onrender.com` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {

--- a/website/src/content/deployment-examples/render.mdx
+++ b/website/src/content/deployment-examples/render.mdx
@@ -29,6 +29,23 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<site>.onrender.com"
+    }
+  }
+}
+```
+
+Make sure then to provide the environment variables in your **Render site > Environment**.
+
 # Connect Render with GitHub
 
 The easiest way to deploy to Render is to use the [GitHub integration](https://render.com/docs/github).
@@ -64,6 +81,12 @@ In the Render setup process you need to configure the following things:
 * Override the *Publish directory* with: `public`.
 * If possible, select or specify the *Node.js Version*. Recommended version is `>= v14`.
 
+<Info>
+
+In case you decide to use environment variables, make sure then to provide them in your **Render site > Environment**.
+
+</Info>
+
 ## Configuring rewrite rules
 
 A Custom Application is a Single-Page Application that uses client-side routing. Therefore, we need to [instruct Render](https://render.com/docs/deploy-create-react-app#using-client-side-routing) to rewrite all requests to serve the `index.html`.
@@ -71,23 +94,6 @@ A Custom Application is a Single-Page Application that uses client-side routing.
 ```
 /* --> /index.html
 ```
-
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<site>.onrender.com"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Render site > Environment**.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/render.mdx
+++ b/website/src/content/deployment-examples/render.mdx
@@ -44,8 +44,6 @@ In case you want to avoid hardcoding certain values, for example the Application
 }
 ```
 
-Make sure then to provide the environment variables in your **Render site > Environment**.
-
 # Connect Render with GitHub
 
 The easiest way to deploy to Render is to use the [GitHub integration](https://render.com/docs/github).
@@ -83,7 +81,7 @@ In the Render setup process you need to configure the following things:
 
 <Info>
 
-In case you decide to use environment variables, make sure then to provide them in your **Render site > Environment**.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in your **Render site > Environment**.
 
 </Info>
 

--- a/website/src/content/deployment-examples/render.mdx
+++ b/website/src/content/deployment-examples/render.mdx
@@ -29,23 +29,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<site>.onrender.com"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Render site > Environment**.
-
 # Connect Render with GitHub
 
 The easiest way to deploy to Render is to use the [GitHub integration](https://render.com/docs/github).
@@ -88,6 +71,23 @@ A Custom Application is a Single-Page Application that uses client-side routing.
 ```
 /* --> /index.html
 ```
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<site>.onrender.com"
+    }
+  }
+}
+```
+
+Make sure then to provide the environment variables in your **Render site > Environment**.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/surge.mdx
+++ b/website/src/content/deployment-examples/surge.mdx
@@ -14,9 +14,9 @@ Before you get started, you need to have:
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Surge project. You can keep the standard Surge URL `https://<project>.surge.sh` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Surge project. You can keep the standard Surge URL `https://<project>.surge.sh` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {

--- a/website/src/content/deployment-examples/surge.mdx
+++ b/website/src/content/deployment-examples/surge.mdx
@@ -29,21 +29,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.surge.sh"
-    }
-  }
-}
-```
-
 # Production bundles
 
 The main command to create the production bundles is `mc-scripts build`. The output folder is `public`, which is what is going to be uploaded to Surge.<br />
@@ -64,6 +49,21 @@ surge public https://<project>.surge.sh
 ```
 
 That's it!
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.surge.sh"
+    }
+  }
+}
+```
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/surge.mdx
+++ b/website/src/content/deployment-examples/surge.mdx
@@ -29,6 +29,21 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.surge.sh"
+    }
+  }
+}
+```
+
 # Production bundles
 
 The main command to create the production bundles is `mc-scripts build`. The output folder is `public`, which is what is going to be uploaded to Surge.<br />
@@ -49,21 +64,6 @@ surge public https://<project>.surge.sh
 ```
 
 That's it!
-
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.surge.sh"
-    }
-  }
-}
-```
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/vercel.mdx
+++ b/website/src/content/deployment-examples/vercel.mdx
@@ -29,23 +29,6 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
-## Using environment variables
-
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
-
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.vercel.app"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Vercel project > Settings > Environment variables**.
-
 # Connect Vercel with GitHub
 
 The easiest way to deploy to Vercel is to use the [GitHub integration](https://vercel.com/docs/concepts/git/vercel-for-github).
@@ -81,6 +64,23 @@ In the Vercel setup process you need to configure the following things:
 
 * Override the *Output directory* with: `public`.
 * If possible, select or specify the *Node.js Version*. Recommended version is `>= v14`.
+
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.vercel.app"
+    }
+  }
+}
+```
+
+Make sure then to provide the environment variables in your **Vercel project > Settings > Environment variables**.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/vercel.mdx
+++ b/website/src/content/deployment-examples/vercel.mdx
@@ -14,9 +14,9 @@ Before you get started, you need to have:
 
 # Configuration
 
-In your Custom Application config, make sure to provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) that you got when you configured the Custom Application in the Merchant Center.
+In your Custom Application config, provide the [Custom Application ID](/api-reference/application-config#envproductionapplicationid) you got when you configured the Custom Application in the Merchant Center.
 
-Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Vercel project. You can keep the standard Vercel URL `https://<project>.vercel.app` or provide your own custom domain.
+Moreover, you need to provide the [production URL](/api-reference/application-config#envproductionurl) from your Vercel project. You can keep the standard Vercel URL `https://<project>.vercel.app` or provide your custom domain.
 
 ```json title="custom-application-config.json"
 {

--- a/website/src/content/deployment-examples/vercel.mdx
+++ b/website/src/content/deployment-examples/vercel.mdx
@@ -29,6 +29,21 @@ Moreover, you need to provide the [production URL](/api-reference/application-co
 }
 ```
 
+## Using environment variables
+
+In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+
+```json title="custom-application-config.json" highlightLines="4"
+{
+  "env": {
+    "production": {
+      "applicationId": "${env:APPLICATION_ID}",
+      "url": "https://<project>.vercel.app"
+    }
+  }
+}
+```
+
 # Connect Vercel with GitHub
 
 The easiest way to deploy to Vercel is to use the [GitHub integration](https://vercel.com/docs/concepts/git/vercel-for-github).
@@ -65,22 +80,11 @@ In the Vercel setup process you need to configure the following things:
 * Override the *Output directory* with: `public`.
 * If possible, select or specify the *Node.js Version*. Recommended version is `>= v14`.
 
-## Using environment variables
+<Info>
 
-In case you want to avoid hardcoding certain values, for example the Application ID, or the Project key, you can [use variable placeholders](/api-reference/application-config#using-variable-placeholders) in your Custom Application config.
+In case you decide to use environment variables, make sure then to provide them in your **Vercel project > Settings > Environment variables**.
 
-```json title="custom-application-config.json" highlightLines="4"
-{
-  "env": {
-    "production": {
-      "applicationId": "${env:APPLICATION_ID}",
-      "url": "https://<project>.vercel.app"
-    }
-  }
-}
-```
-
-Make sure then to provide the environment variables in your **Vercel project > Settings > Environment variables**.
+</Info>
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/vercel.mdx
+++ b/website/src/content/deployment-examples/vercel.mdx
@@ -82,7 +82,7 @@ In the Vercel setup process you need to configure the following things:
 
 <Info>
 
-In case you decide to use environment variables, make sure then to provide them in your **Vercel project > Settings > Environment variables**.
+If your Custom Application config [requires environment variables](#using-environment-variables), make sure to provide them in your **Vercel project > Settings > Environment variables**.
 
 </Info>
 

--- a/website/src/data/navigation.yaml
+++ b/website/src/data/navigation.yaml
@@ -54,8 +54,8 @@
       path: /deployment-examples/render
     - title: Deploying to AWS with S3 and CloudFront
       path: /deployment-examples/aws-s3-cloudfront
-    - title: Deploying to Microsoft Azure with Static Web Apps
-      path: /deployment-examples/azure
+    - title: Deploying to Azure with Static Web Apps
+      path: /deployment-examples/azure-static-web-apps
     - title: Deploying to Surge
       path: /deployment-examples/surge
     - title: Deploying to Cloudflare Pages

--- a/website/src/data/navigation.yaml
+++ b/website/src/data/navigation.yaml
@@ -54,7 +54,7 @@
       path: /deployment-examples/render
     - title: Deploying to AWS with S3 and CloudFront
       path: /deployment-examples/aws-s3-cloudfront
-    - title: Deploying to Microsoft Azure
+    - title: Deploying to Microsoft Azure with Static Web Apps
       path: /deployment-examples/azure
     - title: Deploying to Surge
       path: /deployment-examples/surge

--- a/website/src/data/navigation.yaml
+++ b/website/src/data/navigation.yaml
@@ -54,6 +54,8 @@
       path: /deployment-examples/render
     - title: Deploying to AWS with S3 and CloudFront
       path: /deployment-examples/aws-s3-cloudfront
+    - title: Deploying to Microsoft Azure
+      path: /deployment-examples/azure
     - title: Deploying to Surge
       path: /deployment-examples/surge
     - title: Deploying to Cloudflare Pages


### PR DESCRIPTION
#### Summary

PR adds example of Azure deployment in the docs. 
Closes [#2683](https://github.com/commercetools/merchant-center-application-kit/issues/2683)
