### PR TITLE
refactor: use Yarn patch instead of patch-package

### DIFF
--- a/.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch
+++ b/.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch
@@ -1,7 +1,7 @@
-diff --git a/node_modules/babel-plugin-typescript-to-proptypes/lib/convertBabelToPropTypes.js b/node_modules/babel-plugin-typescript-to-proptypes/lib/convertBabelToPropTypes.js
-index 4d3252f..c939b42 100644
---- a/node_modules/babel-plugin-typescript-to-proptypes/lib/convertBabelToPropTypes.js
-+++ b/node_modules/babel-plugin-typescript-to-proptypes/lib/convertBabelToPropTypes.js
+diff --git a/lib/convertBabelToPropTypes.js b/lib/convertBabelToPropTypes.js
+index 4d3252fb8d0f2d4c69eb4320fbf65ce9cffed707..c939b42e849db5d417d8e0b2c8245c8190baab56 100644
+--- a/lib/convertBabelToPropTypes.js
++++ b/lib/convertBabelToPropTypes.js
 @@ -141,6 +141,13 @@ function convert(type, state, depth) {
          }
          else if (NATIVE_BUILT_INS.includes(name)) {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "jest-watch-typeahead": "1.1.0",
     "lint-staged": "11.2.6",
     "mri": "1.2.0",
-    "patch-package": "6.4.7",
     "postcss": "8.4.14",
     "postcss-load-config": "3.1.4",
     "postcss-modules": "4.3.1",
@@ -171,7 +170,8 @@
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "core-js-compat": "^3.23.4",
-    "intl-messageformat-parser": "6.4.4"
+    "intl-messageformat-parser": "6.4.4",
+    "babel-plugin-typescript-to-proptypes@1.4.2": "patch:babel-plugin-typescript-to-proptypes@npm:1.4.2#.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch"
   },
   "engines": {
     "node": ">=14",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -16,6 +16,3 @@ fi
 echo "Running prettier on package.json files"
 # We need to run prettier to avoid unnecessary formatting changes to package.json (due to Yarn install).
 yarn prettier --write --parser json '**/package.json' &>/dev/null
-
-echo "Patching packages"
-yarn patch-package

--- a/yarn.lock
+++ b/yarn.lock
@@ -12089,13 +12089,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/lockfile@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@yarnpkg/lockfile@npm:1.1.0"
-  checksum: 05b881b4866a3546861fee756e6d3812776ea47fa6eb7098f983d6d0eefa02e12b66c3fff931574120f196286a7ad4879ce02743c8bb2be36c6a576c7852083a
-  languageName: node
-  linkType: hard
-
 "@zxing/text-encoding@npm:0.9.0":
   version: 0.9.0
   resolution: "@zxing/text-encoding@npm:0.9.0"
@@ -13371,6 +13364,21 @@ __metadata:
     "@babel/core": ^7.0.0
     typescript: ^3.0.0 || ^4.0.0
   checksum: 00a9e3f44c98a9f22b8201d7a24d82928ae6e39aec208f8101d8f3d9d5ea8b5ec420b7ae45558d8c1b6f554031305731973b1731d6a61e2a769a2d39827ae23a
+  languageName: node
+  linkType: hard
+
+"babel-plugin-typescript-to-proptypes@patch:babel-plugin-typescript-to-proptypes@npm:1.4.2#.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch::locator=merchant-center-application-kit%40workspace%3A.":
+  version: 1.4.2
+  resolution: "babel-plugin-typescript-to-proptypes@patch:babel-plugin-typescript-to-proptypes@npm%3A1.4.2#.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch::version=1.4.2&hash=b500d9&locator=merchant-center-application-kit%40workspace%3A."
+  dependencies:
+    "@babel/helper-module-imports": ^7.12.5
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-syntax-typescript": ^7.12.1
+    "@babel/types": ^7.12.6
+  peerDependencies:
+    "@babel/core": ^7.0.0
+    typescript: ^3.0.0 || ^4.0.0
+  checksum: 638307f330c6b6759201a8154ecad187c3646111fc7af3a4e3927b41d66080ccb1aeee10af9f80bdbd7dd2e345485919c2fb08233f43ed3bc7ec0f0e5d2d2f44
   languageName: node
   linkType: hard
 
@@ -20344,15 +20352,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-yarn-workspace-root@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "find-yarn-workspace-root@npm:2.0.0"
-  dependencies:
-    micromatch: ^4.0.2
-  checksum: fa5ca8f9d08fe7a54ce7c0a5931ff9b7e36f9ee7b9475fb13752bcea80ec6b5f180fa5102d60b376d5526ce924ea3fc6b19301262efa0a5d248dd710f3644242
-  languageName: node
-  linkType: hard
-
 "flat-cache@npm:^3.0.4":
   version: 3.0.4
   resolution: "flat-cache@npm:3.0.4"
@@ -26167,15 +26166,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"klaw-sync@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "klaw-sync@npm:6.0.0"
-  dependencies:
-    graceful-fs: ^4.1.11
-  checksum: 0da397f8961313c3ef8f79fb63af9002cde5a8fb2aeb1a37351feff0dd6006129c790400c3f5c3b4e757bedcabb13d21ec0a5eaef5a593d59515d4f2c291e475
-  languageName: node
-  linkType: hard
-
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -27805,7 +27795,6 @@ __metadata:
     jest-watch-typeahead: 1.1.0
     lint-staged: 11.2.6
     mri: 1.2.0
-    patch-package: 6.4.7
     postcss: 8.4.14
     postcss-load-config: 3.1.4
     postcss-modules: 4.3.1
@@ -29462,7 +29451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^7.0.3, open@npm:^7.4.2":
+"open@npm:^7.0.3":
   version: 7.4.2
   resolution: "open@npm:7.4.2"
   dependencies:
@@ -30097,29 +30086,6 @@ __metadata:
     ansi-escapes: ^3.1.0
     cross-spawn: ^6.0.5
   checksum: 4763ec1b48cb311d60df37186e31f1b85ec3249a21cc17bbf8407d66c5b55cffe34b4eb529ebd044ed4ced7f3ea3fad744fe15e30a5de31645433e94cd444266
-  languageName: node
-  linkType: hard
-
-"patch-package@npm:6.4.7":
-  version: 6.4.7
-  resolution: "patch-package@npm:6.4.7"
-  dependencies:
-    "@yarnpkg/lockfile": ^1.1.0
-    chalk: ^2.4.2
-    cross-spawn: ^6.0.5
-    find-yarn-workspace-root: ^2.0.0
-    fs-extra: ^7.0.1
-    is-ci: ^2.0.0
-    klaw-sync: ^6.0.0
-    minimist: ^1.2.0
-    open: ^7.4.2
-    rimraf: ^2.6.3
-    semver: ^5.6.0
-    slash: ^2.0.0
-    tmp: ^0.0.33
-  bin:
-    patch-package: index.js
-  checksum: f36d5324da3b69ee635e7cd2c68f4d3dd89dc91d60ffdaad3b602fd953277f4da901c91033683bf6ff31c14799bc049849af3a389455c25d0435fe9cfb0d4088
   languageName: node
   linkType: hard
 
@@ -33268,7 +33234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.2, rimraf@npm:^2.6.3":
+"rimraf@npm:^2.6.2":
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:


### PR DESCRIPTION
Using the built-in [yarn patch](https://yarnpkg.com/cli/patch) functionality instead of the third-party `patch-package`.