### PR TITLE
feat(l10n): add `applyTransformedLocalizedStrings` utility function

### DIFF
--- a/.changeset/odd-years-think.md
+++ b/.changeset/odd-years-think.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/l10n': minor
+'playground': minor
+---
+
+Expose utility function `applyTransformedLocalizedStrings`.

--- a/packages/l10n/src/index.ts
+++ b/packages/l10n/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from './time-zone-information';
 
 export {
+  applyTransformedLocalizedStrings,
   applyTransformedLocalizedFields,
   transformLocalizedFieldToLocalizedString,
   transformLocalizedStringToLocalizedField,

--- a/packages/l10n/src/localize.spec.ts
+++ b/packages/l10n/src/localize.spec.ts
@@ -1,6 +1,7 @@
 import {
   transformLocalizedFieldToLocalizedString,
   transformLocalizedStringToLocalizedField,
+  applyTransformedLocalizedStrings,
   applyTransformedLocalizedFields,
   formatLocalizedString,
 } from './localize';
@@ -75,6 +76,45 @@ describe('transformLocalizedFieldToLocalizedString', () => {
           { locale: 'it', value: 'Ciao' },
         ])
       ).toEqual({ en: 'Hello', it: 'Ciao' });
+    });
+  });
+});
+
+describe('applyTransformedLocalizedStrings', () => {
+  describe('when entity contains localized string field', () => {
+    it('should inject localized field object and remove outdated key', () => {
+      expect(
+        applyTransformedLocalizedStrings(
+          {
+            id: '1',
+            name: { en: 'CD', de: 'CD' },
+          },
+          [{ from: 'name', to: 'nameAllLocales' }]
+        )
+      ).toEqual({
+        id: '1',
+        nameAllLocales: [
+          { locale: 'de', value: 'CD' },
+          { locale: 'en', value: 'CD' },
+        ],
+      });
+    });
+  });
+  describe('when entity does not contain a localized string field', () => {
+    it('should inject localized field object as empty array and remove outdated key', () => {
+      expect(
+        applyTransformedLocalizedStrings({ id: '1', name: null }, [
+          { from: 'name', to: 'nameAllLocales' },
+        ])
+      ).toEqual({ id: '1', nameAllLocales: [] });
+    });
+  });
+
+  describe('when array of field names is empty', () => {
+    it('should not change entity shape', () => {
+      expect(
+        applyTransformedLocalizedFields({ id: '1', version: 2 }, [])
+      ).toEqual({ id: '1', version: 2 });
     });
   });
 });

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -34,7 +34,7 @@ export const transformLocalizedFieldToLocalizedString = (
  * { sv: 'Hej' } -> [{ locale: 'sv', value: 'Hej' }]
  */
 export const transformLocalizedStringToLocalizedField = (
-  localizedString: LocalizedString
+  localizedString?: LocalizedString
 ): LocalizedField[] => {
   if (!localizedString || Object.keys(localizedString).length === 0) return [];
   const sorted = Object.keys(localizedString).sort();
@@ -57,7 +57,7 @@ export const transformLocalizedStringToLocalizedField = (
  *
  * @param objectWithLocalizedFields
  * the object with `LocalizedField` fields
- * that need to be transformed into `LocalizedStrings`
+ * that need to be transformed into `LocalizedString`s
  * @param fieldNames
  * An array of objects with following shape:
  *   * `from`: the field to transform and to remove after
@@ -84,6 +84,46 @@ export const applyTransformedLocalizedFields = <
   const namesToOmit = fieldNames.map((fieldName) => fieldName.from);
   const objectWithouLocalizedFields = omit<Input>(
     objectWithLocalizedFields,
+    namesToOmit
+  );
+  return {
+    ...objectWithouLocalizedFields,
+    ...transformedFieldDefinitions,
+  } as Output;
+};
+
+/**
+ * Given a list of localized string names to map, replace the fields in the
+ * format of `LocalizedString` to a `LocalizedField` object.
+ * The existing "localized" strings (the list version) will be removed.
+ *
+ * @param objectWithLocalizedStrings
+ * the object with `LocalizedString` fields
+ * that need to be transformed into `LocalizedField`s
+ * @param fieldNames
+ * An array of objects with following shape:
+ *   * `from`: the field to transform and to remove after
+ *   * `to`: the target field to write the transformed shape
+ */
+export const applyTransformedLocalizedStrings = <
+  Input extends Record<string, unknown>,
+  Output extends Record<string, unknown>
+>(
+  objectWithLocalizedStrings: Input,
+  fieldNames: FieldNameTranformationMapping[]
+): Output => {
+  const transformedFieldDefinitions = fieldNames.reduce(
+    (nextTransformed, fieldName) => ({
+      ...nextTransformed,
+      [fieldName.to]: transformLocalizedStringToLocalizedField(
+        objectWithLocalizedStrings[fieldName.from] as LocalizedString
+      ),
+    }),
+    {}
+  );
+  const namesToOmit = fieldNames.map((fieldName) => fieldName.from);
+  const objectWithouLocalizedFields = omit<Input>(
+    objectWithLocalizedStrings,
     namesToOmit
   );
   return {

--- a/playground/src/apollo-client.js
+++ b/playground/src/apollo-client.js
@@ -1,32 +1,6 @@
-import omit from 'lodash/omit';
 import { RestLink } from 'apollo-link-rest';
 import { createApolloClient } from '@commercetools-frontend/application-shell';
-import { transformLocalizedStringToLocalizedField } from '@commercetools-frontend/l10n';
-
-// TODO: move to `l10n` package.
-const applyTransformedLocalizedStrings = (
-  objectWithLocalizedStrings,
-  fieldNames
-) => {
-  const transformedFieldDefinitions = fieldNames.reduce(
-    (nextTransformed, fieldName) => ({
-      ...nextTransformed,
-      [fieldName.to]: transformLocalizedStringToLocalizedField(
-        objectWithLocalizedStrings[fieldName.from]
-      ),
-    }),
-    {}
-  );
-  const namesToOmit = fieldNames.map((fieldName) => fieldName.from);
-  const objectWithouLocalizedFields = omit(
-    objectWithLocalizedStrings,
-    namesToOmit
-  );
-  return {
-    ...objectWithouLocalizedFields,
-    ...transformedFieldDefinitions,
-  };
-};
+import { applyTransformedLocalizedStrings } from '@commercetools-frontend/l10n';
 
 const restLink = new RestLink({
   uri: window.app.mcApiUrl,


### PR DESCRIPTION
Similarly to the existing function `applyTransformedLocalizedFields`, we were missing the one for the opposite behavior.