### PR TITLE
refactor: change spacing on page-content-layout

### DIFF
--- a/.changeset/good-foxes-wonder.md
+++ b/.changeset/good-foxes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-components": patch
+---
+
+Refactor to change spacing on `PublicPageContentLayout` enabled only in new design.

--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import CommercetoolsLogoSvg from '@commercetools-frontend/assets/logos/commercetools_primary-logo_horizontal_white-text_RGB.svg';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { customProperties, useTheme } from '@commercetools-uikit/design-system';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 import { designTokens as appKitDesingTokens } from '../../theming';
@@ -60,6 +60,8 @@ const PublicPageLayoutContent: FC<TProps> = (props) => {
 };
 
 const PublicPageLayout: FC<TProps> = (props) => {
+  const { themedValue } = useTheme();
+
   return (
     <Container>
       <Spacings.Stack scale="xl" alignItems="center">
@@ -78,6 +80,7 @@ const PublicPageLayout: FC<TProps> = (props) => {
               <div
                 css={css`
                   color: ${customProperties.colorSurface};
+                  text-align: ${themedValue('left', 'center')};
                 `}
               >
                 {props.welcomeMessage}
@@ -85,9 +88,8 @@ const PublicPageLayout: FC<TProps> = (props) => {
             </Text.Headline>
           </ContainerColumn>
         )}
-        <Spacings.Stack scale="s">
+        <Spacings.Stack scale={themedValue('xs', 'l')}>
           <PublicPageLayoutContent {...props} />
-
           <PublicPageLayoutContent contentScale={props.contentScale}>
             <Spacings.Stack
               scale="xs"

--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -88,7 +88,7 @@ const PublicPageLayout: FC<TProps> = (props) => {
             </Text.Headline>
           </ContainerColumn>
         )}
-        <Spacings.Stack scale={themedValue('xs', 'l')}>
+        <Spacings.Stack scale={themedValue('s', 'l')}>
           <PublicPageLayoutContent {...props} />
           <PublicPageLayoutContent contentScale={props.contentScale}>
             <Spacings.Stack


### PR DESCRIPTION
#### Summary

The `PublicPageLayout` is used internally mainly on the login pages. With the redesign the text alignment on the header and the spacing on the footer (legal message) should change.

There are different ways to achieve this:

1. Add `props` such as `welcomeMessageTextAlignment` and `legalMessageScale`
2. Using `themedValue` for old and new spacings

I wanted to suggest 2. first. I don't see any reason we should allow different text alignments in the header nor different paddings of the legal message to the top.

![CleanShot 2023-03-08 at 14 31 51@2x](https://user-images.githubusercontent.com/1877073/223734071-8d9593de-5ad0-45aa-9876-b5b02ebd6c71.png)

<img width="1070" alt="CleanShot 2023-03-08 at 15 07 45@2x" src="https://user-images.githubusercontent.com/1877073/223734130-0a61d1fa-7905-43bd-ac78-7af7aebe5caa.png">


