### PR TITLE
refactor: clean up unnecessary props and types, refactor `<Route>` to always render as children

### DIFF
--- a/.changeset/thirty-countries-happen.md
+++ b/.changeset/thirty-countries-happen.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/permissions': patch
+'@commercetools-frontend/constants': patch
+'@commercetools-local/visual-testing-app': patch
+---
+
+Cleanup unnecessary props and types, refactor `<Route>` to always render using children.

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -100,7 +100,7 @@ export type TIdTokenUserInfo = {
   aud: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   exp: Scalars['Float'];
-  iat: Scalars['Float'];
+  iat?: Maybe<Scalars['Float']>;
   iss: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   sub: Scalars['String'];
@@ -678,6 +678,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
+  /** @deprecated This field is not used anymore. */
   verificationStatus: TVerificationStatus;
   version?: Maybe<Scalars['Int']>;
 };
@@ -709,7 +710,7 @@ export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 export type TAmILoggedInQuery = { __typename?: 'Query', amILoggedIn: boolean };
 
 export type TFetchProjectQueryVariables = Exact<{
-  projectKey: Scalars['String'];
+  projectKey?: InputMaybe<Scalars['String']>;
 }>;
 
 
@@ -718,7 +719,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat?: number | null, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/application-shell/src/components/application-entry-point/application-entry-point.tsx
+++ b/packages/application-shell/src/components/application-entry-point/application-entry-point.tsx
@@ -7,17 +7,15 @@ import type { TProviderProps } from '@commercetools-frontend/application-shell-c
 import { useIsAuthorized } from '@commercetools-frontend/permissions';
 import RouteCatchAll from '../route-catch-all';
 
