### PR TITLE
fix: patch writing-style vale config to disable custom `BlockIgnores` regex

### DIFF
--- a/.yarn/patches/@commercetools-docs-writing-style-npm-3.3.1-7d206a1314.patch
+++ b/.yarn/patches/@commercetools-docs-writing-style-npm-3.3.1-7d206a1314.patch
@@ -1,0 +1,13 @@
+diff --git a/.vale.ini b/.vale.ini
+index ca41229fb40f50879dab25dc0da8893abdd72f31..3a06aaa5e4225f8b36b7b6b251c2aa8d499c3e05 100644
+--- a/.vale.ini
++++ b/.vale.ini
+@@ -12,7 +12,7 @@ mdx = md
+ 
+ [*.{md,mdx}]
+ BasedOnStyles = Vale, write-good, Google, commercetools
+-BlockIgnores = (?s)(<[A-Z].*?\/>)
++; BlockIgnores = (?s)(<[A-Z].*?\/>)
+ 
+ # Style.Rule = {YES, NO, suggestion, warning, error} to
+ # enable/disable a rule or change its level.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@babel/core": "^7.19.0",
     "@changesets/changelog-github": "0.4.7",
     "@changesets/cli": "2.25.0",
-    "@commercetools-docs/writing-style": "3.1.1",
+    "@commercetools-docs/writing-style": "3.3.1",
     "@commercetools-test-data/core": "4.1.1",
     "@commercetools-uikit/design-system": "^15.3.0",
     "@commercetools/github-labels": "1.1.0",
@@ -171,7 +171,8 @@
     "@typescript-eslint/parser": "^5.10.0",
     "core-js-compat": "^3.23.4",
     "intl-messageformat-parser": "6.4.4",
-    "babel-plugin-typescript-to-proptypes@1.4.2": "patch:babel-plugin-typescript-to-proptypes@npm:1.4.2#.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch"
+    "babel-plugin-typescript-to-proptypes@1.4.2": "patch:babel-plugin-typescript-to-proptypes@npm:1.4.2#.yarn/patches/babel-plugin-typescript-to-proptypes-npm-1.4.2-81920f5edd.patch",
+    "@commercetools-docs/writing-style@3.3.1": "patch:@commercetools-docs/writing-style@npm%3A3.3.1#./.yarn/patches/@commercetools-docs-writing-style-npm-3.3.1-7d206a1314.patch"
   },
   "engines": {
     "node": ">=14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"7zip-bin@npm:5.1.1":
-  version: 5.1.1
-  resolution: "7zip-bin@npm:5.1.1"
-  checksum: 1e58ba3742ac86daa84d2e60c46fd545f235c9f60a00cd36a87a70bf824cc0c821fdc418994f1745081b17e7bc83d155e1e82bd44b06996e7cab0a491ce644c1
+"7zip-bin@npm:5.2.0":
+  version: 5.2.0
+  resolution: "7zip-bin@npm:5.2.0"
+  checksum: 85d3102275342f1f4ba7d17e778e526dee3dbec0f57d29be7afaa6e3c26687d40a6eccf520e9140143f85a51f3353f6b545f760eff3f776c6ffb30dc5252fb7c
   languageName: node
   linkType: hard
 
@@ -3622,17 +3622,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commercetools-docs/writing-style@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@commercetools-docs/writing-style@npm:3.1.1"
+"@commercetools-docs/writing-style@npm:3.3.1":
+  version: 3.3.1
+  resolution: "@commercetools-docs/writing-style@npm:3.3.1"
   dependencies:
-    7zip-bin: 5.1.1
+    7zip-bin: 5.2.0
     node-fetch: 2.6.7
     shelljs: 0.8.5
   bin:
     commercetools-vale: bin/commercetools-vale.js
     commercetools-vale-bin: bin/commercetools-vale-bin.js
-  checksum: e4d52f3f0fd64ba7cfd13ca96866d8d67132f0e05a7da769726872abe8655002f686002034d141177bd7ff2f8ee6890248d5176899c7f4117e980cc2f30bdcd1
+  checksum: bc762fc8dc476138e8dc5e9bb480c324aa7b6dccddf05be0cee4dde6abbf5d60d79745a9b954d7d0cb37eea6344b79ae4ac99efc226d4202c7a82510d758d63d
+  languageName: node
+  linkType: hard
+
+"@commercetools-docs/writing-style@patch:@commercetools-docs/writing-style@npm%3A3.3.1#./.yarn/patches/@commercetools-docs-writing-style-npm-3.3.1-7d206a1314.patch::locator=merchant-center-application-kit%40workspace%3A.":
+  version: 3.3.1
+  resolution: "@commercetools-docs/writing-style@patch:@commercetools-docs/writing-style@npm%3A3.3.1#./.yarn/patches/@commercetools-docs-writing-style-npm-3.3.1-7d206a1314.patch::version=3.3.1&hash=ddfb4e&locator=merchant-center-application-kit%40workspace%3A."
+  dependencies:
+    7zip-bin: 5.2.0
+    node-fetch: 2.6.7
+    shelljs: 0.8.5
+  bin:
+    commercetools-vale: bin/commercetools-vale.js
+    commercetools-vale-bin: bin/commercetools-vale-bin.js
+  checksum: de64819f8b7dce9d19079422b82067dc9c052fc8dda6ba749f5bf319c6689127e5d728371ea9dedf272fa17ca17a6208e675eaab9661fc078249963dbc2a3b0a
   languageName: node
   linkType: hard
 
@@ -27024,7 +27038,7 @@ __metadata:
     "@babel/core": ^7.19.0
     "@changesets/changelog-github": 0.4.7
     "@changesets/cli": 2.25.0
-    "@commercetools-docs/writing-style": 3.1.1
+    "@commercetools-docs/writing-style": 3.3.1
     "@commercetools-test-data/core": 4.1.1
     "@commercetools-uikit/design-system": ^15.3.0
     "@commercetools/github-labels": 1.1.0


### PR DESCRIPTION
To unblock the updates to the `@commercetools-docs/writing-style` package, we're patching the `.vale.ini` config to disable the custom `BlockIgnores` regex, which doesn't work in this repository.

See https://github.com/commercetools/commercetools-docs-kit/issues/1341 for more info about the original issues.