### PR TITLE
feat(cypress): enable caching session across spec by default

### DIFF
--- a/.changeset/perfect-yaks-dance.md
+++ b/.changeset/perfect-yaks-dance.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/cypress': minor
+---
+
+By default caching the session is enabled across spec files when using the `loginToMerchantCenter` command. You can opt out of this by setting `disableCacheAcrossSpecs: true`.

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "babel-plugin-transform-rename-import": "^2.3.0",
     "babel-plugin-typescript-to-proptypes": "1.4.2",
     "cross-env": "7.0.3",
-    "cypress": "10.8.0",
+    "cypress": "10.9.0",
     "dotenv": "16.0.2",
     "eslint": "8.23.1",
     "eslint-formatter-pretty": "4.1.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -43,7 +43,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "cypress": "10.8.0"
+    "cypress": "10.9.0"
   },
   "peerDependencies": {
     "cypress": "8.x || 9.x || 10.x"

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -52,6 +52,10 @@ export type CommandLoginOptions = {
    * The user login credentials.
    */
   login?: LoginCredentials;
+  /**
+   * Turn off caching the session across specs.
+   */
+  disableCacheAcrossSpecs?: boolean;
 };
 // Alias for backwards compatibility
 export type CommandLoginByOidcOptions = CommandLoginOptions;
@@ -120,7 +124,12 @@ function loginByForm(commandOptions: CommandLoginOptions) {
     // For backwards compatibility.
     if (Cypress.config('experimentalSessionAndOrigin')) {
       // https://www.cypress.io/blog/2021/08/04/authenticate-faster-in-tests-cy-session-command/
-      cy.session(sessionKey, authCallback);
+      cy.session(sessionKey, authCallback, {
+        cacheAcrossSpecs:
+          typeof commandOptions.disableCacheAcrossSpecs === 'boolean'
+            ? !commandOptions.disableCacheAcrossSpecs
+            : true,
+      });
     } else {
       cy.log(
         `We recommend turning on the flag "experimentalSessionAndOrigin" to be able to use "cy.session" and thus reduce the time to log in between tests.`
@@ -226,7 +235,12 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
       // For backwards compatibility.
       if (Cypress.config('experimentalSessionAndOrigin')) {
         // https://www.cypress.io/blog/2021/08/04/authenticate-faster-in-tests-cy-session-command/
-        cy.session(sessionKey, authCallback);
+        cy.session(sessionKey, authCallback, {
+          cacheAcrossSpecs:
+            typeof commandOptions.disableCacheAcrossSpecs === 'boolean'
+              ? !commandOptions.disableCacheAcrossSpecs
+              : true,
+        });
       } else {
         cy.log(
           `We recommend turning on the flag "experimentalSessionAndOrigin" to be able to use "cy.session" and thus reduce the time to log in between tests.`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,7 +3936,7 @@ __metadata:
     "@commercetools-frontend/application-config": 21.15.0
     "@commercetools-frontend/application-shell": 21.15.0
     "@manypkg/get-packages": 1.1.3
-    cypress: 10.8.0
+    cypress: 10.9.0
     uuid: 8.3.2
   peerDependencies:
     cypress: 8.x || 9.x || 10.x
@@ -17226,9 +17226,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:10.8.0":
-  version: 10.8.0
-  resolution: "cypress@npm:10.8.0"
+"cypress@npm:10.9.0":
+  version: 10.9.0
+  resolution: "cypress@npm:10.9.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -17274,7 +17274,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: c052690049980e7721e6fca563b724fde839d87d83c1478dfe26ce7d230992717c2c4028e7157bfb39ec274473e51929f49e5aab6a23c2b25cde2a439b1c3cf9
+  checksum: 79e3dccbb82d0b0c92bb8888682766a9738374f473cf2e9a04825a6b3dbe4420c57948cabaf757af0929192a8e61b7f08b32d7f6ee0c3cddf2736cf4f408edc1
   languageName: node
   linkType: hard
 
@@ -28894,7 +28894,7 @@ __metadata:
     babel-plugin-transform-rename-import: ^2.3.0
     babel-plugin-typescript-to-proptypes: 1.4.2
     cross-env: 7.0.3
-    cypress: 10.8.0
+    cypress: 10.9.0
     dotenv: 16.0.2
     eslint: 8.23.1
     eslint-formatter-pretty: 4.1.0


### PR DESCRIPTION
Follow up of #2823 now that [Cypress v10.9.0](https://docs.cypress.io/guides/references/changelog#&#8203;10-9-0) has added the option `cacheAcrossSpecs` 🥳