### PR TITLE
`GO LIVE` [Frontend docs migration] Change frontend links in top nav to the new frontend websites :rocket:

### DIFF
--- a/website/linkinator.config.json
+++ b/website/linkinator.config.json
@@ -18,7 +18,11 @@
     "/.+/merchant-center",
     "/.+/sdk",
     "/.+/tutorials",
-    "/.+/getting-started/initial-setup"
+    "/.+/getting-started/initial-setup",
+    "/.+/frontend-api",
+    "/.+/frontend-studio",
+    "/.+/frontend-development",
+    "/.+/frontend-getting-started/overview"
   ],
   "verbosity": "error",
   "retry": true,

--- a/website/src/data/top-menu.yaml
+++ b/website/src/data/top-menu.yaml
@@ -19,10 +19,10 @@
 - menu-title: Frontend
   items:
     - label: Getting Started
-      href: https://docs.frontastic.cloud/docs/whats-frontastic
+      href: https://docs.commercetools.com/frontend-getting-started/overview
     - label: Studio
-      href: https://docs.frontastic.cloud/docs/whats-the-frontastic-studio
+      href: https://docs.commercetools.com/frontend-studio/
     - label: Developing
-      href: https://docs.frontastic.cloud/docs/developing-your-site-with-frontastic
+      href: https://docs.commercetools.com/frontend-development/
     - label: HTTP API
-      href: https://docs.frontastic.cloud/reference
+      href: https://docs.commercetools.com/frontend-api/

--- a/website/src/data/top-menu.yaml
+++ b/website/src/data/top-menu.yaml
@@ -1,28 +1,28 @@
 - menu-title: Composable Commerce
   items:
     - label: Getting Started
-      href: https://docs.commercetools.com/getting-started/
+      href: /../getting-started/
     - label: Merchant Center
-      href: https://docs.commercetools.com/merchant-center
+      href: /../merchant-center
     - label: Tutorials
-      href: https://docs.commercetools.com/tutorials
+      href: /../tutorials
     - label: HTTP API
-      href: https://docs.commercetools.com/api
+      href: /../api
     - label: GraphQL API
-      href: https://docs.commercetools.com/api/graphql
+      href: /../api/graphql
     - label: Import & Export
-      href: https://docs.commercetools.com/import-export
+      href: /../import-export
     - label: SDKs & Client Libraries
-      href: https://docs.commercetools.com/sdk
+      href: /../sdk
     - label: Custom Applications
-      href: https://docs.commercetools.com/custom-applications
+      href: /../custom-applications
 - menu-title: Frontend
   items:
     - label: Getting Started
-      href: https://docs.commercetools.com/frontend-getting-started/overview
+      href: /../frontend-getting-started/overview
     - label: Studio
-      href: https://docs.commercetools.com/frontend-studio/
+      href: /../frontend-studio/
     - label: Developing
-      href: https://docs.commercetools.com/frontend-development/
+      href: /../frontend-development/
     - label: HTTP API
-      href: https://docs.commercetools.com/frontend-api/
+      href: /../frontend-api/

--- a/website/src/data/top-side-menu.yaml
+++ b/website/src/data/top-side-menu.yaml
@@ -6,9 +6,9 @@
   href: https://techblog.commercetools.com
 - label: Integrations
   href: https://marketplace.commercetools.com
-- label: Support
+- label: Composable Commerce Support
   href: https://support.commercetools.com
-- label: Status
+- label: Composable Commerce Status
   href: https://status.commercetools.com
 - label: Frontend Support
   href: https://frontastic.freshdesk.com/

--- a/website/src/data/top-side-menu.yaml
+++ b/website/src/data/top-side-menu.yaml
@@ -1,7 +1,7 @@
 - label: Sign up
-  href: https://docs.commercetools.com/getting-started/initial-setup
+  href: /../getting-started/initial-setup
 - label: Log in
-  href: https://docs.commercetools.com/docs/login
+  href: /../docs/login
 - label: Tech Blog
   href: https://techblog.commercetools.com
 - label: Integrations


### PR DESCRIPTION
**This pull request**
changes the top nav frontend links to point to the new frontend websites. 
This will be merged along with the **go live** PR in the docs repo.
https://github.com/commercetools/commercetools-docs/pull/2472