### PR TITLE
refactor: to add `includeSubDomains` directive to STS header

### DIFF
--- a/.changeset/many-balloons-appear.md
+++ b/.changeset/many-balloons-appear.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/constants': patch
+---
+
+Enhance `Strict-Transport-Security` header to use the `includeSubDomains` directive.

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -202,7 +202,7 @@ export interface ApplicationWindow extends Window {
 }
 
 export const HTTP_SECURITY_HEADERS = {
-  'Strict-Transport-Security': 'max-age=31536000',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
   'X-XSS-Protection': '1; mode=block',
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -147,6 +147,8 @@ describe('strictTransportSecurity', () => {
 
     expect(
       processedApplicationConfig['Strict-Transport-Security']
-    ).toMatchInlineSnapshot(`"max-age=31536000; includeSubDomains"`);
+    ).toMatchInlineSnapshot(
+      `"max-age=31536000; includeSubDomains; preload; includeSubDomains"`
+    );
   });
 });


### PR DESCRIPTION
Just moving this from the proxy router config, to avoid duplication.