### PR TITLE
Fix problem when calculating CSP headers from Custom Application config file

### DIFF
--- a/.changeset/stale-apes-watch.md
+++ b/.changeset/stale-apes-watch.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Fix CSP headers processing at Custom Application build time when using a deployment URL without an ending backslash

--- a/packages/application-config/src/process-config.ts
+++ b/packages/application-config/src/process-config.ts
@@ -167,7 +167,7 @@ const processConfig = ({
         // otherwise it might create an invalid value when application/CDN URL points to a
         // non-root directory (ex: https://www.my-domain.com/app). This is a valid URL but from
         // the CSP point of view, it will say only the file `app` can be used as a source, so
-        // any other file from that domain will be forbidden. Using the slash (ex: https://www.my-domain.com/app)
+        // any other file from that domain will be forbidden. Using the slash (ex: https://www.my-domain.com/app/)
         // at the end it's like using a wildcard so anything 'below' `app` will be allowed.
         'connect-src': getUniqueValues(
           appConfig.headers?.csp?.['connect-src'],

--- a/packages/application-config/src/process-config.ts
+++ b/packages/application-config/src/process-config.ts
@@ -29,6 +29,8 @@ type ProcessConfigOptions = Partial<LoadingConfigOptions> & {
 const developmentPort = 3001;
 const developmentAppUrl = `http://localhost:${developmentPort}`;
 
+const trimTrailingSlash = (value: string) => value.replace(/\/$/, '');
+
 const omitDevConfigIfEmpty = (
   devConfig: ApplicationRuntimeConfig['env']['__DEVELOPMENT__']
 ) => {
@@ -161,17 +163,35 @@ const processConfig = ({
       ...appConfig.headers,
       csp: {
         ...appConfig.headers?.csp,
+        // We need to make sure the URL we use in these CSP headers have a slash in the end,
+        // otherwise it might create an invalid value when application/CDN URL points to a
+        // non-root directory (ex: https://www.my-domain.com/app). This is a valid URL but from
+        // the CSP point of view, it will say only the file `app` can be used as a source, so
+        // any other file from that domain will be forbidden. Using the slash (ex: https://www.my-domain.com/app)
+        // at the end it's like using a wildcard so anything 'below' `app` will be allowed.
         'connect-src': getUniqueValues(
           appConfig.headers?.csp?.['connect-src'],
-          [mcApiUrl.origin].concat(isProd ? [appUrl.href] : [])
+          [mcApiUrl.origin].concat(
+            isProd ? [`${trimTrailingSlash(appUrl.href)}/`] : []
+          )
         ),
         'script-src': getUniqueValues(
           appConfig.headers?.csp?.['script-src'],
-          isProd ? [appUrl.href, cdnUrl.href] : []
+          isProd
+            ? [
+                `${trimTrailingSlash(appUrl.href)}/`,
+                `${trimTrailingSlash(cdnUrl.href)}/`,
+              ]
+            : []
         ),
         'style-src': getUniqueValues(
           appConfig.headers?.csp?.['style-src'],
-          isProd ? [appUrl.href, cdnUrl.href] : []
+          isProd
+            ? [
+                `${trimTrailingSlash(appUrl.href)}/`,
+                `${trimTrailingSlash(cdnUrl.href)}/`,
+              ]
+            : []
         ),
       },
     },

--- a/packages/application-config/test/process-config.spec.js
+++ b/packages/application-config/test/process-config.spec.js
@@ -1250,6 +1250,35 @@ describe('when app URL is malformed', () => {
     );
   });
 });
+describe('when app URL has non-root path without ending backslash', () => {
+  const appUrl = 'https://avengers.app/admin';
+  beforeEach(() => {
+    loadConfig.mockReturnValue({
+      ...fixtureConfigSimple,
+      env: {
+        ...fixtureConfigSimple.env,
+        production: {
+          ...fixtureConfigSimple.env.production,
+          url: appUrl,
+        },
+      },
+    });
+  });
+  it('CSP headers should include app URL with a backslash', () => {
+    const result = processConfig(
+      createTestOptions({
+        processEnv: {
+          NODE_ENV: 'production',
+        },
+      })
+    );
+
+    Object.values(result.headers.csp).forEach((cspDirectiveValues) =>
+      expect(cspDirectiveValues).toEqual(expect.arrayContaining([`${appUrl}/`]))
+    );
+  });
+});
+
 describe('when CDN URL is malformed', () => {
   beforeEach(() => {
     loadConfig.mockReturnValue({
@@ -1277,6 +1306,44 @@ describe('when CDN URL is malformed', () => {
     );
   });
 });
+describe('when CDN URL has non-root path without ending backslash', () => {
+  const appUrl = 'https://avengers.app/admin';
+  const cdnUrl = 'https://justice-league.app/inventory';
+  beforeEach(() => {
+    loadConfig.mockReturnValue({
+      ...fixtureConfigSimple,
+      env: {
+        ...fixtureConfigSimple.env,
+        production: {
+          ...fixtureConfigSimple.env.production,
+          url: appUrl,
+          cdnUrl: cdnUrl,
+        },
+      },
+    });
+  });
+  it('CSP headers should include CDN URL with a backslash', () => {
+    const result = processConfig(
+      createTestOptions({
+        processEnv: {
+          NODE_ENV: 'production',
+        },
+      })
+    );
+
+    const cspDirectiveValues = result.headers.csp;
+    expect(cspDirectiveValues['connect-src']).toEqual(
+      expect.arrayContaining([`${appUrl}/`])
+    );
+    expect(cspDirectiveValues['script-src']).toEqual(
+      expect.arrayContaining([`${cdnUrl}/`])
+    );
+    expect(cspDirectiveValues['style-src']).toEqual(
+      expect.arrayContaining([`${cdnUrl}/`])
+    );
+  });
+});
+
 describe('when MC API URL is malformed', () => {
   beforeEach(() => {
     loadConfig.mockReturnValue({


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19i0jHdJEBrgUEtirTtEAU7l3QjlVc0yE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=U74fN8l)


#### Summary

When users use an application URL without an ending backslash we add an invalid URL to CSP meta element in compiled HTML when building a Custom Application.

Related to #2851 (end of the thread)

#### Description

When compiling the main `index.html` file for a Custom Application we add a `meta` element with some CSP directives so we can control from which sources scripts/styles can be loaded.
In those directives we need to include the Custom Application hosting provider public URL since the application is going to be loaded from a commercetools domain.

We use [cdnUrl](https://docs.commercetools.com/custom-applications/api-reference/application-config#envproductioncdnurl) or [url](https://docs.commercetools.com/custom-applications/api-reference/application-config#envproductionurl) properties from the config file of the Custom Application.
Currently we just copy the value to the CSP directive, but that can be a problem when the URL does not contain an ending backslash.

Let's say the value we have in the config file is this:
(_for the purpose of this example, we don't host the application in the root directory of the domain_)
```
https://www.my-domain.com/admin
```
This is telling the browser only the file named `admin` from the domain `www.my-domain.com` is allowed to be loaded.

What we need is for that URL to have an ending backslash:
```
https://www.my-domain.com/admin/
```
Using this value we are telling the browser it can fetch anything `below` the directory `admin` from the domain `www.my-domain.com`.


In this PR we update the way we process the config file and calculate those CSP directives to make sure that, when using the `cdnUrl` or `url` properties, they have an ending backslash.