### PR TITLE
Update AWS link in S3 deployment examples

### DIFF
--- a/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
+++ b/website/src/content/deployment-examples/aws-s3-cloudfront.mdx
@@ -8,7 +8,7 @@ This deployment example refers to [AWS](https://aws.amazon.com/) static hosting 
 
 Before you get started, you need to have:
 
-- An [AWS](https://portal.aws.amazon.com/billing/signup#/start) account.
+- An [AWS](https://aws.amazon.com/) account.
 - A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
 - A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
 


### PR DESCRIPTION
#### Summary

Updating an AWS link that points to the billing/signup page because we are getting 401 errors from the link checker.
