### PR TITLE
Update percy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@graphql-codegen/typescript-graphql-files-modules": "2.2.1",
     "@graphql-codegen/typescript-operations": "2.5.3",
     "@manypkg/cli": "0.19.1",
-    "@percy/cli": "1.1.4",
+    "@percy/cli": "1.9.1",
     "@percy/cypress": "3.1.1",
     "@percy/puppeteer": "2.0.2",
     "@preconstruct/cli": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9540,117 +9540,117 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@percy/cli-build@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli-build@npm:1.1.4"
+"@percy/cli-build@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli-build@npm:1.9.1"
   dependencies:
-    "@percy/cli-command": 1.1.4
-  checksum: e5828f8edc259a836afdfd1301964d86d9528946bf32368b537d95c76ceaa1f3700a667324dca7d04b569945868c4d302396de58502506130c08bb56009a9123
+    "@percy/cli-command": 1.9.1
+  checksum: f46be9c45260dcf2d869fe7293f7938c015f9f92b7a471e7d5484cb44f7aab8f06fe365c05dafa5b8e4e5d764f6d43c5ba051ceef0a4788fcbaa6f8ac401ec62
   languageName: node
   linkType: hard
 
-"@percy/cli-command@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli-command@npm:1.1.4"
+"@percy/cli-command@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli-command@npm:1.9.1"
   dependencies:
-    "@percy/config": 1.1.4
-    "@percy/core": 1.1.4
-    "@percy/logger": 1.1.4
+    "@percy/config": 1.9.1
+    "@percy/core": 1.9.1
+    "@percy/logger": 1.9.1
   bin:
     percy-cli-readme: bin/readme.js
-  checksum: b8aeb84a77e71a19e9f2bc9ffbe1eb46757b98a641d74035a24deccda3256dbb3c0d9a5ded4657460284eaae8d8c15f3889696a0db255c0c354202c7d5949385
+  checksum: 7d577ca9adc099c931c5595e4056b5e89f400f44a6ee88f68c582881befa9627ea094a27c88cad9dc01b44e5a1600737ec0fa3c6779061b4fdc97d1a60c1aff8
   languageName: node
   linkType: hard
 
-"@percy/cli-config@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli-config@npm:1.1.4"
+"@percy/cli-config@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli-config@npm:1.9.1"
   dependencies:
-    "@percy/cli-command": 1.1.4
-  checksum: 05150b661e8d9c396f901751fef2577ba41ed27217f11e13049dce7ea64ed68ff41bfec0dd86b0e2a25b925aca1d2e5bbc701e59d78814dbd116f8401616e19d
+    "@percy/cli-command": 1.9.1
+  checksum: fbbe6c263ccebd243e6ea4faa5a2fe65b64990408ce0ec172869d88e21c88b0504c8463199441b79aeb1eed4e204a7d521b90ab80dadd8ab8ba8dcb16934d421
   languageName: node
   linkType: hard
 
-"@percy/cli-exec@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli-exec@npm:1.1.4"
+"@percy/cli-exec@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli-exec@npm:1.9.1"
   dependencies:
-    "@percy/cli-command": 1.1.4
+    "@percy/cli-command": 1.9.1
     cross-spawn: ^7.0.3
     which: ^2.0.2
-  checksum: 9d4e5311cdcbdab8421121065bb8bba9026d7723d4500bd735370121a75d3c449cc14b0b1941f3261382b6704d0e1a205a3daa567d0bebfcc5090088efbef019
+  checksum: da94a224d88931633e352dc853485f5cbd640c4f74a1e1d34d3c72aaebb38b2ad20274ba06114efd7c2269895051b7c4826caef9a9c51b97a845d3152d69ff41
   languageName: node
   linkType: hard
 
-"@percy/cli-snapshot@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli-snapshot@npm:1.1.4"
+"@percy/cli-snapshot@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli-snapshot@npm:1.9.1"
   dependencies:
-    "@percy/cli-command": 1.1.4
+    "@percy/cli-command": 1.9.1
     yaml: ^2.0.0
