### PR TITLE
Fix page title re-render issue with title still displaying previous location.

### DIFF
--- a/.changeset/gold-adults-wonder.md
+++ b/.changeset/gold-adults-wonder.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Fix issue with page title still rendering previous title even after navigating to a new location.

--- a/packages/application-shell/src/components/application-page-title/application-page-title.tsx
+++ b/packages/application-shell/src/components/application-page-title/application-page-title.tsx
@@ -29,13 +29,10 @@ const defaultProps: TApplicationPageTitleProps = {
   additionalParts: [],
 };
 
-const usePageTitle = (props: TApplicationPageTitleProps) => {
-  const location = useLocation();
+const getPageTitle = (pathname: string, additionalParts: string[]) => {
+  const [, projectKeyOrStaticPath, entryPointUriPath] = pathname.split('/');
 
-  const [, projectKeyOrStaticPath, entryPointUriPath] =
-    location.pathname.split('/');
-
-  const customTitleParts = props.additionalParts.map((titlePart: string) => {
+  const customTitleParts = additionalParts.map((titlePart: string) => {
     if (titlePart.length <= maxTitleCharLength) {
       return titlePart;
     }
@@ -62,11 +59,12 @@ const usePageTitle = (props: TApplicationPageTitleProps) => {
 };
 
 const ApplicationPageTitle = (props: TApplicationPageTitleProps) => {
-  const pageTitle = usePageTitle(props);
+  const location = useLocation();
 
   useLayoutEffect(() => {
+    const pageTitle = getPageTitle(location.pathname, props.additionalParts);
     document.title = pageTitle;
-  }, [pageTitle]);
+  }, [location.pathname, props.additionalParts]);
 
   return null;
 };


### PR DESCRIPTION
Fix page title re-render issue with title still displaying previous location instead of the current one.

Navigating to a new page actually persists the initial value, as a result, returning from a `products/<products_id>` page to say `/products` page, the title would still remain as though it was still in the `products/<products_id>` page instead of updating to the new location, in this case, `/products` . 