### PR TITLE
Add flag to override failOnConsole

### DIFF
--- a/packages/jest-preset-mc-app/setup-test-framework.js
+++ b/packages/jest-preset-mc-app/setup-test-framework.js
@@ -65,10 +65,11 @@ function shouldNotThrowWarnings(...messages) {
 }
 
 failOnConsole({
-  shouldFailOnLog: true,
-  shouldFailOnInfo: true,
-  shouldFailOnWarn: true,
-  shouldFailOnError: true,
+  // By default all of them are 'true'
+  shouldFailOnLog: !process.env.allowLog,
+  shouldFailOnInfo: !process.env.allowInfo,
+  shouldFailOnWarn: !process.env.allowWarn,
+  shouldFailOnError: !process.env.allowError,
   silenceMessage: (message) => {
     if (!process.env.CI) {
       return false;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR provides an override mechanism for `failOnConsole` which makes the test to fail when a console is present during the execution. It was difficult to debug without logging and by adding this flag to the test cmd can make it easier for developers to test or debug locally.

| Before | After |
|---|---|
| <img width="617" alt="Screenshot 2022-10-18 at 07 36 11" src="https://user-images.githubusercontent.com/83634106/196344391-23305fe6-72e1-42c2-a1b3-fb1c7c863340.png">  | <img width="630" alt="Screenshot 2022-10-18 at 07 37 07" src="https://user-images.githubusercontent.com/83634106/196344399-1c81d0a0-4639-41db-8e9e-309e13c6d005.png">  |
