### PR TITLE
refactor(jest): improve output for console logs warnings

### DIFF
--- a/.changeset/green-chefs-judge.md
+++ b/.changeset/green-chefs-judge.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/jest-preset-mc-app': patch
+---
+
+Improve output of console usage in tests

--- a/packages/jest-preset-mc-app/fail-on-console.js
+++ b/packages/jest-preset-mc-app/fail-on-console.js
@@ -1,0 +1,123 @@
+// This module is based on the package `jest-fail-on-console` but with some custom adjustments.
+const util = require('util');
+const colors = require('colors/safe');
+
+const defaultErrorMessage = (methodName, bold) =>
+  `Expected test not to call ${bold(`console.${methodName}()`)}.\n\n` +
+  `If the ${methodName} is expected, test for it explicitly by mocking it out using ${bold(
+    'jest.spyOn'
+  )}(console, '${methodName}').mockImplementation() and test that the warning occurs.`;
+
+const failOnConsole = ({
+  errorMessage = defaultErrorMessage,
+  shouldFailOnAssert = false,
+  shouldFailOnDebug = false,
+  shouldFailOnLog = false,
+  shouldFailOnInfo = false,
+  shouldFailOnWarn = true,
+  shouldFailOnError = true,
+  skipTest,
+  silenceMessage,
+  logButNotThrowMessage,
+} = {}) => {
+  const flushUnexpectedConsoleCalls = (
+    methodName,
+    unexpectedConsoleCallStacks
+  ) => {
+    if (unexpectedConsoleCallStacks.length > 0) {
+      const messages = unexpectedConsoleCallStacks.map(([stack, message]) => {
+        const stackLines = stack.split('\n');
+        return (
+          `${colors.red(message)}\n` +
+          `${stackLines
+            .map((line, index) => {
+              if (index === stackLines.length - 1) {
+                return colors.white(line);
+              }
+              return colors.gray(line);
+            })
+            .join('\n')}`
+        );
+      });
+
+      const message = errorMessage(methodName, colors.bold);
+
+      throw new Error(`${message}\n\n${messages.join('\n\n')}`);
+    }
+  };
+
+  const patchConsoleMethod = (methodName) => {
+    let originalMethod = console[methodName];
+
+    const unexpectedConsoleCallStacks = [];
+
+    const captureMessage = (format, ...args) => {
+      const message = util.format(format, ...args);
+
+      if (silenceMessage && silenceMessage(message, methodName)) {
+        return;
+      }
+
+      if (logButNotThrowMessage && logButNotThrowMessage(message, methodName)) {
+        originalMethod(format, ...args);
+        return;
+      }
+
+      // Capture the call stack now so we can warn about it later.
+      // The call stack has helpful information for the test author.
+      // Don't throw yet though b'c it might be accidentally caught and suppressed.
+      const { stack } = new Error();
+      if (stack) {
+        unexpectedConsoleCallStacks.push([
+          stack.substr(stack.indexOf('\n') + 1),
+          message,
+        ]);
+      }
+    };
+
+    const newAssertMethod = (assertion, format, ...args) => {
+      if (assertion) {
+        return;
+      }
+
+      captureMessage(format, ...args);
+    };
+
+    const newMethod =
+      methodName === 'assert' ? newAssertMethod : captureMessage;
+
+    const canSkipTest = () => {
+      const currentTestState = expect.getState();
+      const testName = currentTestState.currentTestName;
+      const testPath = currentTestState.testPath;
+
+      if (skipTest && skipTest({ testName, testPath })) return true;
+
+      return false;
+    };
+    const shouldSkipTest = canSkipTest();
+
+    beforeEach(() => {
+      if (shouldSkipTest) return;
+
+      console[methodName] = newMethod; // eslint-disable-line no-console
+      unexpectedConsoleCallStacks.length = 0;
+    });
+
+    afterEach(() => {
+      if (shouldSkipTest) return;
+
+      flushUnexpectedConsoleCalls(methodName, unexpectedConsoleCallStacks);
+      console[methodName] = originalMethod;
+    });
+  };
+
+  if (shouldFailOnAssert) patchConsoleMethod('assert');
+  if (shouldFailOnDebug) patchConsoleMethod('debug');
+  if (shouldFailOnLog) patchConsoleMethod('log');
+  if (shouldFailOnInfo) patchConsoleMethod('info');
+  if (shouldFailOnWarn) patchConsoleMethod('warn');
+  if (shouldFailOnError) patchConsoleMethod('error');
+};
+
+module.exports = failOnConsole;

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -1,9 +1,5 @@
 const util = require('util');
