### PR TITLE
chore: adjust top nav link

### DIFF
--- a/website/src/data/top-menu.yaml
+++ b/website/src/data/top-menu.yaml
@@ -19,7 +19,7 @@
 - menu-title: Frontend
   items:
     - label: Getting Started
-      href: /../frontend-getting-started/overview
+      href: /../frontend-getting-started/
     - label: Studio
       href: /../frontend-studio/
     - label: Developing


### PR DESCRIPTION
Small change that was made in the docs repo already:
https://github.com/commercetools/commercetools-docs/pull/2549