### PR TITLE
Update `PageContentWide` to render all its children in single-column mode

### DIFF
--- a/.changeset/rich-jokes-grow.md
+++ b/.changeset/rich-jokes-grow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Changed `PageContentWide` component to render all its children when using single-column mode.

--- a/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.spec.tsx
+++ b/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.spec.tsx
@@ -22,14 +22,16 @@ describe('PageContentWide', () => {
 
       screen.getByText('Text content');
     });
-    it('should render single column even when providing several children', () => {
+    it('should render single column with several children', () => {
       renderPageContent([
         <div key="1">1. Text content</div>,
         <div key="2">2. Text content</div>,
+        <div key="3">3. Text content</div>,
       ]);
 
       screen.getByText('1. Text content');
-      expect(screen.queryByText('2. Text content')).not.toBeInTheDocument();
+      screen.getByText('2. Text content');
+      screen.getByText('3. Text content');
     });
   });
 

--- a/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.tsx
+++ b/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.tsx
@@ -60,7 +60,7 @@ function PageContentWide(props: TPageContentWide) {
     <Container>
       <Content columns={props.columns} gapSize={props.gapSize}>
         {props.columns === '1' ? (
-          <>{leftChild}</>
+          <>{props.children}</>
         ) : (
           <>
             <LeftContentColumn>{leftChild}</LeftContentColumn>

--- a/visual-testing-app/src/components/page-content-container-wide/page-content-container-wide.visualroute.tsx
+++ b/visual-testing-app/src/components/page-content-container-wide/page-content-container-wide.visualroute.tsx
@@ -37,6 +37,17 @@ export const Component = () => (
             </PageContentWide>
           ),
         },
+        {
+          name: 'single column with several children',
+          path: 'single-column-with-several-children',
+          spec: (
+            <PageContentWide>
+              <Box />
+              <Box />
+              <Box />
+            </PageContentWide>
+          ),
+        },
 
         {
           name: 'two columns 1/1',

--- a/visual-testing-app/src/components/page-content-container-wide/page-content-container-wide.visualspec.ts
+++ b/visual-testing-app/src/components/page-content-container-wide/page-content-container-wide.visualspec.ts
@@ -7,6 +7,16 @@ describe('PageContentContainerWide', () => {
     await expect(page).toMatch('Page content container wide');
     await percySnapshot(page, 'PageContentContainerWide_singleColumn');
   });
+  it('Single column with several children', async () => {
+    await page.goto(
+      `${HOST}/page-content-container-wide/single-column-with-several-children`
+    );
+    await expect(page).toMatch('Page content container wide');
+    await percySnapshot(
+      page,
+      'PageContentContainerWide_singleColumnSeveralChildren'
+    );
+  });
   it('Two columns half small gap', async () => {
     await page.goto(`${HOST}/page-content-container-wide/two-columns-half`);
     await expect(page).toMatch('Page content container wide');


### PR DESCRIPTION
#### Summary

Update `PageContentWide` to render all its children in single-column mode.

#### Description

The way this component was implemented counted on consumers to provide only one children when using it for rendering a single columns, so it only rendered its first children and skip any other one received.

Since this is causing some issues with its adoption (people having to provide a fragment wrapper over existing children to be used within the `PageContentWide`), we're changing its behaviour for it to render all received children when using a single column.

When using two columns, the component will still render just the first two received children (and skip any other it might receive).
