### PR TITLE
Update `PageContentNarrow` max width

### DIFF
--- a/.changeset/selfish-timers-teach.md
+++ b/.changeset/selfish-timers-teach.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Update `PageContentNarrow` component max width style.

--- a/packages/application-components/src/components/page-content-containers/page-content-narrow/page-content-narrow.tsx
+++ b/packages/application-components/src/components/page-content-containers/page-content-narrow/page-content-narrow.tsx
@@ -14,7 +14,7 @@ const Content = styled.section`
 const Container = styled.div`
   display: grid;
   grid-template-areas: '. content .';
-  grid-template-columns: 1fr minmax(400px, 600px) 1fr;
+  grid-template-columns: 1fr minmax(400px, 742px) 1fr;
   width: 100%;
 `;
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Update `PageContentNarrow` max width

#### Description

After first reviews in MC frontend, UX wanted to make the maximum width of the `PageContentNarrow` component a little bigger (=> **742px**).
