### PR TITLE
refactor(app-shell): render theme based on feature flag

### DIFF
--- a/.changeset/lucky-squids-kick.md
+++ b/.changeset/lucky-squids-kick.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+Render theme using a feature flag. The change is only used internally for now, as we are rolling out some design updates.

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -29,7 +29,6 @@ import {
 import { PortalsContainer } from '@commercetools-frontend/application-components';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
-import { ThemeProvider } from '@commercetools-uikit/design-system';
 import version from '../../version';
 import internalReduxStore from '../../configure-store';
 import { selectProjectKeyFromUrl, getPreviousProjectKey } from '../../utils';
@@ -44,6 +43,7 @@ import ConfigureIntlProvider from '../configure-intl-provider';
 import AppBar from '../app-bar';
 import ProjectContainer from '../project-container';
 import SetupFlopFlipProvider from '../setup-flop-flip-provider';
+import ThemeSwitcher from '../theme-switcher';
 import RequestsInFlightLoader from '../requests-in-flight-loader';
 import GtmUserTracker from '../gtm-user-tracker';
 import GtmApplicationTracker from '../gtm-application-tracker';
@@ -243,6 +243,7 @@ export const RestrictedApplication = <
                     defaultFlags={props.defaultFeatureFlags}
                   >
                     <>
+                      <ThemeSwitcher />
                       <VersionTracker />
                       {/* NOTE: the requests in flight loader will render a loading
                       spinner into the AppBar. */}
@@ -536,7 +537,6 @@ const ApplicationShell = <AdditionalEnvironmentProperties extends {}>(
 
   return (
     <>
-      <ThemeProvider theme="default" />
       <GlobalStyles />
       <ApplicationShellProvider<AdditionalEnvironmentProperties>
         apolloClient={props.apolloClient}

--- a/packages/application-shell/src/components/theme-switcher/index.ts
+++ b/packages/application-shell/src/components/theme-switcher/index.ts
@@ -1,0 +1,1 @@
+export { default } from './theme-switcher';

--- a/packages/application-shell/src/components/theme-switcher/theme-switcher.tsx
+++ b/packages/application-shell/src/components/theme-switcher/theme-switcher.tsx
@@ -1,0 +1,10 @@
+import { ThemeProvider } from '@commercetools-uikit/design-system';
+import { useFeatureToggle } from '@flopflip/react-broadcast';
+import { UI_REDESIGN } from '../../feature-toggles';
+
+const ThemeSwitcher = () => {
+  const isNewThemeEnabled = useFeatureToggle(UI_REDESIGN);
+  return <ThemeProvider theme={isNewThemeEnabled ? 'test' : 'default'} />;
+};
+
+export default ThemeSwitcher;

--- a/packages/application-shell/src/feature-toggles.ts
+++ b/packages/application-shell/src/feature-toggles.ts
@@ -17,4 +17,8 @@
  *   them to off until fetched).
  */
 
-export const FLAGS = {};
+export const UI_REDESIGN = 'uiRedesign';
+
+export const FLAGS = {
+  [UI_REDESIGN]: false,
+};


### PR DESCRIPTION
Prepare the theme to be switched based on a feature flag. This will be used initially for testing purposes only.