### PR TITLE
feat(application-shell): allow passing `themesOverrides` as `props`

### DIFF
--- a/.changeset/hungry-maps-crash.md
+++ b/.changeset/hungry-maps-crash.md
@@ -1,5 +1,7 @@
 ---
-"@commercetools-frontend/application-shell": minor
+"@commercetools-frontend/application-shell": patch
 ---
 
-Add the ability to pass `themesOverrides` as `props` to `ApplicationShell`. 
+Add the ability to pass `internal_themesOverrides` as `props` to `ApplicationShell`.
+
+Please do not use the `prop` unless you work on the Merchant Center internally. It will be removed later again without notice.

--- a/.changeset/hungry-maps-crash.md
+++ b/.changeset/hungry-maps-crash.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+Add the ability to pass `themesOverrides` as `props` to `ApplicationShell`. 

--- a/.changeset/hungry-maps-crash.md
+++ b/.changeset/hungry-maps-crash.md
@@ -1,5 +1,5 @@
 ---
-"@commercetools-frontend/application-shell": patch
+"@commercetools-frontend/application-shell": minor
 ---
 
 Add the ability to pass `themesOverrides` as `props` to `ApplicationShell`. 

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -88,7 +88,7 @@ type Props<AdditionalEnvironmentProperties extends {}> = {
     track: TrackFn
   ) => void;
   disableRoutePermissionCheck?: boolean;
-  themesOverrides?: TOverridesPerTheme;
+  internal_themesOverrides?: TOverridesPerTheme;
   render?: () => JSX.Element;
   children?: ReactNode;
 };
@@ -245,7 +245,9 @@ export const RestrictedApplication = <
                     defaultFlags={props.defaultFeatureFlags}
                   >
                     <>
-                      <ThemeSwitcher themesOverrides={props.themesOverrides} />
+                      <ThemeSwitcher
+                        themesOverrides={props.internal_themesOverrides}
+                      />
                       <VersionTracker />
                       {/* NOTE: the requests in flight loader will render a loading
                       spinner into the AppBar. */}

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -5,7 +5,7 @@ import type { ApolloError } from '@apollo/client/errors';
 import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 import type { TrackingList } from '../../utils/gtm';
-import type { TOverwridesPerTheme } from '../theme-switcher';
+import type { TOverridesPerTheme } from '../theme-switcher';
 
 import {
   type ReactNode,
@@ -88,7 +88,7 @@ type Props<AdditionalEnvironmentProperties extends {}> = {
     track: TrackFn
   ) => void;
   disableRoutePermissionCheck?: boolean;
-  themesOverrides?: TOverwridesPerTheme;
+  themesOverrides?: TOverridesPerTheme;
   render?: () => JSX.Element;
   children?: ReactNode;
 };

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -5,6 +5,7 @@ import type { ApolloError } from '@apollo/client/errors';
 import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 import type { TrackingList } from '../../utils/gtm';
+import type { TOverwridesPerTheme } from '../theme-switcher';
 
 import {
   type ReactNode,
@@ -87,6 +88,7 @@ type Props<AdditionalEnvironmentProperties extends {}> = {
     track: TrackFn
   ) => void;
   disableRoutePermissionCheck?: boolean;
+  themesOverrides?: TOverwridesPerTheme;
   render?: () => JSX.Element;
   children?: ReactNode;
 };
@@ -243,7 +245,7 @@ export const RestrictedApplication = <
                     defaultFlags={props.defaultFeatureFlags}
                   >
                     <>
-                      <ThemeSwitcher />
+                      <ThemeSwitcher themesOverrides={props.themesOverrides} />
                       <VersionTracker />
                       {/* NOTE: the requests in flight loader will render a loading
                       spinner into the AppBar. */}

--- a/packages/application-shell/src/components/theme-switcher/index.ts
+++ b/packages/application-shell/src/components/theme-switcher/index.ts
@@ -1,1 +1,2 @@
 export { default } from './theme-switcher';
+export type { TOverwridesPerTheme } from './theme-switcher';

--- a/packages/application-shell/src/components/theme-switcher/index.ts
+++ b/packages/application-shell/src/components/theme-switcher/index.ts
@@ -1,2 +1,3 @@
+export type { TOverridesPerTheme } from './theme-switcher';
+
 export { default } from './theme-switcher';
