### PR TITLE
Read optional user permissions claim in backend auth middleware

### DIFF
--- a/.changeset/gorgeous-kings-cough.md
+++ b/.changeset/gorgeous-kings-cough.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-backend/express': patch
+---
+
+Now that users can request the Merchant Center API to include logged in user's permissions in the exchange JWT included in proxied requests, our _auth_ middleware will check for that information in the token and will make it available in the `request.session` object under a new property named **userPermissions**.

--- a/.changeset/gorgeous-kings-cough.md
+++ b/.changeset/gorgeous-kings-cough.md
@@ -2,4 +2,4 @@
 '@commercetools-backend/express': patch
 ---
 
-Now that users can request the Merchant Center API to include logged in user's permissions in the exchange JWT included in proxied requests, our _auth_ middleware will check for that information in the token and will make it available in the `request.session` object under a new property named **userPermissions**.
+Now that users can request the Merchant Center API to include logged in user's permissions in the exchange JWT included in proxied requests, our _auth_ middleware will check for that information in the token and will make it available in the `request.session` object under a new property named **userPermissions** (reference [documentation](https://docs.commercetools.com/custom-applications/concepts/integrate-with-your-own-api#validating-the-json-web-token)).

--- a/packages-backend/express/src/auth.spec.js
+++ b/packages-backend/express/src/auth.spec.js
@@ -82,7 +82,7 @@ describe('writeSessionContext', () => {
       iss: mockIssuer,
       sub: 'user-id-1',
       [`${mockIssuer}/claims/project_key`]: 'almond-40',
-      [`${mockIssuer}/claims/user_permissions`]: mockUserPermissions.join(','),
+      [`${mockIssuer}/claims/user_permissions`]: mockUserPermissions,
     };
     const request = {
       decoded_token: mockDecodedToken,

--- a/packages-backend/express/src/auth.spec.js
+++ b/packages-backend/express/src/auth.spec.js
@@ -63,7 +63,7 @@ describe('writeSessionContext', () => {
     const mockDecodedToken = {
       iss: mockIssuer,
       sub: 'user-id-1',
-      [`${mockIssuer}/claims/project_key`]: 'almond-40',
+      [`${mockIssuer}/claims/project_key`]: 'fake-project-key',
     };
     const request = {
       decoded_token: mockDecodedToken,
@@ -72,7 +72,7 @@ describe('writeSessionContext', () => {
     writeSessionContext(request);
 
     expect(request.session).toHaveProperty('userId', mockDecodedToken.sub);
-    expect(request.session).toHaveProperty('projectKey', 'almond-40');
+    expect(request.session).toHaveProperty('projectKey', 'fake-project-key');
     expect(request).not.toHaveProperty('decoded_token');
   });
 
@@ -81,7 +81,7 @@ describe('writeSessionContext', () => {
     const mockDecodedToken = {
       iss: mockIssuer,
       sub: 'user-id-1',
-      [`${mockIssuer}/claims/project_key`]: 'almond-40',
+      [`${mockIssuer}/claims/project_key`]: 'fake-project-key',
       [`${mockIssuer}/claims/user_permissions`]: mockUserPermissions,
     };
     const request = {
@@ -91,7 +91,7 @@ describe('writeSessionContext', () => {
     writeSessionContext(request);
 
     expect(request.session).toHaveProperty('userId', mockDecodedToken.sub);
-    expect(request.session).toHaveProperty('projectKey', 'almond-40');
+    expect(request.session).toHaveProperty('projectKey', 'fake-project-key');
     expect(request.session).toHaveProperty(
       'userPermissions',
       mockUserPermissions

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -24,7 +24,7 @@ type TDecodedJWT = {
 
 const decodedTokenKey = 'decoded_token';
 // Assign a session object to the request object.
-export const writeSessionContext = <Request extends TBaseRequest>(
+const writeSessionContext = <Request extends TBaseRequest>(
   request: Request & { decoded_token?: TDecodedJWT; session?: TSession }
 ) => {
   const decodedToken = request[decodedTokenKey];
@@ -218,4 +218,4 @@ function createSessionAuthVerifier<Request extends TBaseRequest>(
   };
 }
 
-export { createSessionAuthVerifier };
+export { createSessionAuthVerifier, writeSessionContext };

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -19,7 +19,7 @@ import { getFirstHeaderValueOrThrow } from './utils';
 type TDecodedJWT = {
   sub: string;
   iss: string;
-  [property: string]: string;
+  [property: string]: string | string[];
 };
 
 const decodedTokenKey = 'decoded_token';
@@ -35,12 +35,12 @@ export const writeSessionContext = <Request extends TBaseRequest>(
 
     request.session = {
       userId: decodedToken.sub,
-      projectKey: decodedToken[publicClaimForProjectKey],
+      projectKey: decodedToken[publicClaimForProjectKey] as string,
     };
 
     const userPermissions = decodedToken[publicClaimForUserPermissionsKey];
     if (Boolean(userPermissions?.length)) {
-      request.session.userPermissions = userPermissions.split(',');
+      request.session.userPermissions = userPermissions as string[];
     }
   }
 

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -24,18 +24,24 @@ type TDecodedJWT = {
 
 const decodedTokenKey = 'decoded_token';
 // Assign a session object to the request object.
-const writeSessionContext = <Request extends TBaseRequest>(
+export const writeSessionContext = <Request extends TBaseRequest>(
   request: Request & { decoded_token?: TDecodedJWT; session?: TSession }
 ) => {
   const decodedToken = request[decodedTokenKey];
 
   if (decodedToken) {
     const publicClaimForProjectKey = `${decodedToken.iss}/claims/project_key`;
+    const publicClaimForUserPermissionsKey = `${decodedToken.iss}/claims/user_permissions`;
 
     request.session = {
       userId: decodedToken.sub,
       projectKey: decodedToken[publicClaimForProjectKey],
     };
+
+    const userPermissions = decodedToken[publicClaimForUserPermissionsKey];
+    if (Boolean(userPermissions?.length)) {
+      request.session.userPermissions = userPermissions.split(',');
+    }
   }
 
   // Remove the field used by the JWT middleware.

--- a/packages-backend/express/src/types.ts
+++ b/packages-backend/express/src/types.ts
@@ -57,4 +57,5 @@ export type TSessionMiddlewareOptions<Request extends TBaseRequest> = {
 export type TSession = {
   userId: string;
   projectKey: string;
+  userPermissions?: string[];
 };


### PR DESCRIPTION
#### Summary

Write (optional) user permissions in `request.session` object when validating an incoming requests in external services.

#### Description

When using our _auth_ middleware in an external service to validate incoming requests, it read information from the exchange JWT included in the incoming request and writes it into an attribute (called `session`) in the request for consumers to be able to access that info.

Now that the Merchant Center API can include a new public claim with logged in user permissions (when configured at the time of making the request from a Custom Application), the middleware will also read that value and put it into the `request.session` object under a property called *userPermissions*.
The value will be an array of strings with the permissions names.