-type Props<AdditionalEnvironmentProperties extends {}> = {
-  environment: TProviderProps<AdditionalEnvironmentProperties>['environment'];
+type TApplicationEntryPointProps = {
+  environment: TProviderProps<{}>['environment'];
   disableRoutePermissionCheck?: boolean;
   render?: () => JSX.Element;
   children?: ReactNode;
 };
 
-const ApplicationRouteWithPermissionCheck = <
-  AdditionalEnvironmentProperties extends {}
->(
-  props: Props<AdditionalEnvironmentProperties>
+const ApplicationRouteWithPermissionCheck = (
+  props: TApplicationEntryPointProps
 ) => {
   const permissionKeys = entryPointUriPathToPermissionKeys(
     props.environment.entryPointUriPath
@@ -33,23 +31,15 @@ const ApplicationRouteWithPermissionCheck = <
   return <PageUnauthorized />;
 };
 
-const ApplicationRoute = <AdditionalEnvironmentProperties extends {}>(
-  props: Props<AdditionalEnvironmentProperties>
-) => {
+const ApplicationRoute = (props: TApplicationEntryPointProps) => {
   if (props.disableRoutePermissionCheck) {
     return <>{Children.only<ReactNode>(props.children)}</>;
   }
 
-  return (
-    <ApplicationRouteWithPermissionCheck<AdditionalEnvironmentProperties>
-      {...props}
-    />
-  );
+  return <ApplicationRouteWithPermissionCheck {...props} />;
 };
 
-const ApplicationEntryPoint = <AdditionalEnvironmentProperties extends {}>(
-  props: Props<AdditionalEnvironmentProperties>
-) => {
+const ApplicationEntryPoint = (props: TApplicationEntryPointProps) => {
   // If the `children` prop is used (instead of the `render` prop),
   // we pre-configure the application entry point routes to avoid
   // users to do so on their own.
@@ -69,7 +59,7 @@ const ApplicationEntryPoint = <AdditionalEnvironmentProperties extends {}>(
           )
         }
         <Route path={`/:projectKey/${entryPointUriPath}`}>
-          <ApplicationRoute<AdditionalEnvironmentProperties> {...props} />
+          <ApplicationRoute {...props} />
         </Route>
         {/* Catch-all route */}
         <RouteCatchAll />

--- a/packages/application-shell/src/components/application-shell-provider/use-coerced-environment-values.ts
+++ b/packages/application-shell/src/components/application-shell-provider/use-coerced-environment-values.ts
@@ -44,16 +44,14 @@ const shallowlyCoerceValues = (uncoercedEnvironmentValues: ShallowJson) =>
     {}
   );
 
-const useCoercedEnvironmentValues = <
-  AdditionalEnvironmentProperties extends {}
->(
+const useCoercedEnvironmentValues = (
   environment: ShallowJson
-): TApplicationContext<AdditionalEnvironmentProperties>['environment'] => {
+): TApplicationContext<{}>['environment'] => {
   const coercedEnvironmentValues = useMemo(
     () =>
       shallowlyCoerceValues(
         environment
-      ) as TApplicationContext<AdditionalEnvironmentProperties>['environment'],
+      ) as TApplicationContext<{}>['environment'],
     [environment]
   );
   return coercedEnvironmentValues;

--- a/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
+++ b/packages/application-shell/src/components/authenticated/authenticated.spec.tsx
@@ -7,10 +7,9 @@ import type {
   TAmILoggedInQuery,
   TAmILoggedInQueryVariables,
 } from '../../types/generated/mc';
-import type { TProps } from './authenticated';
-import Authenticated from './authenticated';
+import Authenticated, { type TAuthenticatedProps } from './authenticated';
 
-const createTestProps = (custom: Partial<TProps> = {}) => ({
+const createTestProps = (custom: Partial<TAuthenticatedProps> = {}) => ({
   render: jest.fn(() => <div />),
   locale: 'en',
   applicationMessages: {},

--- a/packages/application-shell/src/components/authenticated/authenticated.tsx
+++ b/packages/application-shell/src/components/authenticated/authenticated.tsx
@@ -9,14 +9,14 @@ import OidcCallback from './oidc-callback';
 declare let window: ApplicationWindow;
 
 type RenderFnArgs = { isAuthenticated: boolean };
-export type TProps = {
+export type TAuthenticatedProps = {
   render: (args: RenderFnArgs) => JSX.Element;
   locale: string;
   applicationMessages: TAsyncLocaleDataProps['applicationMessages'];
   children?: never;
 };
 
-const Authenticated = (props: TProps) => {
+const Authenticated = (props: TAuthenticatedProps) => {
   // We attempt to see if the user was already authenticated by looking
   // at the "cached" flag in local storage.
   const cachedAuthenticationState = hasCachedAuthenticationState();
@@ -36,7 +36,7 @@ const Authenticated = (props: TProps) => {
 };
 Authenticated.displayName = 'Authenticated';
 
-const AuthenticationRoutes = (props: TProps) => (
+const AuthenticationRoutes = (props: TAuthenticatedProps) => (
   <Switch>
     <Route path={`/account/oidc/callback`}>
       <OidcCallback

--- a/packages/application-shell/src/components/authenticated/oidc-callback.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback.tsx
@@ -10,7 +10,7 @@ import type { AuthorizeSessionState } from './types';
 
 declare let window: ApplicationWindow;
 
-export type TProps = {
+export type TOidcCallbackProps = {
   locale: string;
   applicationMessages: TAsyncLocaleDataProps['applicationMessages'];
   children?: never;
@@ -18,7 +18,7 @@ export type TProps = {
 type AuthorizeCallbackFragments = { sessionToken?: string; state: string };
 type SessionToken = { nonce: string };
 
-const OidcCallback = (props: TProps) => {
+const OidcCallback = (props: TOidcCallbackProps) => {
   const location = useLocation();
   let errorMessage: string | undefined;
 

--- a/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
@@ -1,4 +1,4 @@
-query FetchProject($projectKey: String!) {
+query FetchProject($projectKey: String) {
   project(key: $projectKey) {
     key
     version
@@ -56,7 +56,6 @@ query FetchProject($projectKey: String!) {
           __typename
         }
       }
-
     }
     owner {
       id

--- a/packages/application-shell/src/components/fetch-project/fetch-project.tsx
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.tsx
@@ -14,13 +14,13 @@ type RenderFnArgs = {
   error?: ApolloError;
   project: TFetchProjectQuery['project'];
 };
-type Props = {
-  projectKey: string;
+type TFetchProjectProps = {
+  projectKey?: string;
   skip?: boolean;
   children: (args: RenderFnArgs) => ReactNode;
 };
 
-const FetchProject = (props: Props) => {
+const FetchProject = (props: TFetchProjectProps) => {
   const { loading, data, error } = useMcQuery<
     TFetchProjectQuery,
     TFetchProjectQueryVariables

--- a/packages/application-shell/src/components/fetch-user/fetch-user.tsx
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.tsx
@@ -14,11 +14,11 @@ type RenderFnArgs = {
   error?: ApolloError;
   user: TFetchLoggedInUserQuery['user'];
 };
-type Props = {
+type TFetchUserProps = {
   children: (args: RenderFnArgs) => ReactNode;
 };
 
-const FetchUser = (props: Props) => {
+const FetchUser = (props: TFetchUserProps) => {
   const { loading, data, error } = useMcQuery<
     TFetchLoggedInUserQuery,
     TFetchLoggedInUserQueryVariables

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -624,16 +624,16 @@ const NavBarLayout = forwardRef<HTMLElement, NavBarLayoutProps>(
 );
 NavBarLayout.displayName = 'NavBarLayout';
 
-type NavbarProps<AdditionalEnvironmentProperties extends {}> = {
+type NavbarProps = {
   applicationLocale: string;
   projectKey: string;
-  environment: TApplicationContext<AdditionalEnvironmentProperties>['environment'];
+  environment: TApplicationContext<{
+    useFullRedirectsForLinks?: boolean;
+  }>['environment'];
   project: TFetchProjectQuery['project'];
   onMenuItemClick?: MenuItemLinkProps['onClick'];
 };
-const NavBar = <AdditionalEnvironmentProperties extends {}>(
-  props: NavbarProps<AdditionalEnvironmentProperties>
-) => {
+const NavBar = (props: NavbarProps) => {
   const {
     navBarNode,
     isMenuOpen,

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -599,10 +599,10 @@ const ApplicationMenu = (props: ApplicationMenuProps) => {
 };
 ApplicationMenu.displayName = 'ApplicationMenu';
 
-type NavBarLayoutProps = {
+type TNavBarLayoutProps = {
   children: ReactNode;
 };
-const NavBarLayout = forwardRef<HTMLElement, NavBarLayoutProps>(
+const NavBarLayout = forwardRef<HTMLElement, TNavBarLayoutProps>(
   (props, ref) => (
     <>
       <Global
@@ -624,7 +624,7 @@ const NavBarLayout = forwardRef<HTMLElement, NavBarLayoutProps>(
 );
 NavBarLayout.displayName = 'NavBarLayout';
 
-type NavbarProps = {
+type TNavbarProps = {
   applicationLocale: string;
   projectKey: string;
   environment: TApplicationContext<{
@@ -633,7 +633,7 @@ type NavbarProps = {
   project: TFetchProjectQuery['project'];
   onMenuItemClick?: MenuItemLinkProps['onClick'];
 };
-const NavBar = (props: NavbarProps) => {
+const NavBar = (props: TNavbarProps) => {
   const {
     navBarNode,
     isMenuOpen,

--- a/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
+++ b/packages/application-shell/src/components/project-suspended/project-suspended.spec.js
@@ -29,10 +29,9 @@ afterAll(() => mockServer.close());
 describe('rendering', () => {
   it('when suspension is temporary it should print correct message', async () => {
     renderApp(
-      <Route
-        path="/:projectKey"
-        render={() => <ProjectSuspended isTemporary={true} />}
-      />,
+      <Route path="/:projectKey">
+        <ProjectSuspended isTemporary={true} />
+      </Route>,
       {
         disableRoutePermissionCheck: true,
         route: '/my-project',

--- a/packages/application-shell/src/components/quick-access/index.tsx
+++ b/packages/application-shell/src/components/quick-access/index.tsx
@@ -5,7 +5,7 @@ import ButlerContainer from './butler-container';
 import pimIndexerStates from './pim-indexer-states';
 import trackingEvents from './tracking-events';
 
-type Props = {
+type TQuickAccessProps = {
   onChangeProjectDataLocale?: (locale: string) => void;
 };
 
@@ -13,7 +13,7 @@ const QuickAccess = lazy(
   () => import('./quick-access' /* webpackChunkName: "quick-access" */)
 );
 
-const QuickAccessTrigger = (props: Props) => {
+const QuickAccessTrigger = (props: TQuickAccessProps) => {
   const [isVisible, setIsVisible] = useState(false);
   const open = useCallback(() => {
     setIsVisible(true);

--- a/packages/application-shell/src/components/quick-access/quick-access.tsx
+++ b/packages/application-shell/src/components/quick-access/quick-access.tsx
@@ -116,7 +116,9 @@ const QuickAccess = (props: Props) => {
     customApplications: true,
     canViewDashboard: true,
   });
-  const applicationContext = useApplicationContext();
+  const applicationContext = useApplicationContext<{
+    useFullRedirectsForLinks?: boolean;
+  }>();
 
   // Destructure functions from props to reference them in the hook dependency list
   const { onPimIndexerStateChange: onPimIndexerStateChangeFromParent } = props;

--- a/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
+++ b/packages/application-shell/src/components/service-page-project-switcher/service-page-project-switcher.spec.js
@@ -7,7 +7,9 @@ describe('rendering', () => {
   describe('when user has access to no projects', () => {
     it('should render nothing', async () => {
       const { container } = renderApp(
-        <Route path={`/:projectKey`} component={ServicePageProjectSwitcher} />,
+        <Route path={`/:projectKey`}>
+          <ServicePageProjectSwitcher />
+        </Route>,
         {
           disableRoutePermissionCheck: true,
           route: '/test-1',
@@ -35,7 +37,9 @@ describe('rendering', () => {
         }),
       ];
       const { container } = renderApp(
-        <Route path={`/:projectKey`} component={ServicePageProjectSwitcher} />,
+        <Route path={`/:projectKey`}>
+          <ServicePageProjectSwitcher />
+        </Route>,
         {
           disableRoutePermissionCheck: true,
           route: '/test-1',

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -15,7 +15,7 @@ import type {
 } from '../../types/generated/mc';
 import AllFeaturesQuery from './fetch-all-features.mc.graphql';
 
-type Props = {
+type TSetupFlopFlipProviderProps = {
   projectKey?: string;
   user?: TFetchLoggedInUserQuery['user'];
   flags?: TFlags;
@@ -53,7 +53,7 @@ type TParsedHttpAdapterFlags = Record<
 const ldClientSideIdProduction = '5979d95f6040390cd07b5e01';
 
 function getUserCustomFieldsForLaunchDarklyAdapter(
-  user?: Props['user'],
+  user?: TSetupFlopFlipProviderProps['user'],
   projectKey?: string
 ): TLaunchDarklyUserCustomFields {
   return {
@@ -80,11 +80,16 @@ const parseFlags = (fetchedFlags: TFetchedFlags): TParsedHttpAdapterFlags =>
     ])
   );
 
-export const SetupFlopFlipProvider = (props: Props) => {
+type TAdditionalEnvironmentProperties = {
+  enableLongLivedFeatureFlags?: boolean;
+};
+
+export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
   const apolloClient = useApolloClient();
-  const enableLongLivedFeatureFlags = useApplicationContext(
-    (context) => context.environment.enableLongLivedFeatureFlags
-  );
+  const enableLongLivedFeatureFlags = useApplicationContext<
+    TAdditionalEnvironmentProperties['enableLongLivedFeatureFlags'],
+    TAdditionalEnvironmentProperties
+  >((context) => context.environment.enableLongLivedFeatureFlags);
   const allMenuFeatureToggles = useAllMenuFeatureToggles();
   const flags = useMemo(
     () => ({

--- a/packages/application-shell/src/components/suspended-route/suspended-route.tsx
+++ b/packages/application-shell/src/components/suspended-route/suspended-route.tsx
@@ -2,7 +2,9 @@ import { Suspense } from 'react';
 import { Route, type RouteProps } from 'react-router-dom';
 import LoadingSpinner from '@commercetools-uikit/loading-spinner';
 
-const SuspendedRoute = (props: RouteProps) => (
+const SuspendedRoute = <Path extends string = string>(
+  props: RouteProps<Path>
+) => (
   <Route {...props}>
     <Suspense fallback={<LoadingSpinner />}>{props.children}</Suspense>
   </Route>

--- a/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
+++ b/packages/application-shell/src/hooks/use-all-menu-feature-toggles/use-all-menu-feature-toggles.ts
@@ -8,6 +8,10 @@ import type {
 } from '../../types/generated/proxy';
 import { FetchAllMenuFeatureToggles } from './fetch-all-menu-feature-toggles.proxy.graphql';
 
+type TAdditionalEnvironmentProperties = {
+  mcProxyApiUrl?: string;
+};
+
 const defaultApiUrl = window.location.origin;
 
 const getDefaultedFeatureToggles = (allFeatureToggles: string[]) =>
@@ -18,11 +22,13 @@ const getDefaultedFeatureToggles = (allFeatureToggles: string[]) =>
     }),
     {}
   );
+
 const useAllMenuFeatureToggles = () => {
   const servedByProxy = useIsServedByProxy();
-  const mcProxyApiUrl = useApplicationContext(
-    (applicationContext) => applicationContext.environment.mcProxyApiUrl
-  );
+  const mcProxyApiUrl = useApplicationContext<
+    TAdditionalEnvironmentProperties['mcProxyApiUrl'],
+    TAdditionalEnvironmentProperties
+  >((applicationContext) => applicationContext.environment.mcProxyApiUrl);
 
   const { data, refetch, loading } = useMcQuery<
     TFetchAllMenuFeatureTogglesQuery,

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
@@ -30,6 +30,9 @@ export type Config = {
     onError?: QueryFunctionOptions['onError'];
   };
 };
+type TAdditionalEnvironmentProperties = {
+  mcProxyApiUrl?: string;
+};
 
 const defaultApiUrl = window.location.origin;
 
@@ -138,9 +141,10 @@ function useApplicationsMenu<Key extends MenuKey>(
   config: Config
 ): MenuLoaderResult<Key> | undefined {
   const apolloClient = useApolloClient();
-  const mcProxyApiUrl = useApplicationContext(
-    (context) => context.environment.mcProxyApiUrl
-  );
+  const mcProxyApiUrl = useApplicationContext<
+    TAdditionalEnvironmentProperties['mcProxyApiUrl'],
+    TAdditionalEnvironmentProperties
+  >((context) => context.environment.mcProxyApiUrl);
 
   const [hasWrittenToCache, setHasWrittenToCache] = useState(false);
 

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -329,9 +329,9 @@ describe('ApplicationContext', () => {
 describe('router', () => {
   const TestComponent = () => (
     <Switch>
-      <Route path="/foo/avengers" render={() => 'Foo'} />
+      <Route path="/foo/avengers">{'Foo'}</Route>
       {/* Define a catch-all route */}
-      <Route render={() => 'None'} />
+      <Route>{'None'}</Route>
     </Switch>
   );
   it('should render fallback when no route is provided', async () => {

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -100,7 +100,7 @@ export type TIdTokenUserInfo = {
   aud: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   exp: Scalars['Float'];
-  iat: Scalars['Float'];
+  iat?: Maybe<Scalars['Float']>;
   iss: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   sub: Scalars['String'];
@@ -678,6 +678,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
+  /** @deprecated This field is not used anymore. */
   verificationStatus: TVerificationStatus;
   version?: Maybe<Scalars['Int']>;
 };
@@ -709,7 +710,7 @@ export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 export type TAmILoggedInQuery = { __typename?: 'Query', amILoggedIn: boolean };
 
 export type TFetchProjectQueryVariables = Exact<{
-  projectKey: Scalars['String'];
+  projectKey?: InputMaybe<Scalars['String']>;
 }>;
 
 
@@ -718,7 +719,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat?: number | null, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -191,13 +191,9 @@ export interface ApplicationWindow extends Window {
     frontendHost: string;
     servedByProxy: boolean;
     // Optional properties. To use them, pass them to the `additionalEnv` object of the application config.
-    mcProxyApiUrl?: string;
     ldClientSideId?: string;
     trackingSentry?: string;
     trackingGtm?: string;
-    enableSignUp?: boolean;
-    enableLongLivedFeatureFlags?: boolean;
-    useFullRedirectsForLinks?: boolean;
     // Properties for OIDC-like workflow for development
     __DEVELOPMENT__?: {
       oidc?: ApplicationOidcForDevelopmentConfig;

--- a/packages/permissions/src/types/generated/mc.ts
+++ b/packages/permissions/src/types/generated/mc.ts
@@ -100,7 +100,7 @@ export type TIdTokenUserInfo = {
   aud: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   exp: Scalars['Float'];
-  iat: Scalars['Float'];
+  iat?: Maybe<Scalars['Float']>;
   iss: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   sub: Scalars['String'];
@@ -678,6 +678,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
+  /** @deprecated This field is not used anymore. */
   verificationStatus: TVerificationStatus;
   version?: Maybe<Scalars['Int']>;
 };
@@ -709,7 +710,7 @@ export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 export type TAmILoggedInQuery = { __typename?: 'Query', amILoggedIn: boolean };
 
 export type TFetchProjectQueryVariables = Exact<{
-  projectKey: Scalars['String'];
+  projectKey?: InputMaybe<Scalars['String']>;
 }>;
 
 
@@ -718,7 +719,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat?: number | null, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/schemas/mc.json
+++ b/schemas/mc.json
@@ -747,13 +747,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5567,8 +5563,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "This field is not used anymore."
           },
           {
             "name": "version",

--- a/test-data/types/generated/mc.ts
+++ b/test-data/types/generated/mc.ts
@@ -100,7 +100,7 @@ export type TIdTokenUserInfo = {
   aud: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   exp: Scalars['Float'];
-  iat: Scalars['Float'];
+  iat?: Maybe<Scalars['Float']>;
   iss: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   sub: Scalars['String'];
@@ -678,6 +678,7 @@ export type TUser = TMetaData & {
   numberFormat: Scalars['String'];
   projects: TProjectQueryResult;
   timeZone?: Maybe<Scalars['String']>;
+  /** @deprecated This field is not used anymore. */
   verificationStatus: TVerificationStatus;
   version?: Maybe<Scalars['Int']>;
 };
@@ -709,7 +710,7 @@ export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 export type TAmILoggedInQuery = { __typename?: 'Query', amILoggedIn: boolean };
 
 export type TFetchProjectQueryVariables = Exact<{
-  projectKey: Scalars['String'];
+  projectKey?: InputMaybe<Scalars['String']>;
 }>;
 
 
@@ -718,7 +719,7 @@ export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat: number, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
+export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email: string, createdAt: string, gravatarHash: string, firstName: string, lastName: string, language: string, numberFormat: string, timeZone?: string | null, launchdarklyTrackingId: string, launchdarklyTrackingGroup: string, launchdarklyTrackingSubgroup?: string | null, launchdarklyTrackingTeam?: Array<string> | null, launchdarklyTrackingTenant: string, defaultProjectKey?: string | null, businessRole?: string | null, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> }, idTokenUserInfo?: { __typename?: 'IdTokenUserInfo', iss: string, sub: string, aud: string, exp: number, iat?: number | null, email?: string | null, name?: string | null, additionalClaims?: string | null } | null } | null };
 
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/visual-testing-app/src/application.tsx
+++ b/visual-testing-app/src/application.tsx
@@ -31,22 +31,18 @@ const allSortedComponents = Object.keys(allUniqueVisualRouteComponents)
 const App = () => (
   <Router>
     <Switch>
-      <Route
-        path="/"
-        exact
-        component={() => (
-          <div>
-            <h1>Visual Testing App</h1>
-            <ul>
-              {allSortedComponents.map(({ routePath }) => (
-                <li key={routePath}>
-                  <a href={routePath}>{routePath}</a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      />
+      <Route path="/" exact>
+        <div>
+          <h1>Visual Testing App</h1>
+          <ul>
+            {allSortedComponents.map(({ routePath }) => (
+              <li key={routePath}>
+                <a href={routePath}>{routePath}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Route>
       {allSortedComponents.map(({ routePath, Component }) => (
         <Route key={routePath} path={routePath}>
           <Suspense fallback={'Loading...'}>


### PR DESCRIPTION
Extracted from #2821

* The generic type argument `AdditionalEnvironmentProperties` is not really used and needed by the internal components. Let's remove it.
* Renamed some types for component props.
* Refactored `<Route>` components to render as children ([as recommended when upgrading to v6](https://reactrouter.com/en/main/upgrading/v5)).