-export type { TOverwridesPerTheme } from './theme-switcher';

--- a/packages/application-shell/src/components/theme-switcher/theme-switcher.tsx
+++ b/packages/application-shell/src/components/theme-switcher/theme-switcher.tsx
@@ -5,10 +5,10 @@ import { themesOverrides as appKitThemesOverrides } from '@commercetools-fronten
 import { UI_REDESIGN } from '../../feature-toggles';
 
 type TThemeOverrides = Record<string, string>;
-export type TOverwridesPerTheme = Record<string, TThemeOverrides>;
+export type TOverridesPerTheme = Record<string, TThemeOverrides>;
 
 type ThemeSwitcherProps = {
-  themesOverrides?: TOverwridesPerTheme;
+  themesOverrides?: TOverridesPerTheme;
 };
 const ThemeSwitcher = (props: ThemeSwitcherProps) => {
   const isNewThemeEnabled = useFeatureToggle(UI_REDESIGN);
@@ -16,7 +16,7 @@ const ThemeSwitcher = (props: ThemeSwitcherProps) => {
   const mergedThemeOverrides = useMemo(
     () => ({
       ...appKitThemesOverrides[theme],
-      ...props.themesOverrides[theme],
+      ...props.themesOverrides?.[theme] ?? {},
     }),
     [theme, props.themesOverrides]
   );

--- a/packages/application-shell/src/components/theme-switcher/theme-switcher.tsx
+++ b/packages/application-shell/src/components/theme-switcher/theme-switcher.tsx
@@ -1,14 +1,27 @@
+import { useMemo } from 'react';
 import { ThemeProvider } from '@commercetools-uikit/design-system';
 import { useFeatureToggle } from '@flopflip/react-broadcast';
-import { themesOverrides } from '@commercetools-frontend/application-components';
+import { themesOverrides as appKitThemesOverrides } from '@commercetools-frontend/application-components';
 import { UI_REDESIGN } from '../../feature-toggles';
 
-const ThemeSwitcher = () => {
+type TThemeOverrides = Record<string, string>;
+export type TOverwridesPerTheme = Record<string, TThemeOverrides>;
+
+type ThemeSwitcherProps = {
+  themesOverrides?: TOverwridesPerTheme;
+};
+const ThemeSwitcher = (props: ThemeSwitcherProps) => {
   const isNewThemeEnabled = useFeatureToggle(UI_REDESIGN);
   const theme = isNewThemeEnabled ? 'test' : 'default';
-  return (
-    <ThemeProvider theme={theme} themeOverrides={themesOverrides[theme]} />
+  const mergedThemeOverrides = useMemo(
+    () => ({
+      ...appKitThemesOverrides[theme],
+      ...props.themesOverrides[theme],
+    }),
+    [theme, props.themesOverrides]
   );
+
+  return <ThemeProvider theme={theme} themeOverrides={mergedThemeOverrides} />;
 };
 
 export default ThemeSwitcher;


### PR DESCRIPTION
#### Summary

This adds a `themesOverrides` `prop` to the `ApplicationShell` allowing to override and pass down theming into an application. It's used now for the redesign but could enable other custom branding too.

#### Description

Assuming the requirement of an application wanting to override a theme while adding custom theme one could specify an entry point as 

```js
const EntryPoint = () => (
  <ApplicationShell
     themesOverrides={themesOverrides}
  >
    <Application>
      <AsyncRoutes />
    </Application>
  </ApplicationShell>
);
```

Where the `themesOverrides` would be 

```js
import {
  transformTokensToCssVarsReferences,
  designTokens as uiKitDesignTokens,
} from '@commercetools-uikit/design-system';

export const themesOverrides = {
  default: {
    backgroundColorForSaveToolbar: uiKitDesignTokens.colorGrey,
  },
  test: {
    backgroundColorForSaveToolbar: uiKitDesignTokens.colorAccent,
  },
};

export const designTokens = transformTokensToCssVarsReferences(
  themesOverrides.default,
  { includeDefaultValue: false }
);
```

These properties would then be accessible inside the application and can be used as 

```css
.container {
   background-color: var(--background-color-for-save-toolbar)
}
```