### PR TITLE
fix(cypress): backwards compat for version < 10.9.0

### DIFF
--- a/.changeset/stale-points-divide.md
+++ b/.changeset/stale-points-divide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/cypress': patch
+---
+
+Fix backwards compatibility with version < `10.9.0`

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -40,6 +40,7 @@
     "@commercetools-frontend/application-config": "21.16.0",
     "@commercetools-frontend/application-shell": "21.16.0",
     "@manypkg/get-packages": "1.1.3",
+    "semver": "7.3.7",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,6 +3959,7 @@ __metadata:
     "@commercetools-frontend/application-shell": 21.16.0
     "@manypkg/get-packages": 1.1.3
     cypress: 10.9.0
+    semver: 7.3.7
     uuid: 8.3.2
   peerDependencies:
     cypress: 8.x || 9.x || 10.x


### PR DESCRIPTION
Leftover of #2830 

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1110551/193210881-091d17e1-6b3a-4a1e-9805-b010995b8f28.png">
