### PR TITLE
Allow to request custom claims in forward-to requests

### DIFF
--- a/.changeset/fifty-cows-reflect.md
+++ b/.changeset/fifty-cows-reflect.md
@@ -14,7 +14,7 @@ const useExternalApiFetcher = () => {
   const { loading, data, error } = useMcQuery(MyQuery, {
     context: createApolloContextForProxyForwardTo({
       uri: externalApiUrl,
-      exchangeTokenClaims: ['permissions'],
+      includeUserPermissions: true,
     }),
   });
 
@@ -46,7 +46,7 @@ const data = await executeHttpClientRequest(
     userAgent,
     forwardToConfig: {
       uri: 'https://my-api.com/my-endpoint',
-      exchangeTokenClaims: ['permissions'],
+      includeUserPermissions: true,
     },
   }
 );

--- a/.changeset/fifty-cows-reflect.md
+++ b/.changeset/fifty-cows-reflect.md
@@ -5,16 +5,16 @@
 Add support for requesting specific `claims` to be included in the exchange JWT sent from Merchant Center API to an external API.
 Currently we only support requesting a custom claim with logged in user's permissions.
 
-```
+```js
 // Apollo example
 const useExternalApiFetcher = () => {
   const externalApiUrl = useApplicationContext(
-    context => context.environment.externalApiUrl
+    (context) => context.environment.externalApiUrl
   );
   const { loading, data, error } = useMcQuery(MyQuery, {
     context: createApolloContextForProxyForwardTo({
       uri: externalApiUrl,
-      exchangeTokenClaims: ['permissions']
+      exchangeTokenClaims: ['permissions'],
     }),
   });
 
@@ -22,11 +22,11 @@ const useExternalApiFetcher = () => {
     loading,
     data,
     error,
-  }
+  };
 };
 ```
 
-```
+```js
 // Custom HTTP client example (using `fetch`)
 const data = await executeHttpClientRequest(
   async (options) => {
@@ -46,7 +46,7 @@ const data = await executeHttpClientRequest(
     userAgent,
     forwardToConfig: {
       uri: 'https://my-api.com/my-endpoint',
-      exchangeTokenClaims: ['permissions']
+      exchangeTokenClaims: ['permissions'],
     },
   }
 );

--- a/.changeset/fifty-cows-reflect.md
+++ b/.changeset/fifty-cows-reflect.md
@@ -1,0 +1,53 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Add support for requesting specific `claims` to be included in the exchange JWT sent from Merchant Center API to an external API.
+Currently we only support requesting a custom claim with logged in user's permissions.
+
+```
+// Apollo example
+const useExternalApiFetcher = () => {
+  const externalApiUrl = useApplicationContext(
+    context => context.environment.externalApiUrl
+  );
+  const { loading, data, error } = useMcQuery(MyQuery, {
+    context: createApolloContextForProxyForwardTo({
+      uri: externalApiUrl,
+      exchangeTokenClaims: ['permissions']
+    }),
+  });
+
+  return {
+    loading,
+    data,
+    error,
+  }
+};
+```
+
+```
+// Custom HTTP client example (using `fetch`)
+const data = await executeHttpClientRequest(
+  async (options) => {
+    const res = await fetch(buildApiUrl('/proxy/forward-to'), {
+      method: 'GET',
+      ...options,
+    });
+    const data = await res.json();
+
+    return {
+      data,
+      statusCode: res.status,
+      getHeader: (key) => res.headers.get(key),
+    };
+  },
+  {
+    userAgent,
+    forwardToConfig: {
+      uri: 'https://my-api.com/my-endpoint',
+      exchangeTokenClaims: ['permissions']
+    },
+  }
+);
+```

--- a/.changeset/twenty-pears-admire.md
+++ b/.changeset/twenty-pears-admire.md
@@ -1,0 +1,15 @@
+---
+'@commercetools-frontend/sdk': patch
+---
+
+Add support for requesting specific `claims` to be included in the exchange JWT sent from Merchant Center API to an external API.
+Currently we only support requesting a custom claim with logged in user's permissions.
+
+```
+actions.forwardTo.get({
+  exchangeTokenClaims: ['permissions'],
+  // ...
+});
+```
+
+// "X-Forward-To-Claims": "permissions"

--- a/.changeset/twenty-pears-admire.md
+++ b/.changeset/twenty-pears-admire.md
@@ -7,7 +7,7 @@ Currently we only support requesting a custom claim with logged in user's permis
 
 ```js
 actions.forwardTo.get({
-  exchangeTokenClaims: ['permissions'],
+  includeUserPermissions: true,
   // ...
 });
 // "X-Forward-To-Claims": "permissions"

