### PR TITLE
Update readable page title document with  feedback

### DIFF
--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -82,11 +82,11 @@ This feature is available from version `21.15.0` onwards.
 
 </Info>
 
-This component can be used to overwrite the default document's `<title>`.
+Use this component to overwrite the document's default <title>
 
 ### Usage
 
-We recommend to render this component in pages where there is a human-readable resource identifier, for example a Product name in the product details page.
+We recommend using this component on pages with a human-readable resource identifier, for example, a Product name on the product details page.
 
 ```js
 import { ApplicationPageTitle } from '@commercetools-frontend/application-shell';
@@ -95,11 +95,11 @@ import { ApplicationPageTitle } from '@commercetools-frontend/application-shell'
 // Red shoes - Products - my-shop - Merchant Center
 ```
 
-The `<ApplicationPageTitle>` component can be rendered multiple times and the last one rendered will overwrite the previous ones.
+When the <ApplicationPageTitle> component is used multiple times, the last one rendered will overwrite the previous ones.
 
 <Info>
 
-Please refer to the [Mapping guidelines](/development/human-readable-page-title#mapping-guidelines) to understand when you should overwrite the title and when not.
+Please refer to the [Mapping guidelines](/development/human-readable-page-title#mapping-guidelines) to understand when to overwrite the title and when not.
 
 </Info>
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -95,7 +95,7 @@ import { ApplicationPageTitle } from '@commercetools-frontend/application-shell'
 // Red shoes - Products - my-shop - Merchant Center
 ```
 
-When the <ApplicationPageTitle> component is used multiple times, the last one rendered will overwrite the previous ones.
+When the `<ApplicationPageTitle>` component is used multiple times, the last one rendered will overwrite the previous ones.
 
 <Info>
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -82,7 +82,7 @@ This feature is available from version `21.15.0` onwards.
 
 </Info>
 
-Use this component to overwrite the document's default <title>
+Use this component to overwrite the document's default `<title>`.
 
 ### Usage
 
@@ -113,15 +113,15 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 ## useMcQuery
 
-A React hook that wraps the [`useQuery`](https://www.apollographql.com/docs/react/data/queries/) hook of Apollo Client. The only difference is that `useMcQuery` properly types the `context` object, which is always used to define the GraphQL `target`. See [Data Fetching](/development/data-fetching).
+A React hook that wraps the [useQuery](https://www.apollographql.com/docs/react/data/queries/) hook of Apollo Client. The only difference is that `useMcQuery` properly types the `context` object, which is always used to define the GraphQL `target`. See [Data Fetching](/development/data-fetching).
 
 ## useMcLazyQuery
 
-A React hook that wraps the [`useLazyQuery`](https://www.apollographql.com/docs/react/data/queries/#manual-execution-with-uselazyquery) hook of Apollo Client. The only difference is that `useMcLazyQuery` properly types the `context` object, which is always used to define the GraphQL `target`. See [Data Fetching](/development/data-fetching).
+A React hook that wraps the [useLazyQuery](https://www.apollographql.com/docs/react/data/queries/#manual-execution-with-uselazyquery) hook of Apollo Client. The only difference is that `useMcLazyQuery` properly types the `context` object, which is always used to define the GraphQL `target`. See [Data Fetching](/development/data-fetching).
 
 ## useMcMutation
 
-A React hook that wraps the [`useMutation`](https://www.apollographql.com/docs/react/data/mutations/) hook of Apollo Client. The only difference is that `useMcMutation` properly types the `context` object, which is always used to define the GraphQL `target`. See [Data Fetching](/development/data-fetching).
+A React hook that wraps the [useMutation](https://www.apollographql.com/docs/react/data/mutations/) hook of Apollo Client. The only difference is that `useMcMutation` properly types the `context` object, which is always used to define the GraphQL `target`. See [Data Fetching](/development/data-fetching).
 
 # Utilities
 

--- a/website/src/releases/2022-09/readable-page-title.mdx
+++ b/website/src/releases/2022-09/readable-page-title.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2022-09-29
 title: Human-readable page titles
-description: Introducing more granular and readable document's titles for all Merchant Center pages to help users identifying the context of the page.
+description: Introducing more granular and readable document titles for all Merchant Center pages to help users identify the page's context.
 type: feature
 topics:
   - Merchant Center

--- a/website/src/releases/2022-09/readable-page-title.mdx
+++ b/website/src/releases/2022-09/readable-page-title.mdx
@@ -8,6 +8,6 @@ topics:
   - UI Components
 ---
 
-Custom Applications now use a more readable, customizable document title by default. You can read more about this feature in the [`Human-readable page title`](/development/human-readable-page-title) documentation.
+Custom Applications now use a more readable, customizable document title by default. You can read more about this feature in the [Human-readable page title](/development/human-readable-page-title) documentation.
 
 As always, if you have questions or feedback, you can open a [GitHub Discussion](https://github.com/commercetools/merchant-center-application-kit/discussions) or a [GitHub Issue](https://github.com/commercetools/merchant-center-application-kit/issues).

--- a/website/src/releases/2022-09/readable-page-title.mdx
+++ b/website/src/releases/2022-09/readable-page-title.mdx
@@ -8,6 +8,6 @@ topics:
   - UI Components
 ---
 
-Custom Applications use a more readable document's title by default, which can be customized. You can read more about this feature in the [`Human-readable page title`](/development/human-readable-page-title) documentation.
+Custom Applications now use a more readable, customizable document title by default. You can read more about this feature in the [`Human-readable page title`](/development/human-readable-page-title) documentation.
 
-As always, if you have questions or feedback you can open a [GitHub Discussion](https://github.com/commercetools/merchant-center-application-kit/discussions) or a [GitHub Issue](https://github.com/commercetools/merchant-center-application-kit/issues).
+As always, if you have questions or feedback, you can open a [GitHub Discussion](https://github.com/commercetools/merchant-center-application-kit/discussions) or a [GitHub Issue](https://github.com/commercetools/merchant-center-application-kit/issues).


### PR DESCRIPTION
This is a follow up doc improvement of the remaining [feedback]( https://github.com/commercetools/merchant-center-application-kit/pull/2793#discussion_r984436515) from the Readabkle page title documentation PR (already merged)