### PR TITLE
refactor: add basic support for `apollo-link-rest` and provide example implementation

### DIFF
--- a/.changeset/blue-cougars-worry.md
+++ b/.changeset/blue-cougars-worry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Add option to `createApolloClient` to pass the Apollo Rest Link. See [documentation](https://docs.commercetools.com/custom-applications/api-reference/commercetools-frontend-application-shell#createapolloclient) for more information.

--- a/.changeset/thick-knives-tan.md
+++ b/.changeset/thick-knives-tan.md
@@ -1,0 +1,5 @@
+---
+'playground': minor
+---
+
+Refactor fetching states using the `@rest` directive.

--- a/packages/application-shell/src/configure-apollo.ts
+++ b/packages/application-shell/src/configure-apollo.ts
@@ -11,6 +11,7 @@ import {
   from,
   createHttpLink,
   InMemoryCache,
+  ApolloLink,
 } from '@apollo/client';
 // import { version as apolloVersion } from '@apollo/client/version';
 import createHttpUserAgent from '@commercetools/http-user-agent';
@@ -28,6 +29,7 @@ declare let window: ApplicationWindow;
 
 type TApolloClientOptions = {
   cache?: InMemoryCacheConfig;
+  restLink?: ApolloLink;
 };
 
 const userAgent = createHttpUserAgent({
@@ -48,18 +50,26 @@ const httpLink = createHttpLink({
   fetch,
 });
 
-// order of links is relevant here
-// in the request-phase they are executed top to bottom
-// in the response/phase they are executed bottom to top
-// `tokenRetryLink` needs to stay after `errorLink` in order to be executed before `errorLink` for responses
-const link = from([
-  headerLink,
-  errorLink,
-  // Avoid logging queries in test environment
-  ...(isLoggerEnabled() ? [loggerLink] : []),
-  tokenRetryLink,
-  httpLink,
-]);
+const createApolloLink = (options: TApolloClientOptions = {}) =>
+  // The order of links is IMPORTANT!
+  // In the request-phase they are executed top to bottom.
+  // In the response/phase they are executed bottom to top.
+  // The `httpLink` is terminating so it must be last, while `tokenRetryLink` and `errorLink`
+  // wrap the links the their right.
+  from([
+    headerLink,
+    // See https://www.apollographql.com/docs/react/api/link/apollo-link-rest/#link-order
+    // State & context links should happen before (to the left of) `restLink`.
+    ...(options.restLink ? [options.restLink] : []),
+    // Must be before `tokenRetryLink`.
+    errorLink,
+    // Avoid logging queries in test environment
+    ...(isLoggerEnabled() ? [loggerLink] : []),
+    // Must be after `errorLink`.
+    tokenRetryLink,
+    // Must be last.
+    httpLink,
+  ]);
 
 // This custom merge function allows to merge two arrays of objects.
 // The incoming list is what we need to update to, but we still need
@@ -87,7 +97,7 @@ const createApolloClient = (
 ): ApolloClient<NormalizedCacheObject> => {
   const customCacheConfig = options?.cache ?? {};
   return new ApolloClient({
-    link,
+    link: createApolloLink(options),
     // https://www.apollographql.com/docs/react/caching/cache-configuration/
     cache: new InMemoryCache({
       ...customCacheConfig,

--- a/packages/application-shell/src/types/generated/ctp.ts
+++ b/packages/application-shell/src/types/generated/ctp.ts
@@ -142,6 +142,7 @@ export type TAddCartLineItem = {
   externalPrice?: InputMaybe<TBaseMoneyInput>;
   externalTaxRate?: InputMaybe<TExternalTaxRateDraft>;
   externalTotalPrice?: InputMaybe<TExternalLineItemTotalPriceDraft>;
+  inventoryMode?: InputMaybe<TInventoryMode>;
   productId?: InputMaybe<Scalars['String']>;
   quantity?: InputMaybe<Scalars['Long']>;
   shippingDetails?: InputMaybe<TItemShippingDetailsDraft>;
@@ -382,6 +383,7 @@ export type TAddStagedOrderLineItem = {
   externalPrice?: InputMaybe<TBaseMoneyInput>;
   externalTaxRate?: InputMaybe<TExternalTaxRateDraft>;
   externalTotalPrice?: InputMaybe<TExternalLineItemTotalPriceDraft>;
+  inventoryMode?: InputMaybe<TInventoryMode>;
   productId?: InputMaybe<Scalars['String']>;
   quantity?: InputMaybe<Scalars['Long']>;
   shippingDetails?: InputMaybe<TItemShippingDetailsDraftType>;
@@ -608,6 +610,10 @@ export type TApplyCartDeltaToCustomLineItemShippingDetailsTargets = {
 export type TApplyCartDeltaToLineItemShippingDetailsTargets = {
   lineItemId: Scalars['String'];
   targetsDelta: Array<TShippingTargetDraft>;
+};
+
+export type TApplyStagedChanges = {
+  dummy?: InputMaybe<Scalars['String']>;
 };
 
 export type TAsset = {
@@ -3116,6 +3122,7 @@ export type TDiscountCodeUpdateAction = {
 
 export type TDiscountedLineItemPortion = {
   __typename?: 'DiscountedLineItemPortion';
+  /** Expands the CartDiscount associated to cart, if the discounts on the cart are of type DirectDiscount, this field will be empty */
   discount?: Maybe<TCartDiscount>;
   discountRef: TReference;
   discountedAmount: TBaseMoney;
@@ -4000,7 +4007,7 @@ export type TLineItem = {
   distributionChannel?: Maybe<TChannel>;
   distributionChannelRef?: Maybe<TReference>;
   id: Scalars['String'];
-  inventoryMode?: Maybe<TItemShippingDetails>;
+  inventoryMode?: Maybe<TInventoryMode>;
   lastModifiedAt?: Maybe<Scalars['DateTime']>;
   lineItemMode: TLineItemMode;
   name?: Maybe<Scalars['String']>;
@@ -4065,6 +4072,7 @@ export type TLineItemDraft = {
   externalPrice?: InputMaybe<TBaseMoneyInput>;
   externalTaxRate?: InputMaybe<TExternalTaxRateDraft>;
   externalTotalPrice?: InputMaybe<TExternalLineItemTotalPriceDraft>;
+  inventoryMode?: InputMaybe<TInventoryMode>;
   productId?: InputMaybe<Scalars['String']>;
   quantity?: InputMaybe<Scalars['Long']>;
   shippingDetails?: InputMaybe<TItemShippingDetailsDraft>;
@@ -4081,6 +4089,7 @@ export type TLineItemDraftOutput = {
   externalPrice?: Maybe<TBaseMoney>;
   externalTaxRate?: Maybe<TExternalTaxRateDraftOutput>;
   externalTotalPrice?: Maybe<TExternalLineItemTotalPrice>;
+  inventoryMode?: Maybe<TInventoryMode>;
   productId?: Maybe<Scalars['String']>;
   quantity?: Maybe<Scalars['Long']>;
   shippingDetails?: Maybe<TItemShippingDetailsDraftOutput>;
@@ -6766,7 +6775,6 @@ export type TPriceSelectorInput = {
   country?: InputMaybe<Scalars['Country']>;
   currency: Scalars['Currency'];
   customerGroup?: InputMaybe<TReferenceInput>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   date?: InputMaybe<Scalars['DateTime']>;
 };
 
@@ -12262,6 +12270,7 @@ export type TStandalonePrice = TVersioned & {
   custom?: Maybe<TCustomFieldsType>;
   customerGroupRef?: Maybe<TReference>;
   discounted?: Maybe<TDiscountedProductPriceValue>;
+  expiresAt?: Maybe<Scalars['DateTime']>;
   id: Scalars['String'];
   key?: Maybe<Scalars['String']>;
   lastModifiedAt: Scalars['DateTime'];
@@ -12316,7 +12325,14 @@ export type TStandalonePriceQueryResult = {
   total: Scalars['Long'];
 };
 
+export type TStandalonePriceStagedChangesApplied = TMessagePayload & {
+  __typename?: 'StandalonePriceStagedChangesApplied';
+  stagedChanges: TStagedPriceValue;
+  type: Scalars['String'];
+};
+
 export type TStandalonePriceUpdateAction = {
+  applyStagedChanges?: InputMaybe<TApplyStagedChanges>;
   changeValue?: InputMaybe<TChangeStandalonePriceValue>;
   setCustomField?: InputMaybe<TSetStandalonePriceCustomFields>;
   setCustomType?: InputMaybe<TCustomFieldsDraft>;
@@ -12466,7 +12482,6 @@ export type TStoreDeleted = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TStoreDistributionChannelsChanged = TMessagePayload & {
   __typename?: 'StoreDistributionChannelsChanged';
   addedDistributionChannels: Array<TChannel>;

--- a/playground/package.json
+++ b/playground/package.json
@@ -39,6 +39,8 @@
     "@commercetools-uikit/primary-button": "^15.1.0",
     "@commercetools-uikit/spacings": "^15.1.0",
     "@commercetools-uikit/text": "^15.1.0",
+    "apollo-link-rest": "^0.9.0-rc.1",
+    "graphql-anywhere": "^4.2.7",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.34",
     "prop-types": "15.8.1",

--- a/playground/src/apollo-client.js
+++ b/playground/src/apollo-client.js
@@ -1,0 +1,58 @@
+import omit from 'lodash/omit';
+import { RestLink } from 'apollo-link-rest';
+import { createApolloClient } from '@commercetools-frontend/application-shell';
+import { transformLocalizedStringToLocalizedField } from '@commercetools-frontend/l10n';
+
+// TODO: move to `l10n` package.
+const applyTransformedLocalizedStrings = (
+  objectWithLocalizedStrings,
+  fieldNames
+) => {
+  const transformedFieldDefinitions = fieldNames.reduce(
+    (nextTransformed, fieldName) => ({
+      ...nextTransformed,
+      [fieldName.to]: transformLocalizedStringToLocalizedField(
+        objectWithLocalizedStrings[fieldName.from]
+      ),
+    }),
+    {}
+  );
+  const namesToOmit = fieldNames.map((fieldName) => fieldName.from);
+  const objectWithouLocalizedFields = omit(
+    objectWithLocalizedStrings,
+    namesToOmit
+  );
+  return {
+    ...objectWithouLocalizedFields,
+    ...transformedFieldDefinitions,
+  };
+};
+
+const restLink = new RestLink({
+  uri: window.app.mcApiUrl,
+  // https://www.apollographql.com/docs/react/api/link/apollo-link-rest/#response-transforming
+  responseTransformer: async (response, typeName) => {
+    const data = await response.json();
+
+    switch (typeName) {
+      case 'StateQueryResult':
+        return {
+          ...data,
+          results: data.results.map((state) =>
+            applyTransformedLocalizedStrings(state, [
+              {
+                from: 'name',
+                to: 'nameAllLocales',
+              },
+            ])
+          ),
+        };
+      default:
+        return data;
+    }
+  },
+});
+
+const configureApollo = () => createApolloClient({ restLink });
+
+export default configureApollo;

--- a/playground/src/components/entry-point/entry-point.jsx
+++ b/playground/src/components/entry-point/entry-point.jsx
@@ -4,6 +4,7 @@ import {
   setupGlobalErrorListener,
 } from '@commercetools-frontend/application-shell';
 import loadMessages from '../../messages';
+import configureApolloClient from '../../apollo-client';
 
 // Here we split up the main (app) bundle with the actual application business logic.
 // Splitting by route is usually recommended and you can potentially have a splitting
@@ -16,8 +17,14 @@ const AsyncPlaygroundRoutes = lazy(
 // in order to catch possible errors on rendering/mounting.
 setupGlobalErrorListener();
 
+const apolloClient = configureApolloClient();
+
 const EntryPoint = () => (
-  <ApplicationShell environment={window.app} applicationMessages={loadMessages}>
+  <ApplicationShell
+    environment={window.app}
+    applicationMessages={loadMessages}
+    apolloClient={apolloClient}
+  >
     <AsyncPlaygroundRoutes />
   </ApplicationShell>
 );

--- a/playground/src/components/state-machines-list/fetch-states.ctp.graphql
+++ b/playground/src/components/state-machines-list/fetch-states.ctp.graphql
@@ -1,12 +1,12 @@
-query FetchStates($limit: Int!, $offset: Int!, $sort: [String!]) {
-  states(limit: $limit, offset: $offset, sort: $sort) {
+query FetchStatesRest($endpoint: String!) {
+  states @rest(type: "StateQueryResult", path: $endpoint) {
     total
     count
     offset
-    results {
+    results @type(name: "State") {
       id
       key
-      nameAllLocales {
+      nameAllLocales @type(name: "LocalizedString") {
         locale
         value
       }

--- a/playground/src/components/state-machines-list/state-machines-list.jsx
+++ b/playground/src/components/state-machines-list/state-machines-list.jsx
@@ -6,7 +6,7 @@ import DataTable from '@commercetools-uikit/data-table';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 import {
-  GRAPHQL_TARGETS,
+  MC_API_PROXY_TARGETS,
   NO_VALUE_FALLBACK,
 } from '@commercetools-frontend/constants';
 import { useMcQuery } from '@commercetools-frontend/application-shell';
@@ -55,21 +55,31 @@ const itemRenderer = (item, column, dataLocale, projectLanguages) => {
 };
 
 const StateMachinesList = (props) => {
-  const { dataLocale, projectLanguages } = useApplicationContext((context) => ({
-    dataLocale: context.dataLocale,
-    projectLanguages: context.project.languages,
-  }));
+  const { dataLocale, projectLanguages, projectKey } = useApplicationContext(
+    (context) => ({
+      dataLocale: context.dataLocale,
+      projectLanguages: context.project.languages,
+      projectKey: context.project.key,
+    })
+  );
   const { page, perPage } = usePaginationState();
   const tableSorting = useDataTableSortingState({ key: 'key', order: 'asc' });
 
+  const searchParams = new URLSearchParams({
+    limit: perPage.value,
+    offset: (page.value - 1) * perPage.value,
+    sort: `${tableSorting.value.key} ${tableSorting.value.order}`,
+  });
+
   const { data, error, loading } = useMcQuery(FetchStatesQuery, {
+    fetchPolicy: 'cache-and-network',
     variables: {
-      limit: perPage.value,
-      offset: (page.value - 1) * perPage.value,
-      sort: [`${tableSorting.value.key} ${tableSorting.value.order}`],
+      endpoint: `/proxy/${
+        MC_API_PROXY_TARGETS.COMMERCETOOLS_PLATFORM
+      }/${projectKey}/states?${searchParams.toString()}`,
     },
     context: {
-      target: GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
+      skipGraphQlTargetCheck: true,
     },
   });
 

--- a/playground/src/components/state-machines-list/state-machines-list.spec.js
+++ b/playground/src/components/state-machines-list/state-machines-list.spec.js
@@ -52,7 +52,7 @@ const fetchState = () => {
 };
 
 const fetchAllStates = () => {
-  return graphql.query('FetchStates', (req, res, ctx) =>
+  return graphql.query('FetchStatesRest', (req, res, ctx) =>
     res(
       ctx.data({
         states: buildGraphqlList(

--- a/schemas/ctp.json
+++ b/schemas/ctp.json
@@ -954,6 +954,18 @@
             "deprecationReason": null
           },
           {
+            "name": "inventoryMode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "InventoryMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "productId",
             "description": null,
             "type": {
@@ -3148,6 +3160,18 @@
             "deprecationReason": null
           },
           {
+            "name": "inventoryMode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "InventoryMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "productId",
             "description": null,
             "type": {
@@ -5250,6 +5274,29 @@
                   }
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ApplyStagedChanges",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "dummy",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -27973,7 +28020,7 @@
         "fields": [
           {
             "name": "discount",
-            "description": null,
+            "description": "Expands the CartDiscount associated to cart, if the discounts on the cart are of type DirectDiscount, this field will be empty",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -35570,8 +35617,8 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "ItemShippingDetails",
+              "kind": "ENUM",
+              "name": "InventoryMode",
               "ofType": null
             },
             "isDeprecated": false,
@@ -36032,6 +36079,18 @@
             "deprecationReason": null
           },
           {
+            "name": "inventoryMode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "InventoryMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "productId",
             "description": null,
             "type": {
@@ -36180,6 +36239,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "ExternalLineItemTotalPrice",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inventoryMode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "InventoryMode",
               "ofType": null
             },
             "isDeprecated": false,
@@ -39849,6 +39920,11 @@
           {
             "kind": "OBJECT",
             "name": "StandalonePriceExternalDiscountSet",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StandalonePriceStagedChangesApplied",
             "ofType": null
           },
           {
@@ -58557,7 +58633,7 @@
           },
           {
             "name": "date",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
@@ -106100,6 +106176,18 @@
             "deprecationReason": null
           },
           {
+            "name": "expiresAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -106606,11 +106694,72 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "StandalonePriceStagedChangesApplied",
+        "description": null,
+        "fields": [
+          {
+            "name": "stagedChanges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StagedPriceValue",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "StandalonePriceUpdateAction",
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "applyStagedChanges",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ApplyStagedChanges",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "changeValue",
             "description": null,
@@ -108151,7 +108300,7 @@
       {
         "kind": "OBJECT",
         "name": "StoreDistributionChannelsChanged",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "addedDistributionChannels",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11938,6 +11938,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/equality@npm:^0.1.2":
+  version: 0.1.11
+  resolution: "@wry/equality@npm:0.1.11"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 1a26a0fd11e3e3a6a197d9a54a5bec523caf693daa24ad2709f496e43dd3cd12290a0d17df81f8a783437795f6c64a1ca2717cdac6e79022bde4450c11e705c9
+  languageName: node
+  linkType: hard
+
 "@wry/equality@npm:^0.5.0":
   version: 0.5.2
   resolution: "@wry/equality@npm:0.5.2"
@@ -12437,12 +12446,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"apollo-link-rest@npm:^0.9.0-rc.1":
+  version: 0.9.0-rc.1
+  resolution: "apollo-link-rest@npm:0.9.0-rc.1"
+  peerDependencies:
+    "@apollo/client": ">=3"
+    graphql: ">=0.11"
+    graphql-anywhere: ">=4"
+    qs: ">=6"
+  checksum: ca0fb1018bfc551ddcdc6134dcff0d4ab278cf8a495c66aa55487ba9b7e835e29f8011ff51d288493d777ffa6df8767da7584e00714b9f6f269861463eae310d
+  languageName: node
+  linkType: hard
+
 "apollo-server-errors@npm:3.3.1":
   version: 3.3.1
   resolution: "apollo-server-errors@npm:3.3.1"
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
   checksum: d09b66e7ac3e2cbc60774280d30118ac4d98f945b5cc1013bb81b9970aae49c0717a550e161fe978d69d7039ec053aeba495890f6eebf452532a2c5e94071a80
+  languageName: node
+  linkType: hard
+
+"apollo-utilities@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "apollo-utilities@npm:1.3.4"
+  dependencies:
+    "@wry/equality": ^0.1.2
+    fast-json-stable-stringify: ^2.0.0
+    ts-invariant: ^0.4.0
+    tslib: ^1.10.0
+  peerDependencies:
+    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 6e0192a3420782909c930f5230808d7fbbdbcdfccddd960120e19bab251b77a16e590b05dbb4a7da2c27c59077fbfd53e56819a9fae694debe7f898e8b0ec1e9
   languageName: node
   linkType: hard
 
@@ -21962,6 +21997,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-anywhere@npm:^4.2.7":
+  version: 4.2.7
+  resolution: "graphql-anywhere@npm:4.2.7"
+  dependencies:
+    apollo-utilities: ^1.3.4
+    ts-invariant: ^0.3.2
+    tslib: ^1.10.0
+  peerDependencies:
+    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 37d96777c05a3dc5b949ea630bb83290ebc64e6fa15e775e0fb36f151f055c67bcce33e10686608817fe549f00c87f62ef12be4dcee6cdf07a4d95eadc10c172
+  languageName: node
+  linkType: hard
+
 "graphql-compose@npm:^9.0.7":
   version: 9.0.7
   resolution: "graphql-compose@npm:9.0.7"
@@ -30080,6 +30128,8 @@ __metadata:
     "@commercetools-uikit/text": ^15.1.0
     "@formatjs/cli": 4.8.4
     "@vercel/node": ^1.14.1
+    apollo-link-rest: ^0.9.0-rc.1
+    graphql-anywhere: ^4.2.7
     moment: ^2.29.4
     moment-timezone: ^0.5.34
     prop-types: 15.8.1
@@ -35660,6 +35710,24 @@ __metadata:
   dependencies:
     tslib: ^2.1.0
   checksum: bb07d56fe4aae69d8860e0301dfdee2d375281159054bc24bf1e49e513fb0835bf7f70a11351344d213a79199c5e695f37ebbf5a447188a377ce0cd81d91ddb5
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.3.2":
+  version: 0.3.3
+  resolution: "ts-invariant@npm:0.3.3"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 22e62a8014dcc81bedaf92167bcbb45bdc39f5ae7c5a19e1b11bd0e046b7e340a17eea53cb27d8011f7cce087226620319c2cf936971fd2dc0bab7e846730629
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.4.0":
+  version: 0.4.4
+  resolution: "ts-invariant@npm:0.4.4"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 58b32fb6b7c479e602e55b9eb63bb99a203c5db09367d3aa7c3cbe000ba62f919eea7f031f55172df9b6d362a6f1a87e906df84b04b8c74c88e507ac58f7a554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've seen a couple of apps using the [apollo-link-rest](https://www.apollographql.com/docs/react/api/link/apollo-link-rest) to use Apollo but for REST requests via the `@rest` directive.

However, most of our Apollo configuration is managed internally and not exposed to, for example, let users create their own Apollo client. It's also important that the Apollo requests are properly configured, for example to include the necessary HTTP headers.

To making it easier to use the `apollo-link-rest`, we can allow users to pass this link as an option to [createApolloClient](https://docs.commercetools.com/custom-applications/api-reference/commercetools-frontend-application-shell#createapolloclient).

The main reason for being so specific is that this link (and the other internal links) must be defined in a specific order.

In the playground app, there is a reference implementation using the `@rest` directive.

As a follow up, I'll update the documentation to describe how to set it up.