### PR TITLE
feat(application-kit): implement `verificationStatus` field

### DIFF
--- a/.changeset/curvy-fireants-hug.md
+++ b/.changeset/curvy-fireants-hug.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/application-shell-connectors': minor
+'@commercetools-frontend/permissions': minor
+---
+
+Include new user-related entity information

--- a/.changeset/curvy-fireants-hug.md
+++ b/.changeset/curvy-fireants-hug.md
@@ -4,4 +4,4 @@
 '@commercetools-frontend/permissions': minor
 ---
 
-Include new user-related entity information
+Include new user-related entity information in application context

--- a/codegen.mc.yml
+++ b/codegen.mc.yml
@@ -30,6 +30,20 @@ extensions:
         config:
           addUnderscoreToArgsType: true
           typesPrefix: T
+      packages/permissions/src/types/generated/mc.ts:
+        plugins:
+          - typescript
+          - typescript-operations
+        config:
+          addUnderscoreToArgsType: true
+          typesPrefix: T
+      test-data/types/generated/mc.ts:
+        plugins:
+          - typescript
+          - typescript-operations
+        config:
+          addUnderscoreToArgsType: true
+          typesPrefix: T
     hooks:
       afterAllFileWrite:
         - prettier --write

--- a/codegen.mc.yml
+++ b/codegen.mc.yml
@@ -2,7 +2,6 @@ schema:
   - '${MC_API_URL}/graphql':
       headers:
         X-Graphql-Target: mc
-  - schemas/client-schema.graphql
 documents: 'packages/**/*.mc.graphql'
 extensions:
   codegen:

--- a/codegen.mc.yml
+++ b/codegen.mc.yml
@@ -2,6 +2,7 @@ schema:
   - '${MC_API_URL}/graphql':
       headers:
         X-Graphql-Target: mc
+  - schemas/client-schema.graphql
 documents: 'packages/**/*.mc.graphql'
 extensions:
   codegen:

--- a/graphql-test-utils/graphql-models/user.js
+++ b/graphql-test-utils/graphql-models/user.js
@@ -26,6 +26,7 @@ const User = new Factory()
     __typename: 'ProjectQueryResult',
     total: 0,
     results: [],
-  }));
+  }))
+  .attr('verificationStatus', () => 'Verified');
 
 export default User;

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -133,6 +133,7 @@ describe('mapUserToApplicationContextUser', () => {
           expect.objectContaining({ key: expect.any(String) }),
         ]),
       }),
+      verificationStatus: expect.any(String),
     });
   });
   it('should map fetched SSO user to user context', () => {
@@ -150,6 +151,7 @@ describe('mapUserToApplicationContextUser', () => {
           expect.objectContaining({ key: expect.any(String) }),
         ]),
       }),
+      verificationStatus: expect.any(String),
       idTokenUserInfo: expect.objectContaining({
         iss: expect.any(String),
         sub: expect.any(String),
@@ -247,6 +249,7 @@ describe('mapUserToApplicationContextUser', () => {
           expect.objectContaining({ key: expect.any(String) }),
         ]),
       }),
+      verificationStatus: expect.any(String),
       idTokenUserInfo: expect.objectContaining({
         iss: expect.any(String),
         sub: expect.any(String),

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -195,6 +195,7 @@ describe('mapUserToApplicationContextUser', () => {
         name: expect.any(String),
         additionalClaims: expect.objectContaining({}),
       }),
+      verificationStatus: expect.any(String),
     });
     expect(reportErrorToSentry).not.toHaveBeenCalled();
   });
@@ -227,6 +228,7 @@ describe('mapUserToApplicationContextUser', () => {
         name: expect.any(String),
         additionalClaims: expect.objectContaining({}),
       }),
+      verificationStatus: expect.any(String),
     });
     expect(reportErrorToSentry).not.toHaveBeenCalled();
   });
@@ -249,7 +251,6 @@ describe('mapUserToApplicationContextUser', () => {
           expect.objectContaining({ key: expect.any(String) }),
         ]),
       }),
-      verificationStatus: expect.any(String),
       idTokenUserInfo: expect.objectContaining({
         iss: expect.any(String),
         sub: expect.any(String),
@@ -260,6 +261,7 @@ describe('mapUserToApplicationContextUser', () => {
         name: expect.any(String),
         additionalClaims: expect.objectContaining({}),
       }),
+      verificationStatus: expect.any(String),
     });
     expect(reportErrorToSentry).toHaveBeenCalled();
   });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -15,8 +15,11 @@ import {
   normalizeAllAppliedDataFences,
 } from './normalizers';
 import getMcApiUrl from '../../utils/get-mc-api-url';
+import { VerificationStatus } from '../../../../../test-data/user/types';
 
-type TFetchedUser = TFetchLoggedInUserQuery['user'] & { isVerified: boolean };
+type TFetchedUser = TFetchLoggedInUserQuery['user'] & {
+  verificationStatus: VerificationStatus;
+};
 type TFetchedProject = TFetchProjectQuery['project'];
 
 type TApplicationContextPermissions = { [key: string]: boolean };
@@ -62,7 +65,7 @@ type TApplicationContextUser = Pick<
   idTokenUserInfo?: Omit<TIdTokenUserInfo, 'additionalClaims'> & {
     additionalClaims: Record<string, unknown>;
   };
-  isVerified: boolean;
+  verificationStatus: VerificationStatus;
 };
 
 const Context = createContext({});
@@ -84,7 +87,7 @@ export const mapUserToApplicationContextUser = (user?: TFetchedUser) => {
     locale: user.language,
     timeZone: user.timeZone || defaultTimeZone,
     projects: user.projects,
-    isVerified: user.isVerified,
+    verificationStatus: user.verificationStatus,
   };
 
   // This property will only be populated when user has logged in using SSO

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -15,11 +15,8 @@ import {
   normalizeAllAppliedDataFences,
 } from './normalizers';
 import getMcApiUrl from '../../utils/get-mc-api-url';
-import { VerificationStatus } from '../../../../../test-data/user/types';
 
-type TFetchedUser = TFetchLoggedInUserQuery['user'] & {
-  verificationStatus: VerificationStatus;
-};
+type TFetchedUser = TFetchLoggedInUserQuery['user'];
 type TFetchedProject = TFetchProjectQuery['project'];
 
 type TApplicationContextPermissions = { [key: string]: boolean };
@@ -58,14 +55,19 @@ type TApplicationContextDataFences = Partial<
 type TApplicationContextEnvironment = ApplicationWindow['app'];
 type TApplicationContextUser = Pick<
   NonNullable<TFetchedUser>,
-  'id' | 'email' | 'firstName' | 'lastName' | 'businessRole' | 'projects'
+  | 'id'
+  | 'email'
+  | 'firstName'
+  | 'lastName'
+  | 'businessRole'
+  | 'projects'
+  | 'verificationStatus'
 > & {
   locale: string;
   timeZone: string;
   idTokenUserInfo?: Omit<TIdTokenUserInfo, 'additionalClaims'> & {
     additionalClaims: Record<string, unknown>;
   };
-  verificationStatus: VerificationStatus;
 };
 
 const Context = createContext({});

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -16,7 +16,7 @@ import {
 } from './normalizers';
 import getMcApiUrl from '../../utils/get-mc-api-url';
 
-type TFetchedUser = TFetchLoggedInUserQuery['user'];
+type TFetchedUser = TFetchLoggedInUserQuery['user'] & { isVerified: boolean };
 type TFetchedProject = TFetchProjectQuery['project'];
 
 type TApplicationContextPermissions = { [key: string]: boolean };
@@ -62,6 +62,7 @@ type TApplicationContextUser = Pick<
   idTokenUserInfo?: Omit<TIdTokenUserInfo, 'additionalClaims'> & {
     additionalClaims: Record<string, unknown>;
   };
+  isVerified: boolean;
 };
 
 const Context = createContext({});
@@ -83,6 +84,7 @@ export const mapUserToApplicationContextUser = (user?: TFetchedUser) => {
     locale: user.language,
     timeZone: user.timeZone || defaultTimeZone,
     projects: user.projects,
+    isVerified: user.isVerified,
   };
 
   // This property will only be populated when user has logged in using SSO

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -17,7 +17,6 @@ export type TAdditionalUserInfo = {
   lastName: Scalars['String'];
 };
 
