### PR TITLE
fix(application-config): enable proper type inference in permission keys and resource accesses formatters

### DIFF
--- a/.changeset/friendly-wolves-buy.md
+++ b/.changeset/friendly-wolves-buy.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Enable proper type inference in `entryPointUriPathToResourceAccesses` and `entryPointUriPathToPermissionKeys` functions

--- a/packages/application-config/src/formatters.spec.ts
+++ b/packages/application-config/src/formatters.spec.ts
@@ -5,7 +5,7 @@ describe.each`
   ${'avengers'}     | ${'Avengers'}
   ${'the-avengers'} | ${'TheAvengers'}
   ${'the_avengers'} | ${'The_Avengers'}
-  ${'avengers-01'}  | ${'Avengers01'}
+  ${'avengers-01'}  | ${'Avengers/01'}
   ${'avengers_01'}  | ${'Avengers_01'}
 `(
   'formatting the entryPointUriPath "$entryPointUriPath" to a resource access key "$formattedResourceAccessKey"',
@@ -26,7 +26,7 @@ describe.each`
   ${'avengers'}     | ${'Avengers'}              | ${['books']}              | ${'AvengersBooks'}
   ${'the-avengers'} | ${'TheAvengers'}           | ${['the-books']}          | ${'TheAvengersTheBooks'}
   ${'the_avengers'} | ${'The_Avengers'}          | ${['the_books']}          | ${'The_AvengersThe_Books'}
-  ${'avengers-01'}  | ${'Avengers01'}            | ${['books-01']}           | ${'Avengers01Books01'}
+  ${'avengers-01'}  | ${'Avengers/01'}           | ${['books-01']}           | ${'Avengers/01Books01'}
   ${'avengers_01'}  | ${'Avengers_01'}           | ${['books_01']}           | ${'Avengers_01Books_01'}
 `(
   'formatting the entryPointUriPath "$entryPointUriPath" with additional permission names "$additionalPermissionNames" to a resource access key "$formattedResourceAccessKey" and "$formattedResourceAccessKeyAdditionalNames"',

--- a/packages/application-config/src/formatters.spec.ts
+++ b/packages/application-config/src/formatters.spec.ts
@@ -22,18 +22,18 @@ describe.each`
 );
 
 describe.each`
-  entryPointUriPath | formattedResourceAccessKey | additionalPermissionNames | formattedResourceAccessKeyAdditionalNames
-  ${'avengers'}     | ${'Avengers'}              | ${['books']}              | ${'AvengersBooks'}
-  ${'the-avengers'} | ${'TheAvengers'}           | ${['the-books']}          | ${'TheAvengersTheBooks'}
-  ${'the_avengers'} | ${'The_Avengers'}          | ${['the-books']}          | ${'The_AvengersTheBooks'}
-  ${'avengers-01'}  | ${'Avengers/01'}           | ${['books-01']}           | ${'Avengers/01Books01'}
-  ${'avengers_01'}  | ${'Avengers_01'}           | ${['books-01']}           | ${'Avengers_01Books01'}
+  entryPointUriPath | formattedResourceAccessKey | permissionGroupNames | formattedResourceAccessKeyAdditionalNames
+  ${'avengers'}     | ${'Avengers'}              | ${['books']}         | ${'AvengersBooks'}
+  ${'the-avengers'} | ${'TheAvengers'}           | ${['the-books']}     | ${'TheAvengersTheBooks'}
+  ${'the_avengers'} | ${'The_Avengers'}          | ${['the-books']}     | ${'The_AvengersTheBooks'}
+  ${'avengers-01'}  | ${'Avengers/01'}           | ${['the-movies']}    | ${'Avengers/01TheMovies'}
+  ${'avengers_01'}  | ${'Avengers_01'}           | ${['the-movies']}    | ${'Avengers_01TheMovies'}
 `(
-  'formatting the entryPointUriPath "$entryPointUriPath" with additional permission names "$additionalPermissionNames" to a resource access key "$formattedResourceAccessKey" and "$formattedResourceAccessKeyAdditionalNames"',
+  'formatting the entryPointUriPath "$entryPointUriPath" with additional permission group names "$permissionGroupNames" to a resource access key "$formattedResourceAccessKey" and "$formattedResourceAccessKeyAdditionalNames"',
   ({
     entryPointUriPath,
     formattedResourceAccessKey,
-    additionalPermissionNames,
+    permissionGroupNames,
     formattedResourceAccessKeyAdditionalNames,
   }) => {
     it(`should format correctly`, () => {
@@ -44,7 +44,7 @@ describe.each`
       expect(
         entryPointUriPathToPermissionKeys(
           entryPointUriPath,
-          additionalPermissionNames
+          permissionGroupNames
         )
       ).toEqual({
         View: `View${formattedResourceAccessKey}`,

--- a/packages/application-config/src/formatters.spec.ts
+++ b/packages/application-config/src/formatters.spec.ts
@@ -25,7 +25,7 @@ describe.each`
   entryPointUriPath | formattedResourceAccessKey | additionalPermissionNames | formattedResourceAccessKeyAdditionalNames
   ${'avengers'}     | ${'Avengers'}              | ${['books']}              | ${'AvengersBooks'}
   ${'the-avengers'} | ${'TheAvengers'}           | ${['the-books']}          | ${'TheAvengersTheBooks'}
-  ${'the_avengers'} | ${'The_Avengers'}          | ${['the_books']}          | ${'The_AvengersThe_Books'}
+  ${'the_avengers'} | ${'The_Avengers'}          | ${['the_books']}          | ${'The_AvengersThe_books'}
   ${'avengers-01'}  | ${'Avengers/01'}           | ${['books-01']}           | ${'Avengers/01Books01'}
   ${'avengers_01'}  | ${'Avengers_01'}           | ${['books_01']}           | ${'Avengers_01Books_01'}
 `(

--- a/packages/application-config/src/formatters.spec.ts
+++ b/packages/application-config/src/formatters.spec.ts
@@ -25,9 +25,9 @@ describe.each`
   entryPointUriPath | formattedResourceAccessKey | additionalPermissionNames | formattedResourceAccessKeyAdditionalNames
   ${'avengers'}     | ${'Avengers'}              | ${['books']}              | ${'AvengersBooks'}
   ${'the-avengers'} | ${'TheAvengers'}           | ${['the-books']}          | ${'TheAvengersTheBooks'}
-  ${'the_avengers'} | ${'The_Avengers'}          | ${['the_books']}          | ${'The_AvengersThe_books'}
+  ${'the_avengers'} | ${'The_Avengers'}          | ${['the-books']}          | ${'The_AvengersTheBooks'}
   ${'avengers-01'}  | ${'Avengers/01'}           | ${['books-01']}           | ${'Avengers/01Books01'}
-  ${'avengers_01'}  | ${'Avengers_01'}           | ${['books_01']}           | ${'Avengers_01Books_01'}
+  ${'avengers_01'}  | ${'Avengers_01'}           | ${['books-01']}           | ${'Avengers_01Books01'}
 `(
   'formatting the entryPointUriPath "$entryPointUriPath" with additional permission names "$additionalPermissionNames" to a resource access key "$formattedResourceAccessKey" and "$formattedResourceAccessKeyAdditionalNames"',
   ({

--- a/packages/application-config/src/formatters.spec.ts
+++ b/packages/application-config/src/formatters.spec.ts
@@ -5,16 +5,18 @@ describe.each`
   ${'avengers'}     | ${'Avengers'}
   ${'the-avengers'} | ${'TheAvengers'}
   ${'the_avengers'} | ${'The_Avengers'}
-  ${'avengers-01'}  | ${'Avengers/01'}
+  ${'avengers-01'}  | ${'Avengers01'}
   ${'avengers_01'}  | ${'Avengers_01'}
 `(
   'formatting the entryPointUriPath "$entryPointUriPath" to a resource access key "$formattedResourceAccessKey"',
   ({ entryPointUriPath, formattedResourceAccessKey }) => {
     it(`should format correctly`, () => {
-      expect(entryPointUriPathToPermissionKeys(entryPointUriPath)).toEqual({
-        View: `View${formattedResourceAccessKey}`,
-        Manage: `Manage${formattedResourceAccessKey}`,
-      });
+      const resourceAccessKeys =
+        entryPointUriPathToPermissionKeys(entryPointUriPath);
+      expect(resourceAccessKeys.View).toBe(`View${formattedResourceAccessKey}`);
+      expect(resourceAccessKeys.Manage).toBe(
+        `Manage${formattedResourceAccessKey}`
+      );
     });
   }
 );
@@ -24,7 +26,7 @@ describe.each`
   ${'avengers'}     | ${'Avengers'}              | ${['books']}              | ${'AvengersBooks'}
   ${'the-avengers'} | ${'TheAvengers'}           | ${['the-books']}          | ${'TheAvengersTheBooks'}
   ${'the_avengers'} | ${'The_Avengers'}          | ${['the_books']}          | ${'The_AvengersThe_Books'}
-  ${'avengers-01'}  | ${'Avengers/01'}           | ${['books-01']}           | ${'Avengers/01Books/01'}
+  ${'avengers-01'}  | ${'Avengers01'}            | ${['books-01']}           | ${'Avengers01Books01'}
   ${'avengers_01'}  | ${'Avengers_01'}           | ${['books_01']}           | ${'Avengers_01Books_01'}
 `(
   'formatting the entryPointUriPath "$entryPointUriPath" with additional permission names "$additionalPermissionNames" to a resource access key "$formattedResourceAccessKey" and "$formattedResourceAccessKeyAdditionalNames"',
@@ -62,12 +64,11 @@ describe.each`
   'formatting the internal applications group "$internalApplicationGroup" to a resource access key "$formattedResourceAccessKey"',
   ({ internalApplicationGroup, formattedResourceAccessKey }) => {
     it(`should format correctly`, () => {
-      expect(
-        entryPointUriPathToPermissionKeys(internalApplicationGroup)
-      ).toEqual({
-        View: `View${formattedResourceAccessKey}`,
-        Manage: `Manage${formattedResourceAccessKey}`,
-      });
+      const permissionKeys = entryPointUriPathToPermissionKeys(
+        internalApplicationGroup
+      );
+      expect(permissionKeys.View).toBe(`View${formattedResourceAccessKey}`);
+      expect(permissionKeys.Manage).toBe(`Manage${formattedResourceAccessKey}`);
     });
   }
 );

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -68,6 +68,7 @@ const formatPermissionNameToResourceAccessKey = (permissionName: string) =>
   permissionName
     // Each word is split by a hyphen.
     .split('-')
+    .map((word) => word.toLowerCase())
     .map(upperFirst)
     .join('');
 

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -56,30 +56,6 @@ const formatEntryPointUriPathToResourceAccessKey = (
     })
     .join('');
 
-/**
- * The function formats the `permissionName` to a resource access key.
- * It makes the first character of the string and the next character after a special character an uppercase.
- *
- * @example
- * - avengers --> Avengers
- * - the-avengers --> TheAvengers
- * - the_avengers --> The_Avengers
- * - avengers-01 --> Avengers01 [ℹ️ mind the difference here compared to `formatEntryPointUriPathToResourceAccessKey`]
- * - avengers_01 --> Avengers_01
- */
-const formatPermissionNameToResourceAccessKey = (permissionName: string) =>
-  permissionName
-    // Splits the string by underscore.
-    .split('_')
-    // Uppercase the first character of each word split.
-    .map(upperFirst)
-    // Join the words by an underscore.
-    .join('_')
-    // Each word is split by a hyphen.
-    .split('-')
-    .map(upperFirst)
-    .join('');
-
 function entryPointUriPathToResourceAccesses(
   entryPointUriPath: string
 ): TImplicitCustomApplicationResourceAccesses<''>;
@@ -102,7 +78,7 @@ function entryPointUriPathToResourceAccesses<PermissionName extends string>(
   const additionalResourceAccesses = (additionalPermissionNames ?? []).reduce(
     (resourceAccesses, permissionName) => {
       const additionalResourceAccessKey =
-        formatPermissionNameToResourceAccessKey(permissionName);
+        formatEntryPointUriPathToResourceAccessKey(permissionName);
       return {
         ...resourceAccesses,
         [`view${additionalResourceAccessKey}`]: `${defaultResourceAccesses.view}${additionalResourceAccessKey}`,

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -2,22 +2,22 @@ import upperFirst from 'lodash/upperFirst';
 import type { CamelCase } from './types';
 
 type TImplicitCustomApplicationResourceAccesses<
-  PermissionName extends string = ''
+  PermissionGroupName extends string = ''
 > = Record<
   | `view`
   | `manage`
-  | `view${Capitalize<CamelCase<PermissionName>>}`
-  | `manage${Capitalize<CamelCase<PermissionName>>}`,
+  | `view${Capitalize<CamelCase<PermissionGroupName>>}`
+  | `manage${Capitalize<CamelCase<PermissionGroupName>>}`,
   string
 >;
 
 type TImplicitCustomApplicationPermissionKeys<
-  PermissionName extends string = ''
+  PermissionGroupName extends string = ''
 > = Record<
   | `View`
   | `Manage`
-  | `View${Capitalize<CamelCase<PermissionName>>}`
-  | `Manage${Capitalize<CamelCase<PermissionName>>}`,
+  | `View${Capitalize<CamelCase<PermissionGroupName>>}`
+  | `Manage${Capitalize<CamelCase<PermissionGroupName>>}`,
   string
 >;
 
@@ -64,8 +64,10 @@ const formatEntryPointUriPathToResourceAccessKey = (
  * - books --> Books
  * - the-books --> TheBooks
  */
-const formatPermissionGroupNameToResourceAccessKey = (permissionName: string) =>
-  permissionName
+const formatPermissionGroupNameToResourceAccessKey = (
+  permissionGroupName: string
+) =>
+  permissionGroupName
     // Each word is split by a hyphen.
     .split('-')
     .map(upperFirst)
@@ -74,33 +76,37 @@ const formatPermissionGroupNameToResourceAccessKey = (permissionName: string) =>
 function entryPointUriPathToResourceAccesses(
   entryPointUriPath: string
 ): TImplicitCustomApplicationResourceAccesses<''>;
-function entryPointUriPathToResourceAccesses<PermissionName extends string>(
+function entryPointUriPathToResourceAccesses<
+  PermissionGroupName extends string
+>(
   entryPointUriPath: string,
-  additionalPermissionNames: PermissionName[]
-): TImplicitCustomApplicationResourceAccesses<PermissionName>;
-function entryPointUriPathToResourceAccesses<PermissionName extends string>(
+  permissionGroupNames: PermissionGroupName[]
+): TImplicitCustomApplicationResourceAccesses<PermissionGroupName>;
+function entryPointUriPathToResourceAccesses<
+  PermissionGroupName extends string
+>(
   entryPointUriPath: string,
-  additionalPermissionNames?: PermissionName[]
-): TImplicitCustomApplicationResourceAccesses<PermissionName> {
+  permissionGroupNames?: PermissionGroupName[]
+): TImplicitCustomApplicationResourceAccesses<PermissionGroupName> {
   const resourceAccessKey =
     formatEntryPointUriPathToResourceAccessKey(entryPointUriPath);
 
   const defaultResourceAccesses = {
     view: `view${resourceAccessKey}`,
     manage: `manage${resourceAccessKey}`,
-  } as TImplicitCustomApplicationResourceAccesses<PermissionName>;
+  } as TImplicitCustomApplicationResourceAccesses<PermissionGroupName>;
 
-  const additionalResourceAccesses = (additionalPermissionNames ?? []).reduce(
-    (resourceAccesses, permissionName) => {
+  const additionalResourceAccesses = (permissionGroupNames ?? []).reduce(
+    (resourceAccesses, permissionGroupName) => {
       const additionalResourceAccessKey =
-        formatPermissionGroupNameToResourceAccessKey(permissionName);
+        formatPermissionGroupNameToResourceAccessKey(permissionGroupName);
       return {
         ...resourceAccesses,
         [`view${additionalResourceAccessKey}`]: `${defaultResourceAccesses.view}${additionalResourceAccessKey}`,
         [`manage${additionalResourceAccessKey}`]: `${defaultResourceAccesses.manage}${additionalResourceAccessKey}`,
       };
     },
-    {} as TImplicitCustomApplicationResourceAccesses<PermissionName>
+    {} as TImplicitCustomApplicationResourceAccesses<PermissionGroupName>
   );
 
   return {
@@ -112,24 +118,25 @@ function entryPointUriPathToResourceAccesses<PermissionName extends string>(
 function entryPointUriPathToPermissionKeys(
   entryPointUriPath: string
 ): TImplicitCustomApplicationPermissionKeys<''>;
-function entryPointUriPathToPermissionKeys<PermissionName extends string>(
+function entryPointUriPathToPermissionKeys<PermissionGroupName extends string>(
   entryPointUriPath: string,
-  additionalPermissionNames: PermissionName[]
-): TImplicitCustomApplicationPermissionKeys<PermissionName>;
-function entryPointUriPathToPermissionKeys<PermissionName extends string>(
+  permissionGroupNames: PermissionGroupName[]
+): TImplicitCustomApplicationPermissionKeys<PermissionGroupName>;
+function entryPointUriPathToPermissionKeys<PermissionGroupName extends string>(
   entryPointUriPath: string,
-  additionalPermissionNames?: PermissionName[]
-): TImplicitCustomApplicationPermissionKeys<PermissionName> {
-  const resourceAccesses = entryPointUriPathToResourceAccesses<PermissionName>(
-    entryPointUriPath,
-    additionalPermissionNames ?? []
-  );
+  permissionGroupNames?: PermissionGroupName[]
+): TImplicitCustomApplicationPermissionKeys<PermissionGroupName> {
+  const resourceAccesses =
+    entryPointUriPathToResourceAccesses<PermissionGroupName>(
+      entryPointUriPath,
+      permissionGroupNames ?? []
+    );
   return Object.entries(resourceAccesses).reduce(
     (permissionKeys, [resourceAccessKey, resourceAccessValue]) => ({
       ...permissionKeys,
       [upperFirst(resourceAccessKey)]: upperFirst(resourceAccessValue),
     }),
-    {} as TImplicitCustomApplicationPermissionKeys<PermissionName>
+    {} as TImplicitCustomApplicationPermissionKeys<PermissionGroupName>
   );
 }
 

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -30,7 +30,7 @@ type TImplicitCustomApplicationPermissionKeys<
  * - avengers --> Avengers
  * - the-avengers --> TheAvengers
  * - the_avengers --> The_Avengers
- * - avengers-01 --> Avengers01
+ * - avengers-01 --> Avengers/01
  * - avengers_01 --> Avengers_01
  */
 const formatEntryPointUriPathToResourceAccessKey = (
@@ -40,12 +40,44 @@ const formatEntryPointUriPathToResourceAccessKey = (
     // Splits the string by underscore.
     .split('_')
     // Uppercase the first character of each word split.
-    .map((word) => upperFirst(word))
+    .map(upperFirst)
     // Join the words by an underscore.
     .join('_')
     // Each word is split by a hyphen.
     .split('-')
-    .map((word) => upperFirst(word))
+    .map((word, i) => {
+      // Regex below checking if the character is numeric.
+      // If the word after the hyphen is numeric, replace the hyphen with a forward slash.
+      // If not, omit the hyphen and uppercase the first character
+      if (i > 0 && /^-?\d+$/.test(word[0])) {
+        return `/${word}`;
+      }
+      return upperFirst(word);
+    })
+    .join('');
+
+/**
+ * The function formats the `permissionName` to a resource access key.
+ * It makes the first character of the string and the next character after a special character an uppercase.
+ *
+ * @example
+ * - avengers --> Avengers
+ * - the-avengers --> TheAvengers
+ * - the_avengers --> The_Avengers
+ * - avengers-01 --> Avengers01 [ℹ️ mind the difference here compared to `formatEntryPointUriPathToResourceAccessKey`]
+ * - avengers_01 --> Avengers_01
+ */
+const formatPermissionNameToResourceAccessKey = (permissionName: string) =>
+  permissionName
+    // Splits the string by underscore.
+    .split('_')
+    // Uppercase the first character of each word split.
+    .map(upperFirst)
+    // Join the words by an underscore.
+    .join('_')
+    // Each word is split by a hyphen.
+    .split('-')
+    .map(upperFirst)
     .join('');
 
 function entryPointUriPathToResourceAccesses(
@@ -70,7 +102,7 @@ function entryPointUriPathToResourceAccesses<PermissionName extends string>(
   const additionalResourceAccesses = (additionalPermissionNames ?? []).reduce(
     (resourceAccesses, permissionName) => {
       const additionalResourceAccessKey =
-        formatEntryPointUriPathToResourceAccessKey(permissionName);
+        formatPermissionNameToResourceAccessKey(permissionName);
       return {
         ...resourceAccesses,
         [`view${additionalResourceAccessKey}`]: `${defaultResourceAccesses.view}${additionalResourceAccessKey}`,

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -56,6 +56,21 @@ const formatEntryPointUriPathToResourceAccessKey = (
     })
     .join('');
 
+/**
+ * The function formats the `permissionName` to a resource access key.
+ * It makes the first character of the string and the next character after a special character an uppercase.
+ *
+ * @example
+ * - avengers --> Avengers
+ * - the-avengers --> TheAvengers
+ * - avengers-01 --> Avengers01 [ℹ️ mind the difference here compared to `formatEntryPointUriPathToResourceAccessKey`] */
+const formatPermissionNameToResourceAccessKey = (permissionName: string) =>
+  permissionName
+    // Each word is split by a hyphen.
+    .split('-')
+    .map(upperFirst)
+    .join('');
+
 function entryPointUriPathToResourceAccesses(
   entryPointUriPath: string
 ): TImplicitCustomApplicationResourceAccesses<''>;
@@ -78,7 +93,7 @@ function entryPointUriPathToResourceAccesses<PermissionName extends string>(
   const additionalResourceAccesses = (additionalPermissionNames ?? []).reduce(
     (resourceAccesses, permissionName) => {
       const additionalResourceAccessKey =
-        formatEntryPointUriPathToResourceAccessKey(permissionName);
+        formatPermissionNameToResourceAccessKey(permissionName);
       return {
         ...resourceAccesses,
         [`view${additionalResourceAccessKey}`]: `${defaultResourceAccesses.view}${additionalResourceAccessKey}`,

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -1,12 +1,13 @@
 import upperFirst from 'lodash/upperFirst';
+import type { CamelCase } from './types';
 
 type TImplicitCustomApplicationResourceAccesses<
   PermissionName extends string = ''
 > = Record<
   | `view`
   | `manage`
-  | `view${Capitalize<PermissionName>}`
-  | `manage${Capitalize<PermissionName>}`,
+  | `view${Capitalize<CamelCase<PermissionName>>}`
+  | `manage${Capitalize<CamelCase<PermissionName>>}`,
   string
 >;
 
@@ -15,8 +16,8 @@ type TImplicitCustomApplicationPermissionKeys<
 > = Record<
   | `View`
   | `Manage`
-  | `View${Capitalize<PermissionName>}`
-  | `Manage${Capitalize<PermissionName>}`,
+  | `View${Capitalize<CamelCase<PermissionName>>}`
+  | `Manage${Capitalize<CamelCase<PermissionName>>}`,
   string
 >;
 
@@ -29,7 +30,7 @@ type TImplicitCustomApplicationPermissionKeys<
  * - avengers --> Avengers
  * - the-avengers --> TheAvengers
  * - the_avengers --> The_Avengers
- * - avengers-01 --> Avengers/01
+ * - avengers-01 --> Avengers01
  * - avengers_01 --> Avengers_01
  */
 const formatEntryPointUriPathToResourceAccessKey = (
@@ -44,15 +45,7 @@ const formatEntryPointUriPathToResourceAccessKey = (
     .join('_')
     // Each word is split by a hyphen.
     .split('-')
-    .map((word, i) => {
-      // Regex below checking if the character is numeric.
-      // If the word after the hyphen is numeric, replace the hyphen with a forward slash.
-      // If not, omit the hyphen and uppercase the first character
-      if (i > 0 && /^-?\d+$/.test(word[0])) {
-        return `/${word}`;
-      }
-      return upperFirst(word);
-    })
+    .map((word) => upperFirst(word))
     .join('');
 
 function entryPointUriPathToResourceAccesses(

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -57,18 +57,17 @@ const formatEntryPointUriPathToResourceAccessKey = (
     .join('');
 
 /**
- * The function formats the `permissionName` to a resource access key.
- * It makes the first character of the string and the next character after a special character an uppercase.
+ * The function formats the permission group name to a resource access key.
+ * It makes the first character of the string and the next character after a special character (`-`) an uppercase.
  *
  * @example
- * - avengers --> Avengers
- * - the-avengers --> TheAvengers
- * - avengers-01 --> Avengers01 [ℹ️ mind the difference here compared to `formatEntryPointUriPathToResourceAccessKey`] */
-const formatPermissionNameToResourceAccessKey = (permissionName: string) =>
+ * - books --> Books
+ * - the-books --> TheBooks
+ */
+const formatPermissionGroupNameToResourceAccessKey = (permissionName: string) =>
   permissionName
     // Each word is split by a hyphen.
     .split('-')
-    .map((word) => word.toLowerCase())
     .map(upperFirst)
     .join('');
 
@@ -94,7 +93,7 @@ function entryPointUriPathToResourceAccesses<PermissionName extends string>(
   const additionalResourceAccesses = (additionalPermissionNames ?? []).reduce(
     (resourceAccesses, permissionName) => {
       const additionalResourceAccessKey =
-        formatPermissionNameToResourceAccessKey(permissionName);
+        formatPermissionGroupNameToResourceAccessKey(permissionName);
       return {
         ...resourceAccesses,
         [`view${additionalResourceAccessKey}`]: `${defaultResourceAccesses.view}${additionalResourceAccessKey}`,

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -58,7 +58,6 @@ export type WordSeparators = '-';
 
 /**
 Represents an array of strings split using a given character or character set.
-Underscore characters are omitted.
 
 source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c993860d0886261da/source/split.d.ts#L22:L29
 

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -54,19 +54,7 @@ export type LoadingConfigOptions = {
 };
 
 // Utility types
-type WordSeparators = '_' | '-';
-
-/**
-Verifies if input string is convertible to number
-
-@example
-```
-const num: ConvertibleToNumber<"80"> = "80"
-```
-*/
-type ConvertibleToNumber<T extends string> =
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  T extends `${infer _Result extends number}` ? T : never;
+export type WordSeparators = '-';
 
 /**
 Represents an array of strings split using a given character or character set.
@@ -87,16 +75,7 @@ export type Split<
   S extends string,
   Delimiter extends string
 > = S extends `${infer Head}${Delimiter}${infer Tail}`
-  ? [
-      Delimiter extends '_'
-        ? `${Head}_`
-        : Delimiter extends '-'
-        ? Tail extends ConvertibleToNumber<Tail>
-          ? `${Head}/`
-          : Head
-        : Head,
-      ...Split<Tail, Delimiter>
-    ]
+  ? [Head, ...Split<Tail, Delimiter>]
   : S extends Delimiter
   ? []
   : [S];

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -52,3 +52,86 @@ export type LoadingConfigOptions = {
   processEnv: NodeJS.ProcessEnv;
   applicationPath: string;
 };
+
+// Utility types
+type WordSeparators = '_' | '-';
+
+/**
+Represents an array of strings split using a given character or character set.
+Underscore characters are omitted.
+
+source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c993860d0886261da/source/split.d.ts#L22:L29
+
+@example
+```
+declare function split<S extends string, D extends string>(string: S, separator: D): Split<S, D>;
+type Item = 'foo' | 'bar' | 'baz' | 'waldo';
+const items = 'foo,bar,baz,waldo';
+let array: Item[];
+array = split(items, ',');
+```
+*/
+type Split<
+  S extends string,
+  Delimiter extends string
+> = S extends `${infer Head}${Delimiter}${infer Tail}`
+  ? [Delimiter extends '_' ? `${Head}_` : Head, ...Split<Tail, Delimiter>]
+  : S extends Delimiter
+  ? []
+  : [S];
+
+/**
+Step by step takes the first item in an array literal, formats it and adds it to a string literal, and then recursively appends the remainder.
+Only to be used by `CamelCaseStringArray<>`.
+
+source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c993860d0886261da/source/camel-case.d.ts#L11:L18
+*/
+type InnerCamelCaseStringArray<
+  Parts extends readonly unknown[],
+  PreviousPart
+> = Parts extends [`${infer FirstPart}`, ...infer RemainingParts]
+  ? FirstPart extends undefined
+    ? ''
+    : FirstPart extends ''
+    ? InnerCamelCaseStringArray<RemainingParts, PreviousPart>
+    : `${PreviousPart extends ''
+        ? FirstPart
+        : Capitalize<FirstPart>}${InnerCamelCaseStringArray<
+        RemainingParts,
+        FirstPart
+      >}`
+  : '';
+
+/**
+Starts fusing the output of `Split<>`, an array literal of strings, into a camel-cased string literal.
+It's separate from `InnerCamelCaseStringArray<>` to keep a clean API outwards to the rest of the code.
+
+source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c993860d0886261da/source/camel-case.d.ts#L27:L30
+*/
+type CamelCaseStringArray<Parts extends readonly string[]> = Parts extends [
+  `${infer FirstPart}`,
+  ...infer RemainingParts
+]
+  ? Uncapitalize<`${FirstPart}${InnerCamelCaseStringArray<
+      RemainingParts,
+      FirstPart
+    >}`>
+  : never;
+
+/**
+Convert a string literal to camel-case.
+This can be useful when, for example, converting some kebab-cased command-line flags or a snake-cased database result.
+
+source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c993860d0886261da/source/camel-case.d.ts#L73
+
+@example
+```
+const someVariable: CamelCase<'foo-bar'> = 'fooBar';
+const anotherVariable: CamelCase<'foo_bar'> = 'foo_Bar';
+```
+*/
+export type CamelCase<K> = K extends string
+  ? CamelCaseStringArray<
+      Split<K extends Uppercase<K> ? Uppercase<K> : K, WordSeparators>
+    >
+  : K;

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -75,7 +75,7 @@ export type Split<
   S extends string,
   Delimiter extends string
 > = S extends `${infer Head}${Delimiter}${infer Tail}`
-  ? [Head, ...Split<Tail, Delimiter>]
+  ? [Lowercase<Head>, ...Split<Tail, Delimiter>]
   : S extends Delimiter
   ? []
   : [S];

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -74,7 +74,7 @@ export type Split<
   S extends string,
   Delimiter extends string
 > = S extends `${infer Head}${Delimiter}${infer Tail}`
-  ? [Lowercase<Head>, ...Split<Tail, Delimiter>]
+  ? [Head, ...Split<Tail, Delimiter>]
   : S extends Delimiter
   ? []
   : [S];

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -57,6 +57,18 @@ export type LoadingConfigOptions = {
 type WordSeparators = '_' | '-';
 
 /**
+Verifies if input string is convertible to number
+
+@example
+```
+const num: ConvertibleToNumber<"80"> = "80"
+```
+*/
+type ConvertibleToNumber<T extends string> =
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  T extends `${infer _Result extends number}` ? T : never;
+
+/**
 Represents an array of strings split using a given character or character set.
 Underscore characters are omitted.
 
@@ -71,11 +83,20 @@ let array: Item[];
 array = split(items, ',');
 ```
 */
-type Split<
+export type Split<
   S extends string,
   Delimiter extends string
 > = S extends `${infer Head}${Delimiter}${infer Tail}`
-  ? [Delimiter extends '_' ? `${Head}_` : Head, ...Split<Tail, Delimiter>]
+  ? [
+      Delimiter extends '_'
+        ? `${Head}_`
+        : Delimiter extends '-'
+        ? Tail extends ConvertibleToNumber<Tail>
+          ? `${Head}/`
+          : Head
+        : Head,
+      ...Split<Tail, Delimiter>
+    ]
   : S extends Delimiter
   ? []
   : [S];


### PR DESCRIPTION
#### Summary

Currently the output type of  e.g. `entryPointUriPathToResourceAccesses` function does not work as expected.
<img width="798" alt="Screenshot 2022-09-30 at 11 16 24" src="https://user-images.githubusercontent.com/49066275/193237398-d0448126-6dca-4494-9e71-57d5e95a6a54.png">

The goal of this PR is to fix that. 

I had to refactor a little the `Split` utility type taken from the `type-fest` library to work well in our case.

Refactoring [this test](https://github.com/commercetools/merchant-center-application-kit/blob/af9f6681dcd5d28ba036c5fd07140cbf904a3c52/packages/application-config/src/formatters.spec.ts#L22:L55) to enable static type checking (without any type assertion) turned out to be a bigger challenge than this fix 😕, so I left this test as is.

To play with this PR you might want to use [this playground](https://codesandbox.io/s/typescript-playground-export-forked-u297ue)
