### PR TITLE
refactor(app-shell): throw if required `forwardToConfig.uri` option is missing

### DIFF
--- a/.changeset/cool-forks-share.md
+++ b/.changeset/cool-forks-share.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-website/custom-applications': patch
+---
+
+Validate that `forwardToConfig.uri` is defined, when using a custom HTTP client.

--- a/packages/application-shell/src/utils/http-client.spec.ts
+++ b/packages/application-shell/src/utils/http-client.spec.ts
@@ -161,4 +161,21 @@ describe('Custom HTTP client (fetch)', () => {
     expect(data).toEqual({ message: 'Hello' });
     expect(oidcStorage.setActiveSession).toHaveBeenCalledWith('12345');
   });
+
+  it('should throw an error if the "uri" option of "forwardToConfig" is missing', async () => {
+    expect(() =>
+      createHttpClientOptions({
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        userAgent: 'hello',
+        forwardToConfig: {
+          uri: '',
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Missing required \\"uri\\" option."`
+    );
+  });
 });

--- a/packages/application-shell/src/utils/http-client.ts
+++ b/packages/application-shell/src/utils/http-client.ts
@@ -27,9 +27,21 @@ export type TForwardToAudiencePolicy =
 export type TForwardToConfigVersion = 'v1' | 'v2';
 
 export type TForwardToConfig = {
+  /**
+   * The URL of the external API to forward the request to.
+   */
   uri: string;
+  /**
+   * Additional HTTP headers to be included in the request to the external API.
+   */
   headers?: THeaders;
+  /**
+   * The audience policy for verifying the incoming request from the Merchant Center API.
+   */
   audiencePolicy?: TForwardToAudiencePolicy;
+  /**
+   * The version of the `/proxy/forward-to` endpoint to use.
+   */
   version?: TForwardToConfigVersion;
 };
 
@@ -134,6 +146,9 @@ const getAppliedForwardToHeaders = (
 ): THeaders => {
   if (!forwardToConfig) {
     return {};
+  }
+  if (!forwardToConfig.uri) {
+    throw new Error(`Missing required "uri" option.`);
   }
   return {
     ...Object.entries(forwardToConfig.headers ?? {}).reduce(

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -226,7 +226,7 @@ const useExternalApiFetcher = () => {
 
 Available options are:
 
-* `uri` (**required**): The URL to request to from the external API.
+* `uri` (**required**): The URL of the external API to forward the request to.
 * `headers` (optional): Additional HTTP headers to be included in the request to the external API.
 * `audiencePolicy` (optional): See [configuring the audience policy](/concepts/integrate-with-your-own-api#configuring-the-audience-policy).
 * `version` (optional): See [versioning](/concepts/integrate-with-your-own-api#versioning).
@@ -309,7 +309,7 @@ The `THttpClientConfig` object accepts the following options:
   ```
 * `headers` (optional): Additional HTTP headers to be included in the request. The provided recommended headers won't be overwritten.
 * `forwardToConfig` (optional): Configuration for using the `/proxy/forward-to` endpoint to [connect to an external API](/concepts/integrate-with-your-own-api#usage-for-custom-http-client).
-  * `uri` (**required**): The URL to request to from the external API.
+  * `uri` (**required**): The URL of the external API to forward the request to.
   * `headers` (optional): Additional HTTP headers to be included in the request to the external API.
   * `audiencePolicy` (optional): See [configuring the audience policy](/concepts/integrate-with-your-own-api#configuring-the-audience-policy).
   * `version` (recommended): See [versioning](/concepts/integrate-with-your-own-api#versioning).


### PR DESCRIPTION
See https://github.com/commercetools/merchant-center-application-kit/issues/2732#issuecomment-1220331401