### PR TITLE
fix: to allow disabling Sentry and GTM through environment variable

### DIFF
--- a/.changeset/twenty-wombats-accept.md
+++ b/.changeset/twenty-wombats-accept.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/application-shell": patch
+"@commercetools-frontend/sentry": patch
+---
+
+Fix to allow disabling Sentry and GTM through setting environment variable to `null`.

--- a/packages/application-shell/src/utils/gtm.ts
+++ b/packages/application-shell/src/utils/gtm.ts
@@ -31,6 +31,10 @@ const getDataAttribute = (node: Node, key: string) => {
   }
   return undefined;
 };
+const isGtmEnabled = () =>
+  window.dataLayer &&
+  window.app.trackingGtm &&
+  window.app.trackingGtm !== 'null';
 
 // The way that tracking works is like so:
 //
@@ -117,7 +121,7 @@ export const trackTiming = ({
   value: string | number;
   label?: string;
 }) => {
-  if (window.dataLayer && window.app.trackingGtm) {
+  if (isGtmEnabled()) {
     logTracking({
       variable,
       value,
@@ -137,15 +141,13 @@ export const trackTiming = ({
 
 // Track custom dimensions
 export const trackApplicationName = (applicationName: string) => {
-  if (window.dataLayer && window.app.trackingGtm)
-    window.dataLayer.push({ applicationName });
+  if (isGtmEnabled()) window.dataLayer.push({ applicationName });
 };
 export const trackProjectKey = (projectKey?: string) => {
-  if (window.dataLayer && window.app.trackingGtm && projectKey)
-    window.dataLayer.push({ projectKey });
+  if (isGtmEnabled() && projectKey) window.dataLayer.push({ projectKey });
 };
 export const trackUserBusinessRole = (userBusinessRole?: string) => {
-  if (window.dataLayer && window.app.trackingGtm && userBusinessRole) {
+  if (isGtmEnabled() && userBusinessRole) {
     window.dataLayer.push({ userBusinessRole });
   }
 };
@@ -274,11 +276,9 @@ export const boot = (trackingEventList: TrackingList) => {
 };
 
 export const updateUser = (userId: string) => {
-  if (window.dataLayer && window.app.trackingGtm)
-    window.dataLayer.push({ userId });
+  if (isGtmEnabled()) window.dataLayer.push({ userId });
 };
 
 export const stopTrackingUser = () => {
-  if (window.dataLayer && window.app.trackingGtm)
-    window.dataLayer.push({ userId: undefined });
+  if (isGtmEnabled()) window.dataLayer.push({ userId: undefined });
 };

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -72,7 +72,7 @@ export const redactUnsafeEventFields = (event: Event) => {
 };
 
 export const boot = () => {
-  if (window.app.trackingSentry) {
+  if (window.app.trackingSentry && window.app.trackingSentry !== 'null') {
     Sentry.init({
       dsn: window.app.trackingSentry,
       release: window.app.revision,


### PR DESCRIPTION
#### Summary

Not all environments require Sentry and Google Tag Manager to run. This is usually the case when defining a Custom Application Config without the respective values then being parsed and placed on `window.app`. 

However, in some scenarios we intend to disable Sentry and GTM with a shared Custom Application Config.

#### Description

The values read in a Custom Application Config and defined as `env:FOO` have to be defined otherwise the script will rightfully throw an error. Whenever a value is set as e.g. `process.env.FOO` it will be parsed and replaced as `"null"`. This string is then coerced before putting it onto the application's context for usage.

The booting of Sentry and GTM however, happens outside of React. As such those values are read from `window.app` and are not covered. So `"null"` and `"false"` are possible values on `window.app`. To be able to disable Sentry and GTM via internal CLIs we would like to set their values to `null`. As a result we should handle `"null"` as a case in these few instances where we read from `window.app`.
