### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,5 +39,6 @@
     "enabled": true
   },
   "labels": ["🤖 Type: Dependencies"],
+  "stopUpdatingLabel": "🖐 Status: On Hold",
   "ignoreDeps": []
 }

--- a/scripts/build_website.sh
+++ b/scripts/build_website.sh
@@ -18,4 +18,4 @@ echo "Merging websites into one folder"
 
 rm -rf vercel-public
 cp -R public/website vercel-public
-cp -R public/website-components-playground vercel-public/playground
+cp -R website-components-playground/dist vercel-public/playground


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

I wondered the other day if we could tell Renovate to stop updating certain PRs as we plan to work on e.g. that major dependency update in the future. This can save us some CI cost and needless timeline entries on the affected PRs.

Turns it Renovate can do that https://docs.renovatebot.com/configuration-options/#stopupdatinglabel