### PR TITLE
feat(config): support loading intl messages that use TX Structured JSON format

### DIFF
--- a/.changeset/hip-beers-cry.md
+++ b/.changeset/hip-beers-cry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': minor
+---
+
+Support referencing Intl messages `${intl:}` that use [Transifex's Structured JSON format](https://help.transifex.com/en/articles/6220899-structured-json).

--- a/.changeset/late-donkeys-film.md
+++ b/.changeset/late-donkeys-film.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/i18n': patch
+---
+
+Refine import data type to include Structured JSON format

--- a/.changeset/late-donkeys-film.md
+++ b/.changeset/late-donkeys-film.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/i18n': patch
 ---
 
-Refine import data type to include Structured JSON format
+Refine import data type to include Structured JSON format. Export some utility functions: `parseChunkImport`, `mergeMessages`, `isStructuredJson`, `mapLocaleToIntlLocale`.

--- a/.changeset/polite-squids-argue.md
+++ b/.changeset/polite-squids-argue.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-applications/merchant-center-template-starter-typescript': patch
+'@commercetools-applications/merchant-center-template-starter': patch
+'@commercetools-local/playground': patch
+---
+
+Use `parseChunkImport` function

--- a/application-templates/starter-typescript/src/load-messages.ts
+++ b/application-templates/starter-typescript/src/load-messages.ts
@@ -1,6 +1,6 @@
 import {
   type TI18NImportData,
-  type TMergedMessages,
+  type TMessageTranslations,
   parseChunkImport,
 } from '@commercetools-frontend/i18n';
 
@@ -19,7 +19,7 @@ const getChunkImport = (locale: string): Promise<TI18NImportData> => {
   }
 };
 
