### PR TITLE
fix(mc-scripts): support prod sourcemaps when using Vite

### DIFF
--- a/.changeset/gold-tips-push.md
+++ b/.changeset/gold-tips-push.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Add support for production sourcemaps when using Vite

--- a/.changeset/gold-tips-push.md
+++ b/.changeset/gold-tips-push.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/mc-scripts': patch
 ---
 
-Add support for production sourcemaps when using Vite
+Add opt-in support for production sourcemaps when using Vite, by defining the environment variable `ENABLE_EXPERIMENTAL_VITE_BUNDLER_SOURCEMAP=true`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,6 +251,7 @@ jobs:
       - name: Building Playground application
         run: yarn playground:build
         env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
           APP_ID: ${{ secrets.APP_ID_PLAYGROUND }}
           MC_API_URL: ${{ secrets.MC_API_URL }}
           CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -44,7 +44,11 @@ async function run() {
         // https://github.com/vitejs/vite/issues/2433#issuecomment-1361094727
         cache: false,
       },
-      sourcemap: true,
+      sourcemap:
+        // Generating sourcemaps can increase the memory footprint of the build process,
+        // therefore it's an opt-in option.
+        // TODO: make it a CLI option when Vite support becomes stable.
+        process.env.ENABLE_EXPERIMENTAL_VITE_BUNDLER_SOURCEMAP === 'true',
     },
     server: {
       port: DEFAULT_PORT,

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -40,7 +40,11 @@ async function run() {
         // NOTE that after the build, Vite will write the `index.html` (template)
         // at the `/public/public/index.html` location. See `fs.renameSync` below.
         input: paths.appIndexHtml,
+        // Reduce the memory footpring when building sourcemaps.
+        // https://github.com/vitejs/vite/issues/2433#issuecomment-1361094727
+        cache: false,
       },
+      sourcemap: true,
     },
     server: {
       port: DEFAULT_PORT,


### PR DESCRIPTION
Until now Vite (Rollup) had some issues when running production builds with the [sourcemaps option](https://vitejs.dev/config/build-options.html#build-sourcemap) activated.

You can read a bit the thread here: https://github.com/vitejs/vite/issues/2433

However, yesterday an attempt to mitigate this issue was released in Rollup: https://github.com/vitejs/vite/issues/2433#issuecomment-1363786257

The fix is opt-in via the `cache` option of Rollup by turning it off. To quote the outcome:

> The memory still scales proportionately to the number of files, but it should consume less memory per file now.

Let's try it out then!