### PR TITLE
fix(mc-scripts): treat `*.css` imports as side effects

### DIFF
--- a/.changeset/rude-cups-scream.md
+++ b/.changeset/rude-cups-scream.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Treat `*.css` imports as side effects in Webpack loaders

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
@@ -360,6 +360,11 @@ function createWebpackConfigForDevelopment(
                   },
                 },
               ],
+              // Don't consider CSS imports dead code even if the
+              // containing package claims to have no side effects.
+              // Remove this when webpack adds a warning or an error for this.
+              // See https://github.com/webpack/webpack/issues/6571
+              sideEffects: true,
             },
           ],
         },

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
@@ -392,6 +392,11 @@ function createWebpackConfigForProduction(
                   },
                 },
               ],
+              // Don't consider CSS imports dead code even if the
+              // containing package claims to have no side effects.
+              // Remove this when webpack adds a warning or an error for this.
+              // See https://github.com/webpack/webpack/issues/6571
+              sideEffects: true,
             },
           ],
         },


### PR DESCRIPTION
Leftover of #2883 

Instructs Webpack to treat `*.css` file imports as side effects.

References:
* https://github.com/facebook/create-react-app/pull/5197
* https://github.com/webpack/webpack/issues/6571

PS: interestingly enough, Vite handles this automatically.