### PR TITLE
Disable dev-only redux immutability check

### DIFF
--- a/.changeset/lemon-roses-camp.md
+++ b/.changeset/lemon-roses-camp.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Disable development-only Redux Toolkit default [immutability middleware](https://redux-toolkit.js.org/api/immutabilityMiddleware) check

--- a/packages/application-shell/src/configure-store.ts
+++ b/packages/application-shell/src/configure-store.ts
@@ -123,6 +123,12 @@ export const createReduxStore = (
       ...getDefaultMiddleware({
         // https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data
         serializableCheck: false,
+        // This default check is logging warnings to console for some MC FE tests, probably
+        // due to lower resources when running tests on CI.
+        // We don't consider this check to be very valuable in this context so we decided
+        // to turn it off.
+        // https://redux-toolkit.js.org/api/immutabilityMiddleware
+        immutableCheck: false,
       }),
       loggerMiddleware,
     ],


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1Dqiph3gpq9veiNK6hiyuZld9OSLU4h88%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Lszhi3H)

#### Summary

Disable dev-only redux immutability check

#### Description

We've seen some tests randomly failing in the frontend due to [this default check](https://redux-toolkit.js.org/api/immutabilityMiddleware) `redux-toolkit` middleware is adding to our store.
The check tries to make sure you don't mutate your store state directly by traversing all the state tree and it logs a warning to the console if it takes more that 32ms by default.
The message it logs is not very helpful to really understand what is causing the process to take so long.

In the context where we use the redux store (the `application-shell` package in this case) we don't see this check very valuable as we control state updates and we know for sure we're no mutating it so we decided to turn off the check.
