### PR TITLE
Restore legacy app named icons

### DIFF
--- a/.changeset/tough-avocados-shop.md
+++ b/.changeset/tough-avocados-shop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Restore legacy application named icons.

--- a/packages/application-shell/src/components/navbar/legacy-icons/box.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/box.tsx
@@ -1,0 +1,6 @@
+import { BoxIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <BoxIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/cart.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/cart.tsx
@@ -1,0 +1,6 @@
+import { CartIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <CartIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/gear.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/gear.tsx
@@ -1,0 +1,6 @@
+import { GearIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <GearIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/list-with-search.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/list-with-search.tsx
@@ -1,0 +1,6 @@
+import { ListWithSearchIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <ListWithSearchIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/speedometer.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/speedometer.tsx
@@ -1,0 +1,6 @@
+import { SpeedometerIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <SpeedometerIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/tag-multi.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/tag-multi.tsx
@@ -1,0 +1,6 @@
+import { TagMultiIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <TagMultiIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/tree-structure.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/tree-structure.tsx
@@ -1,0 +1,6 @@
+import { TreeStructureIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <TreeStructureIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/legacy-icons/user-filled.tsx
+++ b/packages/application-shell/src/components/navbar/legacy-icons/user-filled.tsx
@@ -1,0 +1,6 @@
+import { UserFilledIcon } from '@commercetools-uikit/icons';
+
+// @ts-ignore
+const Icon = (props) => <UserFilledIcon {...props} />;
+
+export default Icon;

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -91,6 +91,16 @@ const ConnectedSquareIcon = lazy(
   () => import('./legacy-icons/connected-square')
 );
 const WorldIcon = lazy(() => import('./legacy-icons/world'));
+const TreeStructureIcon = lazy(() => import('./legacy-icons/tree-structure'));
+const UserFilledIcon = lazy(() => import('./legacy-icons/user-filled'));
+const SpeedometerIcon = lazy(() => import('./legacy-icons/speedometer'));
+const TagMultiIcon = lazy(() => import('./legacy-icons/tag-multi'));
+const CartIcon = lazy(() => import('./legacy-icons/cart'));
+const BoxIcon = lazy(() => import('./legacy-icons/box'));
+const GearIcon = lazy(() => import('./legacy-icons/gear'));
+const ListWithSearchIcon = lazy(
+  () => import('./legacy-icons/list-with-search')
+);
 
 type IconProps = Parameters<typeof BackIcon>[0];
 type IconSwitcherProps = { icon: string } & IconProps;
@@ -104,6 +114,25 @@ const IconSwitcher = ({ icon, ...iconProps }: IconSwitcherProps) => {
   }
   // Backwards compatibility for apps using the "icon name".
   switch (icon) {
+    // Legacy application icons
+    // TODO: To be removed once MC applications icons updates are published
+    case 'TreeStructureIcon':
+      return <TreeStructureIcon {...iconProps} />;
+    case 'UserFilledIcon':
+      return <UserFilledIcon {...iconProps} />;
+    case 'SpeedometerIcon':
+      return <SpeedometerIcon {...iconProps} />;
+    case 'TagMultiIcon':
+      return <TagMultiIcon {...iconProps} />;
+    case 'CartIcon':
+      return <CartIcon {...iconProps} />;
+    case 'BoxIcon':
+      return <BoxIcon {...iconProps} />;
+    case 'GearIcon':
+      return <GearIcon {...iconProps} />;
+    case 'ListWithSearchIcon':
+      return <ListWithSearchIcon {...iconProps} />;
+
     // Custom application icons set
     case 'HeartIcon':
       return <HeartIcon {...iconProps} />;


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX194YlURFaXRvB3F6cMjU5EyPK4RwVws%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Ih1JkWt)

#### Summary

Restore legacy app named icons

#### Description

This is a consequence of this PR: #2894.
Over there we removed some legacy icons used in legacy custom applications where you could configure the application icon (to be used in the navigation bar) using a code name.
The new policy is to provide the actual SVG at configuration level and we made an update to MC applications to set it up like this (github.com/commercetools/merchant-center-frontend/pull/13243/).

We catch an issue when deploying the new versions of the applications since their configuration is cached in the MC proxy for an hour so, after publishing them with the new version of `app-kit` where we didn't support legacy named icons anymore, as the MC proxy would have the previous applications configurations cached, the legacy icons names would be used but the new version of `app-kit` wouldn't know anything about theme.

To prevent such issue or making the deployment more complex (having to coordinated frontend applications deployments with MC proxy restart), we're adding those named icons back.
We can finally remove them once those deployments are done.

