### PR TITLE
fix(docs): use PortalsContainer to correctly render stacked modal pages

### DIFF
--- a/website-components-playground/src/components/modal-controller.tsx
+++ b/website-components-playground/src/components/modal-controller.tsx
@@ -10,7 +10,6 @@ type TModalControllerFunctionOptions = {
   setIsOpen: (nextValue: boolean) => void;
 };
 type TModalControllerProps = {
-  containerId: string;
   title: string;
   buttonLabel: string;
   children: (options: TModalControllerFunctionOptions) => ReactNode;
@@ -23,15 +22,11 @@ const GridContainer = styled.div`
   height: 100%;
   width: 100%;
 `;
-const PortalContainer = styled.div`
-  flex: 1;
-`;
 
 const ModalController = (props: TModalControllerProps) => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <>
-      <PortalContainer id={props.containerId} />
       <div
         css={css`
           height: 100%;

--- a/website-components-playground/src/components/playground-controller.tsx
+++ b/website-components-playground/src/components/playground-controller.tsx
@@ -1,5 +1,8 @@
 import { useLayoutEffect, useState, type ReactNode } from 'react';
 import styled from '@emotion/styled';
+import { css, Global } from '@emotion/react';
+import { PortalsContainer } from '@commercetools-frontend/application-components';
+import { PORTALS_CONTAINER_ID } from '@commercetools-frontend/constants';
 import { AngleRightIcon, AngleDownIcon } from '@commercetools-uikit/icons';
 import IconButton from '@commercetools-uikit/icon-button';
 import Spacings from '@commercetools-uikit/spacings';
@@ -48,6 +51,19 @@ const PlaygroundController = (props: TPlaygroundControllerProps) => {
             <PlaygroundContainer>
               <Spacings.Stack scale="s">
                 <PreviewContainer height="400px">
+                  <PortalsContainer />
+                  <Global
+                    // Overwrite styles to restrict the modal container to be within the
+                    // preview container instead of full screen.
+                    // This is only needed for the playground previews, therefore we
+                    // override the styles here.
+                    styles={css`
+                      .ReactModal__Body--open #${PORTALS_CONTAINER_ID} {
+                        position: absolute;
+                        overflow: auto;
+                      }
+                    `}
+                  />
                   {props.children({ values })}
                 </PreviewContainer>
                 <Spacings.Inline alignItems="center">

--- a/website-components-playground/src/pages/confirmation-dialog.tsx
+++ b/website-components-playground/src/pages/confirmation-dialog.tsx
@@ -5,8 +5,6 @@ import LayoutApp from '../layouts/layout-app';
 import PlaygroundController from '../components/playground-controller';
 import ModalController from '../components/modal-controller';
 
-const containerId = 'confirmation-dialog';
-
 const ConfirmationDialogExample = () => (
   <LayoutApp>
     <PlaygroundController
@@ -39,7 +37,6 @@ const ConfirmationDialogExample = () => (
     >
       {({ values }) => (
         <ModalController
-          containerId={containerId}
           title="Open the Confirmation Dialog by clicking on the button"
           buttonLabel="Open Confirmation Dialog"
         >
@@ -56,9 +53,6 @@ const ConfirmationDialogExample = () => (
                 alert('confirmed');
                 setIsOpen(false);
               }}
-              getParentSelector={() =>
-                document.querySelector(`#${containerId}`) as HTMLElement
-              }
             >
               <Spacings.Stack scale="m">
                 {(values.content as string).split('\n').map((text, index) => (

--- a/website-components-playground/src/pages/custom-form-modal-page.tsx
+++ b/website-components-playground/src/pages/custom-form-modal-page.tsx
@@ -7,8 +7,6 @@ import LayoutApp from '../layouts/layout-app';
 import PlaygroundController from '../components/playground-controller';
 import ModalController from '../components/modal-controller';
 
-const containerId = 'custom-form-modal-page';
-
 const CustomFormModalPageExample = () => (
   <LayoutApp>
     <PlaygroundController
@@ -43,7 +41,6 @@ const CustomFormModalPageExample = () => (
         <ModalController
           title="Open the Custom Form Modal Page by clicking on the button"
           buttonLabel="Open Custom Form Modal Page"
-          containerId={containerId}
         >
           {({ isOpen, setIsOpen }) => (
             <Formik<{ email: string }>
@@ -84,9 +81,6 @@ const CustomFormModalPageExample = () => (
                     </>
                   }
                   hideControls={Boolean(values.hideControls)}
-                  getParentSelector={() =>
-                    document.querySelector(`#${containerId}`) as HTMLElement
-                  }
                 >
                   <TextField
                     name="email"

--- a/website-components-playground/src/pages/form-dialog.tsx
+++ b/website-components-playground/src/pages/form-dialog.tsx
@@ -8,8 +8,6 @@ import LayoutApp from '../layouts/layout-app';
 import PlaygroundController from '../components/playground-controller';
 import ModalController from '../components/modal-controller';
 
-const containerId = 'form-dialog';
-
 const FormDialogExample = () => (
   <LayoutApp>
     <PlaygroundController
@@ -36,7 +34,6 @@ const FormDialogExample = () => (
     >
       {({ values }) => (
         <ModalController
-          containerId={containerId}
           title="Open the Form Dialog by clicking on the button"
           buttonLabel="Open Form Dialog"
         >
@@ -66,9 +63,6 @@ const FormDialogExample = () => (
                     formikProps.handleSubmit(
                       event as FormEvent<HTMLFormElement>
                     )
-                  }
-                  getParentSelector={() =>
-                    document.querySelector(`#${containerId}`) as HTMLElement
                   }
                 >
                   <Spacings.Stack scale="m">

--- a/website-components-playground/src/pages/form-modal-page.tsx
+++ b/website-components-playground/src/pages/form-modal-page.tsx
@@ -7,8 +7,6 @@ import LayoutApp from '../layouts/layout-app';
 import PlaygroundController from '../components/playground-controller';
 import ModalController from '../components/modal-controller';
 
-const containerId = 'form-modal-page';
-
 const FormModalPageExample = () => (
   <LayoutApp>
     <PlaygroundController
@@ -55,7 +53,6 @@ const FormModalPageExample = () => (
         <ModalController
           title="Open the Form Modal Page by clicking on the button"
           buttonLabel="Open Form Modal Page"
-          containerId={containerId}
         >
           {({ isOpen, setIsOpen }) => (
             <Formik<{ email: string }>
@@ -86,9 +83,6 @@ const FormModalPageExample = () => (
                     formikProps.handleSubmit(
                       event as FormEvent<HTMLFormElement>
                     )
-                  }
-                  getParentSelector={() =>
-                    document.querySelector(`#${containerId}`) as HTMLElement
                   }
                   hideControls={Boolean(values.hideControls)}
                 >

--- a/website-components-playground/src/pages/info-dialog.tsx
+++ b/website-components-playground/src/pages/info-dialog.tsx
@@ -5,8 +5,6 @@ import LayoutApp from '../layouts/layout-app';
 import ModalController from '../components/modal-controller';
 import PlaygroundController from '../components/playground-controller';
 
-const containerId = 'info-dialog';
-
 const InfoDialogExample = () => (
   <LayoutApp>
     <PlaygroundController
@@ -39,7 +37,6 @@ const InfoDialogExample = () => (
     >
       {({ values }) => (
         <ModalController
-          containerId={containerId}
           title="Open the Info Dialog by clicking on the button"
           buttonLabel="Open Info Dialog"
         >
@@ -49,9 +46,6 @@ const InfoDialogExample = () => (
               size={values.size as 'm' | 'l' | 'scale'}
               isOpen={isOpen}
               onClose={() => setIsOpen(false)}
-              getParentSelector={() =>
-                document.querySelector(`#${containerId}`) as HTMLElement
-              }
             >
               <Spacings.Stack scale="m">
                 {(values.content as string).split('\n').map((text, index) => (

--- a/website-components-playground/src/pages/info-modal-page.tsx
+++ b/website-components-playground/src/pages/info-modal-page.tsx
@@ -4,8 +4,6 @@ import LayoutApp from '../layouts/layout-app';
 import PlaygroundController from '../components/playground-controller';
 import ModalController from '../components/modal-controller';
 
-const containerId = 'info-modal-page';
-
 const InfoModalPageExample = () => (
   <LayoutApp>
     <PlaygroundController
@@ -29,7 +27,6 @@ const InfoModalPageExample = () => (
         <ModalController
           title="Open the Info Modal Page by clicking on the button"
           buttonLabel="Open Info Modal Page"
-          containerId={containerId}
         >
           {({ isOpen, setIsOpen }) => (
             <InfoModalPage
@@ -37,14 +34,10 @@ const InfoModalPageExample = () => (
               isOpen={isOpen}
               onClose={() => setIsOpen(false)}
               subtitle={values.subtitle as string}
-              getParentSelector={() =>
-                document.querySelector(`#${containerId}`) as HTMLElement
-              }
             >
               <ModalController
                 title="Open Another Modal Page by clicking the button"
                 buttonLabel="Open Modal Page"
-                containerId={containerId}
               >
                 {/* eslint-disable-next-line no-shadow */}
                 {({ isOpen, setIsOpen }) => (
@@ -53,14 +46,10 @@ const InfoModalPageExample = () => (
                     isOpen={isOpen}
                     subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
                     onClose={() => setIsOpen(false)}
-                    getParentSelector={() =>
-                      document.querySelector(`#${containerId}`) as HTMLElement
-                    }
                   >
                     <ModalController
                       title="Open Another Modal Page by clicking the button"
                       buttonLabel="Open Modal Page"
-                      containerId={containerId}
                     >
                       {/* eslint-disable-next-line no-shadow */}
                       {({ isOpen, setIsOpen }) => (
@@ -69,16 +58,10 @@ const InfoModalPageExample = () => (
                           isOpen={isOpen}
                           subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
                           onClose={() => setIsOpen(false)}
-                          getParentSelector={() =>
-                            document.querySelector(
-                              `#${containerId}`
-                            ) as HTMLElement
-                          }
                         >
                           <ModalController
                             title="Open Another Modal Page by clicking the button"
                             buttonLabel="Open Modal Page"
-                            containerId={containerId}
                           >
                             {/* eslint-disable-next-line no-shadow */}
                             {({ isOpen, setIsOpen }) => (
@@ -87,16 +70,10 @@ const InfoModalPageExample = () => (
                                 isOpen={isOpen}
                                 subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
                                 onClose={() => setIsOpen(false)}
-                                getParentSelector={() =>
-                                  document.querySelector(
-                                    `#${containerId}`
-                                  ) as HTMLElement
-                                }
                               >
                                 <ModalController
                                   title="Open Another Modal Page by clicking the button"
                                   buttonLabel="Open Modal Page"
-                                  containerId={containerId}
                                 >
                                   {/* eslint-disable-next-line no-shadow */}
                                   {({ isOpen, setIsOpen }) => (
@@ -105,11 +82,6 @@ const InfoModalPageExample = () => (
                                       isOpen={isOpen}
                                       subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
                                       onClose={() => setIsOpen(false)}
-                                      getParentSelector={() =>
-                                        document.querySelector(
-                                          `#${containerId}`
-                                        ) as HTMLElement
-                                      }
                                     >
                                       <Text.Body>
                                         {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}

--- a/website-components-playground/src/pages/tabular-modal-page.tsx
+++ b/website-components-playground/src/pages/tabular-modal-page.tsx
@@ -10,8 +10,6 @@ import LayoutApp from '../layouts/layout-app';
 import PlaygroundController from '../components/playground-controller';
 import ModalController from '../components/modal-controller';
 
-const containerId = 'tabular-modal-page';
-
 const exampleCustomTitleRow = (
   <Spacings.Inline scale="m">
     <Spacings.Inline alignItems="center">
@@ -85,16 +83,12 @@ const TabularModalPageExample = () => {
           <ModalController
             title={values.title as string}
             buttonLabel="Open Tabular Modal Page"
-            containerId={containerId}
           >
             {({ isOpen, setIsOpen }) => (
               <TabularModalPage
                 title={values.title as string}
                 isOpen={isOpen}
                 onClose={() => setIsOpen(false)}
-                getParentSelector={() =>
-                  document.querySelector(`#${containerId}`) as HTMLElement
-                }
                 tabControls={
                   <>
                     <TabHeader


### PR DESCRIPTION
Before

<img width="791" alt="image" src="https://user-images.githubusercontent.com/1110551/221434135-fcb9639c-778f-4f63-aaa9-8829011ff867.png">


After

<img width="794" alt="image" src="https://user-images.githubusercontent.com/1110551/221434094-92f77ab7-348a-43df-8316-038f6e092c2b.png">
