### PR TITLE
refactor(main-pages): Fix customMainPage height

### DIFF
--- a/.changeset/mighty-files-vanish.md
+++ b/.changeset/mighty-files-vanish.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-components': patch
 ---
 
-Fix height cropping issue on customFormMainPage
+Fix main page components to use available height space.

--- a/.changeset/mighty-files-vanish.md
+++ b/.changeset/mighty-files-vanish.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Fix height cropping issue on customFormMainPage

--- a/packages/application-components/src/components/main-pages/custom-form-main-page/custom-form-main-page.tsx
+++ b/packages/application-components/src/components/main-pages/custom-form-main-page/custom-form-main-page.tsx
@@ -71,9 +71,9 @@ const CustomFormMainPage = (props: CustomFormMainPageProps) => {
             </Spacings.Inline>
           )}
           <Divider />
-          <MainPageContent>{props.children}</MainPageContent>
         </Spacings.Stack>
       </MainPageContainer>
+      <MainPageContent>{props.children}</MainPageContent>
     </PageWrapper>
   );
 };

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -12,5 +12,7 @@ export const Divider = styled.hr`
 `;
 
 export const MainPageContent = styled.div`
+  flex: 1;
+  flex-basis: 0;
   overflow: auto;
 `;

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { customProperties } from '@commercetools-uikit/design-system';
 
 export const MainPageContainer = styled.div`
-  padding: ${customProperties.spacingL};
+  padding: ${customProperties.spacingM};
 `;
 
 export const Divider = styled.hr`
@@ -15,5 +15,5 @@ export const MainPageContent = styled.div`
   flex: 1;
   flex-basis: 0;
   overflow: auto;
-  padding: ${customProperties.spacingL};
+  padding: ${customProperties.spacingM};
 `;

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -15,4 +15,5 @@ export const MainPageContent = styled.div`
   flex: 1;
   flex-basis: 0;
   overflow: auto;
