### PR TITLE
PCM-2794: fix quick access to product list

### DIFF
--- a/.changeset/proud-ants-flow.md
+++ b/.changeset/proud-ants-flow.md
@@ -1,5 +1,5 @@
 ---
-"@commercetools-frontend/application-shell": patch
+'@commercetools-frontend/application-shell': patch
 ---
 
-PCM-2794: fix quick access to product list
+Fix QuickAccess component to make it use the right products list URL.

--- a/.changeset/proud-ants-flow.md
+++ b/.changeset/proud-ants-flow.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+PCM-2794: fix quick access to product list

--- a/packages/application-shell/src/components/quick-access/create-commands.ts
+++ b/packages/application-shell/src/components/quick-access/create-commands.ts
@@ -57,7 +57,7 @@ const createCommands = ({
         keywords: ['Go to Products'],
         action: {
           type: actionTypes.go,
-          to: `/${applicationContext.project.key}/products/pim-search`,
+          to: `/${applicationContext.project.key}/products`,
         },
         subCommands: [
           hasSomePermissions(
@@ -68,7 +68,7 @@ const createCommands = ({
             text: intl.formatMessage(messages.openProductList),
             action: {
               type: actionTypes.go,
-              to: `/${applicationContext.project.key}/products/pim-search`,
+              to: `/${applicationContext.project.key}/products`,
             },
           },
           hasSomePermissions(
@@ -91,7 +91,7 @@ const createCommands = ({
               text: intl.formatMessage(messages.openPimSearch),
               action: {
                 type: actionTypes.go,
-                to: `/${applicationContext.project.key}/products/pim-search`,
+                to: `/${applicationContext.project.key}/products`,
               },
             },
           hasSomePermissions(

--- a/packages/application-shell/src/components/quick-access/quick-access.spec.js
+++ b/packages/application-shell/src/components/quick-access/quick-access.spec.js
@@ -707,9 +707,7 @@ describe('QuickAccess', () => {
     await screen.findByText('Open Products');
     fireEvent.keyUp(searchInput, { key: 'Enter' });
     await waitFor(() => {
-      expect(history.location.pathname).toBe(
-        '/test-with-big-data/products/pim-search'
-      );
+      expect(history.location.pathname).toBe('/test-with-big-data/products');
     });
     // should close quick access
     expect(screen.queryByTestId('quick-access')).not.toBeInTheDocument();


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR aims to fix the product list quick access. Currently the url to which it directs to is `/products/pim-search` which displays the text `We could not find what you are looking for`. In other to solve this, we need to use the real link which is `/products`. 