-/** Only used by the navbar menu component in ApplicationShell. */
 export type TAllPermissionsForAllApplications = {
   __typename?: 'AllPermissionsForAllApplications';
   allAppliedActionRights: Array<TAppliedActionRight>;
@@ -61,7 +60,6 @@ export type TChangeUserLanguage = {
   language: Scalars['String'];
 };
 
-/** NOTE: This is _not_ a username it is the user's name. */
 export type TChangeUserName = {
   firstName: Scalars['String'];
   lastName: Scalars['String'];
@@ -98,16 +96,12 @@ export type TFeature = {
 
 export type TIdTokenUserInfo = {
   __typename?: 'IdTokenUserInfo';
-  /** Additional custom claims. This is a stringified JSON object. */
   additionalClaims?: Maybe<Scalars['String']>;
   aud: Scalars['String'];
-  /** Claims from scope `email` */
   email?: Maybe<Scalars['String']>;
   exp: Scalars['Float'];
   iat: Scalars['Float'];
-  /** Standard claims */
   iss: Scalars['String'];
-  /** Claims from scope `profile` */
   name?: Maybe<Scalars['String']>;
   sub: Scalars['String'];
 };
@@ -124,10 +118,6 @@ export type TInvitationOrganizationInput = {
   version: Scalars['Int'];
 };
 
-/**
- * Note: you can not brute-force fetch user information
- * by trying emails. Only information about the membership itself.
- */
 export type TInvitationQueryResult = {
   __typename?: 'InvitationQueryResult';
   gravatarHash?: Maybe<Scalars['String']>;
@@ -291,11 +281,6 @@ export type TOAuthClientTemplate = {
   oAuthScopes: Array<TPermissionScope>;
 };
 
-/**
- * TODO: use `Reference` instead once there is no more usage of the following fields:
- * - name
- * - createdAt
- */
 export type TOrganization = {
   __typename?: 'Organization';
   /** @deprecated This field will be removed in the future. */
@@ -316,10 +301,6 @@ export type TOrganizationDraftType = {
   ownerId: Scalars['String'];
 };
 
-/**
- * Note:
- *   This is not a `Organization` type as in the future MC schema will not support e.g. expanding on team members on its internal schema.
- */
 export type TOrganizationTeamsCreated = {
   __typename?: 'OrganizationTeamsCreated';
   id: Scalars['String'];
@@ -613,7 +594,6 @@ export type TResetUser = {
 };
 
 export type TSetUserTimeZone = {
-  /** NOTE: This is optional as not passing it unsets the timezone. */
   timeZone?: InputMaybe<Scalars['String']>;
 };
 
@@ -684,10 +664,6 @@ export type TUser = TMetaData & {
   firstName: Scalars['String'];
   gravatarHash: Scalars['String'];
   id: Scalars['ID'];
-  /**
-   * Contains additional claims information from the user id_token.
-   * This is only defined when logging in via SSO.
-   */
   idTokenUserInfo?: Maybe<TIdTokenUserInfo>;
   language: Scalars['String'];
   lastModifiedAt: Scalars['String'];
@@ -700,7 +676,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
-  verificationStatus: Scalars['String'];
+  verificationStatus: TVerificationStatus;
   version?: Maybe<Scalars['Int']>;
 };
 
@@ -720,6 +696,11 @@ export type TUserUpdateAction = {
   setTimeZone?: InputMaybe<TSetUserTimeZone>;
 };
 
+export enum TVerificationStatus {
+  Unverified = 'Unverified',
+  Verified = 'Verified'
+}
+
 export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -735,7 +716,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: TVerificationStatus, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -700,6 +700,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
+  verificationStatus: Scalars['String'];
   version?: Maybe<Scalars['Int']>;
 };
 
@@ -734,7 +735,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/application-shell/src/components/fetch-user/fetch-user.mc.graphql
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.mc.graphql
@@ -38,6 +38,6 @@ query FetchLoggedInUser {
       name
       additionalClaims
     }
-    isVerified @client
+    verificationStatus @client
   }
 }

--- a/packages/application-shell/src/components/fetch-user/fetch-user.mc.graphql
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.mc.graphql
@@ -38,5 +38,6 @@ query FetchLoggedInUser {
       name
       additionalClaims
     }
+    isVerified @client
   }
 }

--- a/packages/application-shell/src/components/fetch-user/fetch-user.mc.graphql
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.mc.graphql
@@ -38,6 +38,6 @@ query FetchLoggedInUser {
       name
       additionalClaims
     }
-    verificationStatus @client
+    verificationStatus
   }
 }

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -95,6 +95,7 @@ const defaultUser = {
   launchdarklyTrackingId: '111',
   launchdarklyTrackingTeam: undefined,
   launchdarklyTrackingTenant: 'gcp-eu',
+  verificationStatus: 'verified',
 };
 
 const defaultEnvironment: Partial<TProviderProps<{}>['environment']> = {

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -40,6 +40,7 @@ import { entryPointUriPathToPermissionKeys } from '@commercetools-frontend/appli
 import ApplicationEntryPoint from '../components/application-entry-point';
 import { createReduxStore } from '../configure-store';
 import createApolloClient from '../configure-apollo';
+import { TVerificationStatus } from '../types/generated/mc';
 
 // These default values get merged with the values provided by the test from
 // the call to "render"
@@ -95,7 +96,7 @@ const defaultUser = {
   launchdarklyTrackingId: '111',
   launchdarklyTrackingTeam: undefined,
   launchdarklyTrackingTenant: 'gcp-eu',
-  verificationStatus: 'Verified',
+  verificationStatus: TVerificationStatus.Verified,
 };
 
 const defaultEnvironment: Partial<TProviderProps<{}>['environment']> = {

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -95,7 +95,7 @@ const defaultUser = {
   launchdarklyTrackingId: '111',
   launchdarklyTrackingTeam: undefined,
   launchdarklyTrackingTenant: 'gcp-eu',
-  verificationStatus: 'verified',
+  verificationStatus: 'Verified',
 };
 
 const defaultEnvironment: Partial<TProviderProps<{}>['environment']> = {

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -17,7 +17,6 @@ export type TAdditionalUserInfo = {
   lastName: Scalars['String'];
 };
 
-/** Only used by the navbar menu component in ApplicationShell. */
 export type TAllPermissionsForAllApplications = {
   __typename?: 'AllPermissionsForAllApplications';
   allAppliedActionRights: Array<TAppliedActionRight>;
@@ -61,7 +60,6 @@ export type TChangeUserLanguage = {
   language: Scalars['String'];
 };
 
-/** NOTE: This is _not_ a username it is the user's name. */
 export type TChangeUserName = {
   firstName: Scalars['String'];
   lastName: Scalars['String'];
@@ -98,16 +96,12 @@ export type TFeature = {
 
 export type TIdTokenUserInfo = {
   __typename?: 'IdTokenUserInfo';
-  /** Additional custom claims. This is a stringified JSON object. */
   additionalClaims?: Maybe<Scalars['String']>;
   aud: Scalars['String'];
-  /** Claims from scope `email` */
   email?: Maybe<Scalars['String']>;
   exp: Scalars['Float'];
   iat: Scalars['Float'];
-  /** Standard claims */
   iss: Scalars['String'];
-  /** Claims from scope `profile` */
   name?: Maybe<Scalars['String']>;
   sub: Scalars['String'];
 };
@@ -124,10 +118,6 @@ export type TInvitationOrganizationInput = {
   version: Scalars['Int'];
 };
 
-/**
- * Note: you can not brute-force fetch user information
- * by trying emails. Only information about the membership itself.
- */
 export type TInvitationQueryResult = {
   __typename?: 'InvitationQueryResult';
   gravatarHash?: Maybe<Scalars['String']>;
@@ -291,11 +281,6 @@ export type TOAuthClientTemplate = {
   oAuthScopes: Array<TPermissionScope>;
 };
 
-/**
- * TODO: use `Reference` instead once there is no more usage of the following fields:
- * - name
- * - createdAt
- */
 export type TOrganization = {
   __typename?: 'Organization';
   /** @deprecated This field will be removed in the future. */
@@ -316,10 +301,6 @@ export type TOrganizationDraftType = {
   ownerId: Scalars['String'];
 };
 
-/**
- * Note:
- *   This is not a `Organization` type as in the future MC schema will not support e.g. expanding on team members on its internal schema.
- */
 export type TOrganizationTeamsCreated = {
   __typename?: 'OrganizationTeamsCreated';
   id: Scalars['String'];
@@ -613,7 +594,6 @@ export type TResetUser = {
 };
 
 export type TSetUserTimeZone = {
-  /** NOTE: This is optional as not passing it unsets the timezone. */
   timeZone?: InputMaybe<Scalars['String']>;
 };
 
@@ -684,10 +664,6 @@ export type TUser = TMetaData & {
   firstName: Scalars['String'];
   gravatarHash: Scalars['String'];
   id: Scalars['ID'];
-  /**
-   * Contains additional claims information from the user id_token.
-   * This is only defined when logging in via SSO.
-   */
   idTokenUserInfo?: Maybe<TIdTokenUserInfo>;
   language: Scalars['String'];
   lastModifiedAt: Scalars['String'];
@@ -700,7 +676,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
-  verificationStatus: Scalars['String'];
+  verificationStatus: TVerificationStatus;
   version?: Maybe<Scalars['Int']>;
 };
 
@@ -720,6 +696,11 @@ export type TUserUpdateAction = {
   setTimeZone?: InputMaybe<TSetUserTimeZone>;
 };
 
+export enum TVerificationStatus {
+  Unverified = 'Unverified',
+  Verified = 'Verified'
+}
+
 export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -735,7 +716,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: TVerificationStatus, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -700,6 +700,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
+  verificationStatus: Scalars['String'];
   version?: Maybe<Scalars['Int']>;
 };
 
@@ -734,7 +735,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -1,6 +1,7 @@
 import { screen, render } from '@testing-library/react';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import branchOnPermissions from './branch-on-permissions';
+import { TVerificationStatus } from '../../../../application-shell/src/types/generated/mc';
 
 const AuthorizedComponent = () => <div>{'Authorized'}</div>;
 const UnauthorizedComponent = () => <div>{'Not authorized'}</div>;
@@ -39,7 +40,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         launchdarklyTrackingId: '111',
         launchdarklyTrackingTeam: undefined,
         launchdarklyTrackingTenant: 'gcp-eu',
-        verificationStatus: 'Verified',
+        verificationStatus: TVerificationStatus.Verified,
       }}
       project={{
         key: 'foo-1',

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -39,7 +39,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         launchdarklyTrackingId: '111',
         launchdarklyTrackingTeam: undefined,
         launchdarklyTrackingTenant: 'gcp-eu',
-        verificationStatus: 'verified',
+        verificationStatus: 'Verified',
       }}
       project={{
         key: 'foo-1',

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -39,6 +39,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
         launchdarklyTrackingId: '111',
         launchdarklyTrackingTeam: undefined,
         launchdarklyTrackingTenant: 'gcp-eu',
+        verificationStatus: 'verified',
       }}
       project={{
         key: 'foo-1',

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -1,7 +1,7 @@
 import { screen, render } from '@testing-library/react';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import branchOnPermissions from './branch-on-permissions';
-import { TVerificationStatus } from '../../../../application-shell/src/types/generated/mc';
+import { TVerificationStatus } from '../../types/generated/mc';
 
 const AuthorizedComponent = () => <div>{'Authorized'}</div>;
 const UnauthorizedComponent = () => <div>{'Not authorized'}</div>;

--- a/packages/permissions/src/types/generated/mc.ts
+++ b/packages/permissions/src/types/generated/mc.ts
@@ -1,0 +1,734 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type TAdditionalUserInfo = {
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+};
+
+export type TAllPermissionsForAllApplications = {
+  __typename?: 'AllPermissionsForAllApplications';
+  allAppliedActionRights: Array<TAppliedActionRight>;
+  allAppliedDataFences: Array<TAppliedDataFence>;
+  allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
+  allAppliedPermissions: Array<TAppliedPermission>;
+};
+
+export type TAppliedActionRight = {
+  __typename?: 'AppliedActionRight';
+  group: Scalars['String'];
+  name: Scalars['String'];
+  value: Scalars['Boolean'];
+};
+
+export type TAppliedDataFence = TStoreDataFence;
+
+export type TAppliedMenuVisibilities = {
+  __typename?: 'AppliedMenuVisibilities';
+  name: Scalars['String'];
+  value: Scalars['Boolean'];
+};
+
+export type TAppliedPermission = {
+  __typename?: 'AppliedPermission';
+  name: Scalars['String'];
+  value: Scalars['Boolean'];
+};
+
+export type TCartClassificationValue = {
+  __typename?: 'CartClassificationValue';
+  allLocaleLabels: Array<Maybe<TLocalizedField>>;
+  key: Scalars['String'];
+};
+
+export type TChangeUserBusinessRole = {
+  businessRole?: InputMaybe<Scalars['String']>;
+};
+
+export type TChangeUserLanguage = {
+  language: Scalars['String'];
+};
+
+export type TChangeUserName = {
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+};
+
+export type TChangeUserNumberFormat = {
+  numberFormat: Scalars['String'];
+};
+
+export type TChangeUserPassword = {
+  password: Scalars['String'];
+};
+
+export type TDataFence = {
+  type: Scalars['String'];
+};
+
+export type TDeleteAccountRequest = {
+  __typename?: 'DeleteAccountRequest';
+  jwt?: Maybe<Scalars['String']>;
+};
+
+export type TDeletedUser = {
+  __typename?: 'DeletedUser';
+  id: Scalars['String'];
+};
+
+export type TFeature = {
+  __typename?: 'Feature';
+  name: Scalars['String'];
+  reason?: Maybe<Scalars['String']>;
+  value: Scalars['Boolean'];
+};
+
+export type TIdTokenUserInfo = {
+  __typename?: 'IdTokenUserInfo';
+  additionalClaims?: Maybe<Scalars['String']>;
+  aud: Scalars['String'];
+  email?: Maybe<Scalars['String']>;
+  exp: Scalars['Float'];
+  iat: Scalars['Float'];
+  iss: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  sub: Scalars['String'];
+};
+
+export type TInvitationInput = {
+  emails: Array<Scalars['String']>;
+  organization: TInvitationOrganizationInput;
+  team: TInvitationTeamInput;
+};
+
+export type TInvitationOrganizationInput = {
+  id: Scalars['ID'];
+  name?: InputMaybe<Scalars['String']>;
+  version: Scalars['Int'];
+};
+
+export type TInvitationQueryResult = {
+  __typename?: 'InvitationQueryResult';
+  gravatarHash?: Maybe<Scalars['String']>;
+  hasValidEmail: Scalars['Boolean'];
+  isAlreadyAMemberOfTeam: Scalars['Boolean'];
+  isKnownUser: Scalars['Boolean'];
+  version: Scalars['Int'];
+};
+
+export type TInvitationResult = {
+  __typename?: 'InvitationResult';
+  email: Scalars['String'];
+  jwt?: Maybe<Scalars['String']>;
+  status: TInvitationStatus;
+};
+
+export enum TInvitationStatus {
+  InvitationFailure = 'InvitationFailure',
+  InvitationSent = 'InvitationSent',
+  PendingRegistration = 'PendingRegistration'
+}
+
+export type TInvitationTeamInput = {
+  id: Scalars['ID'];
+};
+
+export type TInvitationWhereInput = {
+  email: Scalars['String'];
+  organizationId: Scalars['ID'];
+  teamId: Scalars['ID'];
+};
+
+export type TLocalizedField = {
+  __typename?: 'LocalizedField';
+  locale: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type TMetaData = {
+  createdAt: Scalars['String'];
+  lastModifiedAt: Scalars['String'];
+  version?: Maybe<Scalars['Int']>;
+};
+
+export type TMutation = {
+  __typename?: 'Mutation';
+  createMyOrganization?: Maybe<TOrganizationCreated>;
+  createMyProject?: Maybe<TProjectPendingCreation>;
+  createOAuthClient: TOAuthClient;
+  deleteAccount: TDeletedUser;
+  deleteOAuthClient: TOAuthClient;
+  invite: Array<TInvitationResult>;
+  random: Scalars['String'];
+  resetPassword: TResetUser;
+  sendLinkToDeleteAccount?: Maybe<TDeleteAccountRequest>;
+  sendLinkToResetPassword?: Maybe<TResetPasswordRequest>;
+  sendLinkToSignUp?: Maybe<TSignUpRequest>;
+  signUp: TSignedUpUser;
+  updateUser: TUser;
+};
+
+
+export type TMutation_CreateMyOrganizationArgs = {
+  draft: TOrganizationDraftType;
+};
+
+
+export type TMutation_CreateMyProjectArgs = {
+  draft: TProjectDraftType;
+  myPermission: TMyPermissionInitializationInput;
+};
+
+
+export type TMutation_CreateOAuthClientArgs = {
+  draft: TOAuthClientCreationInput;
+};
+
+
+export type TMutation_DeleteAccountArgs = {
+  jwt: Scalars['String'];
+};
+
+
+export type TMutation_DeleteOAuthClientArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_InviteArgs = {
+  draft: TInvitationInput;
+  origin?: InputMaybe<Scalars['String']>;
+};
+
+
+export type TMutation_RandomArgs = {
+  byteLength: Scalars['Int'];
+};
+
+
+export type TMutation_ResetPasswordArgs = {
+  draft: TResetPasswordDraft;
+  jwt: Scalars['String'];
+};
+
+
+export type TMutation_SendLinkToResetPasswordArgs = {
+  email: Scalars['String'];
+};
+
+
+export type TMutation_SendLinkToSignUpArgs = {
+  additionalInfo?: InputMaybe<TAdditionalUserInfo>;
+  email: Scalars['String'];
+  language?: InputMaybe<Scalars['String']>;
+};
+
+
+export type TMutation_SignUpArgs = {
+  draft: TUserDraft;
+  jwt: Scalars['String'];
+};
+
+
+export type TMutation_UpdateUserArgs = {
+  actions: Array<TUserUpdateAction>;
+  version: Scalars['Int'];
+};
+
+export type TMyPermissionInitializationInput = {
+  teamId: Scalars['String'];
+};
+
+export type TOAuthClient = {
+  __typename?: 'OAuthClient';
+  createdAt?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  lastUsedAt?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  ownerId: Scalars['ID'];
+  permissions: Array<TProjectPermission>;
+  secret: Scalars['String'];
+};
+
+export type TOAuthClientCreationInput = {
+  name: Scalars['String'];
+  ownerId: Scalars['ID'];
+  permissions: Array<TProjectPermissionInput>;
+};
+
+export type TOAuthClientQueryResult = TQueryResult & {
+  __typename?: 'OAuthClientQueryResult';
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TOAuthClient>;
+  total: Scalars['Int'];
+};
+
+export type TOAuthClientTemplate = {
+  __typename?: 'OAuthClientTemplate';
+  key: Scalars['String'];
+  oAuthScopes: Array<TPermissionScope>;
+};
+
+export type TOrganization = {
+  __typename?: 'Organization';
+  /** @deprecated This field will be removed in the future. */
+  createdAt: Scalars['String'];
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
+export type TOrganizationCreated = {
+  __typename?: 'OrganizationCreated';
+  id: Scalars['String'];
+  name: Scalars['String'];
+  teams: Array<TOrganizationTeamsCreated>;
+};
+
+export type TOrganizationDraftType = {
+  name: Scalars['String'];
+  ownerId: Scalars['String'];
+};
+
+export type TOrganizationTeamsCreated = {
+  __typename?: 'OrganizationTeamsCreated';
+  id: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export enum TPermissionScope {
+  CreateAnonymousToken = 'create_anonymous_token',
+  GetPermissionForAnyProject = 'get_permission_for_any_project',
+  IntrospectOauthTokens = 'introspect_oauth_tokens',
+  ManageApiClients = 'manage_api_clients',
+  ManageAttributeGroups = 'manage_attribute_groups',
+  ManageAuditLog = 'manage_audit_log',
+  ManageBusinessUnits = 'manage_business_units',
+  ManageCartDiscounts = 'manage_cart_discounts',
+  ManageCategories = 'manage_categories',
+  ManageChangeHistory = 'manage_change_history',
+  ManageCustomerGroups = 'manage_customer_groups',
+  ManageCustomers = 'manage_customers',
+  ManageDiscountCodes = 'manage_discount_codes',
+  ManageExtensions = 'manage_extensions',
+  ManageGlobalSubscriptions = 'manage_global_subscriptions',
+  ManageImportContainers = 'manage_import_containers',
+  ManageImportSinks = 'manage_import_sinks',
+  ManageKeyValueDocuments = 'manage_key_value_documents',
+  ManageMyBusinessUnits = 'manage_my_business_units',
+  ManageMyOrders = 'manage_my_orders',
+  ManageMyPayments = 'manage_my_payments',
+  ManageMyProfile = 'manage_my_profile',
+  ManageMyQuoteRequests = 'manage_my_quote_requests',
+  ManageMyQuotes = 'manage_my_quotes',
+  ManageMyShoppingLists = 'manage_my_shopping_lists',
+  ManageOrderEdits = 'manage_order_edits',
+  ManageOrders = 'manage_orders',
+  ManagePayments = 'manage_payments',
+  ManageProductSelections = 'manage_product_selections',
+  ManageProducts = 'manage_products',
+  ManageProject = 'manage_project',
+  ManageProjectSettings = 'manage_project_settings',
+  ManageQuoteRequests = 'manage_quote_requests',
+  ManageQuotes = 'manage_quotes',
+  ManageShippingMethods = 'manage_shipping_methods',
+  ManageShoppingLists = 'manage_shopping_lists',
+  ManageStagedQuotes = 'manage_staged_quotes',
+  ManageStandalonePrices = 'manage_standalone_prices',
+  ManageStates = 'manage_states',
+  ManageStores = 'manage_stores',
+  ManageSubscriptions = 'manage_subscriptions',
+  ManageTaxCategories = 'manage_tax_categories',
+  ManageTypes = 'manage_types',
+  ViewApiClients = 'view_api_clients',
+  ViewAttributeGroups = 'view_attribute_groups',
+  ViewAuditLog = 'view_audit_log',
+  ViewBusinessUnits = 'view_business_units',
+  ViewCartDiscounts = 'view_cart_discounts',
+  ViewCategories = 'view_categories',
+  ViewChangeHistory = 'view_change_history',
+  ViewCustomerGroups = 'view_customer_groups',
+  ViewCustomers = 'view_customers',
+  ViewDiscountCodes = 'view_discount_codes',
+  ViewImportContainers = 'view_import_containers',
+  ViewImportSinks = 'view_import_sinks',
+  ViewKeyValueDocuments = 'view_key_value_documents',
+  ViewMessages = 'view_messages',
+  ViewOrderEdits = 'view_order_edits',
+  ViewOrders = 'view_orders',
+  ViewPayments = 'view_payments',
+  ViewProductSelections = 'view_product_selections',
+  ViewProducts = 'view_products',
+  ViewProjectSettings = 'view_project_settings',
+  ViewProjects = 'view_projects',
+  ViewPublishedProducts = 'view_published_products',
+  ViewQuoteRequests = 'view_quote_requests',
+  ViewQuotes = 'view_quotes',
+  ViewShippingMethods = 'view_shipping_methods',
+  ViewShoppingLists = 'view_shopping_lists',
+  ViewStagedQuotes = 'view_staged_quotes',
+  ViewStandalonePrices = 'view_standalone_prices',
+  ViewStates = 'view_states',
+  ViewStores = 'view_stores',
+  ViewTaxCategories = 'view_tax_categories',
+  ViewTypes = 'view_types'
+}
+
+export type TProject = TMetaData & {
+  __typename?: 'Project';
+  allAppliedActionRights: Array<TAppliedActionRight>;
+  allAppliedDataFences: Array<TAppliedDataFence>;
+  /** @deprecated This field has been moved into the menuPermissionsForAllApplications field. */
+  allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
+  allAppliedPermissions: Array<TAppliedPermission>;
+  allPermissionsForAllApplications: TAllPermissionsForAllApplications;
+  apiVersion: Scalars['String'];
+  countries: Array<Scalars['String']>;
+  createdAt: Scalars['String'];
+  currencies: Array<Scalars['String']>;
+  expiry: TProjectExpiry;
+  initialized: Scalars['Boolean'];
+  isProductionProject: Scalars['Boolean'];
+  key: Scalars['String'];
+  languages: Array<Scalars['String']>;
+  lastModifiedAt: Scalars['String'];
+  name: Scalars['String'];
+  owner: TOrganization;
+  plan: Scalars['String'];
+  shippingRateInputType?: Maybe<TShippingRateInputType>;
+  suspension: TProjectSuspension;
+  version?: Maybe<Scalars['Int']>;
+};
+
+export type TProjectDraftType = {
+  countries: Array<Scalars['String']>;
+  currencies: Array<Scalars['String']>;
+  deleteDaysAfterCreation?: InputMaybe<Scalars['Int']>;
+  key: Scalars['String'];
+  languages: Array<Scalars['String']>;
+  messagesEnabled?: InputMaybe<Scalars['Boolean']>;
+  name: Scalars['String'];
+  ownerId: Scalars['String'];
+};
+
+export type TProjectExpiry = {
+  __typename?: 'ProjectExpiry';
+  daysLeft?: Maybe<Scalars['Int']>;
+  isActive: Scalars['Boolean'];
+};
+
+export type TProjectPendingCreation = {
+  __typename?: 'ProjectPendingCreation';
+  id: Scalars['String'];
+  key: Scalars['String'];
+  name: Scalars['String'];
+  version: Scalars['Int'];
+};
+
+export type TProjectPermission = {
+  __typename?: 'ProjectPermission';
+  key: TPermissionScope;
+  projectKey?: Maybe<Scalars['String']>;
+  storeKey?: Maybe<Scalars['String']>;
+};
+
+export type TProjectPermissionInput = {
+  key: TPermissionScope;
+  projectKey?: InputMaybe<Scalars['String']>;
+  storeKey?: InputMaybe<Scalars['String']>;
+};
+
+export type TProjectQueryResult = TQueryResult & {
+  __typename?: 'ProjectQueryResult';
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TProject>;
+  total: Scalars['Int'];
+};
+
+export type TProjectSuspension = {
+  __typename?: 'ProjectSuspension';
+  isActive: Scalars['Boolean'];
+  reason?: Maybe<TProjectSuspensionReason>;
+};
+
+export enum TProjectSuspensionReason {
+  Other = 'Other',
+  Payment = 'Payment',
+  TemporaryMaintenance = 'TemporaryMaintenance'
+}
+
+export type TQuery = {
+  __typename?: 'Query';
+  allFeatures: Array<TFeature>;
+  allImpliedOAuthScopes: Array<Scalars['String']>;
+  allSupportedActionRights?: Maybe<Array<TSupportedActionRight>>;
+  allSupportedMenuVisibilities?: Maybe<Array<TSupportedMenuVisibility>>;
+  allSupportedOAuthScopes: Array<Scalars['String']>;
+  allSupportedOAuthScopesForOAuthClients: Array<TSupportedOAuthScopeForOAuthClient>;
+  allSupportedResources?: Maybe<Array<TSupportedResource>>;
+  allSupportedStoreScopes?: Maybe<Array<TSupportedStoreScope>>;
+  amILoggedIn: Scalars['Boolean'];
+  invitation?: Maybe<TInvitationQueryResult>;
+  me?: Maybe<TUser>;
+  oAuthClient?: Maybe<TOAuthClient>;
+  oAuthClientTemplates: Array<TOAuthClientTemplate>;
+  oAuthClients: TOAuthClientQueryResult;
+  project?: Maybe<TProject>;
+  release?: Maybe<Scalars['String']>;
+  releases?: Maybe<TReleaseHistory>;
+  storeOAuthScopes: Array<TPermissionScope>;
+};
+
+
+export type TQuery_AllImpliedOAuthScopesArgs = {
+  onlyConfiguredOnTrustedClient?: InputMaybe<Scalars['Boolean']>;
+  resourceAccessPermissions: Array<Scalars['String']>;
+};
+
+
+export type TQuery_InvitationArgs = {
+  where?: InputMaybe<TInvitationWhereInput>;
+};
+
+
+export type TQuery_OAuthClientArgs = {
+  id: Scalars['String'];
+};
+
+
+export type TQuery_OAuthClientsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Array<Scalars['String']>>;
+};
+
+
+export type TQuery_ProjectArgs = {
+  key?: InputMaybe<Scalars['String']>;
+};
+
+
+export type TQuery_ReleasesArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  origin: TReleaseOrigin;
+};
+
+export type TQueryResult = {
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  total: Scalars['Int'];
+};
+
+export type TReference = {
+  __typename?: 'Reference';
+  id: Scalars['String'];
+  typeId: Scalars['String'];
+};
+
+export type TReferenceInput = {
+  id: Scalars['ID'];
+  typeId: Scalars['String'];
+};
+
+export type TReleaseEntry = {
+  __typename?: 'ReleaseEntry';
+  description: Scalars['String'];
+  guid: Scalars['String'];
+  link: Scalars['String'];
+  releasedAt: Scalars['String'];
+  title: Scalars['String'];
+};
+
+export type TReleaseHistory = {
+  __typename?: 'ReleaseHistory';
+  description: Scalars['String'];
+  entries: TReleaseQueryResult;
+  link: Scalars['String'];
+  title: Scalars['String'];
+};
+
+
+export type TReleaseHistory_EntriesArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+export enum TReleaseOrigin {
+  Ctp = 'ctp',
+  Mc = 'mc'
+}
+
+export type TReleaseQueryResult = TQueryResult & {
+  __typename?: 'ReleaseQueryResult';
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TReleaseEntry>;
+  total: Scalars['Int'];
+};
+
+export type TResetPasswordDraft = {
+  password: Scalars['String'];
+};
+
+export type TResetPasswordRequest = {
+  __typename?: 'ResetPasswordRequest';
+  jwt?: Maybe<Scalars['String']>;
+};
+
+export type TResetUser = {
+  __typename?: 'ResetUser';
+  id: Scalars['String'];
+};
+
+export type TSetUserTimeZone = {
+  timeZone?: InputMaybe<Scalars['String']>;
+};
+
+export type TShippingRateInputType = {
+  __typename?: 'ShippingRateInputType';
+  type: TShippingRateType;
+  values?: Maybe<Array<Maybe<TCartClassificationValue>>>;
+};
+
+export enum TShippingRateType {
+  CartClassification = 'CartClassification',
+  CartScore = 'CartScore',
+  CartValue = 'CartValue'
+}
+
+export type TSignUpRequest = {
+  __typename?: 'SignUpRequest';
+  jwt?: Maybe<Scalars['String']>;
+};
+
+export type TSignedUpUser = {
+  __typename?: 'SignedUpUser';
+  id: Scalars['String'];
+};
+
+export type TStoreDataFence = TDataFence & {
+  __typename?: 'StoreDataFence';
+  group: Scalars['String'];
+  name: Scalars['String'];
+  type: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type TSupportedActionRight = {
+  __typename?: 'SupportedActionRight';
+  group: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export type TSupportedMenuVisibility = {
+  __typename?: 'SupportedMenuVisibility';
+  group: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export type TSupportedOAuthScopeForOAuthClient = {
+  __typename?: 'SupportedOAuthScopeForOAuthClient';
+  name: Scalars['String'];
+};
+
+export type TSupportedResource = {
+  __typename?: 'SupportedResource';
+  name: Scalars['String'];
+};
+
+export type TSupportedStoreScope = {
+  __typename?: 'SupportedStoreScope';
+  group: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export type TUser = TMetaData & {
+  __typename?: 'User';
+  businessRole?: Maybe<Scalars['String']>;
+  createdAt: Scalars['String'];
+  defaultProjectKey?: Maybe<Scalars['String']>;
+  email: Scalars['String'];
+  firstName: Scalars['String'];
+  gravatarHash: Scalars['String'];
+  id: Scalars['ID'];
+  idTokenUserInfo?: Maybe<TIdTokenUserInfo>;
+  language: Scalars['String'];
+  lastModifiedAt: Scalars['String'];
+  lastName: Scalars['String'];
+  launchdarklyTrackingGroup: Scalars['String'];
+  launchdarklyTrackingId: Scalars['String'];
+  launchdarklyTrackingSubgroup?: Maybe<Scalars['String']>;
+  launchdarklyTrackingTeam?: Maybe<Array<Scalars['String']>>;
+  launchdarklyTrackingTenant: Scalars['String'];
+  numberFormat: Scalars['String'];
+  projects: TProjectQueryResult;
+  timeZone?: Maybe<Scalars['String']>;
+  verificationStatus: TVerificationStatus;
+  version?: Maybe<Scalars['Int']>;
+};
+
+export type TUserDraft = {
+  businessRole?: InputMaybe<Scalars['String']>;
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  password: Scalars['String'];
+};
+
+export type TUserUpdateAction = {
+  changeBusinessRole?: InputMaybe<TChangeUserBusinessRole>;
+  changeLanguage?: InputMaybe<TChangeUserLanguage>;
+  changeName?: InputMaybe<TChangeUserName>;
+  changeNumberFormat?: InputMaybe<TChangeUserNumberFormat>;
+  changePassword?: InputMaybe<TChangeUserPassword>;
+  setTimeZone?: InputMaybe<TSetUserTimeZone>;
+};
+
+export enum TVerificationStatus {
+  Unverified = 'Unverified',
+  Verified = 'Verified'
+}
+
+export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TAmILoggedInQuery = { __typename?: 'Query', amILoggedIn: boolean };
+
+export type TFetchProjectQueryVariables = Exact<{
+  projectKey: Scalars['String'];
+}>;
+
+
+export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
+
+export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: TVerificationStatus, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+
+export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+
+export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TAllFeaturesQuery = { __typename?: 'Query', allFeatures: Array<{ __typename?: 'Feature', name: string, value: boolean, reason?: string | null }> };
+
+export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };

--- a/schemas/client-schema.graphql
+++ b/schemas/client-schema.graphql
@@ -1,3 +1,0 @@
-type User {
-  verificationStatus: String!
-}

--- a/schemas/client-schema.graphql
+++ b/schemas/client-schema.graphql
@@ -1,0 +1,3 @@
+type User {
+  verificationStatus: String!
+}

--- a/schemas/mc.json
+++ b/schemas/mc.json
@@ -11,12 +11,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "AdditionalUserInfo",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "firstName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -32,7 +32,7 @@
           },
           {
             "name": "lastName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -58,7 +58,7 @@
         "fields": [
           {
             "name": "allAppliedActionRights",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -82,7 +82,7 @@
           },
           {
             "name": "allAppliedDataFences",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -106,7 +106,7 @@
           },
           {
             "name": "allAppliedMenuVisibilities",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -130,7 +130,7 @@
           },
           {
             "name": "allAppliedPermissions",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -161,11 +161,11 @@
       {
         "kind": "OBJECT",
         "name": "AppliedActionRight",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "group",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -181,7 +181,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -197,7 +197,7 @@
           },
           {
             "name": "value",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -220,7 +220,7 @@
       {
         "kind": "UNION",
         "name": "AppliedDataFence",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -236,11 +236,11 @@
       {
         "kind": "OBJECT",
         "name": "AppliedMenuVisibilities",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -256,7 +256,7 @@
           },
           {
             "name": "value",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -279,11 +279,11 @@
       {
         "kind": "OBJECT",
         "name": "AppliedPermission",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -299,7 +299,7 @@
           },
           {
             "name": "value",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -332,11 +332,11 @@
       {
         "kind": "OBJECT",
         "name": "CartClassificationValue",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "allLocaleLabels",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -356,7 +356,7 @@
           },
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -379,12 +379,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeUserBusinessRole",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "businessRole",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -402,12 +402,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeUserLanguage",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "language",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -434,7 +434,7 @@
         "inputFields": [
           {
             "name": "firstName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -450,7 +450,7 @@
           },
           {
             "name": "lastName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -472,12 +472,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeUserNumberFormat",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "numberFormat",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -499,12 +499,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeUserPassword",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "password",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -526,11 +526,11 @@
       {
         "kind": "INTERFACE",
         "name": "DataFence",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "type",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -559,11 +559,11 @@
       {
         "kind": "OBJECT",
         "name": "DeleteAccountRequest",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "jwt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -582,11 +582,11 @@
       {
         "kind": "OBJECT",
         "name": "DeletedUser",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -609,11 +609,11 @@
       {
         "kind": "OBJECT",
         "name": "Feature",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -629,7 +629,7 @@
           },
           {
             "name": "reason",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -641,7 +641,7 @@
           },
           {
             "name": "value",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -684,7 +684,7 @@
       {
         "kind": "OBJECT",
         "name": "IdTokenUserInfo",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "additionalClaims",
@@ -700,7 +700,7 @@
           },
           {
             "name": "aud",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -728,7 +728,7 @@
           },
           {
             "name": "exp",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -744,7 +744,7 @@
           },
           {
             "name": "iat",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -788,7 +788,7 @@
           },
           {
             "name": "sub",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -821,12 +821,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InvitationInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "emails",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -850,7 +850,7 @@
           },
           {
             "name": "organization",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -866,7 +866,7 @@
           },
           {
             "name": "team",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -888,12 +888,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InvitationOrganizationInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -909,7 +909,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -921,7 +921,7 @@
           },
           {
             "name": "version",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -947,7 +947,7 @@
         "fields": [
           {
             "name": "gravatarHash",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -959,7 +959,7 @@
           },
           {
             "name": "hasValidEmail",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -975,7 +975,7 @@
           },
           {
             "name": "isAlreadyAMemberOfTeam",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -991,7 +991,7 @@
           },
           {
             "name": "isKnownUser",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1007,7 +1007,7 @@
           },
           {
             "name": "version",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1030,11 +1030,11 @@
       {
         "kind": "OBJECT",
         "name": "InvitationResult",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "email",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1050,7 +1050,7 @@
           },
           {
             "name": "jwt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1062,7 +1062,7 @@
           },
           {
             "name": "status",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1085,26 +1085,26 @@
       {
         "kind": "ENUM",
         "name": "InvitationStatus",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "InvitationFailure",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "InvitationSent",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PendingRegistration",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -1114,12 +1114,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InvitationTeamInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1141,12 +1141,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InvitationWhereInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "email",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1162,7 +1162,7 @@
           },
           {
             "name": "organizationId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1178,7 +1178,7 @@
           },
           {
             "name": "teamId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1200,11 +1200,11 @@
       {
         "kind": "OBJECT",
         "name": "LocalizedField",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "locale",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1220,7 +1220,7 @@
           },
           {
             "name": "value",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1243,11 +1243,11 @@
       {
         "kind": "INTERFACE",
         "name": "MetaData",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "createdAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1263,7 +1263,7 @@
           },
           {
             "name": "lastModifiedAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1279,7 +1279,7 @@
           },
           {
             "name": "version",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1309,15 +1309,15 @@
       {
         "kind": "OBJECT",
         "name": "Mutation",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "createMyOrganization",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "draft",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1342,11 +1342,11 @@
           },
           {
             "name": "createMyProject",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "draft",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1362,7 +1362,7 @@
               },
               {
                 "name": "myPermission",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1387,11 +1387,11 @@
           },
           {
             "name": "createOAuthClient",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "draft",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1420,11 +1420,11 @@
           },
           {
             "name": "deleteAccount",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "jwt",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1453,11 +1453,11 @@
           },
           {
             "name": "deleteOAuthClient",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "id",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1486,11 +1486,11 @@
           },
           {
             "name": "invite",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "draft",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1506,7 +1506,7 @@
               },
               {
                 "name": "origin",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1539,11 +1539,11 @@
           },
           {
             "name": "random",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "byteLength",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1572,11 +1572,11 @@
           },
           {
             "name": "resetPassword",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "draft",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1592,7 +1592,7 @@
               },
               {
                 "name": "jwt",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1621,7 +1621,7 @@
           },
           {
             "name": "sendLinkToDeleteAccount",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -1633,11 +1633,11 @@
           },
           {
             "name": "sendLinkToResetPassword",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "email",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1662,11 +1662,11 @@
           },
           {
             "name": "sendLinkToSignUp",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "additionalInfo",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "AdditionalUserInfo",
@@ -1678,7 +1678,7 @@
               },
               {
                 "name": "email",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1694,7 +1694,7 @@
               },
               {
                 "name": "language",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1715,11 +1715,11 @@
           },
           {
             "name": "signUp",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "draft",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1735,7 +1735,7 @@
               },
               {
                 "name": "jwt",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1764,11 +1764,11 @@
           },
           {
             "name": "updateUser",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "actions",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1792,7 +1792,7 @@
               },
               {
                 "name": "version",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1828,12 +1828,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "MyPermissionInitializationInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "teamId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1855,11 +1855,11 @@
       {
         "kind": "OBJECT",
         "name": "OAuthClient",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "createdAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1871,7 +1871,7 @@
           },
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1887,7 +1887,7 @@
           },
           {
             "name": "lastUsedAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1899,7 +1899,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1915,7 +1915,7 @@
           },
           {
             "name": "ownerId",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1931,7 +1931,7 @@
           },
           {
             "name": "permissions",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1955,7 +1955,7 @@
           },
           {
             "name": "secret",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1978,12 +1978,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "OAuthClientCreationInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1999,7 +1999,7 @@
           },
           {
             "name": "ownerId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2015,7 +2015,7 @@
           },
           {
             "name": "permissions",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2045,11 +2045,11 @@
       {
         "kind": "OBJECT",
         "name": "OAuthClientQueryResult",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "count",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2065,7 +2065,7 @@
           },
           {
             "name": "offset",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2081,7 +2081,7 @@
           },
           {
             "name": "results",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2105,7 +2105,7 @@
           },
           {
             "name": "total",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2134,11 +2134,11 @@
       {
         "kind": "OBJECT",
         "name": "OAuthClientTemplate",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2154,7 +2154,7 @@
           },
           {
             "name": "oAuthScopes",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2189,7 +2189,7 @@
         "fields": [
           {
             "name": "createdAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2205,7 +2205,7 @@
           },
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2221,7 +2221,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2244,11 +2244,11 @@
       {
         "kind": "OBJECT",
         "name": "OrganizationCreated",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2264,7 +2264,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2280,7 +2280,7 @@
           },
           {
             "name": "teams",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2311,12 +2311,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "OrganizationDraftType",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2332,7 +2332,7 @@
           },
           {
             "name": "ownerId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2358,7 +2358,7 @@
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2374,7 +2374,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2397,458 +2397,458 @@
       {
         "kind": "ENUM",
         "name": "PermissionScope",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "create_anonymous_token",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "get_permission_for_any_project",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "introspect_oauth_tokens",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_api_clients",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_attribute_groups",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_audit_log",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_business_units",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_cart_discounts",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_categories",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_change_history",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_customer_groups",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_customers",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_discount_codes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_extensions",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_global_subscriptions",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_import_containers",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_import_sinks",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_key_value_documents",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_business_units",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_orders",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_payments",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_profile",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_quote_requests",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_quotes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_my_shopping_lists",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_order_edits",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_orders",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_payments",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_product_selections",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_products",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_project",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_project_settings",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_quote_requests",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_quotes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_shipping_methods",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_shopping_lists",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_staged_quotes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_standalone_prices",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_states",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_stores",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_subscriptions",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_tax_categories",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "manage_types",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_api_clients",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_attribute_groups",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_audit_log",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_business_units",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_cart_discounts",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_categories",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_change_history",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_customer_groups",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_customers",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_discount_codes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_import_containers",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_import_sinks",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_key_value_documents",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_messages",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_order_edits",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_orders",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_payments",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_product_selections",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_products",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_project_settings",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_projects",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_published_products",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_quote_requests",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_quotes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_shipping_methods",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_shopping_lists",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_staged_quotes",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_standalone_prices",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_states",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_stores",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_tax_categories",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "view_types",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -2858,11 +2858,11 @@
       {
         "kind": "OBJECT",
         "name": "Project",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "allAppliedActionRights",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2886,7 +2886,7 @@
           },
           {
             "name": "allAppliedDataFences",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2910,7 +2910,7 @@
           },
           {
             "name": "allAppliedMenuVisibilities",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2934,7 +2934,7 @@
           },
           {
             "name": "allAppliedPermissions",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2958,7 +2958,7 @@
           },
           {
             "name": "allPermissionsForAllApplications",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2974,7 +2974,7 @@
           },
           {
             "name": "apiVersion",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2990,7 +2990,7 @@
           },
           {
             "name": "countries",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3014,7 +3014,7 @@
           },
           {
             "name": "createdAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3030,7 +3030,7 @@
           },
           {
             "name": "currencies",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3054,7 +3054,7 @@
           },
           {
             "name": "expiry",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3070,7 +3070,7 @@
           },
           {
             "name": "initialized",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3086,7 +3086,7 @@
           },
           {
             "name": "isProductionProject",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3102,7 +3102,7 @@
           },
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3118,7 +3118,7 @@
           },
           {
             "name": "languages",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3142,7 +3142,7 @@
           },
           {
             "name": "lastModifiedAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3158,7 +3158,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3174,7 +3174,7 @@
           },
           {
             "name": "owner",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3190,7 +3190,7 @@
           },
           {
             "name": "plan",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3206,7 +3206,7 @@
           },
           {
             "name": "shippingRateInputType",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3218,7 +3218,7 @@
           },
           {
             "name": "suspension",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3234,7 +3234,7 @@
           },
           {
             "name": "version",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3259,12 +3259,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ProjectDraftType",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "countries",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3288,7 +3288,7 @@
           },
           {
             "name": "currencies",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3312,7 +3312,7 @@
           },
           {
             "name": "deleteDaysAfterCreation",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -3324,7 +3324,7 @@
           },
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3340,7 +3340,7 @@
           },
           {
             "name": "languages",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3364,7 +3364,7 @@
           },
           {
             "name": "messagesEnabled",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -3376,7 +3376,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3392,7 +3392,7 @@
           },
           {
             "name": "ownerId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3414,11 +3414,11 @@
       {
         "kind": "OBJECT",
         "name": "ProjectExpiry",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "daysLeft",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3430,7 +3430,7 @@
           },
           {
             "name": "isActive",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3453,11 +3453,11 @@
       {
         "kind": "OBJECT",
         "name": "ProjectPendingCreation",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3473,7 +3473,7 @@
           },
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3489,7 +3489,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3505,7 +3505,7 @@
           },
           {
             "name": "version",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3528,11 +3528,11 @@
       {
         "kind": "OBJECT",
         "name": "ProjectPermission",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3548,7 +3548,7 @@
           },
           {
             "name": "projectKey",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3560,7 +3560,7 @@
           },
           {
             "name": "storeKey",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3579,12 +3579,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ProjectPermissionInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "key",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3600,7 +3600,7 @@
           },
           {
             "name": "projectKey",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -3612,7 +3612,7 @@
           },
           {
             "name": "storeKey",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -3630,11 +3630,11 @@
       {
         "kind": "OBJECT",
         "name": "ProjectQueryResult",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "count",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3650,7 +3650,7 @@
           },
           {
             "name": "offset",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3666,7 +3666,7 @@
           },
           {
             "name": "results",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3690,7 +3690,7 @@
           },
           {
             "name": "total",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3719,11 +3719,11 @@
       {
         "kind": "OBJECT",
         "name": "ProjectSuspension",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "isActive",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3739,7 +3739,7 @@
           },
           {
             "name": "reason",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "ENUM",
@@ -3758,26 +3758,26 @@
       {
         "kind": "ENUM",
         "name": "ProjectSuspensionReason",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "Other",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "Payment",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "TemporaryMaintenance",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -3787,11 +3787,11 @@
       {
         "kind": "OBJECT",
         "name": "Query",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "allFeatures",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3815,11 +3815,11 @@
           },
           {
             "name": "allImpliedOAuthScopes",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "onlyConfiguredOnTrustedClient",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -3831,7 +3831,7 @@
               },
               {
                 "name": "resourceAccessPermissions",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -3876,7 +3876,7 @@
           },
           {
             "name": "allSupportedActionRights",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3896,7 +3896,7 @@
           },
           {
             "name": "allSupportedMenuVisibilities",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3916,7 +3916,7 @@
           },
           {
             "name": "allSupportedOAuthScopes",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3940,7 +3940,7 @@
           },
           {
             "name": "allSupportedOAuthScopesForOAuthClients",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3964,7 +3964,7 @@
           },
           {
             "name": "allSupportedResources",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3984,7 +3984,7 @@
           },
           {
             "name": "allSupportedStoreScopes",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -4004,7 +4004,7 @@
           },
           {
             "name": "amILoggedIn",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4020,11 +4020,11 @@
           },
           {
             "name": "invitation",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "where",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InvitationWhereInput",
@@ -4045,7 +4045,7 @@
           },
           {
             "name": "me",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -4057,11 +4057,11 @@
           },
           {
             "name": "oAuthClient",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "id",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -4086,7 +4086,7 @@
           },
           {
             "name": "oAuthClientTemplates",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4110,11 +4110,11 @@
           },
           {
             "name": "oAuthClients",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "limit",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4126,7 +4126,7 @@
               },
               {
                 "name": "offset",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4138,7 +4138,7 @@
               },
               {
                 "name": "sort",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -4171,11 +4171,11 @@
           },
           {
             "name": "project",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "key",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4196,7 +4196,7 @@
           },
           {
             "name": "release",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4208,11 +4208,11 @@
           },
           {
             "name": "releases",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "limit",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4224,7 +4224,7 @@
               },
               {
                 "name": "offset",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4236,7 +4236,7 @@
               },
               {
                 "name": "origin",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -4261,7 +4261,7 @@
           },
           {
             "name": "storeOAuthScopes",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4292,11 +4292,11 @@
       {
         "kind": "INTERFACE",
         "name": "QueryResult",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "count",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4312,7 +4312,7 @@
           },
           {
             "name": "offset",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4328,7 +4328,7 @@
           },
           {
             "name": "total",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4367,11 +4367,11 @@
       {
         "kind": "OBJECT",
         "name": "Reference",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4387,7 +4387,7 @@
           },
           {
             "name": "typeId",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4410,12 +4410,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ReferenceInput",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4431,7 +4431,7 @@
           },
           {
             "name": "typeId",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4453,11 +4453,11 @@
       {
         "kind": "OBJECT",
         "name": "ReleaseEntry",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "description",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4473,7 +4473,7 @@
           },
           {
             "name": "guid",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4489,7 +4489,7 @@
           },
           {
             "name": "link",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4505,7 +4505,7 @@
           },
           {
             "name": "releasedAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4521,7 +4521,7 @@
           },
           {
             "name": "title",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4544,11 +4544,11 @@
       {
         "kind": "OBJECT",
         "name": "ReleaseHistory",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "description",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4564,11 +4564,11 @@
           },
           {
             "name": "entries",
-            "description": "",
+            "description": null,
             "args": [
               {
                 "name": "limit",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4580,7 +4580,7 @@
               },
               {
                 "name": "offset",
-                "description": "",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4605,7 +4605,7 @@
           },
           {
             "name": "link",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4621,7 +4621,7 @@
           },
           {
             "name": "title",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4644,20 +4644,20 @@
       {
         "kind": "ENUM",
         "name": "ReleaseOrigin",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "ctp",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "mc",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -4667,11 +4667,11 @@
       {
         "kind": "OBJECT",
         "name": "ReleaseQueryResult",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "count",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4687,7 +4687,7 @@
           },
           {
             "name": "offset",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4703,7 +4703,7 @@
           },
           {
             "name": "results",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4727,7 +4727,7 @@
           },
           {
             "name": "total",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4756,12 +4756,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ResetPasswordDraft",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "password",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4783,11 +4783,11 @@
       {
         "kind": "OBJECT",
         "name": "ResetPasswordRequest",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "jwt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4806,11 +4806,11 @@
       {
         "kind": "OBJECT",
         "name": "ResetUser",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4833,7 +4833,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetUserTimeZone",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -4856,11 +4856,11 @@
       {
         "kind": "OBJECT",
         "name": "ShippingRateInputType",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "type",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4876,7 +4876,7 @@
           },
           {
             "name": "values",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -4899,26 +4899,26 @@
       {
         "kind": "ENUM",
         "name": "ShippingRateType",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "CartClassification",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "CartScore",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "CartValue",
-            "description": "",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -4928,11 +4928,11 @@
       {
         "kind": "OBJECT",
         "name": "SignUpRequest",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "jwt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4951,11 +4951,11 @@
       {
         "kind": "OBJECT",
         "name": "SignedUpUser",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4978,11 +4978,11 @@
       {
         "kind": "OBJECT",
         "name": "StoreDataFence",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "group",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4998,7 +4998,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5014,7 +5014,7 @@
           },
           {
             "name": "type",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5030,7 +5030,7 @@
           },
           {
             "name": "value",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5069,11 +5069,11 @@
       {
         "kind": "OBJECT",
         "name": "SupportedActionRight",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "group",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5089,7 +5089,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5112,11 +5112,11 @@
       {
         "kind": "OBJECT",
         "name": "SupportedMenuVisibility",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "group",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5132,7 +5132,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5155,11 +5155,11 @@
       {
         "kind": "OBJECT",
         "name": "SupportedOAuthScopeForOAuthClient",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5182,11 +5182,11 @@
       {
         "kind": "OBJECT",
         "name": "SupportedResource",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5209,11 +5209,11 @@
       {
         "kind": "OBJECT",
         "name": "SupportedStoreScope",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "group",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5229,7 +5229,7 @@
           },
           {
             "name": "name",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5252,11 +5252,11 @@
       {
         "kind": "OBJECT",
         "name": "User",
-        "description": "",
+        "description": null,
         "fields": [
           {
             "name": "businessRole",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5268,7 +5268,7 @@
           },
           {
             "name": "createdAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5284,7 +5284,7 @@
           },
           {
             "name": "defaultProjectKey",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5296,7 +5296,7 @@
           },
           {
             "name": "email",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5312,7 +5312,7 @@
           },
           {
             "name": "firstName",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5328,7 +5328,7 @@
           },
           {
             "name": "gravatarHash",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5344,7 +5344,7 @@
           },
           {
             "name": "id",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5372,7 +5372,7 @@
           },
           {
             "name": "language",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5388,7 +5388,7 @@
           },
           {
             "name": "lastModifiedAt",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5404,7 +5404,7 @@
           },
           {
             "name": "lastName",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5420,7 +5420,7 @@
           },
           {
             "name": "launchdarklyTrackingGroup",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5436,7 +5436,7 @@
           },
           {
             "name": "launchdarklyTrackingId",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5452,7 +5452,7 @@
           },
           {
             "name": "launchdarklyTrackingSubgroup",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5464,7 +5464,7 @@
           },
           {
             "name": "launchdarklyTrackingTeam",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -5484,7 +5484,7 @@
           },
           {
             "name": "launchdarklyTrackingTenant",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5500,7 +5500,7 @@
           },
           {
             "name": "numberFormat",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5516,7 +5516,7 @@
           },
           {
             "name": "projects",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5532,7 +5532,7 @@
           },
           {
             "name": "timeZone",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5543,8 +5543,24 @@
             "deprecationReason": null
           },
           {
+            "name": "verificationStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "version",
-            "description": "",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5569,12 +5585,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "UserDraft",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "businessRole",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -5586,7 +5602,7 @@
           },
           {
             "name": "firstName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5602,7 +5618,7 @@
           },
           {
             "name": "lastName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5618,7 +5634,7 @@
           },
           {
             "name": "password",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5640,12 +5656,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "UserUpdateAction",
-        "description": "",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "changeBusinessRole",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ChangeUserBusinessRole",
@@ -5657,7 +5673,7 @@
           },
           {
             "name": "changeLanguage",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ChangeUserLanguage",
@@ -5669,7 +5685,7 @@
           },
           {
             "name": "changeName",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ChangeUserName",
@@ -5681,7 +5697,7 @@
           },
           {
             "name": "changeNumberFormat",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ChangeUserNumberFormat",
@@ -5693,7 +5709,7 @@
           },
           {
             "name": "changePassword",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ChangeUserPassword",
@@ -5705,7 +5721,7 @@
           },
           {
             "name": "setTimeZone",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetUserTimeZone",
@@ -6631,7 +6647,7 @@
     "directives": [
       {
         "name": "collectMetrics",
-        "description": "",
+        "description": null,
         "isRepeatable": false,
         "locations": [
           "FIELD_DEFINITION"
@@ -6640,7 +6656,7 @@
       },
       {
         "name": "deprecate",
-        "description": "",
+        "description": null,
         "isRepeatable": false,
         "locations": [
           "FIELD_DEFINITION"
@@ -6648,7 +6664,7 @@
         "args": [
           {
             "name": "reason",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6660,7 +6676,7 @@
           },
           {
             "name": "withCounter",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -6672,7 +6688,7 @@
           },
           {
             "name": "withLog",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -6689,13 +6705,15 @@
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
         "locations": [
+          "ARGUMENT_DEFINITION",
           "ENUM_VALUE",
-          "FIELD_DEFINITION"
+          "FIELD_DEFINITION",
+          "INPUT_FIELD_DEFINITION"
         ],
         "args": [
           {
             "name": "reason",
-            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
+            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6737,7 +6755,7 @@
       },
       {
         "name": "isAuthenticated",
-        "description": "",
+        "description": null,
         "isRepeatable": false,
         "locations": [
           "FIELD_DEFINITION"
@@ -6746,7 +6764,7 @@
       },
       {
         "name": "rateLimit",
-        "description": "",
+        "description": null,
         "isRepeatable": false,
         "locations": [
           "FIELD_DEFINITION"
@@ -6754,7 +6772,7 @@
         "args": [
           {
             "name": "arrayLengthField",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6766,7 +6784,7 @@
           },
           {
             "name": "identityArgs",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6782,7 +6800,7 @@
           },
           {
             "name": "max",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -6794,7 +6812,7 @@
           },
           {
             "name": "message",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6806,7 +6824,7 @@
           },
           {
             "name": "window",
-            "description": "",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -6837,6 +6855,32 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ]
+      },
+      {
+        "name": "specifiedBy",
+        "description": "Exposes a URL that specifies the behavior of this scalar.",
+        "isRepeatable": false,
+        "locations": [
+          "SCALAR"
+        ],
+        "args": [
+          {
+            "name": "url",
+            "description": "The URL that specifies the behavior of this scalar.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },

--- a/schemas/mc.json
+++ b/schemas/mc.json
@@ -54,7 +54,7 @@
       {
         "kind": "OBJECT",
         "name": "AllPermissionsForAllApplications",
-        "description": "Only used by the navbar menu component in ApplicationShell.",
+        "description": null,
         "fields": [
           {
             "name": "allAppliedActionRights",
@@ -429,7 +429,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeUserName",
-        "description": "NOTE: This is _not_ a username it is the user's name.",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -688,7 +688,7 @@
         "fields": [
           {
             "name": "additionalClaims",
-            "description": "Additional custom claims. This is a stringified JSON object.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -716,7 +716,7 @@
           },
           {
             "name": "email",
-            "description": "Claims from scope `email`",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -760,7 +760,7 @@
           },
           {
             "name": "iss",
-            "description": "Standard claims",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -776,7 +776,7 @@
           },
           {
             "name": "name",
-            "description": "Claims from scope `profile`",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -943,7 +943,7 @@
       {
         "kind": "OBJECT",
         "name": "InvitationQueryResult",
-        "description": "Note: you can not brute-force fetch user information\nby trying emails. Only information about the membership itself.",
+        "description": null,
         "fields": [
           {
             "name": "gravatarHash",
@@ -2185,7 +2185,7 @@
       {
         "kind": "OBJECT",
         "name": "Organization",
-        "description": "TODO: use `Reference` instead once there is no more usage of the following fields:\n- name\n- createdAt",
+        "description": null,
         "fields": [
           {
             "name": "createdAt",
@@ -2354,7 +2354,7 @@
       {
         "kind": "OBJECT",
         "name": "OrganizationTeamsCreated",
-        "description": "Note:\n  This is not a `Organization` type as in the future MC schema will not support e.g. expanding on team members on its internal schema.",
+        "description": null,
         "fields": [
           {
             "name": "id",
@@ -4838,7 +4838,7 @@
         "inputFields": [
           {
             "name": "timeZone",
-            "description": "NOTE: This is optional as not passing it unsets the timezone.",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -5360,7 +5360,7 @@
           },
           {
             "name": "idTokenUserInfo",
-            "description": "Contains additional claims information from the user id_token.\nThis is only defined when logging in via SSO.",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -5550,8 +5550,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "VerificationStatus",
                 "ofType": null
               }
             },
@@ -5734,6 +5734,29 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "VerificationStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "Unverified",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Verified",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -6764,73 +6787,42 @@
       },
       {
         "name": "rateLimit",
-        "description": null,
+        "description": "Controls the rate of traffic.",
         "isRepeatable": false,
         "locations": [
-          "FIELD_DEFINITION"
+          "FIELD_DEFINITION",
+          "OBJECT"
         ],
         "args": [
           {
-            "name": "arrayLengthField",
-            "description": null,
+            "name": "duration",
+            "description": "Number of seconds before limit is reset.",
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "identityArgs",
-            "description": null,
-            "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Int",
                 "ofType": null
               }
             },
-            "defaultValue": null,
+            "defaultValue": "60",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "max",
-            "description": null,
+            "name": "limit",
+            "description": "Number of occurrences allowed over duration.",
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "window",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
+            "defaultValue": "60",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -6866,7 +6858,7 @@
       },
       {
         "name": "specifiedBy",
-        "description": "Exposes a URL that specifies the behavior of this scalar.",
+        "description": "Exposes a URL that specifies the behaviour of this scalar.",
         "isRepeatable": false,
         "locations": [
           "SCALAR"
@@ -6874,7 +6866,7 @@
         "args": [
           {
             "name": "url",
-            "description": "The URL that specifies the behavior of this scalar.",
+            "description": "The URL that specifies the behaviour of this scalar.",
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/test-data/types/generated/mc.ts
+++ b/test-data/types/generated/mc.ts
@@ -1,0 +1,734 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type TAdditionalUserInfo = {
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+};
+
+export type TAllPermissionsForAllApplications = {
+  __typename?: 'AllPermissionsForAllApplications';
+  allAppliedActionRights: Array<TAppliedActionRight>;
+  allAppliedDataFences: Array<TAppliedDataFence>;
+  allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
+  allAppliedPermissions: Array<TAppliedPermission>;
+};
+
+export type TAppliedActionRight = {
+  __typename?: 'AppliedActionRight';
+  group: Scalars['String'];
+  name: Scalars['String'];
+  value: Scalars['Boolean'];
+};
+
+export type TAppliedDataFence = TStoreDataFence;
+
+export type TAppliedMenuVisibilities = {
+  __typename?: 'AppliedMenuVisibilities';
+  name: Scalars['String'];
+  value: Scalars['Boolean'];
+};
+
+export type TAppliedPermission = {
+  __typename?: 'AppliedPermission';
+  name: Scalars['String'];
+  value: Scalars['Boolean'];
+};
+
+export type TCartClassificationValue = {
+  __typename?: 'CartClassificationValue';
+  allLocaleLabels: Array<Maybe<TLocalizedField>>;
+  key: Scalars['String'];
+};
+
+export type TChangeUserBusinessRole = {
+  businessRole?: InputMaybe<Scalars['String']>;
+};
+
+export type TChangeUserLanguage = {
+  language: Scalars['String'];
+};
+
+export type TChangeUserName = {
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+};
+
+export type TChangeUserNumberFormat = {
+  numberFormat: Scalars['String'];
+};
+
+export type TChangeUserPassword = {
+  password: Scalars['String'];
+};
+
+export type TDataFence = {
+  type: Scalars['String'];
+};
+
+export type TDeleteAccountRequest = {
+  __typename?: 'DeleteAccountRequest';
+  jwt?: Maybe<Scalars['String']>;
+};
+
+export type TDeletedUser = {
+  __typename?: 'DeletedUser';
+  id: Scalars['String'];
+};
+
+export type TFeature = {
+  __typename?: 'Feature';
+  name: Scalars['String'];
+  reason?: Maybe<Scalars['String']>;
+  value: Scalars['Boolean'];
+};
+
+export type TIdTokenUserInfo = {
+  __typename?: 'IdTokenUserInfo';
+  additionalClaims?: Maybe<Scalars['String']>;
+  aud: Scalars['String'];
+  email?: Maybe<Scalars['String']>;
+  exp: Scalars['Float'];
+  iat: Scalars['Float'];
+  iss: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  sub: Scalars['String'];
+};
+
+export type TInvitationInput = {
+  emails: Array<Scalars['String']>;
+  organization: TInvitationOrganizationInput;
+  team: TInvitationTeamInput;
+};
+
+export type TInvitationOrganizationInput = {
+  id: Scalars['ID'];
+  name?: InputMaybe<Scalars['String']>;
+  version: Scalars['Int'];
+};
+
+export type TInvitationQueryResult = {
+  __typename?: 'InvitationQueryResult';
+  gravatarHash?: Maybe<Scalars['String']>;
+  hasValidEmail: Scalars['Boolean'];
+  isAlreadyAMemberOfTeam: Scalars['Boolean'];
+  isKnownUser: Scalars['Boolean'];
+  version: Scalars['Int'];
+};
+
+export type TInvitationResult = {
+  __typename?: 'InvitationResult';
+  email: Scalars['String'];
+  jwt?: Maybe<Scalars['String']>;
+  status: TInvitationStatus;
+};
+
+export enum TInvitationStatus {
+  InvitationFailure = 'InvitationFailure',
+  InvitationSent = 'InvitationSent',
+  PendingRegistration = 'PendingRegistration'
+}
+
+export type TInvitationTeamInput = {
+  id: Scalars['ID'];
+};
+
+export type TInvitationWhereInput = {
+  email: Scalars['String'];
+  organizationId: Scalars['ID'];
+  teamId: Scalars['ID'];
+};
+
+export type TLocalizedField = {
+  __typename?: 'LocalizedField';
+  locale: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type TMetaData = {
+  createdAt: Scalars['String'];
+  lastModifiedAt: Scalars['String'];
+  version?: Maybe<Scalars['Int']>;
+};
+
+export type TMutation = {
+  __typename?: 'Mutation';
+  createMyOrganization?: Maybe<TOrganizationCreated>;
+  createMyProject?: Maybe<TProjectPendingCreation>;
+  createOAuthClient: TOAuthClient;
+  deleteAccount: TDeletedUser;
+  deleteOAuthClient: TOAuthClient;
+  invite: Array<TInvitationResult>;
+  random: Scalars['String'];
+  resetPassword: TResetUser;
+  sendLinkToDeleteAccount?: Maybe<TDeleteAccountRequest>;
+  sendLinkToResetPassword?: Maybe<TResetPasswordRequest>;
+  sendLinkToSignUp?: Maybe<TSignUpRequest>;
+  signUp: TSignedUpUser;
+  updateUser: TUser;
+};
+
+
+export type TMutation_CreateMyOrganizationArgs = {
+  draft: TOrganizationDraftType;
+};
+
+
+export type TMutation_CreateMyProjectArgs = {
+  draft: TProjectDraftType;
+  myPermission: TMyPermissionInitializationInput;
+};
+
+
+export type TMutation_CreateOAuthClientArgs = {
+  draft: TOAuthClientCreationInput;
+};
+
+
+export type TMutation_DeleteAccountArgs = {
+  jwt: Scalars['String'];
+};
+
+
+export type TMutation_DeleteOAuthClientArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_InviteArgs = {
+  draft: TInvitationInput;
+  origin?: InputMaybe<Scalars['String']>;
+};
+
+
+export type TMutation_RandomArgs = {
+  byteLength: Scalars['Int'];
+};
+
+
+export type TMutation_ResetPasswordArgs = {
+  draft: TResetPasswordDraft;
+  jwt: Scalars['String'];
+};
+
+
+export type TMutation_SendLinkToResetPasswordArgs = {
+  email: Scalars['String'];
+};
+
+
+export type TMutation_SendLinkToSignUpArgs = {
+  additionalInfo?: InputMaybe<TAdditionalUserInfo>;
+  email: Scalars['String'];
+  language?: InputMaybe<Scalars['String']>;
+};
+
+
+export type TMutation_SignUpArgs = {
+  draft: TUserDraft;
+  jwt: Scalars['String'];
+};
+
+
+export type TMutation_UpdateUserArgs = {
+  actions: Array<TUserUpdateAction>;
+  version: Scalars['Int'];
+};
+
+export type TMyPermissionInitializationInput = {
+  teamId: Scalars['String'];
+};
+
+export type TOAuthClient = {
+  __typename?: 'OAuthClient';
+  createdAt?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  lastUsedAt?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  ownerId: Scalars['ID'];
+  permissions: Array<TProjectPermission>;
+  secret: Scalars['String'];
+};
+
+export type TOAuthClientCreationInput = {
+  name: Scalars['String'];
+  ownerId: Scalars['ID'];
+  permissions: Array<TProjectPermissionInput>;
+};
+
+export type TOAuthClientQueryResult = TQueryResult & {
+  __typename?: 'OAuthClientQueryResult';
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TOAuthClient>;
+  total: Scalars['Int'];
+};
+
+export type TOAuthClientTemplate = {
+  __typename?: 'OAuthClientTemplate';
+  key: Scalars['String'];
+  oAuthScopes: Array<TPermissionScope>;
+};
+
+export type TOrganization = {
+  __typename?: 'Organization';
+  /** @deprecated This field will be removed in the future. */
+  createdAt: Scalars['String'];
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
+export type TOrganizationCreated = {
+  __typename?: 'OrganizationCreated';
+  id: Scalars['String'];
+  name: Scalars['String'];
+  teams: Array<TOrganizationTeamsCreated>;
+};
+
+export type TOrganizationDraftType = {
+  name: Scalars['String'];
+  ownerId: Scalars['String'];
+};
+
+export type TOrganizationTeamsCreated = {
+  __typename?: 'OrganizationTeamsCreated';
+  id: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export enum TPermissionScope {
+  CreateAnonymousToken = 'create_anonymous_token',
+  GetPermissionForAnyProject = 'get_permission_for_any_project',
+  IntrospectOauthTokens = 'introspect_oauth_tokens',
+  ManageApiClients = 'manage_api_clients',
+  ManageAttributeGroups = 'manage_attribute_groups',
+  ManageAuditLog = 'manage_audit_log',
+  ManageBusinessUnits = 'manage_business_units',
+  ManageCartDiscounts = 'manage_cart_discounts',
+  ManageCategories = 'manage_categories',
+  ManageChangeHistory = 'manage_change_history',
+  ManageCustomerGroups = 'manage_customer_groups',
+  ManageCustomers = 'manage_customers',
+  ManageDiscountCodes = 'manage_discount_codes',
+  ManageExtensions = 'manage_extensions',
+  ManageGlobalSubscriptions = 'manage_global_subscriptions',
+  ManageImportContainers = 'manage_import_containers',
+  ManageImportSinks = 'manage_import_sinks',
+  ManageKeyValueDocuments = 'manage_key_value_documents',
+  ManageMyBusinessUnits = 'manage_my_business_units',
+  ManageMyOrders = 'manage_my_orders',
+  ManageMyPayments = 'manage_my_payments',
+  ManageMyProfile = 'manage_my_profile',
+  ManageMyQuoteRequests = 'manage_my_quote_requests',
+  ManageMyQuotes = 'manage_my_quotes',
+  ManageMyShoppingLists = 'manage_my_shopping_lists',
+  ManageOrderEdits = 'manage_order_edits',
+  ManageOrders = 'manage_orders',
+  ManagePayments = 'manage_payments',
+  ManageProductSelections = 'manage_product_selections',
+  ManageProducts = 'manage_products',
+  ManageProject = 'manage_project',
+  ManageProjectSettings = 'manage_project_settings',
+  ManageQuoteRequests = 'manage_quote_requests',
+  ManageQuotes = 'manage_quotes',
+  ManageShippingMethods = 'manage_shipping_methods',
+  ManageShoppingLists = 'manage_shopping_lists',
+  ManageStagedQuotes = 'manage_staged_quotes',
+  ManageStandalonePrices = 'manage_standalone_prices',
+  ManageStates = 'manage_states',
+  ManageStores = 'manage_stores',
+  ManageSubscriptions = 'manage_subscriptions',
+  ManageTaxCategories = 'manage_tax_categories',
+  ManageTypes = 'manage_types',
+  ViewApiClients = 'view_api_clients',
+  ViewAttributeGroups = 'view_attribute_groups',
+  ViewAuditLog = 'view_audit_log',
+  ViewBusinessUnits = 'view_business_units',
+  ViewCartDiscounts = 'view_cart_discounts',
+  ViewCategories = 'view_categories',
+  ViewChangeHistory = 'view_change_history',
+  ViewCustomerGroups = 'view_customer_groups',
+  ViewCustomers = 'view_customers',
+  ViewDiscountCodes = 'view_discount_codes',
+  ViewImportContainers = 'view_import_containers',
+  ViewImportSinks = 'view_import_sinks',
+  ViewKeyValueDocuments = 'view_key_value_documents',
+  ViewMessages = 'view_messages',
+  ViewOrderEdits = 'view_order_edits',
+  ViewOrders = 'view_orders',
+  ViewPayments = 'view_payments',
+  ViewProductSelections = 'view_product_selections',
+  ViewProducts = 'view_products',
+  ViewProjectSettings = 'view_project_settings',
+  ViewProjects = 'view_projects',
+  ViewPublishedProducts = 'view_published_products',
+  ViewQuoteRequests = 'view_quote_requests',
+  ViewQuotes = 'view_quotes',
+  ViewShippingMethods = 'view_shipping_methods',
+  ViewShoppingLists = 'view_shopping_lists',
+  ViewStagedQuotes = 'view_staged_quotes',
+  ViewStandalonePrices = 'view_standalone_prices',
+  ViewStates = 'view_states',
+  ViewStores = 'view_stores',
+  ViewTaxCategories = 'view_tax_categories',
+  ViewTypes = 'view_types'
+}
+
+export type TProject = TMetaData & {
+  __typename?: 'Project';
+  allAppliedActionRights: Array<TAppliedActionRight>;
+  allAppliedDataFences: Array<TAppliedDataFence>;
+  /** @deprecated This field has been moved into the menuPermissionsForAllApplications field. */
+  allAppliedMenuVisibilities: Array<TAppliedMenuVisibilities>;
+  allAppliedPermissions: Array<TAppliedPermission>;
+  allPermissionsForAllApplications: TAllPermissionsForAllApplications;
+  apiVersion: Scalars['String'];
+  countries: Array<Scalars['String']>;
+  createdAt: Scalars['String'];
+  currencies: Array<Scalars['String']>;
+  expiry: TProjectExpiry;
+  initialized: Scalars['Boolean'];
+  isProductionProject: Scalars['Boolean'];
+  key: Scalars['String'];
+  languages: Array<Scalars['String']>;
+  lastModifiedAt: Scalars['String'];
+  name: Scalars['String'];
+  owner: TOrganization;
+  plan: Scalars['String'];
+  shippingRateInputType?: Maybe<TShippingRateInputType>;
+  suspension: TProjectSuspension;
+  version?: Maybe<Scalars['Int']>;
+};
+
+export type TProjectDraftType = {
+  countries: Array<Scalars['String']>;
+  currencies: Array<Scalars['String']>;
+  deleteDaysAfterCreation?: InputMaybe<Scalars['Int']>;
+  key: Scalars['String'];
+  languages: Array<Scalars['String']>;
+  messagesEnabled?: InputMaybe<Scalars['Boolean']>;
+  name: Scalars['String'];
+  ownerId: Scalars['String'];
+};
+
+export type TProjectExpiry = {
+  __typename?: 'ProjectExpiry';
+  daysLeft?: Maybe<Scalars['Int']>;
+  isActive: Scalars['Boolean'];
+};
+
+export type TProjectPendingCreation = {
+  __typename?: 'ProjectPendingCreation';
+  id: Scalars['String'];
+  key: Scalars['String'];
+  name: Scalars['String'];
+  version: Scalars['Int'];
+};
+
+export type TProjectPermission = {
+  __typename?: 'ProjectPermission';
+  key: TPermissionScope;
+  projectKey?: Maybe<Scalars['String']>;
+  storeKey?: Maybe<Scalars['String']>;
+};
+
+export type TProjectPermissionInput = {
+  key: TPermissionScope;
+  projectKey?: InputMaybe<Scalars['String']>;
+  storeKey?: InputMaybe<Scalars['String']>;
+};
+
+export type TProjectQueryResult = TQueryResult & {
+  __typename?: 'ProjectQueryResult';
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TProject>;
+  total: Scalars['Int'];
+};
+
+export type TProjectSuspension = {
+  __typename?: 'ProjectSuspension';
+  isActive: Scalars['Boolean'];
+  reason?: Maybe<TProjectSuspensionReason>;
+};
+
+export enum TProjectSuspensionReason {
+  Other = 'Other',
+  Payment = 'Payment',
+  TemporaryMaintenance = 'TemporaryMaintenance'
+}
+
+export type TQuery = {
+  __typename?: 'Query';
+  allFeatures: Array<TFeature>;
+  allImpliedOAuthScopes: Array<Scalars['String']>;
+  allSupportedActionRights?: Maybe<Array<TSupportedActionRight>>;
+  allSupportedMenuVisibilities?: Maybe<Array<TSupportedMenuVisibility>>;
+  allSupportedOAuthScopes: Array<Scalars['String']>;
+  allSupportedOAuthScopesForOAuthClients: Array<TSupportedOAuthScopeForOAuthClient>;
+  allSupportedResources?: Maybe<Array<TSupportedResource>>;
+  allSupportedStoreScopes?: Maybe<Array<TSupportedStoreScope>>;
+  amILoggedIn: Scalars['Boolean'];
+  invitation?: Maybe<TInvitationQueryResult>;
+  me?: Maybe<TUser>;
+  oAuthClient?: Maybe<TOAuthClient>;
+  oAuthClientTemplates: Array<TOAuthClientTemplate>;
+  oAuthClients: TOAuthClientQueryResult;
+  project?: Maybe<TProject>;
+  release?: Maybe<Scalars['String']>;
+  releases?: Maybe<TReleaseHistory>;
+  storeOAuthScopes: Array<TPermissionScope>;
+};
+
+
+export type TQuery_AllImpliedOAuthScopesArgs = {
+  onlyConfiguredOnTrustedClient?: InputMaybe<Scalars['Boolean']>;
+  resourceAccessPermissions: Array<Scalars['String']>;
+};
+
+
+export type TQuery_InvitationArgs = {
+  where?: InputMaybe<TInvitationWhereInput>;
+};
+
+
+export type TQuery_OAuthClientArgs = {
+  id: Scalars['String'];
+};
+
+
+export type TQuery_OAuthClientsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Array<Scalars['String']>>;
+};
+
+
+export type TQuery_ProjectArgs = {
+  key?: InputMaybe<Scalars['String']>;
+};
+
+
+export type TQuery_ReleasesArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  origin: TReleaseOrigin;
+};
+
+export type TQueryResult = {
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  total: Scalars['Int'];
+};
+
+export type TReference = {
+  __typename?: 'Reference';
+  id: Scalars['String'];
+  typeId: Scalars['String'];
+};
+
+export type TReferenceInput = {
+  id: Scalars['ID'];
+  typeId: Scalars['String'];
+};
+
+export type TReleaseEntry = {
+  __typename?: 'ReleaseEntry';
+  description: Scalars['String'];
+  guid: Scalars['String'];
+  link: Scalars['String'];
+  releasedAt: Scalars['String'];
+  title: Scalars['String'];
+};
+
+export type TReleaseHistory = {
+  __typename?: 'ReleaseHistory';
+  description: Scalars['String'];
+  entries: TReleaseQueryResult;
+  link: Scalars['String'];
+  title: Scalars['String'];
+};
+
+
+export type TReleaseHistory_EntriesArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+export enum TReleaseOrigin {
+  Ctp = 'ctp',
+  Mc = 'mc'
+}
+
+export type TReleaseQueryResult = TQueryResult & {
+  __typename?: 'ReleaseQueryResult';
+  count: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TReleaseEntry>;
+  total: Scalars['Int'];
+};
+
+export type TResetPasswordDraft = {
+  password: Scalars['String'];
+};
+
+export type TResetPasswordRequest = {
+  __typename?: 'ResetPasswordRequest';
+  jwt?: Maybe<Scalars['String']>;
+};
+
+export type TResetUser = {
+  __typename?: 'ResetUser';
+  id: Scalars['String'];
+};
+
+export type TSetUserTimeZone = {
+  timeZone?: InputMaybe<Scalars['String']>;
+};
+
+export type TShippingRateInputType = {
+  __typename?: 'ShippingRateInputType';
+  type: TShippingRateType;
+  values?: Maybe<Array<Maybe<TCartClassificationValue>>>;
+};
+
+export enum TShippingRateType {
+  CartClassification = 'CartClassification',
+  CartScore = 'CartScore',
+  CartValue = 'CartValue'
+}
+
+export type TSignUpRequest = {
+  __typename?: 'SignUpRequest';
+  jwt?: Maybe<Scalars['String']>;
+};
+
+export type TSignedUpUser = {
+  __typename?: 'SignedUpUser';
+  id: Scalars['String'];
+};
+
+export type TStoreDataFence = TDataFence & {
+  __typename?: 'StoreDataFence';
+  group: Scalars['String'];
+  name: Scalars['String'];
+  type: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type TSupportedActionRight = {
+  __typename?: 'SupportedActionRight';
+  group: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export type TSupportedMenuVisibility = {
+  __typename?: 'SupportedMenuVisibility';
+  group: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export type TSupportedOAuthScopeForOAuthClient = {
+  __typename?: 'SupportedOAuthScopeForOAuthClient';
+  name: Scalars['String'];
+};
+
+export type TSupportedResource = {
+  __typename?: 'SupportedResource';
+  name: Scalars['String'];
+};
+
+export type TSupportedStoreScope = {
+  __typename?: 'SupportedStoreScope';
+  group: Scalars['String'];
+  name: Scalars['String'];
+};
+
+export type TUser = TMetaData & {
+  __typename?: 'User';
+  businessRole?: Maybe<Scalars['String']>;
+  createdAt: Scalars['String'];
+  defaultProjectKey?: Maybe<Scalars['String']>;
+  email: Scalars['String'];
+  firstName: Scalars['String'];
+  gravatarHash: Scalars['String'];
+  id: Scalars['ID'];
+  idTokenUserInfo?: Maybe<TIdTokenUserInfo>;
+  language: Scalars['String'];
+  lastModifiedAt: Scalars['String'];
+  lastName: Scalars['String'];
+  launchdarklyTrackingGroup: Scalars['String'];
+  launchdarklyTrackingId: Scalars['String'];
+  launchdarklyTrackingSubgroup?: Maybe<Scalars['String']>;
+  launchdarklyTrackingTeam?: Maybe<Array<Scalars['String']>>;
+  launchdarklyTrackingTenant: Scalars['String'];
+  numberFormat: Scalars['String'];
+  projects: TProjectQueryResult;
+  timeZone?: Maybe<Scalars['String']>;
+  verificationStatus: TVerificationStatus;
+  version?: Maybe<Scalars['Int']>;
+};
+
+export type TUserDraft = {
+  businessRole?: InputMaybe<Scalars['String']>;
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  password: Scalars['String'];
+};
+
+export type TUserUpdateAction = {
+  changeBusinessRole?: InputMaybe<TChangeUserBusinessRole>;
+  changeLanguage?: InputMaybe<TChangeUserLanguage>;
+  changeName?: InputMaybe<TChangeUserName>;
+  changeNumberFormat?: InputMaybe<TChangeUserNumberFormat>;
+  changePassword?: InputMaybe<TChangeUserPassword>;
+  setTimeZone?: InputMaybe<TSetUserTimeZone>;
+};
+
+export enum TVerificationStatus {
+  Unverified = 'Unverified',
+  Verified = 'Verified'
+}
+
+export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TAmILoggedInQuery = { __typename?: 'Query', amILoggedIn: boolean };
+
+export type TFetchProjectQueryVariables = Exact<{
+  projectKey: Scalars['String'];
+}>;
+
+
+export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
+
+export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, verificationStatus: TVerificationStatus, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+
+export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+
+export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TAllFeaturesQuery = { __typename?: 'Query', allFeatures: Array<{ __typename?: 'Feature', name: string, value: boolean, reason?: string | null }> };
+
+export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };

--- a/test-data/user/generator.ts
+++ b/test-data/user/generator.ts
@@ -24,7 +24,7 @@ const generator = Generator<TUser>({
     launchdarklyTrackingTenant: '',
     projects: null,
     idTokenUserInfo: null,
-    verificationStatus: 'verified',
+    verificationStatus: 'Verified',
   },
 });
 

--- a/test-data/user/generator.ts
+++ b/test-data/user/generator.ts
@@ -1,6 +1,7 @@
 import type { TUser } from './types';
 
 import { fake, sequence, Generator } from '@commercetools-test-data/core';
+import { TVerificationStatus } from '../types/generated/mc';
 
 const generator = Generator<TUser>({
   fields: {
@@ -24,7 +25,7 @@ const generator = Generator<TUser>({
     launchdarklyTrackingTenant: '',
     projects: null,
     idTokenUserInfo: null,
-    verificationStatus: 'Verified',
+    verificationStatus: TVerificationStatus.Verified,
   },
 });
 

--- a/test-data/user/generator.ts
+++ b/test-data/user/generator.ts
@@ -24,6 +24,7 @@ const generator = Generator<TUser>({
     launchdarklyTrackingTenant: '',
     projects: null,
     idTokenUserInfo: null,
+    verificationStatus: 'verified',
   },
 });
 

--- a/test-data/user/types.ts
+++ b/test-data/user/types.ts
@@ -32,6 +32,7 @@ type TBaseUser = {
     name?: string | null | undefined;
     additionalClaims?: string | null;
   };
+  isVerified: boolean;
 };
 
 export type TUser = TBaseUser & {

--- a/test-data/user/types.ts
+++ b/test-data/user/types.ts
@@ -1,7 +1,7 @@
 import type { TBuilder } from '@commercetools-test-data/core';
 import type { TProject, TProjectGraphql } from '../project';
 
-export type VerificationStatus = 'verified' | 'unverified';
+type VerificationStatus = 'Verified' | 'Unverified';
 
 export type TCreateUserBuilder = () => TBuilder<TUser>;
 

--- a/test-data/user/types.ts
+++ b/test-data/user/types.ts
@@ -1,6 +1,8 @@
 import type { TBuilder } from '@commercetools-test-data/core';
 import type { TProject, TProjectGraphql } from '../project';
 
+export type VerificationStatus = 'verified' | 'unverified';
+
 export type TCreateUserBuilder = () => TBuilder<TUser>;
 
 type TBaseUser = {
@@ -32,7 +34,7 @@ type TBaseUser = {
     name?: string | null | undefined;
     additionalClaims?: string | null;
   };
-  isVerified: boolean;
+  verificationStatus: VerificationStatus;
 };
 
 export type TUser = TBaseUser & {

--- a/test-data/user/types.ts
+++ b/test-data/user/types.ts
@@ -1,5 +1,5 @@
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TVerificationStatus } from '../../packages/application-shell/src/types/generated/mc';
+import { TVerificationStatus } from '../types/generated/mc';
 import type { TProject, TProjectGraphql } from '../project';
 
 export type TCreateUserBuilder = () => TBuilder<TUser>;

--- a/test-data/user/types.ts
+++ b/test-data/user/types.ts
@@ -1,7 +1,6 @@
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TVerificationStatus } from '../../packages/application-shell/src/types/generated/mc';
 import type { TProject, TProjectGraphql } from '../project';
-
-type VerificationStatus = 'Verified' | 'Unverified';
 
 export type TCreateUserBuilder = () => TBuilder<TUser>;
 
@@ -34,7 +33,7 @@ type TBaseUser = {
     name?: string | null | undefined;
     additionalClaims?: string | null;
   };
-  verificationStatus: VerificationStatus;
+  verificationStatus: TVerificationStatus;
 };
 
 export type TUser = TBaseUser & {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary

This PR proposes a `verificationStatus` field following work [from this PR](https://github.com/commercetools/merchant-center-services/pull/2292) within `mc-services`.

## Description

One of the goals of the First Contact team is to improve email verification flow for users of the Merchant Center. We have identified that the `User` entity will require a field indicating verification status, which will be eventually implemented by the Distributed Systems team. 

However, we also wanted to get a head start on refactoring components in other Merchant Center applications that will require use of this field.

The goal of this PR is to:
1. Access this field in `ApplicationShell`'s `FetchLoggedInUser` query from the stubbed `mc-services` field, and
2. Expose this field in the `ApplicationShell` connectors for downstream use within each MC application
