### PR TITLE
fix(babel-preset): refine browser targets

### DIFF
--- a/.changeset/gentle-bats-begin.md
+++ b/.changeset/gentle-bats-begin.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/babel-preset-mc-app': patch
+---
+
+Refine browser targets

--- a/packages/babel-preset-mc-app/create.js
+++ b/packages/babel-preset-mc-app/create.js
@@ -1,5 +1,10 @@
 // https://jamie.build/last-2-versions
-const browsersTarget = ['>0.25%', 'not ie 11', 'not op_mini all'];
+// https://browsersl.ist/
+const browsersTarget = [
+  'supports es6-module and >0.25%',
+  'not ie 11',
+  'not op_mini all',
+];
 
 const defaultOptions = {
   // Enables new JSX runtime `automatic`.

--- a/packages/babel-preset-mc-app/create.js
+++ b/packages/babel-preset-mc-app/create.js
@@ -1,3 +1,6 @@
+// https://jamie.build/last-2-versions
+const browsersTarget = ['>0.25%', 'not ie 11', 'not op_mini all'];
+
 const defaultOptions = {
   // Enables new JSX runtime `automatic`.
   runtime: 'classic',
@@ -40,7 +43,7 @@ module.exports = function createBabePresetConfigForMcApp(api, opts = {}, env) {
         require('@babel/preset-env').default,
         {
           targets: {
-            browsers: ['last 2 versions'],
+            browsers: browsersTarget,
             node: 'current',
           },
         },
@@ -50,7 +53,7 @@ module.exports = function createBabePresetConfigForMcApp(api, opts = {}, env) {
         require('@babel/preset-env').default,
         {
           targets: {
-            browsers: ['last 2 versions'],
+            browsers: browsersTarget,
           },
           ...(options.disableCoreJs
             ? {}


### PR DESCRIPTION
Based on this: https://jamie.build/last-2-versions

<img width="726" alt="image" src="https://user-images.githubusercontent.com/1110551/225367667-3638ba6b-82c7-4593-a20d-3dee5bab0968.png">

<img width="739" alt="image" src="https://user-images.githubusercontent.com/1110551/225367756-7634abcb-5982-4cb6-b821-adfca0c2e4d7.png">

<img width="730" alt="image" src="https://user-images.githubusercontent.com/1110551/225369801-388c068b-cbd2-4de6-85e4-2f7e671cfb6e.png">