--- a/.changeset/twenty-pears-admire.md
+++ b/.changeset/twenty-pears-admire.md
@@ -5,7 +5,7 @@
 Add support for requesting specific `claims` to be included in the exchange JWT sent from Merchant Center API to an external API.
 Currently we only support requesting a custom claim with logged in user's permissions.
 
-```
+```js
 actions.forwardTo.get({
   exchangeTokenClaims: ['permissions'],
   // ...

--- a/.changeset/twenty-pears-admire.md
+++ b/.changeset/twenty-pears-admire.md
@@ -10,6 +10,5 @@ actions.forwardTo.get({
   exchangeTokenClaims: ['permissions'],
   // ...
 });
-```
-
 // "X-Forward-To-Claims": "permissions"
+```

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -14,6 +14,7 @@ export const SUPPORTED_HEADERS = {
   X_FEATURE_FLAG: 'X-Feature-Flag',
   X_FORWARD_TO: 'X-Forward-To',
   X_FORWARD_TO_AUDIENCE_POLICY: 'X-Forward-To-Audience-Policy',
+  X_FORWARD_TO_CLAIMS: 'X-Forward-To-Claims',
   X_GRAPHQL_TARGET: 'X-Graphql-Target',
   X_GRAPHQL_OPERATION_NAME: 'X-Graphql-Operation-Name',
   X_PROJECT_KEY: 'X-Project-Key',

--- a/packages/application-shell/src/utils/http-client.spec.ts
+++ b/packages/application-shell/src/utils/http-client.spec.ts
@@ -7,7 +7,6 @@ import {
   buildApiUrl,
   createHttpClientOptions,
   executeHttpClientRequest,
-  TForwardToExchangeTokenClaim,
 } from './http-client';
 import * as oidcStorage from './oidc-storage';
 
@@ -149,12 +148,7 @@ describe('Custom HTTP client (fetch)', () => {
       userAgent: 'hello',
       forwardToConfig: {
         uri: 'https://my-api.com',
-        // Force casting here to allow adding a non valid claim to check it will
-        // not be included in the header
-        exchangeTokenClaims: [
-          'permissions',
-          'imaginary-claim',
-        ] as TForwardToExchangeTokenClaim[],
+        includeUserPermissions: true,
       },
     });
 

--- a/packages/application-shell/src/utils/http-client.spec.ts
+++ b/packages/application-shell/src/utils/http-client.spec.ts
@@ -2,10 +2,12 @@
 import type { Headers } from 'headers-polyfill';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { SUPPORTED_HEADERS } from '../constants';
 import {
   buildApiUrl,
   createHttpClientOptions,
   executeHttpClientRequest,
+  TForwardToExchangeTokenClaim,
 } from './http-client';
 import * as oidcStorage from './oidc-storage';
 
@@ -84,6 +86,9 @@ describe('Custom HTTP client (fetch)', () => {
             'x-forward-to-audience-policy',
             'forward-url-full-path'
           );
+          expect(req.headers.get(SUPPORTED_HEADERS.X_FORWARD_TO_CLAIMS)).toBe(
+            null
+          );
         } catch (error) {
           if (error instanceof Error)
             return res(ctx.status(400), ctx.json({ message: error.message }));
@@ -121,6 +126,43 @@ describe('Custom HTTP client (fetch)', () => {
       method: 'GET',
     });
     await expect(res.json()).resolves.toEqual({ message: 'Hello' });
+  });
+
+  it('should include "X-Forward-To-Claims" header when config is provided (for /forward-to)', async () => {
+    const mockResponseData = { message: 'Hello' };
+    mockServer.use(
+      rest.get(buildApiUrl('/proxy/forward-to'), (req, res, ctx) => {
+        throwIfMissingHeader(
+          req.headers,
+          SUPPORTED_HEADERS.X_FORWARD_TO_CLAIMS,
+          'permissions'
+        );
+
+        return res(ctx.status(200), ctx.json(mockResponseData));
+      })
+    );
+
+    const httpRequestOptions = createHttpClientOptions({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      userAgent: 'hello',
+      forwardToConfig: {
+        uri: 'https://my-api.com',
+        // Force casting here to allow adding a non valid claim to check it will
+        // not be included in the header
+        exchangeTokenClaims: [
+          'permissions',
+          'imaginary-claim',
+        ] as TForwardToExchangeTokenClaim[],
+      },
+    });
+
+    const res = await fetch(buildApiUrl('/proxy/forward-to'), {
+      ...httpRequestOptions,
+      method: 'GET',
+    });
+    await expect(res.json()).resolves.toEqual(mockResponseData);
   });
 
   it('should execute request and renew token', async () => {

--- a/packages/application-shell/src/utils/http-client.ts
+++ b/packages/application-shell/src/utils/http-client.ts
@@ -42,8 +42,7 @@ export type TForwardToConfig = {
    */
   audiencePolicy?: TForwardToAudiencePolicy;
   /**
-   * Request the Merchange Center API to include the user permission in the
-   * exchange token sent in the forwarded request to the external API.
+   * A list of user permissions to be included in the request to the external API.
    */
   includeUserPermissions?: boolean;
   /**
@@ -134,8 +133,6 @@ export type TFetcher<Data> = (
   options: TOptions
 ) => Promise<TFetcherResponse<Data>>;
 
-const allowedForwardToExchangeClaims = ['permissions'];
-
 const defaultUserAgent = createHttpUserAgent({
   name: 'unknown-http-client',
   libraryName: window.app.applicationName,
@@ -179,13 +176,7 @@ const getAppliedForwardToHeaders = (
     [SUPPORTED_HEADERS.X_FORWARD_TO]: forwardToConfig.uri,
     [SUPPORTED_HEADERS.X_FORWARD_TO_AUDIENCE_POLICY]:
       forwardToConfig.audiencePolicy ?? defaultForwardToAudiencePolicy,
-    ...(Boolean(exchangeTokenClaims?.length)
-      ? {
-          [SUPPORTED_HEADERS.X_FORWARD_TO_CLAIMS]: exchangeTokenClaims!
-            .filter((token) => allowedForwardToExchangeClaims.includes(token))
-            .join(' '),
-        }
-      : {}),
+    [SUPPORTED_HEADERS.X_FORWARD_TO_CLAIMS]: exchangeTokenClaims.join(' '),
   };
 };
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -35,6 +35,7 @@
     "@types/react-redux": "^7.1.24",
     "buffer": "6.0.3",
     "fast-equals": "2.0.4",
+    "omit-empty-es": "1.1.3",
     "prop-types": "15.8.1",
     "qss": "2.0.3",
     "unfetch": "4.2.0",

--- a/packages/sdk/src/actions/actions.spec.ts
+++ b/packages/sdk/src/actions/actions.spec.ts
@@ -1,4 +1,3 @@
-import { TForwardToExchangeTokenClaim } from '../types';
 import * as actions from './actions';
 
 describe.each`
@@ -127,12 +126,7 @@ describe.each`
           'x-foo': 'bar',
           'accept-language': '*',
         },
-        // Force casting here to allow adding a non valid claim to check it will
-        // not be included in the header
-        exchangeTokenClaims: [
-          'permissions',
-          'imaginary-claim',
-        ] as TForwardToExchangeTokenClaim[],
+        includeUserPermissions: true,
       };
       const payloadWithBody = {
         ...payloadWithoutBody,
@@ -160,7 +154,7 @@ describe.each`
       expect(result).toEqual({
         type: 'SDK',
         payload: {
-          exchangeTokenClaims: ['permissions', 'imaginary-claim'],
+          includeUserPermissions: true,
           method,
           uri: '/proxy/forward-to',
           mcApiProxyTarget: undefined,

--- a/packages/sdk/src/actions/actions.ts
+++ b/packages/sdk/src/actions/actions.ts
@@ -13,6 +13,8 @@ import type {
   TSdkActionPostForService,
 } from '../types';
 
+const allowedForwardToExchangeClaims = ['permissions'];
+
 export function get(payload: TSdkActionPayloadForUri): TSdkActionGetForUri;
 export function get(
   payload: TSdkActionPayloadForService
@@ -67,6 +69,15 @@ const enhancePayloadForForwardToProxy = (payload: TSdkActionPayloadForUri) => {
       'X-Forward-To': payload.uri,
       'X-Forward-To-Audience-Policy':
         payload.audiencePolicy || 'forward-url-full-path',
+      ...(Boolean(payload.exchangeTokenClaims?.length)
+        ? {
+            'X-Forward-To-Claims': payload
+              .exchangeTokenClaims!.filter((token) =>
+                allowedForwardToExchangeClaims.includes(token)
+              )
+              .join(' '),
+          }
+        : {}),
     },
   };
 };

--- a/packages/sdk/src/actions/actions.ts
+++ b/packages/sdk/src/actions/actions.ts
@@ -11,6 +11,7 @@ import type {
   TSdkActionHeadForService,
   TSdkActionPostForUri,
   TSdkActionPostForService,
+  TForwardToExchangeTokenClaim,
 } from '../types';
 
 const allowedForwardToExchangeClaims = ['permissions'];
@@ -53,6 +54,12 @@ export function post(payload: TSdkActionPayload & TSdkActionPayloadBody) {
 
 const enhancePayloadForForwardToProxy = (payload: TSdkActionPayloadForUri) => {
   const headers = payload.headers ?? {};
+  const exchangeTokenClaims: TForwardToExchangeTokenClaim[] = [];
+
+  if (payload.includeUserPermissions) {
+    exchangeTokenClaims.push('permissions');
+  }
+
   return {
     uri: '/proxy/forward-to',
     mcApiProxyTarget: undefined,
@@ -69,12 +76,10 @@ const enhancePayloadForForwardToProxy = (payload: TSdkActionPayloadForUri) => {
       'X-Forward-To': payload.uri,
       'X-Forward-To-Audience-Policy':
         payload.audiencePolicy || 'forward-url-full-path',
-      ...(Boolean(payload.exchangeTokenClaims?.length)
+      ...(Boolean(exchangeTokenClaims?.length)
         ? {
-            'X-Forward-To-Claims': payload
-              .exchangeTokenClaims!.filter((token) =>
-                allowedForwardToExchangeClaims.includes(token)
-              )
+            'X-Forward-To-Claims': exchangeTokenClaims!
+              .filter((token) => allowedForwardToExchangeClaims.includes(token))
               .join(' '),
           }
         : {}),

--- a/packages/sdk/src/actions/actions.ts
+++ b/packages/sdk/src/actions/actions.ts
@@ -1,3 +1,4 @@
+import omitEmpty from 'omit-empty-es';
 import type {
   TSdkActionPayload,
   TSdkActionPayloadBody,
@@ -14,7 +15,7 @@ import type {
   TForwardToExchangeTokenClaim,
 } from '../types';
 
-const allowedForwardToExchangeClaims = ['permissions'];
+export type THeaders = Record<string, string>;
 
 export function get(payload: TSdkActionPayloadForUri): TSdkActionGetForUri;
 export function get(
@@ -63,7 +64,7 @@ const enhancePayloadForForwardToProxy = (payload: TSdkActionPayloadForUri) => {
   return {
     uri: '/proxy/forward-to',
     mcApiProxyTarget: undefined,
-    headers: {
+    headers: omitEmpty<THeaders>({
       ...Object.entries(headers).reduce(
         (customForwardHeaders, [headerName, headerValue]) => ({
           ...customForwardHeaders,
@@ -76,14 +77,8 @@ const enhancePayloadForForwardToProxy = (payload: TSdkActionPayloadForUri) => {
       'X-Forward-To': payload.uri,
       'X-Forward-To-Audience-Policy':
         payload.audiencePolicy || 'forward-url-full-path',
-      ...(Boolean(exchangeTokenClaims?.length)
-        ? {
-            'X-Forward-To-Claims': exchangeTokenClaims!
-              .filter((token) => allowedForwardToExchangeClaims.includes(token))
-              .join(' '),
-          }
-        : {}),
-    },
+      'X-Forward-To-Claims': exchangeTokenClaims.join(' '),
+    }),
   };
 };
 export const forwardTo = {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -23,7 +23,7 @@ export interface TSdkActionPayloadBase {
 export interface TSdkActionPayloadForUri extends TSdkActionPayloadBase {
   uri: string;
   audiencePolicy?: TForwardToAudiencePolicy;
-  exchangeTokenClaims?: TForwardToExchangeTokenClaim[];
+  includeUserPermissions?: boolean;
 }
 
 export interface TSdkActionPayloadForService extends TSdkActionPayloadBase {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -8,6 +8,8 @@ export type TForwardToAudiencePolicy =
   | 'forward-url-full-path'
   | 'forward-url-origin';
 
+export type TForwardToExchangeTokenClaim = 'permissions';
+
 export type TSdkActionPayloadMethod<Method extends THttpMethod> = {
   method: Method;
 };
@@ -21,6 +23,7 @@ export interface TSdkActionPayloadBase {
 export interface TSdkActionPayloadForUri extends TSdkActionPayloadBase {
   uri: string;
   audiencePolicy?: TForwardToAudiencePolicy;
+  exchangeTokenClaims?: TForwardToExchangeTokenClaim[];
 }
 
 export interface TSdkActionPayloadForService extends TSdkActionPayloadBase {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4250,6 +4250,7 @@ __metadata:
     "@types/uuid": 8.3.4
     buffer: 6.0.3
     fast-equals: 2.0.4
+    omit-empty-es: 1.1.3
     prop-types: 15.8.1
     qss: 2.0.3
     react: 17.0.2


### PR DESCRIPTION
#### Summary

Allow custom claims in exchange JWT send in forwarded requests to external services.
Allow to request custom claims to be included in the exchange JWT sent from MC Gateway when sending requests from a Custom Application to an external service by using the `/proxy/forward-to` endpoint ([docs](https://docs.commercetools.com/custom-applications/concepts/integrate-with-your-own-api)).

NOTE: _we will have another PR for updating the docs_.

#### Description

We agreed that requesting the Gateway to include custom claims will be _triggered_ by including a new header (*X-Forward-To-Claims*) with a space separated list of wanted claims (we will only support *permissions* in this first iteration).

In this PR we update our requests helpers to make it easy to include the new helper:
* GraphQL context
* Custom HTTP client
* SDK actions