-  checksum: 63aac9c9279607abb1e0446770a3fa5e188c8d1e706f931a4a018772763a709dd2a70832e359682fff49ff47393662b37deadf1e3804896b6329705eff2640d0
+  checksum: d1f6178fc30fde664dbb2015fd2937d274a7df293564fe1a48f82e99c1f71f5bf553d5af94b0e44e96c31cce0a171230ed42322d1dee149adb89df5f57167a59
   languageName: node
   linkType: hard
 
-"@percy/cli-upload@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli-upload@npm:1.1.4"
+"@percy/cli-upload@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli-upload@npm:1.9.1"
   dependencies:
-    "@percy/cli-command": 1.1.4
+    "@percy/cli-command": 1.9.1
     fast-glob: ^3.2.11
     image-size: ^1.0.0
-  checksum: d75755ac45410754c9e92d88f119220b19fde90f54ea50ee5059f686694002e59cabf1349d55798858a3dd32635192643e5e4329a1f872ea22e1f53d6f033bc3
+  checksum: 8e9e2917841f17d4a508baf5c5b627119a7dd65934e88937c196077afbf9bcdfb04953162b589ffb3551eb7e25a627cc85342c8e9c456ef35a89535fa8467e7d
   languageName: node
   linkType: hard
 
-"@percy/cli@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/cli@npm:1.1.4"
+"@percy/cli@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/cli@npm:1.9.1"
   dependencies:
-    "@percy/cli-build": 1.1.4
-    "@percy/cli-command": 1.1.4
-    "@percy/cli-config": 1.1.4
-    "@percy/cli-exec": 1.1.4
-    "@percy/cli-snapshot": 1.1.4
-    "@percy/cli-upload": 1.1.4
-    "@percy/client": 1.1.4
-    "@percy/logger": 1.1.4
+    "@percy/cli-build": 1.9.1
+    "@percy/cli-command": 1.9.1
+    "@percy/cli-config": 1.9.1
+    "@percy/cli-exec": 1.9.1
+    "@percy/cli-snapshot": 1.9.1
+    "@percy/cli-upload": 1.9.1
+    "@percy/client": 1.9.1
+    "@percy/logger": 1.9.1
   bin:
     percy: bin/run.cjs
-  checksum: 3ae1e4422be404b0e61033223b16d98b164e483c53e9dd347a7e0ddb819743824e810415974d245cc2e05407e3b1cf23b265131f4faef7df004c6bd051366c40
+  checksum: 16cdedcdd5ef973bb6f2bff07a9d596951ffb2ece234fe4456e3c9a62c790e93c39dc804e16d54c158852668d4ce91dacd45dbddd01e9c10d744dcd683f7af27
   languageName: node
   linkType: hard
 
-"@percy/client@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/client@npm:1.1.4"
+"@percy/client@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/client@npm:1.9.1"
   dependencies:
-    "@percy/env": 1.1.4
-    "@percy/logger": 1.1.4
-  checksum: bd5f3b354cfa272ce3a9bd50e1c70bc77d19ca7213c1668e2addef1f3c5188b20d9b2a8153986c96ee1595cf6723d60c45234c40a643107cd6a55b627fd3224e
+    "@percy/env": 1.9.1
+    "@percy/logger": 1.9.1
+  checksum: 07d7e453670ceed2f7ae563b8f582b5555c5bddde886414d130ad572eb1a4e689f07640ddd1d2c51e89cc7a285b1a35ba7fd16c1763f68ae3504a83008da2817
   languageName: node
   linkType: hard
 
-"@percy/config@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/config@npm:1.1.4"
+"@percy/config@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/config@npm:1.9.1"
   dependencies:
-    "@percy/logger": 1.1.4
+    "@percy/logger": 1.9.1
     ajv: ^8.6.2
     cosmiconfig: ^7.0.0
     yaml: ^2.0.0
-  checksum: 6c7f5269de5032bb987aa84824fd5b11f5288c1f01daa3ee35582b8948809a1c00ded5a9d76f67b2dd4a263b812a94313c9067dbcb14fa88995d9262334f2543
+  checksum: 3427b65bb2ae42233f917bc0ca6ea95d13fac44d03ee0e96c7ea4c614395207c1fe18622226bab8565300ed8c31420d1e5ee4cff057bdabb419d9dd0de140094
   languageName: node
   linkType: hard
 
