### PR TITLE
feat(app-shell): enhance http utilities to configure custom HTTP clients for `/forward-to` endpoint

### DIFF
--- a/.changeset/pretty-wolves-drive.md
+++ b/.changeset/pretty-wolves-drive.md
@@ -1,0 +1,44 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Extend the utility functions to configure custom HTTP clients to support the configuration for the `/proxy/forward-to` endpoint.
+
+```js
+import createHttpUserAgent from '@commercetools/http-user-agent';
+import {
+  buildApiUrl,
+  createHttpClientOptions,
+  executeHttpClientRequest,
+} from '@commercetools-frontend/application-shell';
+
+const userAgent = createHttpUserAgent({
+  name: 'fetch-client',
+  version: '2.6.0',
+  libraryName: window.app.applicationName,
+  contactEmail: 'support@my-company.com',
+});
+
+// Simple example using `fetch`.
+const data = await executeHttpClientRequest(
+  async (options) => {
+    const res = await fetch(buildApiUrl('/proxy/forward-to'), {
+      method: 'GET',
+      ...options,
+    });
+    const data = await res.json();
+
+    return {
+      data,
+      statusCode: res.status,
+      getHeader: (key) => res.headers.get(key),
+    };
+  },
+  {
+    userAgent,
+    forwardToConfig: {
+      uri: 'https://my-api.com/my-endpoint',
+    },
+  }
+);
+```

--- a/packages/application-shell/src/apollo-links/header-link.spec.js
+++ b/packages/application-shell/src/apollo-links/header-link.spec.js
@@ -13,16 +13,16 @@ import {
   getCorrelationId,
   selectProjectKeyFromUrl,
   selectTeamIdFromLocalStorage,
+  selectUserId,
 } from '../utils';
 import * as oidcStorage from '../utils/oidc-storage';
 import headerLink from './header-link';
 
