### PR TITLE
refactor(pages): Move form control to the same line as title row.

### DIFF
--- a/.changeset/loud-brooms-yell.md
+++ b/.changeset/loud-brooms-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Remove unnecessary form control margin space

--- a/.changeset/loud-brooms-yell.md
+++ b/.changeset/loud-brooms-yell.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-components': patch
 ---
 
-Remove unnecessary form control margin space
+Move form control to the same line as title row.

--- a/packages/application-components/src/components/detail-pages/custom-form-detail-page/custom-form-detail-page.tsx
+++ b/packages/application-components/src/components/detail-pages/custom-form-detail-page/custom-form-detail-page.tsx
@@ -12,6 +12,7 @@ import Spacings from '@commercetools-uikit/spacings';
 import PageHeaderTitle from '../../internals/page-header-title';
 import PageTopBar from '../../internals/page-top-bar';
 import { ContentWrapper, PageWrapper } from '../../internals/page.styles';
+import { FormControlContainer } from '../../internals/form-control.styles';
 
 const DetailPageContainer = styled.div`
   background-color: ${customProperties.colorNeutral95};
@@ -87,18 +88,22 @@ const CustomFormDetailPage = (props: CustomFormDetailPageProps) => {
             previousPathLabel={props.previousPathLabel}
             onClick={props.onPreviousPathClick}
           />
-          {props.customTitleRow || (
-            <PageHeaderTitle
-              title={props.title ?? ''}
-              subtitle={props.subtitle}
-              titleSize="big"
-            />
-          )}
-          {!props.hideControls && props.formControls && (
-            <Spacings.Inline justifyContent="flex-end">
-              {props.formControls}
-            </Spacings.Inline>
-          )}
+          <Spacings.Inline scale="l" justifyContent="space-between">
+            {props.customTitleRow || (
+              <PageHeaderTitle
+                title={props.title ?? ''}
+                subtitle={props.subtitle}
+                titleSize="big"
+              />
+            )}
+            {!props.hideControls && props.formControls && (
+              <FormControlContainer>
+                <Spacings.Inline justifyContent="flex-end">
+                  {props.formControls}
+                </Spacings.Inline>
+              </FormControlContainer>
+            )}
+          </Spacings.Inline>
         </Spacings.Stack>
       </DetailPageContainer>
       <ContentWrapper>{props.children}</ContentWrapper>

--- a/packages/application-components/src/components/internals/form-control.styles.tsx
+++ b/packages/application-components/src/components/internals/form-control.styles.tsx
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const FormControlContainer = styled.div`
+  align-self: flex-end;
+`;

--- a/packages/application-components/src/components/main-pages/custom-form-main-page/custom-form-main-page.tsx
+++ b/packages/application-components/src/components/main-pages/custom-form-main-page/custom-form-main-page.tsx
@@ -13,8 +13,8 @@ import {
   Divider,
   MainPageContainer,
   MainPageContent,
-  FormControlContainer,
 } from '../internals/main-page.styles';
+import { FormControlContainer } from '../../internals/form-control.styles';
 
 type CustomFormMainPageProps = {
   /**

--- a/packages/application-components/src/components/main-pages/custom-form-main-page/custom-form-main-page.tsx
+++ b/packages/application-components/src/components/main-pages/custom-form-main-page/custom-form-main-page.tsx
@@ -13,6 +13,7 @@ import {
   Divider,
   MainPageContainer,
   MainPageContent,
+  FormControlContainer,
 } from '../internals/main-page.styles';
 
 type CustomFormMainPageProps = {
@@ -58,18 +59,22 @@ const CustomFormMainPage = (props: CustomFormMainPageProps) => {
     <PageWrapper>
       <MainPageContainer>
         <Spacings.Stack scale="l">
-          {props.customTitleRow || (
-            <PageHeaderTitle
-              title={props.title ?? ''}
-              subtitle={props.subtitle}
-              titleSize="big"
-            />
-          )}
-          {!props.hideControls && props.formControls && (
-            <Spacings.Inline justifyContent="flex-end">
-              {props.formControls}
-            </Spacings.Inline>
-          )}
+          <Spacings.Inline scale="l" justifyContent="space-between">
+            {props.customTitleRow || (
+              <PageHeaderTitle
+                title={props.title ?? ''}
+                subtitle={props.subtitle}
+                titleSize="big"
+              />
+            )}
+            {!props.hideControls && props.formControls && (
+              <FormControlContainer>
+                <Spacings.Inline justifyContent="flex-end">
+                  {props.formControls}
+                </Spacings.Inline>
+              </FormControlContainer>
+            )}
+          </Spacings.Inline>
           <Divider />
         </Spacings.Stack>
       </MainPageContainer>

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -17,7 +17,3 @@ export const MainPageContent = styled.div`
   overflow: auto;
   padding: ${customProperties.spacingM};
 `;
-
-export const FormControlContainer = styled.div`
-  align-self: flex-end;
-`;

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -17,3 +17,7 @@ export const MainPageContent = styled.div`
   overflow: auto;
   padding: ${customProperties.spacingM};
 `;
+
+export const FormControlContainer = styled.div`
+  align-self: flex-end;
+`;


### PR DESCRIPTION
#### Summary
Remove unnecessary space from form control, making the layout more compact

#### Screenshots
Before
<img width="597" alt="image" src="https://user-images.githubusercontent.com/6726467/191035578-80d0bc88-f9c5-4167-9173-28a35c2602b5.png">


After
<img width="599" alt="image" src="https://user-images.githubusercontent.com/6726467/191035648-064eff08-c3d1-4dea-afca-e5696436dbb7.png">