-"@percy/core@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/core@npm:1.1.4"
+"@percy/core@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/core@npm:1.9.1"
   dependencies:
-    "@percy/client": 1.1.4
-    "@percy/config": 1.1.4
-    "@percy/dom": 1.1.4
-    "@percy/logger": 1.1.4
+    "@percy/client": 1.9.1
+    "@percy/config": 1.9.1
+    "@percy/dom": 1.9.1
+    "@percy/logger": 1.9.1
     content-disposition: ^0.5.4
     cross-spawn: ^7.0.3
     extract-zip: ^2.0.1
@@ -9660,7 +9660,7 @@ __metadata:
     path-to-regexp: ^6.2.0
     rimraf: ^3.0.2
     ws: ^8.0.0
-  checksum: e29c1ce4fc3ddab62eb562ce8d6510e58bbae1e422a78a164791ec7f310a29903f93a0510f44e908b5209044538adf883bd7d572310e1fb188b64b86157eb1e2
+  checksum: 38cf58417efc756af59ef334f9e1353258da92b430b1f742ef2570166dd4569da8fef98c306e6b06e1e81f03c3b425dabb6c67339fb525db52269242a992f09c
   languageName: node
   linkType: hard
 
@@ -9675,17 +9675,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@percy/dom@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/dom@npm:1.1.4"
-  checksum: 3b113eacc56acd36c225e34646ad3fcfe9c25074fe35df59f45be59a526a3b196f225a0f2fa7f30e9c28cb73c8ac27b9b02018cc0e6041557ff16501e59cfb07
+"@percy/dom@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/dom@npm:1.9.1"
+  checksum: f4c288652015a75f6f0cbb99fa01fd1aa37b701540601d20d50f56962cc373348de00bbf0a4ff35c75b98c890623abab6da2740a8349e85f1b152b8d5b02bac0
   languageName: node
   linkType: hard
 
-"@percy/env@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/env@npm:1.1.4"
-  checksum: 1a30c1c252b50caeb43043727e5bbd4f9234d8c80b6db61fc2946a894c81715ec334a7fa41b46b67f6b72f73b1ed127e36ab58ced3ee580b69db372482fa454d
+"@percy/env@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/env@npm:1.9.1"
+  checksum: 177f7417cc47af3dca7dd75043c93b68f1c8f33d4bce6796f371996a782f939bca894832b174766ebb806991b20a90df4eca88203ca6328e731e92ce14735851
   languageName: node
   linkType: hard
 
@@ -9696,10 +9696,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@percy/logger@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@percy/logger@npm:1.1.4"
-  checksum: a985b58a1a02ef3c9e8fda61424f631bafa34ab739266abe847237a3e93abfb16db1ce2cb5722c2e27fd1f511c20f1154b6be83182fc7976a47a07a12adbce79
+"@percy/logger@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@percy/logger@npm:1.9.1"
+  checksum: 970c3af3940f238481f575268ff920316651b7fd4d53a178651f53279709a9c2e8e672f3aada6eb06c829bd9d1eadb4a0cf6fa9946f04ee61987d38a270cb4d3
   languageName: node
   linkType: hard
 
@@ -28580,7 +28580,7 @@ __metadata:
     "@graphql-codegen/typescript-graphql-files-modules": 2.2.1
     "@graphql-codegen/typescript-operations": 2.5.3
     "@manypkg/cli": 0.19.1
-    "@percy/cli": 1.1.4
+    "@percy/cli": 1.9.1
     "@percy/cypress": 3.1.1
     "@percy/puppeteer": 2.0.2
     "@preconstruct/cli": 2.2.1


### PR DESCRIPTION
#### Summary

Updates [@percy/cli](url) dependency from version `1.1.4` to `1.9.1`.

#### Description

There's also an update available for package [@percy/cypress](https://togithub.com/percy/percy-cypress) from version `3.1.1` to `3.1.2` but I'm not including it here since that [changes cypress usage to v10](https://github.com/percy/percy-cypress/releases/tag/v3.1.2) which we are not using yet so I think it's better having a separate PR for those two packages combined.
