### PR TITLE
refactor(config): expose `sanitizeSvg` function, fix diffing logic

### DIFF
--- a/.changeset/smart-ants-wash.md
+++ b/.changeset/smart-ants-wash.md
@@ -3,4 +3,4 @@
 '@commercetools-frontend/mc-scripts': patch
 ---
 
-Sanitize SVG icon only when comparing diffs, as the icon is sanitized in the API. Expose the `sanitizeSvg` logic from the `@commercetools-frontend/application-config/ssr` entry point.
+Sanitize SVG icon only when comparing diffs, as the icon is sanitized in the API. Expose the `sanitizeSvg` logic from the `@commercetools-frontend/application-config`.

--- a/.changeset/smart-ants-wash.md
+++ b/.changeset/smart-ants-wash.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-config': patch
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Sanitize SVG icon only when comparing diffs, as the icon is sanitized in the API. Expose the `sanitizeSvg` logic from the `@commercetools-frontend/application-config/ssr` entry point.

--- a/packages/application-config/src/index.ts
+++ b/packages/application-config/src/index.ts
@@ -1,5 +1,6 @@
 export { default as processConfig } from './process-config';
 export { getConfigPath } from './load-config';
+export { default as sanitizeSvg } from './sanitize-svg';
 export * from './constants';
 export * from './errors';
 export * from './types';

--- a/packages/application-config/src/sanitize-svg.ts
+++ b/packages/application-config/src/sanitize-svg.ts
@@ -8,9 +8,10 @@ const DOMPurify = createDOMPurify(jsdom.window);
 export default function sanitizeSvg(data: string) {
   return DOMPurify.sanitize(data, {
     USE_PROFILES: { svg: true },
+    RETURN_DOM: true,
     FORBID_ATTR: [
       // To avoid injection by using `style="filter:url(\"data:image/svg+xml,<svg`
       'style',
     ],
-  });
+  }).innerHTML;
 }

--- a/packages/application-config/src/ssr.ts
+++ b/packages/application-config/src/ssr.ts
@@ -1,2 +1,1 @@
 export * from './formatters';
-export { default as sanitizeSvg } from './sanitize-svg';

--- a/packages/application-config/src/ssr.ts
+++ b/packages/application-config/src/ssr.ts
@@ -1,1 +1,2 @@
 export * from './formatters';
+export { default as sanitizeSvg } from './sanitize-svg';

--- a/packages/application-config/src/transformers.ts
+++ b/packages/application-config/src/transformers.ts
@@ -2,7 +2,6 @@ import type { JSONSchemaForCustomApplicationConfigurationFiles } from './schema'
 import type { CustomApplicationData } from './types';
 import { entryPointUriPathToResourceAccesses } from './formatters';
 import { validateEntryPointUriPath, validateSubmenuLinks } from './validations';
-import sanitizeSvg from './sanitize-svg';
 
 // The `uriPath` of each submenu link is supposed to be defined relative
 // to the `entryPointUriPath`. Computing the full path is done internally to keep
@@ -45,7 +44,7 @@ function transformCustomApplicationConfigToData(
         oAuthScopes: appConfig.oAuthScopes.manage,
       },
     ],
