### PR TITLE
refactor(sentry): decrease transactions sample rate to 5%

### DIFF
--- a/.changeset/lovely-days-kiss.md
+++ b/.changeset/lovely-days-kiss.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/sentry': patch
+---
+
+Decrease transactions sample rate to 5%

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -92,12 +92,12 @@ export const boot = () => {
           routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
         }),
       ],
-      // Sending 20% of transactions. We can adjust that as we see a need to.
+      // Sending 5% of transactions. We can adjust that as we see a need to.
       // Generally we need to find a balance between performance and data volume.
       // If we need more flexible and dynamic way of gathering important samples,
       // we can implement the `tracesSampler` function.
       // https://docs.sentry.io/platforms/javascript/guides/react/configuration/sampling/#sampling-transaction-events
-      tracesSampleRate: 0.2,
+      tracesSampleRate: 0.05,
       beforeSend(event) {
         return redactUnsafeEventFields(event);
       },


### PR DESCRIPTION
We're getting lots of transaction events which adds to our spending limit. Let's reduce the number of transactions we send.