### PR TITLE
refactor: to remove jest/no-jest-import rule

### DIFF
--- a/.changeset/wise-garlics-grow.md
+++ b/.changeset/wise-garlics-grow.md
@@ -1,0 +1,8 @@
+---
+"@commercetools-frontend/eslint-config-mc-app": patch
+"@commercetools-backend/eslint-config-node": patch
+---
+
+Remove `jest/no-jest-import` rule from ESLint configs. 
+
+This allows consumers of our configs to update to `eslint-plugin-jest` v27 which removes the rule as a breaking change.

--- a/packages-backend/eslint-config-node/index.js
+++ b/packages-backend/eslint-config-node/index.js
@@ -117,7 +117,6 @@ module.exports = {
         'jest/no-identical-title': statusCode.error,
         'jest/no-interpolation-in-snapshots': statusCode.error,
         'jest/no-jasmine-globals': statusCode.error,
-        'jest/no-jest-import': statusCode.error,
         'jest/no-mocks-import': statusCode.error,
         'jest/valid-describe-callback': statusCode.error,
         'jest/valid-expect': statusCode.error,

--- a/packages/eslint-config-mc-app/helpers/rules-presets.js
+++ b/packages/eslint-config-mc-app/helpers/rules-presets.js
@@ -260,7 +260,6 @@ const craRules = {
     'jest/no-identical-title': statusCode.error,
     'jest/no-interpolation-in-snapshots': statusCode.error,
     'jest/no-jasmine-globals': statusCode.error,
-    'jest/no-jest-import': statusCode.error,
     'jest/no-mocks-import': statusCode.error,
     'jest/valid-describe-callback': statusCode.error,
     'jest/valid-expect': statusCode.error,


### PR DESCRIPTION
#### Summary

In `eslint-plugin-jest` v27 the rule `jest/no-jest-import` has been removed. So it can’t be used in the `eslint-config-mc-app`. Given that it’s not recommended to be used anymore already [here](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v27.0.0) we could remove it already.

This will mean that consumers can update to v27 of `eslint-plugin-jest` already.