+  padding: ${customProperties.spacingL};
 `;

--- a/visual-testing-app/src/components/custom-form-main-page/custom-form-main-page.visualroute.tsx
+++ b/visual-testing-app/src/components/custom-form-main-page/custom-form-main-page.visualroute.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { RevertIcon } from '@commercetools-uikit/icons';
 import { CustomFormMainPage } from '@commercetools-frontend/application-components';
 import TextField from '@commercetools-uikit/text-field';
@@ -6,59 +7,52 @@ import { Suite, Spec } from '../../test-utils';
 
 export const routePath = '/custom-form-main-page';
 
-const Content = () => (
-  <Spacings.Stack scale="l">
-    <Spacings.Inline scale="l">
-      <TextField title="First Name" value="foo" onChange={() => {}} />
-      <TextField title="Last Name" value="foo" onChange={() => {}} />
-    </Spacings.Inline>
-    <TextField title="Email Address" value="foo" onChange={() => {}} />
-    <TextField title="Business Role" value="foo" onChange={() => {}} />
-  </Spacings.Stack>
+type CustomFormMainPageContainerProps = {
+  customTitleRow?: ReactNode;
+};
+
+const CustomFormMainPageContainer = (
+  props: CustomFormMainPageContainerProps
+) => (
+  <div style={{ height: '750px' }}>
+    <CustomFormMainPage
+      title="Lorem Ipsum"
+      subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      formControls={
+        <>
+          <CustomFormMainPage.FormSecondaryButton
+            label="Revert changes"
+            iconLeft={<RevertIcon />}
+            onClick={() => {}}
+          />
+          <CustomFormMainPage.FormPrimaryButton
+            label="Save"
+            onClick={() => {}}
+          />
+        </>
+      }
+      {...props}
+    >
+      <Spacings.Stack scale="l">
+        <Spacings.Inline scale="l">
+          <TextField title="First Name" value="foo" onChange={() => {}} />
+          <TextField title="Last Name" value="foo" onChange={() => {}} />
+        </Spacings.Inline>
+        <TextField title="Email Address" value="foo" onChange={() => {}} />
+        <TextField title="Business Role" value="foo" onChange={() => {}} />
+      </Spacings.Stack>
+    </CustomFormMainPage>
+  </div>
 );
+CustomFormMainPageContainer.displayName = 'CustomFormMainPageContainer';
 
 export const Component = () => (
   <Suite>
     <Spec label="CustomFormMainPage">
-      <CustomFormMainPage
-        title="Lorem Ipsum"
-        subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        formControls={
-          <>
-            <CustomFormMainPage.FormSecondaryButton
-              label="Revert changes"
-              iconLeft={<RevertIcon />}
-              onClick={() => {}}
-            />
-            <CustomFormMainPage.FormPrimaryButton
-              label="Save"
-              onClick={() => {}}
-            />
-          </>
-        }
-      >
-        <Content />
-      </CustomFormMainPage>
+      <CustomFormMainPageContainer />
     </Spec>
     <Spec label="CustomFormMainPage with customTitleRow">
-      <CustomFormMainPage
-        customTitleRow={<div>John Doe</div>}
-        formControls={
-          <>
-            <CustomFormMainPage.FormSecondaryButton
-              label="Revert changes"
-              iconLeft={<RevertIcon />}
-              onClick={() => {}}
-            />
-            <CustomFormMainPage.FormPrimaryButton
-              label="Save"
-              onClick={() => {}}
-            />
-          </>
-        }
-      >
-        <Content />
-      </CustomFormMainPage>
+      <CustomFormMainPageContainer customTitleRow={<h2>John Doe</h2>} />
     </Spec>
   </Suite>
 );

--- a/visual-testing-app/src/components/form-main-page/form-main-page.visualroute.tsx
+++ b/visual-testing-app/src/components/form-main-page/form-main-page.visualroute.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { RevertIcon } from '@commercetools-uikit/icons';
 import { FormMainPage } from '@commercetools-frontend/application-components';
 import TextField from '@commercetools-uikit/text-field';
@@ -6,40 +7,42 @@ import { Suite, Spec } from '../../test-utils';
 
 export const routePath = '/form-main-page';
 
-const Content = () => (
-  <Spacings.Stack scale="l">
-    <Spacings.Inline scale="l">
-      <TextField title="First Name" value="foo" onChange={() => {}} />
-      <TextField title="Last Name" value="foo" onChange={() => {}} />
-    </Spacings.Inline>
-    <TextField title="Email Address" value="foo" onChange={() => {}} />
-    <TextField title="Business Role" value="foo" onChange={() => {}} />
-  </Spacings.Stack>
+type FormMainPageContainerProps = {
+  customTitleRow?: ReactNode;
+};
+
+const FormMainPageContainer = (props: FormMainPageContainerProps) => (
+  <div style={{ height: '750px' }}>
+    <FormMainPage
+      title="Lorem Ipsum"
+      subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      labelPrimaryButton="Save"
+      labelSecondaryButton="Revert changes"
+      iconLeftSecondaryButton={<RevertIcon />}
+      onSecondaryButtonClick={() => {}}
+      onPrimaryButtonClick={() => {}}
+      {...props}
+    >
+      <Spacings.Stack scale="l">
+        <Spacings.Inline scale="l">
+          <TextField title="First Name" value="foo" onChange={() => {}} />
+          <TextField title="Last Name" value="foo" onChange={() => {}} />
+        </Spacings.Inline>
+        <TextField title="Email Address" value="foo" onChange={() => {}} />
+        <TextField title="Business Role" value="foo" onChange={() => {}} />
+      </Spacings.Stack>
+    </FormMainPage>
+  </div>
 );
+FormMainPageContainer.displayName = 'FormMainPageContainer';
 
 export const Component = () => (
   <Suite>
     <Spec label="FormMainPage">
-      <FormMainPage
-        title="Lorem Ipsum"
-        subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        labelPrimaryButton="Save"
-        labelSecondaryButton="Revert changes"
-        iconLeftSecondaryButton={<RevertIcon />}
-        onSecondaryButtonClick={() => {}}
-        onPrimaryButtonClick={() => {}}
-      >
-        <Content />
-      </FormMainPage>
+      <FormMainPageContainer />
     </Spec>
     <Spec label="FormMainPage with customTitleRow">
-      <FormMainPage
-        customTitleRow={<div>John Doe</div>}
-        onSecondaryButtonClick={() => {}}
-        onPrimaryButtonClick={() => {}}
-      >
-        <Content />
-      </FormMainPage>
+      <FormMainPageContainer customTitleRow={<h2>John Doe</h2>} />
     </Spec>
   </Suite>
 );

--- a/visual-testing-app/src/components/info-main-page/info-main-page.visualroute.tsx
+++ b/visual-testing-app/src/components/info-main-page/info-main-page.visualroute.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { InfoMainPage } from '@commercetools-frontend/application-components';
 import TextField from '@commercetools-uikit/text-field';
 import Spacings from '@commercetools-uikit/spacings';
@@ -5,31 +6,37 @@ import { Suite, Spec } from '../../test-utils';
 
 export const routePath = '/info-main-page';
 
-const Content = () => (
-  <Spacings.Stack scale="l">
-    <Spacings.Inline scale="l">
-      <TextField title="First Name" value="foo" onChange={() => {}} />
-      <TextField title="Last Name" value="foo" onChange={() => {}} />
-    </Spacings.Inline>
-    <TextField title="Email Address" value="foo" onChange={() => {}} />
-    <TextField title="Business Role" value="foo" onChange={() => {}} />
-  </Spacings.Stack>
+type InfoMainPageContainerProps = {
+  customTitleRow?: ReactNode;
+};
+
+const InfoMainPageContainer = (props: InfoMainPageContainerProps) => (
+  <div style={{ height: '750px' }}>
+    <InfoMainPage
+      title="Lorem Ipsum"
+      subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      {...props}
+    >
+      <Spacings.Stack scale="l">
+        <Spacings.Inline scale="l">
+          <TextField title="First Name" value="foo" onChange={() => {}} />
+          <TextField title="Last Name" value="foo" onChange={() => {}} />
+        </Spacings.Inline>
+        <TextField title="Email Address" value="foo" onChange={() => {}} />
+        <TextField title="Business Role" value="foo" onChange={() => {}} />
+      </Spacings.Stack>
+    </InfoMainPage>
+  </div>
 );
+InfoMainPageContainer.displayName = 'InfoMainPageContainer';
 
 export const Component = () => (
   <Suite>
     <Spec label="InfoMainPage">
-      <InfoMainPage
-        title="Lorem Ipsum"
-        subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      >
-        <Content />
-      </InfoMainPage>
+      <InfoMainPageContainer />
     </Spec>
     <Spec label="InfoMainPage with customTitleRow">
-      <InfoMainPage customTitleRow={<div>John Doe</div>}>
-        <Content />
-      </InfoMainPage>
+      <InfoMainPageContainer customTitleRow={<h2>John Doe</h2>} />
     </Spec>
   </Suite>
 );


### PR DESCRIPTION
#### Summary
Previously, the height of the content was cropped in the layout. This was fixed by allowing the content to take the remaining spaces on the layout. 

This issue was pointed out [here](https://github.com/commercetools/merchant-center-frontend/pull/12782#issuecomment-1241702339)

#### Screenshots

Before
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/6726467/189641892-edb30025-5a37-4b8a-b503-6983a49b1b6d.png">


After
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/6726467/189641805-d442df74-43d2-4d72-afe0-0064788c9cd6.png">

