### PR TITLE
feat: enables configuring of webpack dev server port via HTTP_PORT en…

### DIFF
--- a/packages/application-config/src/process-config.ts
+++ b/packages/application-config/src/process-config.ts
@@ -25,8 +25,7 @@ type ProcessConfigOptions = Partial<LoadingConfigOptions> & {
   disableCache?: boolean;
 };
 
-// TODO: make it configurable.
-const developmentPort = 3001;
+const developmentPort = parseInt(String(process.env.HTTP_PORT), 10) || 3001;
 const developmentAppUrl = `http://localhost:${developmentPort}`;
 
 const omitDevConfigIfEmpty = (


### PR DESCRIPTION
…v var

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

By using process.env.HTTP_PORT for deciding developmentPort same as is done for start command at https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/mc-scripts/src/commands/start.ts#L33
we can use a custom local port for dev server.
#### Description
as the initial compilation with mc-scripts start takes about half a year it would be really nice if i didn't have to restart it because something else needs port 3001

The issue of the callback after login is being called on localhost:3001 
remains but at least that is something that can be easily manually handled.