### PR TITLE
fix: use base path for playground app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
       "destination": "/"
     },
     {
+      "source": "/custom-applications/playground/(.*)",
+      "destination": "/playground/$1"
+    },
+    {
       "source": "/custom-applications/(.*)",
       "destination": "/$1"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -5,12 +5,12 @@
   },
   "rewrites": [
     {
-      "source": "/custom-applications",
-      "destination": "/"
+      "source": "/custom-applications/playground/(.*)",
+      "destination": "/playground/index.html"
     },
     {
-      "source": "/custom-applications/playground/(.*)",
-      "destination": "/playground"
+      "source": "/custom-applications",
+      "destination": "/"
     },
     {
       "source": "/custom-applications/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -5,12 +5,16 @@
   },
   "rewrites": [
     {
-      "source": "/custom-applications/playground/(.*)",
-      "destination": "/playground/index.html"
-    },
-    {
       "source": "/custom-applications",
       "destination": "/"
+    },
+    {
+      "source": "/custom-applications/playground/assets/(.*)",
+      "destination": "/playground/assets/$1"
+    },
+    {
+      "source": "/custom-applications/playground/(.*)",
+      "destination": "/playground/index.html"
     },
     {
       "source": "/custom-applications/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
     },
     {
       "source": "/custom-applications/playground/(.*)",
-      "destination": "/playground/$1"
+      "destination": "/playground"
     },
     {
       "source": "/custom-applications/(.*)",

--- a/website-components-playground/src/application.tsx
+++ b/website-components-playground/src/application.tsx
@@ -1,7 +1,8 @@
 import './globals.css';
 import { lazy } from 'react';
 import { Router, Switch, Route } from 'react-router-dom';
-import history from '@commercetools-frontend/browser-history';
+import { createBrowserHistory } from 'history';
+import { createEnhancedHistory } from '@commercetools-frontend/browser-history';
 import IndexPage from './pages';
 
 const ConfirmationDialog = lazy(() => import('./pages/confirmation-dialog'));
@@ -27,6 +28,11 @@ const CustomFormModalPage = lazy(
 const TabularDetailPage = lazy(() => import('./pages/tabular-detail-page'));
 const TabularMainPage = lazy(() => import('./pages/tabular-main-page'));
 const TabularModalPage = lazy(() => import('./pages/tabular-modal-page'));
+
+const history = createEnhancedHistory(
+  createBrowserHistory({ basename: '/custom-applications/playground' })
+);
+
 const Application = () => (
   <Router history={history}>
     <Switch>

--- a/website-components-playground/src/hooks/use-window-height.ts
+++ b/website-components-playground/src/hooks/use-window-height.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useLayoutEffect } from 'react';
 
 const useWindowHeight = () => {
-  const [height, setHeight] = useState(0);
+  const [height, setHeight] = useState(400);
 
   const updateHeight = useCallback(() => {
     const bodyElement = document?.querySelector('body');

--- a/website-components-playground/src/hooks/use-window-height.ts
+++ b/website-components-playground/src/hooks/use-window-height.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useLayoutEffect } from 'react';
 
 const useWindowHeight = () => {
-  const [height, setHeight] = useState(400);
+  const [height, setHeight] = useState(0);
 
   const updateHeight = useCallback(() => {
     const bodyElement = document?.querySelector('body');

--- a/website-components-playground/vite.config.js
+++ b/website-components-playground/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/custom-applications/playground/',
   define: {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
     'process.env.CI': JSON.stringify(process.env.CI),

--- a/website/src/components/playground.js
+++ b/website/src/components/playground.js
@@ -11,10 +11,9 @@ const getIframeUrl = (urlPath, isFullScreen = false) => {
 };
 
 const PlaygroundController = (props) => {
-  const [iframeHeight, setIframeHeight] = useState(0);
+  const [iframeHeight, setIframeHeight] = useState(400);
   useEffect(() => {
     const onReceiveMessage = (event) => {
-      console.log('Received event message', event);
       if (Array.isArray(event.data)) {
         const [eventSource, value] = event.data;
         switch (eventSource) {

--- a/website/src/components/playground.js
+++ b/website/src/components/playground.js
@@ -14,6 +14,7 @@ const PlaygroundController = (props) => {
   const [iframeHeight, setIframeHeight] = useState(0);
   useEffect(() => {
     const onReceiveMessage = (event) => {
+      console.log('Received event message', event);
       if (Array.isArray(event.data)) {
         const [eventSource, value] = event.data;
         switch (eventSource) {


### PR DESCRIPTION
Regression for serving the components playground pages.

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/1110551/221416199-9a9b1820-9080-4034-bfb6-1d0ef20a89d8.png">

I don't since when we had this regression to be honest. We switched the components playground to use Vite back in november #2879 but it seems weird to me that nobody noticed that in 3 months.

Anyway, this is a quick fix, we need to reconsider a bit the page structure and how we want to handle the playground components.