### PR TITLE
fix(mc-scripts): enable sourcemaps in Vite build

### DIFF
--- a/.changeset/popular-geckos-compare.md
+++ b/.changeset/popular-geckos-compare.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Enable sourcemaps in Vite build

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -34,6 +34,7 @@ async function run() {
     },
     build: {
       outDir: 'public',
+      sourcemap: true,
       rollupOptions: {
         // This is necessary to instruct Vite that the `index.html` (template)
         // is located in the `/public` folder.


### PR DESCRIPTION
Ref #2577 