-    icon: sanitizeSvg(appConfig.icon),
+    icon: appConfig.icon,
     mainMenuLink: appConfig.mainMenuLink,
     submenuLinks: appConfig.submenuLinks.map((submenuLink) => ({
       ...submenuLink,

--- a/packages/application-config/test/process-config.spec.js
+++ b/packages/application-config/test/process-config.spec.js
@@ -46,7 +46,7 @@ describe('processing a simple config', () => {
             oAuthScopes: [],
           },
         ],
-        icon: '<svg><path fill="#000000"></path></svg>',
+        icon: '<svg><path fill="#000000" /></svg>',
         mainMenuLink: {
           defaultLabel: 'Avengers',
           labelAllLocales: [],
@@ -69,7 +69,7 @@ describe('processing a simple config', () => {
           accountLinks: undefined,
           menuLinks: {
             defaultLabel: 'Avengers',
-            icon: '<svg><path fill="#000000"></path></svg>',
+            icon: '<svg><path fill="#000000" /></svg>',
             labelAllLocales: [],
             permissions: [],
             submenuLinks: [],
@@ -119,7 +119,7 @@ describe('processing a simple config', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -179,7 +179,7 @@ describe('processing a simple config', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -202,7 +202,7 @@ describe('processing a simple config', () => {
             accountLinks: undefined,
             menuLinks: {
               defaultLabel: 'Avengers',
-              icon: '<svg><path fill="#000000"></path></svg>',
+              icon: '<svg><path fill="#000000" /></svg>',
               labelAllLocales: [],
               permissions: [],
               submenuLinks: [],
@@ -256,7 +256,7 @@ describe('processing a simple config', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -314,7 +314,7 @@ describe('processing a full config', () => {
             oAuthScopes: [],
           },
         ],
-        icon: '<svg><path fill="#000000"></path></svg>',
+        icon: '<svg><path fill="#000000" /></svg>',
         mainMenuLink: {
           defaultLabel: 'Avengers',
           labelAllLocales: [],
@@ -338,7 +338,7 @@ describe('processing a full config', () => {
           accountLinks: undefined,
           menuLinks: {
             defaultLabel: 'Avengers',
-            icon: '<svg><path fill="#000000"></path></svg>',
+            icon: '<svg><path fill="#000000" /></svg>',
             labelAllLocales: [],
             permissions: [],
             submenuLinks: [],
@@ -398,7 +398,7 @@ describe('processing a full config', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -471,7 +471,7 @@ describe('processing a full config', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -495,7 +495,7 @@ describe('processing a full config', () => {
             accountLinks: undefined,
             menuLinks: {
               defaultLabel: 'Avengers',
-              icon: '<svg><path fill="#000000"></path></svg>',
+              icon: '<svg><path fill="#000000" /></svg>',
               labelAllLocales: [],
               permissions: [],
               submenuLinks: [],
@@ -557,7 +557,7 @@ describe('processing a full config', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -638,7 +638,7 @@ describe('processing a config with environment variable placeholders', () => {
             oAuthScopes: [],
           },
         ],
-        icon: '<svg><path fill="#000000"></path></svg>',
+        icon: '<svg><path fill="#000000" /></svg>',
         mainMenuLink: {
           defaultLabel: 'Avengers',
           labelAllLocales: [],
@@ -661,7 +661,7 @@ describe('processing a config with environment variable placeholders', () => {
           accountLinks: undefined,
           menuLinks: {
             defaultLabel: 'Avengers',
-            icon: '<svg><path fill="#000000"></path></svg>',
+            icon: '<svg><path fill="#000000" /></svg>',
             labelAllLocales: [],
             permissions: [],
             submenuLinks: [],
@@ -715,7 +715,7 @@ describe('processing a config with environment variable placeholders', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -779,7 +779,7 @@ describe('processing a config with environment variable placeholders', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -802,7 +802,7 @@ describe('processing a config with environment variable placeholders', () => {
             accountLinks: undefined,
             menuLinks: {
               defaultLabel: 'Avengers',
-              icon: '<svg><path fill="#000000"></path></svg>',
+              icon: '<svg><path fill="#000000" /></svg>',
               labelAllLocales: [],
               permissions: [],
               submenuLinks: [],
@@ -860,7 +860,7 @@ describe('processing a config with environment variable placeholders', () => {
               oAuthScopes: [],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],
@@ -918,7 +918,7 @@ describe('processing a config with intl variable placeholders', () => {
             oAuthScopes: [],
           },
         ],
-        icon: '<svg><path fill="#000000"></path></svg>',
+        icon: '<svg><path fill="#000000" /></svg>',
         mainMenuLink: {
           defaultLabel: 'Avengers',
           labelAllLocales: [
@@ -1112,7 +1112,7 @@ describe('processing a config with OIDC', () => {
             oAuthScopes: ['manage_orders'],
           },
         ],
-        icon: '<svg><path fill="#000000"></path></svg>',
+        icon: '<svg><path fill="#000000" /></svg>',
         mainMenuLink: {
           defaultLabel: 'Avengers',
           labelAllLocales: [],
@@ -1133,7 +1133,7 @@ describe('processing a config with OIDC', () => {
           },
           accountLinks: undefined,
           menuLinks: {
-            icon: '<svg><path fill="#000000"></path></svg>',
+            icon: '<svg><path fill="#000000" /></svg>',
             defaultLabel: 'Avengers',
             labelAllLocales: [],
             permissions: [],
@@ -1188,7 +1188,7 @@ describe('processing a config with OIDC', () => {
               oAuthScopes: ['manage_orders'],
             },
           ],
-          icon: '<svg><path fill="#000000"></path></svg>',
+          icon: '<svg><path fill="#000000" /></svg>',
           mainMenuLink: {
             defaultLabel: 'Avengers',
             labelAllLocales: [],

--- a/packages/mc-scripts/src/utils/get-config-diff.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { CustomApplicationData } from '@commercetools-frontend/application-config';
+import { sanitizeSvg } from '@commercetools-frontend/application-config/ssr';
 
 // Since not all terminal supports colors, to make things more consistent for testing purposes,
 // during tests the color used is appended before the string instead of coloring it.
@@ -392,8 +393,11 @@ const getConfigDiff = (
 
   // Icon
   const iconDiff = getStringDiff({
+    // This icon stored in the database has already been sanitized.
     previousValue: oldConfig.icon,
-    nextValue: newConfig.icon,
+    // Sanitize the raw icon as-if it was stored in the database,
+    // to ensure the data can be safely compared.
+    nextValue: sanitizeSvg(newConfig.icon),
     label: 'icon',
   });
   if (iconDiff) {

--- a/packages/mc-scripts/src/utils/get-config-diff.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
-import type { CustomApplicationData } from '@commercetools-frontend/application-config';
-import { sanitizeSvg } from '@commercetools-frontend/application-config/ssr';
+import {
+  sanitizeSvg,
+  type CustomApplicationData,
+} from '@commercetools-frontend/application-config';
 
 // Since not all terminal supports colors, to make things more consistent for testing purposes,
 // during tests the color used is appended before the string instead of coloring it.


### PR DESCRIPTION
I noticed when using the CLI `config:sync` command that the SVG icon was always marked as changed.

The problem is in the fact that the API sanitizes the SVG before saving the data but we were also pre-sanitizing it when the config was parsed. This lead to updates to have run the sanitize 2 times.

Now we don't sanitize when parsing the icon but only during the diffing, so ensure the diffed data is the same.