### PR TITLE
 Fix Renovate dependency updates to skip postinstall script

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -31,6 +31,10 @@ runs:
         CYPRESS_INSTALL_BINARY: "0"
       shell: bash
 
+    - name: Setup
+      run: yarn setup
+      shell: bash
+
     - name: Building packages
       run: yarn build
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -31,10 +31,6 @@ runs:
         CYPRESS_INSTALL_BINARY: "0"
       shell: bash
 
-    - name: Setup
-      run: yarn setup
-      shell: bash
-
     - name: Building packages
       run: yarn build
       shell: bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "auth": "npm_config_registry=https://registry.npmjs.org npm whoami",
+    "setup": "yarn husky install && yarn manypkg check && yarn preconstruct dev",
     "clean": "manypkg exec rm -rf build dist test-utils/dist experimental/dist task/dist add-commands/dist",
     "extract-intl": "formatjs extract --format=./packages/i18n/transifex-transformer.js --out-file=./packages/i18n/data/core.json 'packages/**/*messages.ts'",
     "compile-intl": "yarn workspace @commercetools-frontend/i18n compile-data",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -4,14 +4,12 @@ set -e
 
 if [ -n "$SKIP_POSTINSTALL_DEV_SETUP" ]; then
   echo "Skipping development setup."
-elif [[ $NPM_CONFIG_CACHE =~ "renovate" ]]; then
-  echo "Renovate update detected, skipping post install."
+elif [[ $CI == "true" ]]; then
+  echo "Running on CI, skipping post install."
 else
   echo "Preparing development setup."
-  yarn husky install
-  yarn manypkg check
-  yarn preconstruct dev
 
+  yarn setup
 fi
 
 echo "Running prettier on package.json files"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -4,8 +4,8 @@ set -e
 
 if [ -n "$SKIP_POSTINSTALL_DEV_SETUP" ]; then
   echo "Skipping development setup."
-elif [[ $CI == "true" ]]; then
-  echo "Running on CI, skipping post install."
+elif [[ $YARN_ENABLE_SCRIPTS == "0" ]]; then
+  echo "Yarn scripts disabled, skipping post install."
 else
   echo "Preparing development setup."
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -4,7 +4,8 @@ set -e
 
 if [ -n "$SKIP_POSTINSTALL_DEV_SETUP" ]; then
   echo "Skipping development setup."
-
+elif [[ $NPM_CONFIG_CACHE =~ "renovate" ]]; then
+  echo "Renovate update detected, skipping post install."
 else
   echo "Preparing development setup."
   yarn husky install

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -4,8 +4,9 @@ set -e
 
 if [ -n "$SKIP_POSTINSTALL_DEV_SETUP" ]; then
   echo "Skipping development setup."
-elif [[ $YARN_ENABLE_SCRIPTS == "0" ]]; then
-  echo "Yarn scripts disabled, skipping post install."
+# https://github.com/renovatebot/renovate/discussions/17442#discussioncomment-3499129
+elif [ "$BUILDPACK" == "true" ]; then
+  echo "Running in Renovate. Skipping post install steps."
 else
   echo "Preparing development setup."
 


### PR DESCRIPTION
#### Summary

This pull request skips the post install step/script whenever the PR is coming from Renovate.

#### Description

Renovate pull requests are failing across repositories. The Renovate pull requests fail as postinstall scripts run and perform tasks which aren't allowed in Renovate's sandbox.

Thinking about it conceptually Renovate has no interest in running post install steps. They're always unrelated to the dependency update itself which just bumps versions and updates a lockfile.

In other dependency managers: `yarn@2` or `npm` for that matter by using `--ignore-scripts`. Moreover, it has the notion of `postupgradetasks` as a config to run tasks before the commit is made but _after_ the dependencies are updated. Initially all a clear indicator that Renovate does not intend to run post install scripts. This assumption was proven right in my discussion with their team below.

After reading Renovate's configuration and trying to find alternative solutions I settled on this until there is hopefully something better.

There are better alternatives to this approach:

1. `yarn@3` and the `postinstall` plugin allows skipping with a e.g. `--skip-postinstall`
    - I intend to open a issue there. However Renovate can't assumpe that only one postinstall plugin is used as there are multiple for yarn
2. Renovate sets a `SKIP_POST_INSTALL` environment variable
    - It is a custom solution which is not understood by `yarn@3` natively and would require changes in user land

I tried out this change on flopflip and it works there on PRs.

Renovate discussion: https://github.com/renovatebot/renovate/discussions/17442
Slack Reference: https://commercetools.slack.com/archives/C020CPEGQLX/p1661519362801979

P.S.: Open to better solutions but after hours of debugging this is close to the only solution I can think of for now.