-jest.mock('../utils/', () => ({
-  getCorrelationId: jest.fn(() => 'test-correlation-id'),
-  selectProjectKeyFromUrl: jest.fn(() => 'project-1'),
-  selectTeamIdFromLocalStorage: jest.fn(() => 'team-1'),
-  selectUserId: jest.fn(() => 'user-1'),
-}));
+jest.mock('@commercetools/http-user-agent', () => jest.fn(() => 'user-agent'));
+jest.mock('../utils/get-correlation-id');
+jest.mock('../utils/select-project-key-from-url');
+jest.mock('../utils/select-team-id-from-local-storage');
+jest.mock('../utils/select-user-id');
 jest.mock('../utils/oidc-storage');
 
 describe('headerLink', () => {
@@ -32,6 +32,12 @@ describe('headerLink', () => {
 });
 
 const mockServer = setupServer();
+beforeEach(() => {
+  getCorrelationId.mockImplementation(() => 'test-correlation-id');
+  selectProjectKeyFromUrl.mockImplementation(() => 'project-1');
+  selectTeamIdFromLocalStorage.mockImplementation(() => 'team-1');
+  selectUserId.mockImplementation(() => 'user-1');
+});
 afterEach(() => {
   mockServer.resetHandlers();
 });
@@ -87,12 +93,14 @@ describe('configuring header link', () => {
       Object {
         "credentials": "include",
         "headers": Object {
+          "Accept": "application/json",
           "X-Correlation-Id": "test-correlation-id",
           "X-Feature-Flag": "test-feature-a",
           "X-Graphql-Operation-Name": "Test",
           "X-Graphql-Target": "mc",
           "X-Project-Key": "project-1",
           "X-Team-Id": "team-1",
+          "X-User-Agent": "user-agent",
         },
       }
     `);
@@ -162,11 +170,13 @@ describe('configuring header link', () => {
         Object {
           "credentials": "include",
           "headers": Object {
+            "Accept": "application/json",
             "X-Correlation-Id": "test-correlation-id",
             "X-Graphql-Operation-Name": "Test",
             "X-Graphql-Target": "mc",
             "X-Project-Key": "test-project-key",
             "X-Team-Id": "team-1",
+            "X-User-Agent": "user-agent",
           },
         }
       `);
@@ -201,11 +211,13 @@ describe('configuring header link', () => {
         Object {
           "credentials": "include",
           "headers": Object {
+            "Accept": "application/json",
             "X-Correlation-Id": "test-correlation-id",
             "X-Graphql-Operation-Name": "Test",
             "X-Graphql-Target": "mc",
             "X-Project-Key": "project-1",
             "X-Team-Id": "test-team-id",
+            "X-User-Agent": "user-agent",
           },
         }
       `);
@@ -240,12 +252,14 @@ describe('configuring header link', () => {
         Object {
           "credentials": "include",
           "headers": Object {
+            "Accept": "application/json",
             "X-Correlation-Id": "test-correlation-id",
             "X-Feature-Flag": "test-feature-flag",
             "X-Graphql-Operation-Name": "Test",
             "X-Graphql-Target": "mc",
             "X-Project-Key": "project-1",
             "X-Team-Id": "team-1",
+            "X-User-Agent": "user-agent",
           },
         }
       `);
@@ -288,6 +302,7 @@ describe('configuring header link', () => {
               "version": "v2",
             },
             "headers": Object {
+              "Accept": "application/json",
               "Accept-version": "v2",
               "X-Correlation-Id": "test-correlation-id",
               "X-Forward-To": "https://avengers.app",
@@ -296,6 +311,7 @@ describe('configuring header link', () => {
               "X-Graphql-Target": "mc",
               "X-Project-Key": "project-1",
               "X-Team-Id": "team-1",
+              "X-User-Agent": "user-agent",
             },
           }
         `);
@@ -345,6 +361,7 @@ describe('configuring header link', () => {
               "version": "v2",
             },
             "headers": Object {
+              "Accept": "application/json",
               "Accept-version": "v2",
               "X-Correlation-Id": "test-correlation-id",
               "X-Forward-To": "https://avengers.app",
@@ -353,6 +370,7 @@ describe('configuring header link', () => {
               "X-Graphql-Target": "mc",
               "X-Project-Key": "project-1",
               "X-Team-Id": "team-1",
+              "X-User-Agent": "user-agent",
               "x-forward-header-accept-language": "*",
               "x-forward-header-x-foo": "bar",
             },
@@ -391,12 +409,14 @@ describe('configuring header link', () => {
         Object {
           "credentials": "include",
           "headers": Object {
+            "Accept": "application/json",
             "Authorization": "Bearer jwt-token",
             "X-Correlation-Id": "test-correlation-id",
             "X-Graphql-Operation-Name": "Test",
             "X-Graphql-Target": "mc",
             "X-Project-Key": "project-1",
             "X-Team-Id": "team-1",
+            "X-User-Agent": "user-agent",
           },
         }
       `);
@@ -416,8 +436,10 @@ describe('configuring header link', () => {
     const projectKey = undefined;
 
     beforeEach(async () => {
-      selectProjectKeyFromUrl.mockReturnValueOnce(null);
-      selectTeamIdFromLocalStorage.mockReturnValueOnce(null);
+      selectProjectKeyFromUrl.mockClear();
+      selectTeamIdFromLocalStorage.mockClear();
+      selectProjectKeyFromUrl.mockImplementation(() => null);
+      selectTeamIdFromLocalStorage.mockImplementation(() => null);
 
       await waitFor(
         execute(link, {

--- a/packages/application-shell/src/configure-apollo.ts
+++ b/packages/application-shell/src/configure-apollo.ts
@@ -1,12 +1,8 @@
-import type {
-  NormalizedCacheObject,
-  InMemoryCacheConfig,
-  FieldMergeFunction,
-  Reference,
-} from '@apollo/client';
-import type { ApplicationWindow } from '@commercetools-frontend/constants';
-
 import {
+  type NormalizedCacheObject,
+  type InMemoryCacheConfig,
+  type FieldMergeFunction,
+  type Reference,
   ApolloClient,
   from,
   createHttpLink,
@@ -14,7 +10,6 @@ import {
   ApolloLink,
 } from '@apollo/client';
 // import { version as apolloVersion } from '@apollo/client/version';
-import createHttpUserAgent from '@commercetools/http-user-agent';
 import {
   errorLink,
   headerLink,
@@ -23,30 +18,14 @@ import {
 } from './apollo-links';
 import { getMcApiUrl } from './utils';
 import { isLoggerEnabled } from './utils/logger';
-import version from './version';
-
-declare let window: ApplicationWindow;
 
 type TApolloClientOptions = {
   cache?: InMemoryCacheConfig;
   restLink?: ApolloLink;
 };
 
-const userAgent = createHttpUserAgent({
-  name: 'apollo-client',
-  // version: apolloVersion,
-  libraryName: [window.app.applicationName, 'application-shell'].join('/'),
-  libraryVersion: version,
-  contactUrl: 'https://git.io/fjuyC', // points to the appkit repo issues
-  contactEmail: 'support@commercetools.com',
-});
-
 const httpLink = createHttpLink({
   uri: `${getMcApiUrl()}/graphql`,
-  headers: {
-    accept: 'application/json',
-    'x-user-agent': userAgent,
-  },
   fetch,
 });
 

--- a/packages/application-shell/src/export-types.ts
+++ b/packages/application-shell/src/export-types.ts
@@ -1,13 +1,11 @@
-import type {
-  TApolloContext as ApolloContext,
-  TForwardToAudiencePolicy as ForwardToAudiencePolicy,
-} from './utils/apollo-context';
+import type { TApolloContext as ApolloContext } from './utils/apollo-context';
 import type {
   TFetcher,
   TFetcherResponse,
   THeaders,
   TConfig,
   TOptions,
+  TForwardToAudiencePolicy as ForwardToAudiencePolicy,
 } from './utils/http-client';
 
 export type TApolloContext = ApolloContext;

--- a/packages/application-shell/src/utils/apollo-client-runtime-cache.ts
+++ b/packages/application-shell/src/utils/apollo-client-runtime-cache.ts
@@ -1,6 +1,4 @@
-import type { NormalizedCacheObject } from '@apollo/client';
-
-import { ApolloClient } from '@apollo/client';
+import { type NormalizedCacheObject, ApolloClient } from '@apollo/client';
 
 // Keep an in-memory reference to the apollo client that would be initialized
 // by the application. This is useful to retrieve on runtime the reference

--- a/packages/application-shell/src/utils/apollo-context.ts
+++ b/packages/application-shell/src/utils/apollo-context.ts
@@ -1,22 +1,11 @@
 import type { TGraphQLTargets } from '@commercetools-frontend/constants';
-
+import type { THeaders, TForwardToConfig } from './http-client';
 import getMcApiUrl from './get-mc-api-url';
-
-export type THeaders = Record<string, string>;
-
-export type TForwardToAudiencePolicy =
-  | 'forward-url-full-path'
-  | 'forward-url-origin';
 
 export type TApolloContext = {
   uri?: string;
   headers?: THeaders;
-  forwardToConfig?: {
-    version: string;
-    uri: string;
-    headers?: THeaders;
-    audiencePolicy: TForwardToAudiencePolicy;
-  };
+  forwardToConfig?: TForwardToConfig;
   skipGraphQlTargetCheck?: boolean;
   skipTokenRetry?: boolean;
   target?: TGraphQLTargets;
@@ -25,26 +14,13 @@ export type TApolloContext = {
   featureFlag?: string;
 };
 
-type TApolloContextProxyForwardTo = {
-  // The GraphQL endpoint of the external server
-  uri: string;
-  headers?: THeaders;
-  audiencePolicy?: TForwardToAudiencePolicy;
-};
-
 const createApolloContextForProxyForwardTo = (
-  proxyForwardTocontext: TApolloContextProxyForwardTo
+  proxyForwardTocontext: TForwardToConfig
 ): TApolloContext => ({
   // Send the request to the forward-to endpoint.
   uri: `${getMcApiUrl()}/proxy/forward-to`,
   // Custom properties to be used by the "header-link".
-  forwardToConfig: {
-    version: 'v2',
-    uri: proxyForwardTocontext.uri,
-    headers: proxyForwardTocontext.headers,
-    audiencePolicy:
-      proxyForwardTocontext.audiencePolicy || 'forward-url-full-path',
-  },
+  forwardToConfig: proxyForwardTocontext,
   skipGraphQlTargetCheck: true,
 });
 

--- a/packages/application-shell/src/utils/select-user-id/select-user-id.ts
+++ b/packages/application-shell/src/utils/select-user-id/select-user-id.ts
@@ -1,5 +1,4 @@
 import type { TFetchUserIdQuery } from '../../types/generated/mc';
-
 import { getCachedApolloClient } from '../apollo-client-runtime-cache';
 import { FetchUserId } from './select-user-id.mc.graphql';
 


### PR DESCRIPTION
Ref #2732

This PR iterates on the recent addition for the HTTP client utils #2734 

When using the `/proxy/forward-to` endpoint there are additional configuration headers to be provided.

Similarly to what we already have for the Apollo client [createApolloContextForProxyForwardTo](https://docs.commercetools.com/custom-applications/api-reference/commercetools-frontend-application-shell#createapollocontextforproxyforwardto), we enhance the `executeHttpClientRequest` config to support the `forwardToConfig`.

Since we now have most of the same logic in the Apollo client, I refactored things a bit to use the HTTP utils in the Apollo client, to avoid duplication.