### PR TITLE
Docs about custom claims in MC gateway forwarded requests

### DIFF
--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -213,6 +213,8 @@ const useExternalApiFetcher = () => {
       },
       // Optionally define the audience policy
       audiencePolicy: 'forward-url-full-path',
+      // Optionally ask for users permissions to be included in exchange JWT
+      exchangeTokenClaims: ['permissions']
     }),
   });
 
@@ -229,6 +231,7 @@ Available options are:
 * `uri` (**required**): The URL of the external API to forward the request to.
 * `headers` (optional): Additional HTTP headers to be included in the request to the external API.
 * `audiencePolicy` (optional): See [configuring the audience policy](/concepts/integrate-with-your-own-api#configuring-the-audience-policy).
+* `exchangeTokenClaims` (optional): See [configuring custom claims](/concepts/integrate-with-your-own-api#configuring-custom-claims)
 * `version` (optional): See [versioning](/concepts/integrate-with-your-own-api#versioning).
 
 ## executeHttpClientRequest
@@ -312,6 +315,7 @@ The `THttpClientConfig` object accepts the following options:
   * `uri` (**required**): The URL of the external API to forward the request to.
   * `headers` (optional): Additional HTTP headers to be included in the request to the external API.
   * `audiencePolicy` (optional): See [configuring the audience policy](/concepts/integrate-with-your-own-api#configuring-the-audience-policy).
+  * `exchangeTokenClaims` (optional): See [configuring custom claims](/concepts/integrate-with-your-own-api#configuring-custom-claims)
   * `version` (recommended): See [versioning](/concepts/integrate-with-your-own-api#versioning).
 
 

--- a/website/src/content/concepts/integrate-with-your-own-api.mdx
+++ b/website/src/content/concepts/integrate-with-your-own-api.mdx
@@ -31,6 +31,7 @@ Requests to that endpoint should additionally pass the following HTTP headers:
 - `Accept-version` (**required**): See [Versioning](#versioning).
 - `X-Forward-To` (**required**): Set it to the external API URL.
 - `X-Forward-To-Audience-Policy` (**required**): See [Configuring the audience policy](#configuring-the-audience-policy).
+- `X-Forward-To-Claims` (optional): See [Configuring custom claims](#configuring-custom-claims)
 - `X-Project-Key` (**required**): The key of the commercetools Project currently being used by the Custom Application. The Merchant Center API Gateway will perform a validation check to ensure that the user has access to the Project, then forward the request to your server only if the check was successful.<br/>
 The project key can be retrieved from the [Application context](/api-reference/commercetools-frontend-application-shell-connectors#application-context).
 
@@ -59,6 +60,28 @@ For example, given the forward-to URL `https://my-custom-app.com/api/123`, the `
 
 - `forward-url-full-path`: `https://my-custom-app.com/api/123`
 - `forward-url-origin`: `https://my-custom-app.com`
+
+## Configuring custom claims
+
+<Info>
+
+This feature is available from version `21.14.0` onwards.
+
+</Info>
+
+This header can be used to make the Merchant Center API Gateway to include extra public claims in the exchange token sent along with forwarded requests.
+
+The value must be a list of the claims separated by an empty space.
+
+Currently we support this optional claims:
+* *permissions*: Will make the Merchant Center API Gateway to include the logged in Merchant Center user permissions.
+
+```
+"X-Forward-To-Claims": "permissions"
+```
+
+You can find more information about how to include this header in the request using our helpers in the sections below.
+
 
 ## Custom HTTP headers
 
@@ -111,6 +134,12 @@ actions.forwardTo.get({
   uri: 'https://my-custom-app.com/api',
   audiencePolicy: 'forward-url-origin',
 });
+
+// To make the MC API Gateway include the user permissions in the exchange JWT
+actions.forwardTo.get({
+  uri: 'https://my-custom-app.com/api',
+  exchangeTokenClaims: ['permissions'],
+});
 ```
 
 <Info>
@@ -159,6 +188,7 @@ The Exchange token structure consist of **Registered Claim Names** and **Private
   "aud": "<audience-url>",
   "type": "exchange",
   "<hostname>/claims/project_key": "<project-key>",
+  "<hostname>/claims/user_permissions": "<permission-1>,<permission-2>,...",
   "iat": 1600092341
 }
 ```
@@ -170,6 +200,8 @@ The Exchange token structure consist of **Registered Claim Names** and **Private
 - `iat`: This value represents the time at which the JWT was issued.
 - `type`: This value is a **private claim** and is always set to `exchange`.
 - `<iss>/claims/project_key`: This value represents the Project key that the request is associated to. The claim is a **public claim** prefixed by a collision-resistant namespace, as per the JWT specification.
+- `<iss>/claims/user_permissions` (optional): This value will contain a comma separated list of the permissions names the Merchant Center user which issued the requests has available. This is an optional feature you can opt-in by providing a custom header when sending the request from your Custom Application (see [Configuring custom claims](#configuring-custom-claims)).
+
 
 ## Validating the JSON Web Token
 
@@ -189,6 +221,7 @@ The package includes an async Express.js middleware that performs the token vali
 type TSession = {
   userId: string;
   projectKey: string;
+  userPermissions?: string[];
 };
 ```
 


### PR DESCRIPTION
#### Summary

Docs about custom claims in MC gateway forwarded requests

#### Description

In this PR we update the docs to explain about the new feature users will have to make the MC API Gateway to include MC logged in user permissions in the exchange JWT sent in requests forwarded to external services.

**IMPORTANT**: We must not merge this PR until both the Gateway changes are deployed and a new AppKit version with required changes is released.