-const loadMessages = async (locale: string): Promise<TMergedMessages> => {
+const loadMessages = async (locale: string): Promise<TMessageTranslations> => {
   try {
     const chunkImport = await getChunkImport(locale);
     return parseChunkImport(chunkImport);

--- a/application-templates/starter-typescript/src/load-messages.ts
+++ b/application-templates/starter-typescript/src/load-messages.ts
@@ -1,6 +1,7 @@
-import type {
-  TI18NImportData,
-  TMergedMessages,
+import {
+  type TI18NImportData,
+  type TMergedMessages,
+  parseChunkImport,
 } from '@commercetools-frontend/i18n';
 
 const getChunkImport = (locale: string): Promise<TI18NImportData> => {
@@ -21,10 +22,7 @@ const getChunkImport = (locale: string): Promise<TI18NImportData> => {
 const loadMessages = async (locale: string): Promise<TMergedMessages> => {
   try {
     const chunkImport = await getChunkImport(locale);
-    // Prefer loading `default` (for ESM bundles) and
-    // fall back to normal import (for CJS bundles).
-    // @ts-ignore
-    return chunkImport.default || chunkImport;
+    return parseChunkImport(chunkImport);
   } catch (error) {
     console.warn(
       `Something went wrong while loading the app messages for ${locale}`,

--- a/application-templates/starter/src/load-messages.js
+++ b/application-templates/starter/src/load-messages.js
@@ -1,3 +1,5 @@
+import { parseChunkImport } from '@commercetools-frontend/i18n';
+
 const getChunkImport = (locale) => {
   switch (locale) {
     case 'de':
@@ -14,9 +16,7 @@ const getChunkImport = (locale) => {
 const loadMessages = async (locale) => {
   try {
     const chunkImport = await getChunkImport(locale);
-    // Prefer loading `default` (for ESM bundles) and
-    // fall back to normal import (for CJS bundles).
-    return chunkImport.default || chunkImport;
+    return parseChunkImport(chunkImport);
   } catch (error) {
     console.warn(
       `Something went wrong while loading the app messages for ${locale}`,

--- a/packages/application-config/src/substitute-variable-placeholders.ts
+++ b/packages/application-config/src/substitute-variable-placeholders.ts
@@ -1,6 +1,15 @@
 import fs from 'fs';
 import type { LoadingConfigOptions } from './types';
 
+type TMessageKeyValue = string;
+// Transifex's Structured JSON format.
+// https://help.transifex.com/en/articles/6220899-structured-json
+type TMessageStructuredJson = {
+  string: string;
+  // ...
+};
+type TMessage = Record<string, TMessageKeyValue | TMessageStructuredJson>;
+
 /**
  * NOTE:
  * Allows variable placeholders. Supported types are:
@@ -30,6 +39,10 @@ const isIntlVariablePlaceholder = (valueOfPlaceholder: string) =>
 
 const isFilePathVariablePlaceholder = (valueOfPlaceholder: string) =>
   Boolean(valueOfPlaceholder.match(filePathRefSyntax));
+
+const isStructuredJson = (
+  message: TMessageKeyValue | TMessageStructuredJson
+): message is TMessageStructuredJson => typeof message !== 'string';
 
 const substituteEnvVariablePlaceholder = (
   valueOfPlaceholder: string,
@@ -67,7 +80,7 @@ const substituteIntlVariablePlaceholder = (
       loadingOptions.applicationPath,
     ],
   });
-  const translations: Record<string, string> = require(translationsFilePath);
+  const translations: TMessage = require(translationsFilePath);
 
   const hasIntlMessage = translations.hasOwnProperty(requestedIntlMessageId);
 
@@ -77,10 +90,15 @@ const substituteIntlVariablePlaceholder = (
     );
   }
 
+  const translation = translations[requestedIntlMessageId];
+  const translationValue = isStructuredJson(translation)
+    ? translation.string
+    : translation;
+
   const escapedMatchedString = matchedString.replace(/[${}:]/g, '\\$&');
   return valueOfEnvConfig.replace(
     new RegExp(`(${escapedMatchedString})+`, 'g'),
-    translations[requestedIntlMessageId]
+    translationValue
   );
 };
 

--- a/packages/application-config/src/substitute-variable-placeholders.ts
+++ b/packages/application-config/src/substitute-variable-placeholders.ts
@@ -42,7 +42,8 @@ const isFilePathVariablePlaceholder = (valueOfPlaceholder: string) =>
 
 const isStructuredJson = (
   message: TMessageKeyValue | TMessageStructuredJson
-): message is TMessageStructuredJson => typeof message !== 'string';
+): message is TMessageStructuredJson =>
+  (message as TMessageStructuredJson)?.string !== undefined;
 
 const substituteEnvVariablePlaceholder = (
   valueOfPlaceholder: string,

--- a/packages/application-config/test/fixtures/i18n/data/de.json
+++ b/packages/application-config/test/fixtures/i18n/data/de.json
@@ -1,4 +1,4 @@
 {
-  "Menu.Avengers": "Die Avengers",
-  "Menu.Avengers.New": "Avenger hinzufügen"
+  "Menu.Avengers": { "string": "Die Avengers" },
+  "Menu.Avengers.New": { "string": "Avenger hinzufügen" }
 }

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -62,7 +62,10 @@ const Application = (props) => (
 
 ```js
 import { IntlProvider } from 'react-intl';
-import { AsyncLocaleData } from '@commercetools-frontend/i18n';
+import {
+  AsyncLocaleData,
+  parseChunkImport,
+} from '@commercetools-frontend/i18n';
 
 const loadMessages = (lang) => {
   let loadAppI18nPromise;
@@ -84,7 +87,7 @@ const loadMessages = (lang) => {
   }
 
   return loadAppI18nPromise.then(
-    (result) => result.default,
+    (result) => parseChunkImport(result),
     (error) => {
       // eslint-disable-next-line no-console
       console.warn(

--- a/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.spec.tsx
@@ -1,10 +1,10 @@
 import { mocked } from 'jest-mock';
 import { render, waitFor } from '@testing-library/react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
+import type { TMessageTranslations } from '../export-types';
 import loadI18n from '../load-i18n';
 import type { TRenderFunctionResult, Props } from './async-locale-data';
 import { AsyncLocaleData } from './async-locale-data';
-import type { TMessageTranslations } from './use-async-intl-messages';
 
 jest.mock('@commercetools-frontend/sentry');
 

--- a/packages/i18n/src/async-locale-data/async-locale-data.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.tsx
@@ -1,17 +1,17 @@
 import { useEffect, ReactNode, useCallback } from 'react';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import type { MergedMessages } from '../export-types';
+import type { TMessageTranslations } from '../export-types';
 import loadI18n from '../load-i18n';
 import { extractLanguageTagFromLocale, mergeMessages } from '../utils';
 import useAsyncIntlMessages from './use-async-intl-messages';
 
 export type TMessageTranslationsAsync = (
   locale: string
-) => Promise<MergedMessages>;
+) => Promise<TMessageTranslations>;
 export type TRenderFunctionResult = {
   isLoading: boolean;
   locale?: string;
-  messages?: MergedMessages;
+  messages?: TMessageTranslations;
 };
 export type Props = {
   // The locale is optional, which indicates that we don't know yet
@@ -20,13 +20,13 @@ export type Props = {
   // therefore causing flashing of translated content on subsequent re-renders.
   locale?: string;
   applicationMessages:
-    | { [locale: string]: MergedMessages }
+    | { [locale: string]: TMessageTranslations }
     | TMessageTranslationsAsync;
   children: (state: TRenderFunctionResult) => ReactNode;
 };
 
 const getMessagesForLocale = (
-  data?: { [locale: string]: MergedMessages },
+  data?: { [locale: string]: TMessageTranslations },
   locale?: string
 ) => {
   if (!data || !locale) return {};

--- a/packages/i18n/src/async-locale-data/async-locale-data.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.tsx
@@ -1,21 +1,17 @@
 import { useEffect, ReactNode, useCallback } from 'react';
-import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
-
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
+import type { MergedMessages } from '../export-types';
 import loadI18n from '../load-i18n';
 import { extractLanguageTagFromLocale, mergeMessages } from '../utils';
 import useAsyncIntlMessages from './use-async-intl-messages';
 
-export type TMessageTranslations =
-  | Record<string, string>
-  | Record<string, MessageFormatElement[]>;
 export type TMessageTranslationsAsync = (
   locale: string
-) => Promise<TMessageTranslations>;
+) => Promise<MergedMessages>;
 export type TRenderFunctionResult = {
   isLoading: boolean;
   locale?: string;
-  messages?: TMessageTranslations;
+  messages?: MergedMessages;
 };
 export type Props = {
   // The locale is optional, which indicates that we don't know yet
@@ -24,13 +20,13 @@ export type Props = {
   // therefore causing flashing of translated content on subsequent re-renders.
   locale?: string;
   applicationMessages:
-    | { [locale: string]: TMessageTranslations }
+    | { [locale: string]: MergedMessages }
     | TMessageTranslationsAsync;
   children: (state: TRenderFunctionResult) => ReactNode;
 };
 
 const getMessagesForLocale = (
-  data?: { [locale: string]: TMessageTranslations },
+  data?: { [locale: string]: MergedMessages },
   locale?: string
 ) => {
   if (!data || !locale) return {};

--- a/packages/i18n/src/async-locale-data/use-async-intl-messages.ts
+++ b/packages/i18n/src/async-locale-data/use-async-intl-messages.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
-import type { MergedMessages } from '../export-types';
+import type { TMessageTranslations } from '../export-types';
 
 export type TMessageTranslationsAsync = (
   locale: string
-) => Promise<MergedMessages>;
+) => Promise<TMessageTranslations>;
 export type TState = {
   isLoading: boolean;
-  messages?: MergedMessages;
+  messages?: TMessageTranslations;
   error?: Error;
 };
 export type THookOptions = {

--- a/packages/i18n/src/async-locale-data/use-async-intl-messages.ts
+++ b/packages/i18n/src/async-locale-data/use-async-intl-messages.ts
@@ -1,15 +1,12 @@
 import { useEffect, useState } from 'react';
-import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
+import type { MergedMessages } from '../export-types';
 
-export type TMessageTranslations =
-  | Record<string, string>
-  | Record<string, MessageFormatElement[]>;
 export type TMessageTranslationsAsync = (
   locale: string
-) => Promise<TMessageTranslations>;
+) => Promise<MergedMessages>;
 export type TState = {
   isLoading: boolean;
-  messages?: TMessageTranslations;
+  messages?: MergedMessages;
   error?: Error;
 };
 export type THookOptions = {

--- a/packages/i18n/src/export-types.ts
+++ b/packages/i18n/src/export-types.ts
@@ -8,15 +8,16 @@ export type TMessageStructuredJson = {
   character_limit?: string;
 };
 
-export type MergedMessages =
+export type TMessageTranslations =
   | Record<string, string>
-  | Record<string, MessageFormatElement[]>
+  | Record<string, MessageFormatElement[]>;
+
+export type TMergedMessages =
+  | TMessageTranslations
   | Record<string, TMessageStructuredJson>;
 
-export type I18NImportData = {
-  default: MergedMessages;
+export type TI18NImportData = {
+  default: TMergedMessages;
 };
 
 export type TAsyncLocaleDataProps = Props;
-export type TI18NImportData = I18NImportData;
-export type TMergedMessages = MergedMessages;

--- a/packages/i18n/src/export-types.ts
+++ b/packages/i18n/src/export-types.ts
@@ -1,5 +1,21 @@
+import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
 import type { Props } from './async-locale-data/async-locale-data';
-import type { I18NImportData, MergedMessages } from './load-i18n';
+
+export type TMessageStructuredJson = {
+  string: string;
+  developer_comment?: string;
+  context?: string;
+  character_limit?: string;
+};
+
+export type MergedMessages =
+  | Record<string, string>
+  | Record<string, MessageFormatElement[]>
+  | Record<string, TMessageStructuredJson>;
+
+export type I18NImportData = {
+  default: MergedMessages;
+};
 
 export type TAsyncLocaleDataProps = Props;
 export type TI18NImportData = I18NImportData;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -7,3 +7,9 @@ export {
   useAsyncIntlMessages,
 } from './async-locale-data';
 export { default as sharedMessages } from './shared-messages';
+export {
+  parseChunkImport,
+  mergeMessages,
+  isStructuredJson,
+  mapLocaleToIntlLocale,
+} from './utils';

--- a/packages/i18n/src/load-i18n.ts
+++ b/packages/i18n/src/load-i18n.ts
@@ -1,13 +1,6 @@
-import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
+import type { I18NImportData, MergedMessages } from './export-types';
 import loadMomentLocales from './moment-locales';
 import { mergeMessages, mapLocaleToIntlLocale } from './utils';
-
-export type I18NImportData = {
-  default: Record<string, string> | Record<string, MessageFormatElement[]>;
-};
-export type MergedMessages =
-  | Record<string, string>
-  | Record<string, MessageFormatElement[]>;
 
 const getUiKitChunkImport = (locale: string): Promise<I18NImportData> => {
   const intlLocale = mapLocaleToIntlLocale(locale);

--- a/packages/i18n/src/load-i18n.ts
+++ b/packages/i18n/src/load-i18n.ts
@@ -1,8 +1,12 @@
-import type { I18NImportData, MergedMessages } from './export-types';
+import type { TI18NImportData, TMessageTranslations } from './export-types';
 import loadMomentLocales from './moment-locales';
-import { mergeMessages, mapLocaleToIntlLocale } from './utils';
+import {
+  parseChunkImport,
+  mergeMessages,
+  mapLocaleToIntlLocale,
+} from './utils';
 
-const getUiKitChunkImport = (locale: string): Promise<I18NImportData> => {
+const getUiKitChunkImport = (locale: string): Promise<TI18NImportData> => {
   const intlLocale = mapLocaleToIntlLocale(locale);
   switch (intlLocale) {
     case 'de':
@@ -28,7 +32,7 @@ const getUiKitChunkImport = (locale: string): Promise<I18NImportData> => {
   }
 };
 
-const getAppKitChunkImport = (locale: string): Promise<I18NImportData> => {
+const getAppKitChunkImport = (locale: string): Promise<TI18NImportData> => {
   const intlLocale = mapLocaleToIntlLocale(locale);
   switch (intlLocale) {
     case 'de':
@@ -56,7 +60,7 @@ const getAppKitChunkImport = (locale: string): Promise<I18NImportData> => {
 
 const getCommunityKitChunkImport = async (
   locale: string
-): Promise<I18NImportData> => {
+): Promise<TI18NImportData> => {
   const intlLocale = mapLocaleToIntlLocale(locale);
   switch (intlLocale) {
     case 'de':
@@ -86,7 +90,7 @@ const getCommunityKitChunkImport = async (
 // locale. https://webpack.js.org/api/module-methods/#import-
 export default async function loadI18n(
   locale: string
-): Promise<MergedMessages> {
+): Promise<TMessageTranslations> {
   // Load moment localizations
   await loadMomentLocales(locale);
 
@@ -102,8 +106,8 @@ export default async function loadI18n(
   // Prefer loading `default` (for ESM bundles) and
   // fall back to normal import (for CJS bundles).
   return mergeMessages(
-    uiKitChunkImport.default || uiKitChunkImport,
-    appKitChunkImport.default || appKitChunkImport,
-    communityKitChunkImport.default || communityKitChunkImport
+    parseChunkImport(uiKitChunkImport),
+    parseChunkImport(appKitChunkImport),
+    parseChunkImport(communityKitChunkImport)
   );
 }

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -1,10 +1,42 @@
-import type { MergedMessages } from './export-types';
+import type {
+  TI18NImportData,
+  TMessageTranslations,
+  TMessageStructuredJson,
+} from './export-types';
 
 export const extractLanguageTagFromLocale = (locale: string): string =>
   locale.includes('-') ? locale.split('-')[0] : locale;
 
-export const mergeMessages = (...messages: MergedMessages[]): MergedMessages =>
-  Object.assign({}, ...messages);
+export const isStructuredJson = (
+  message: TMessageTranslations | TMessageStructuredJson
+): message is TMessageStructuredJson =>
+  (message as TMessageStructuredJson)?.string !== undefined;
+
+export const parseChunkImport = (
+  chunkImport: TI18NImportData
+): TMessageTranslations => {
+  // Prefer loading `default` (for ESM bundles) and
+  // fall back to normal import (for CJS bundles).
+  const contents = chunkImport.default || chunkImport;
+
+  return Object.entries(contents).reduce(
+    (messages, [messageKey, messageValue]) => {
+      const messageAsString = isStructuredJson(messageValue)
+        ? messageValue.string
+        : messageValue;
+
+      return {
+        ...messages,
+        [messageKey]: messageAsString,
+      };
+    },
+    {} as TMessageTranslations
+  );
+};
+
+export const mergeMessages = (
+  ...messages: TMessageTranslations[]
+): TMessageTranslations => Object.assign({}, ...messages);
 
 export const mapLocaleToIntlLocale = (locale: string): string => {
   if (locale.startsWith('de')) return 'de';

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -1,15 +1,10 @@
-import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
-
-export type TMessageTranslations =
-  | Record<string, string>
-  | Record<string, MessageFormatElement[]>;
+import type { MergedMessages } from './export-types';
 
 export const extractLanguageTagFromLocale = (locale: string): string =>
   locale.includes('-') ? locale.split('-')[0] : locale;
 
-export const mergeMessages = (
-  ...messages: TMessageTranslations[]
-): TMessageTranslations => Object.assign({}, ...messages);
+export const mergeMessages = (...messages: MergedMessages[]): MergedMessages =>
+  Object.assign({}, ...messages);
 
 export const mapLocaleToIntlLocale = (locale: string): string => {
   if (locale.startsWith('de')) return 'de';

--- a/playground/src/messages.js
+++ b/playground/src/messages.js
@@ -1,3 +1,5 @@
+import { parseChunkImport } from '@commercetools-frontend/i18n';
+
 const loadMessages = (lang) => {
   let loadAppI18nPromise;
   switch (lang) {
@@ -18,7 +20,7 @@ const loadMessages = (lang) => {
   }
 
   return loadAppI18nPromise.then(
-    (result) => result.default,
+    (result) => parseChunkImport(result),
     (error) => {
       // eslint-disable-next-line no-console
       console.warn(


### PR DESCRIPTION
As we're looking into adopting [Transifex's Structured JSON format](https://help.transifex.com/en/articles/6220899-structured-json), we can provide better support for it in our tools.