### PR TITLE
fix: remove deprecated and experimental support for `Feature-Policy` header

### DIFF
--- a/.changeset/silent-planets-live.md
+++ b/.changeset/silent-planets-live.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-config': patch
+'@commercetools-frontend/mc-html-template': patch
+'@commercetools-website/custom-applications': patch
+---
+
+Remove deprecated and experimental support for `Feature-Policy` header

--- a/packages/application-config/schema.json
+++ b/packages/application-config/schema.json
@@ -173,10 +173,6 @@
           "additionalProperties": false,
           "required": ["connect-src"]
         },
-        "featurePolicies": {
-          "description": "See https://docs.commercetools.com/custom-applications/api-reference/application-config#headersfeaturepolicies",
-          "type": "object"
-        },
         "permissionsPolicies": {
           "description": "See https://docs.commercetools.com/custom-applications/api-reference/application-config#headerspermissionspolicies",
           "type": "object"

--- a/packages/application-config/src/schema.ts
+++ b/packages/application-config/src/schema.ts
@@ -103,12 +103,6 @@ export interface JSONSchemaForCustomApplicationConfigurationFiles {
       'frame-src'?: CspDirective;
     };
     /**
-     * See https://docs.commercetools.com/custom-applications/api-reference/application-config#headersfeaturepolicies
-     */
-    featurePolicies?: {
-      [k: string]: unknown;
-    };
-    /**
      * See https://docs.commercetools.com/custom-applications/api-reference/application-config#headerspermissionspolicies
      */
     permissionsPolicies?: {

--- a/packages/application-config/test/fixtures/config-full.json
+++ b/packages/application-config/test/fixtures/config-full.json
@@ -37,9 +37,6 @@
       "script-src": ["https://track.avengers.app"],
       "connect-src": ["https://track.avengers.app"]
     },
-    "featurePolicies": {
-      "microphone": "none"
-    },
     "permissionsPolicies": {
       "microphone": "()"
     },

--- a/packages/application-config/test/process-config.spec.js
+++ b/packages/application-config/test/process-config.spec.js
@@ -371,9 +371,6 @@ describe('processing a full config', () => {
           'script-src': ['https://track.avengers.app'],
           'style-src': [],
         },
-        featurePolicies: {
-          microphone: 'none',
-        },
         permissionsPolicies: {
           microphone: '()',
         },
@@ -439,9 +436,6 @@ describe('processing a full config', () => {
               'https://cdn.avengers.app/',
             ],
             'style-src': ['https://avengers.app/', 'https://cdn.avengers.app/'],
-          },
-          featurePolicies: {
-            microphone: 'none',
           },
           permissionsPolicies: {
             microphone: '()',
@@ -535,9 +529,6 @@ describe('processing a full config', () => {
             'script-src': ['https://track.avengers.app'],
             'style-src': [],
           },
-          featurePolicies: {
-            microphone: 'none',
-          },
           permissionsPolicies: {
             microphone: '()',
           },
@@ -605,9 +596,6 @@ describe('processing a full config', () => {
               'https://cdn.avengers.app/',
             ],
             'style-src': ['https://avengers.app/', 'https://cdn.avengers.app/'],
-          },
-          featurePolicies: {
-            microphone: 'none',
           },
           permissionsPolicies: {
             microphone: '()',

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -95,25 +95,6 @@ describe('csp', () => {
     );
   });
 });
-describe('featurePolicies', () => {
-  it('should set the header value', () => {
-    const testApplicationConfig = {
-      ...defaultApplicationConfig,
-      headers: {
-        featurePolicies: {
-          microphone: "'none'",
-          camera: ["'self'", "'https://example.com'"],
-        },
-      },
-    };
-
-    const processedApplicationConfig = processHeaders(testApplicationConfig);
-
-    expect(processedApplicationConfig['Feature-Policy']).toMatchInlineSnapshot(
-      `"microphone 'none'; camera 'self' 'https://example.com'"`
-    );
-  });
-});
 describe('permissionsPolicies', () => {
   it('should set the header value', () => {
     const testApplicationConfig = {

--- a/packages/mc-html-template/src/process-headers.ts
+++ b/packages/mc-html-template/src/process-headers.ts
@@ -145,13 +145,6 @@ const processHeaders = (
       ].join('; '),
     }),
 
-    // Allow to extend the `Feature-Policy` header.
-    ...(applicationConfig.headers?.featurePolicies && {
-      'Feature-Policy': toHeaderString(
-        applicationConfig.headers.featurePolicies as TCspDirective
-      ),
-    }),
-
     // Allow to extend the `Permissions-Policy` header.
     ...(applicationConfig.headers?.permissionsPolicies && {
       'Permissions-Policy': toStructuredHeaderString(

--- a/website/src/content/api-reference/application-config.mdx
+++ b/website/src/content/api-reference/application-config.mdx
@@ -462,27 +462,9 @@ The required [Content Security Policy (CSP)](https://developer.mozilla.org/en-US
 
 </Info>
 
-## `headers.featurePolicies`
-
-An optional object to configure the [HTTP `Feature-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy).
-
-```json
-{
-  "headers": {
-    "featurePolicies": {
-      "microphone": "'none'",
-      "camera": "'none'",
-      "payment": "'none'",
-      "usb": "'none'",
-      "geolocation": "'none'"
-    }
-  }
-}
-```
-
 ## `headers.permissionsPolicies`
 
-An optional object to configure the [HTTP `Permission-Policy` header](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md).
+An optional object to configure the [HTTP `Permission-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy).
 
 ```json
 {


### PR DESCRIPTION
The (experimental) `Feature-Policy` header is deprecated and only the `Permissions-Policy` header should be used instead.

<img width="837" alt="image" src="https://user-images.githubusercontent.com/1110551/182569913-f7b3fcb8-fe3f-4d2c-a3b4-e31e98c1a36d.png">


<img width="806" alt="image" src="https://user-images.githubusercontent.com/1110551/182569850-81805c04-8bfe-44ab-bebc-82369d7af1f3.png">