-const colors = require('colors/safe');
 const MutationObserver = require('@sheerun/mutationobserver-shim');
-const loadConfig = require('./load-config');
-
-const jestConfig = loadConfig();
 
 global.window.app = {
   applicationName: 'my-app',
@@ -24,89 +20,3 @@ Object.defineProperty(window, 'TextDecoder', {
   writable: true,
   value: util.TextDecoder,
 });
-
-let additionalSilencedWarnings = [];
-let additionalNonThrowingWarnings = [];
-
-function hasMatchingRegexForMessage(messages, msgRegExps) {
-  return msgRegExps.some((msgRegex) =>
-    messages.some((msg) => msgRegex.test(msg))
-  );
-}
-
-function shouldSilenceWarnings(...messages) {
-  const silencedByJestConfig = hasMatchingRegexForMessage(
-    messages,
-    jestConfig.silenceConsoleWarnings
-  );
-  const additionallySilenced = hasMatchingRegexForMessage(
-    messages,
-    additionalSilencedWarnings
-  );
-
-  return silencedByJestConfig || additionallySilenced;
-}
-
-function shouldNotThrowWarnings(...messages) {
-  const notThrowingByJestConfig = hasMatchingRegexForMessage(
-    messages,
-    jestConfig.notThrowWarnings
-  );
-  const additionallyNonThrowing = hasMatchingRegexForMessage(
-    messages,
-    additionalNonThrowingWarnings
-  );
-
-  return notThrowingByJestConfig || additionallyNonThrowing;
-}
-
-// setup file
-function logOrThrow(log, method, messages) {
-  let warning = `@commercetools-frontend/jest-preset-mc-app: console.${method} calls should not be used in tests.`;
-  if (process.env.CI) {
-    if (shouldSilenceWarnings(messages)) return;
-
-    log(warning, '\n', ...messages);
-
-    // NOTE: That some warnings should be logged allowing us to refactor graceully
-    // without having to introduce a breaking change.
-    if (shouldNotThrowWarnings(messages)) return;
-
-    warning = `@commercetools-frontend/jest-preset-mc-app: console.${method} calls not allowed in tests.`;
-
-    throw new Error(...messages);
-  } else {
-    log(colors.bgYellow.black(' WARN '), warning, '\n', ...messages);
-  }
-}
-
-// eslint-disable-next-line no-console
-const logMessage = console.log;
-global.console.log = (...messages) => {
-  logOrThrow(logMessage, 'log', messages);
-};
-
-// eslint-disable-next-line no-console
-const logInfo = console.info;
-global.console.info = (...messages) => {
-  logOrThrow(logInfo, 'info', messages);
-};
-
-// eslint-disable-next-line no-console
-const logWarning = console.warn;
-global.console.warn = (...messages) => {
-  logOrThrow(logWarning, 'warn', messages);
-};
-
-// eslint-disable-next-line no-console
-const logError = console.error;
-global.console.error = (...messages) => {
-  logOrThrow(logError, 'error', messages);
-};
-
-global.console.config = {};
-
-global.console.config.addSilencedWarning = (rexExp) =>
-  additionalSilencedWarnings.push(rexExp);
-global.console.config.addNonThrowingWarning = (rexExp) =>
-  additionalNonThrowingWarnings.push(rexExp);


### PR DESCRIPTION
Some time ago I stumbled upon this library [jest-fail-on-console](https://www.npmjs.com/package/jest-fail-on-console) and I tried it out in our test-data repository (https://github.com/commercetools/test-data/pull/148).

Essentially it does more or less what we were already doing but I noticed the output is more readable. Therefore I tried to implement it in out jest-preset and (partially) replace our own custom implementation.

**Before**

<img width="1119" alt="Screenshot 2022-09-21 at 09 35 52" src="https://user-images.githubusercontent.com/1110551/191444048-57ce2ec2-a588-4436-9f09-12edc819de9b.png">


**After**

<img width="1100" alt="Screenshot 2022-09-21 at 09 36 27" src="https://user-images.githubusercontent.com/1110551/191444093-59a1670d-eb42-4ea3-8092-45cbd667e62c.png">
