### PR TITLE
fix(PublicPageLayout): add padding-bottom

### DIFF
--- a/.changeset/gentle-foxes-explain.md
+++ b/.changeset/gentle-foxes-explain.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Add bottom padding for `PublicPageLayout`

--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -39,7 +39,7 @@ const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   display: flex;
-  padding-top: ${customProperties.spacingXl};
+  padding: ${customProperties.spacingXl} 0;
   justify-content: center;
   background-size: cover;
   background-image: url(data:image/png;base64,${base64Background});


### PR DESCRIPTION
#### Summary

Updates the `PublicPageLayout` Container's padding from `padding-top: ${customProperties.spacingXl};` 
to `padding: ${customProperties.spacingXl} 0;` per conversation [here](https://commercetools.slack.com/archives/CCL83RA06/p1673993172112769).

#### Description

|Before|After|
|----|----|
|![Screenshot 2023-01-18 at 9 06 57 AM](https://user-images.githubusercontent.com/49931992/213237784-b0fc9fcc-09e5-4813-a1ba-0f0a46b400f3.png)|![Screenshot 2023-01-18 at 9 06 09 AM](https://user-images.githubusercontent.com/49931992/213237918-565cb498-e657-41af-9e9a-940c865dcb0c.png)|