### PR TITLE
fix(application-shell-connectors): prevent Sentry reports when `additionalClaims` value is falsy

### DIFF
--- a/.changeset/tame-llamas-heal.md
+++ b/.changeset/tame-llamas-heal.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+---
+
+Fix redundant Sentry error reports when SSO user additional claims are falsy

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -90,7 +90,7 @@ export const mapUserToApplicationContextUser = (user?: TFetchedUser) => {
     let additionalClaims: Record<string, unknown> = {};
     try {
       additionalClaims = JSON.parse(
-        user.idTokenUserInfo.additionalClaims || ''
+        user.idTokenUserInfo.additionalClaims || '{}'
       );
     } catch (error) {
       reportErrorToSentry(

--- a/test-data/user/types.ts
+++ b/test-data/user/types.ts
@@ -30,7 +30,7 @@ type TBaseUser = {
     iat: number;
     email?: string | null | undefined;
     name?: string | null | undefined;
-    additionalClaims?: string;
+    additionalClaims?: string | null;
   };
 };
 


### PR DESCRIPTION
Fixes https://jira.commercetools.com/browse/SHIELD-616

 