### PR TITLE
Update notifications ui for the redesign

### DIFF
--- a/.changeset/gorgeous-files-judge.md
+++ b/.changeset/gorgeous-files-judge.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/react-notifications': patch
+---
+
+Refactor notifications ui for the new theme

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -28,6 +28,7 @@
     "@commercetools-uikit/hooks": "^15.9.0",
     "@commercetools-uikit/icon-button": "^15.9.0",
     "@commercetools-uikit/icons": "^15.9.0",
+    "@commercetools-uikit/secondary-icon-button": "^15.9.0",
     "@commercetools-uikit/spacings": "^15.9.0",
     "@commercetools-uikit/utils": "^15.9.0",
     "@emotion/react": "11.10.4",

--- a/packages/react-notifications/src/components/notification/notification.styles.ts
+++ b/packages/react-notifications/src/components/notification/notification.styles.ts
@@ -4,7 +4,7 @@ import type {
 } from '@commercetools-frontend/constants';
 
 import { css, keyframes } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_SIDE,
@@ -14,18 +14,34 @@ type StyleProps = {
   type: TAppNotificationKind;
   domain: TAppNotificationDomain;
   fixed: boolean;
+  isNewTheme?: boolean;
 };
 
 const getColorByType = (value: TAppNotificationKind) => {
   switch (value) {
     case NOTIFICATION_KINDS_SIDE.success:
-      return customProperties.colorPrimary;
+      return designTokens.colorPrimary;
     case NOTIFICATION_KINDS_SIDE.info:
-      return customProperties.colorInfo;
+      return designTokens.colorInfo;
     case NOTIFICATION_KINDS_SIDE.error:
-      return customProperties.colorError;
+      return designTokens.colorError;
     case NOTIFICATION_KINDS_SIDE.warning:
-      return customProperties.colorWarning;
+      return designTokens.colorWarning;
+    default:
+      return 'transparent';
+  }
+};
+
+const getBorderColor = (notificationKind: TAppNotificationKind) => {
+  switch (notificationKind) {
+    case NOTIFICATION_KINDS_SIDE.success:
+      return designTokens.colorPrimary85;
+    case NOTIFICATION_KINDS_SIDE.info:
+      return designTokens.colorInfo85;
+    case NOTIFICATION_KINDS_SIDE.error:
+      return designTokens.colorError85;
+    case NOTIFICATION_KINDS_SIDE.warning:
+      return designTokens.colorWarning85;
     default:
       return 'transparent';
   }
@@ -51,7 +67,7 @@ const showNotificationSideAnimation = keyframes`
   }
 `;
 
-const getStylesForIcon = (props: StyleProps) => css`
+const getStylesForNotificationIcon = (props: StyleProps) => css`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,23 +76,30 @@ const getStylesForIcon = (props: StyleProps) => css`
   top: 0;
   width: 48px;
   height: 100%;
-  color: ${customProperties.colorSurface};
+  color: ${designTokens.colorSurface};
   border-radius: 3px 0 0 3px;
   background: ${getColorByType(props.type)};
+`;
+
+const getStylesForCloseIcon = (isNewTheme = false) => css`
+  ${isNewTheme ? '& svg { width: 12px; height: 12px; }' : ''}
 `;
 
 const getStylesForContent = (props: StyleProps) => {
   const fontColor =
     props.domain === NOTIFICATION_DOMAINS.SIDE
-      ? customProperties.colorSolid
-      : customProperties.colorSurface;
+      ? designTokens.colorSolid
+      : designTokens.colorSurface;
   return css`
     flex-basis: 100%;
     flex-grow: 1;
-    padding: 0 ${customProperties.spacingS};
+    padding: 0
+      ${props.isNewTheme ? designTokens.spacingM : designTokens.spacingS};
     margin: 0;
     font-size: ${props.domain === NOTIFICATION_DOMAINS.SIDE
-      ? '0.929rem'
+      ? props.isNewTheme
+        ? '1rem'
+        : '0.929rem'
       : 'inherit'};
 
     color: ${fontColor};
@@ -95,9 +118,9 @@ const getStylesForNotification = (props: StyleProps) => {
   const baseStyles = css`
     position: relative;
     display: flex;
-    align-items: flex-start;
-    padding: ${customProperties.spacingM};
-    color: ${customProperties.colorSurface};
+    align-items: center;
+    padding: ${designTokens.spacingM};
+    color: ${designTokens.colorSurface};
   `;
   const pageStyles = css`
     ${baseStyles};
@@ -108,7 +131,7 @@ const getStylesForNotification = (props: StyleProps) => {
       : getColorByType(props.type)};
 
     > * + * {
-      margin-left: ${customProperties.spacingS};
+      margin-left: ${designTokens.spacingS};
     }
   `;
 
@@ -124,13 +147,18 @@ const getStylesForNotification = (props: StyleProps) => {
       const sideStyles = css`
         ${baseStyles};
         animation: ${showNotificationAnimation} 0.3s forwards;
-        padding: ${customProperties.spacingM} ${customProperties.spacingM}
-          ${customProperties.spacingM} 50px !important;
+        padding: ${designTokens.spacingM} ${designTokens.spacingM}
+          ${designTokens.spacingM} 50px !important;
         text-align: left;
-        background: ${customProperties.colorSurface};
-        border: 1px solid ${getColorByType(props.type)};
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
-        border-radius: ${customProperties.borderRadius6};
+        background: ${designTokens.colorSurface};
+        border: 1px solid
+          ${props.isNewTheme
+            ? getBorderColor(props.type)
+            : getColorByType(props.type)};
+        box-shadow: ${props.isNewTheme
+          ? '0px 2px 5px 0px rgba(0, 0, 0, 0.15)'
+          : '0 1px 2px rgba(0, 0, 0, 0.24)'};
+        border-radius: ${designTokens.borderRadius6};
         word-break: break-word;
         hyphens: auto; /* still not supported on Chrome */
       `;
@@ -141,8 +169,8 @@ const getStylesForNotification = (props: StyleProps) => {
         animation: ${showNotificationSideAnimation} 0.3s forwards;
         position: relative;
         z-index: 10000;
-        margin-top: ${customProperties.spacingL} !important;
-        right: ${customProperties.spacingXl};
+        margin-top: ${designTokens.spacingL} !important;
+        right: ${designTokens.spacingXl};
         float: right;
         clear: both;
         max-width: 50%;
@@ -153,4 +181,9 @@ const getStylesForNotification = (props: StyleProps) => {
   }
 };
 
-export { getStylesForIcon, getStylesForContent, getStylesForNotification };
+export {
+  getStylesForNotificationIcon,
+  getStylesForCloseIcon,
+  getStylesForContent,
+  getStylesForNotification,
+};

--- a/packages/react-notifications/src/components/notification/notification.styles.ts
+++ b/packages/react-notifications/src/components/notification/notification.styles.ts
@@ -81,8 +81,13 @@ const getStylesForNotificationIcon = (props: StyleProps) => css`
   background: ${getColorByType(props.type)};
 `;
 
-const getStylesForCloseIcon = (isNewTheme = false) => css`
-  ${isNewTheme ? '& svg { width: 12px; height: 12px; }' : ''}
+const getStylesForCloseIcon = (props: StyleProps) => css`
+  display: flex;
+  justify-content: center;
+  ${props.isNewTheme ? '& svg { width: 16px; height: 16px; }' : ''}
+  ${props.isNewTheme && props.domain !== NOTIFICATION_DOMAINS.SIDE
+    ? '& svg { fill: ' + designTokens.colorSurface + '; }'
+    : ''}
 `;
 
 const getStylesForContent = (props: StyleProps) => {

--- a/packages/react-notifications/src/components/notification/notification.tsx
+++ b/packages/react-notifications/src/components/notification/notification.tsx
@@ -11,6 +11,7 @@ import {
   ErrorIcon,
   WarningIcon,
   InfoIcon,
+  InformationIcon,
   CheckBoldIcon,
 } from '@commercetools-uikit/icons';
 import { useTheme } from '@commercetools-uikit/design-system';
@@ -45,15 +46,23 @@ type PropsIcon = {
     | 'surface'
     | 'primary'
     | 'primary40';
+  isNewTheme: boolean;
 };
 
 const NotificationIcon = (props: PropsIcon) => {
-  if (props.type === NOTIFICATION_KINDS_SIDE.error)
+  if (props.type === NOTIFICATION_KINDS_SIDE.error) {
     return <ErrorIcon color={props.color} />;
-  if (props.type === NOTIFICATION_KINDS_SIDE.info)
-    return <InfoIcon color={props.color} />;
-  if (props.type === NOTIFICATION_KINDS_SIDE.warning)
+  }
+  if (props.type === NOTIFICATION_KINDS_SIDE.info) {
+    return props.isNewTheme ? (
+      <InformationIcon color={props.color} />
+    ) : (
+      <InfoIcon color={props.color} />
+    );
+  }
+  if (props.type === NOTIFICATION_KINDS_SIDE.warning) {
     return <WarningIcon color={props.color} />;
+  }
 
   return <CheckBoldIcon color={props.color} />;
 };
@@ -87,7 +96,7 @@ const Notification = (props: Props) => {
         {props.children}
       </div>
       {props.onCloseClick ? (
-        <div css={getStylesForCloseIcon(isNewTheme)}>
+        <div css={getStylesForCloseIcon({ ...props, isNewTheme })}>
           <Button
             label={intl.formatMessage(messages.hideNotification)}
             onClick={props.onCloseClick}
@@ -98,7 +107,11 @@ const Notification = (props: Props) => {
       ) : null}
       {props.domain === NOTIFICATION_DOMAINS.SIDE ? (
         <div css={getStylesForNotificationIcon(props)}>
-          <NotificationIcon type={props.type} color="surface" />
+          <NotificationIcon
+            type={props.type}
+            color="surface"
+            isNewTheme={isNewTheme}
+          />
         </div>
       ) : null}
     </div>

--- a/packages/react-notifications/src/components/notification/notification.tsx
+++ b/packages/react-notifications/src/components/notification/notification.tsx
@@ -1,3 +1,4 @@
+// TODO: @redesign cleanup
 import type {
   TAppNotificationKind,
   TAppNotificationDomain,
@@ -12,7 +13,9 @@ import {
   InfoIcon,
   CheckBoldIcon,
 } from '@commercetools-uikit/icons';
+import { useTheme } from '@commercetools-uikit/design-system';
 import IconButton from '@commercetools-uikit/icon-button';
+import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
 import {
   NOTIFICATION_DOMAINS,
   NOTIFICATION_KINDS_SIDE,
@@ -22,7 +25,8 @@ import { useFieldId } from '@commercetools-uikit/hooks';
 import filterDataAttributes from '../../utils/filter-data-attributes';
 import messages from './messages';
 import {
-  getStylesForIcon,
+  getStylesForNotificationIcon,
+  getStylesForCloseIcon,
   getStylesForContent,
   getStylesForNotification,
 } from './notification.styles';
@@ -69,19 +73,22 @@ const defaultProps: Pick<Props, 'fixed'> = {
 const Notification = (props: Props) => {
   const intl = useIntl();
   const id = useFieldId(undefined, sequentialId);
+  const { isNewTheme, themedValue } = useTheme();
+  const Button = themedValue(IconButton, SecondaryIconButton);
+
   return (
     <div
       role="alertdialog"
       aria-describedby={id}
-      css={getStylesForNotification(props)}
+      css={getStylesForNotification({ ...props, isNewTheme })}
       {...filterDataAttributes(props)}
     >
-      <div id={id} css={getStylesForContent(props)}>
+      <div id={id} css={getStylesForContent({ ...props, isNewTheme })}>
         {props.children}
       </div>
       {props.onCloseClick ? (
-        <div>
-          <IconButton
+        <div css={getStylesForCloseIcon(isNewTheme)}>
+          <Button
             label={intl.formatMessage(messages.hideNotification)}
             onClick={props.onCloseClick}
             icon={<CloseBoldIcon />}
@@ -90,7 +97,7 @@ const Notification = (props: Props) => {
         </div>
       ) : null}
       {props.domain === NOTIFICATION_DOMAINS.SIDE ? (
-        <div css={getStylesForIcon(props)}>
+        <div css={getStylesForNotificationIcon(props)}>
           <NotificationIcon type={props.type} color="surface" />
         </div>
       ) : null}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4405,6 +4405,7 @@ __metadata:
     "@commercetools-uikit/hooks": ^15.9.0
     "@commercetools-uikit/icon-button": ^15.9.0
     "@commercetools-uikit/icons": ^15.9.0
+    "@commercetools-uikit/secondary-icon-button": ^15.9.0
     "@commercetools-uikit/spacings": ^15.9.0
     "@commercetools-uikit/utils": ^15.9.0
     "@emotion/react": 11.10.4


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Update notifications ui for the redesign

#### Description

Adjusted notifications styles for them to look as expected in both the current and the new theme.

Default theme:
![image](https://user-images.githubusercontent.com/97907068/215042313-2d71024e-0272-4101-a000-549ea342cef7.png)


New theme:
![image](https://user-images.githubusercontent.com/97907068/215042202-ae98604e-8876-47a3-af26-701cbeb89095.png)

