### PR TITLE
chore(appkit): use `Text.Detail` for login page footer

### DIFF
--- a/.changeset/lucky-apricots-camp.md
+++ b/.changeset/lucky-apricots-camp.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Use Text.Detail for PublicPageLayout footer

--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -103,14 +103,17 @@ const PublicPageLayout: FC<TProps> = (props) => {
               scale="xs"
               alignItems={props.contentScale === 'wide' ? 'center' : 'stretch'}
             >
-              {props.legalMessage && (
-                <Text.Body tone={themedValue('inverted', 'secondary')}>
-                  {props.legalMessage}
-                </Text.Body>
+              {props.legalMessage &&
+                themedValue(
+                  <Text.Body tone="inverted">{props.legalMessage}</Text.Body>,
+                  <Text.Detail tone="secondary">
+                    {props.legalMessage}
+                  </Text.Detail>
+                )}
+              {themedValue(
+                <Text.Body tone="inverted">{`${year} © commercetools`}</Text.Body>,
+                <Text.Detail tone="secondary">{`${year} © commercetools`}</Text.Detail>
               )}
-              <Text.Body
-                tone={themedValue('inverted', 'secondary')}
-              >{`${year} © commercetools`}</Text.Body>
             </Spacings.Stack>
           </PublicPageLayoutContent>
         </Spacings.Stack>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary

Missed this requirement a few days ago when making changes to the login page design.

Old theme:
![image](https://user-images.githubusercontent.com/15024562/228954694-5bafe62e-4411-4d83-b843-e81da410d656.png)

New theme:
![image](https://user-images.githubusercontent.com/15024562/228954740-8d79586a-dbba-46b4-b5a5-931476faec97.png)


