### PR TITLE
fix(app-shell): spacing for long label in menu items

### DIFF
--- a/.changeset/weak-poets-drive.md
+++ b/.changeset/weak-poets-drive.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix navbar menu spacing for long labels

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -348,7 +348,7 @@
 }
 .item_menu-collapsed.list-item.item__active .item-icon-text .title {
   max-height: 44px;
-  overflow-x: hidden;
+  overflow: hidden;
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
   -webkit-line-clamp: 2;

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -252,7 +252,7 @@
 /*  Second level menu */
 
 .sublist {
-  padding: 55px var(--spacing-l) var(--spacing-m);
+  padding: 75px var(--spacing-l) var(--spacing-m);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   font-weight: var(--font-weight-for-navbar-link);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
@@ -345,6 +345,14 @@
 
 .list-item.item__active .item-icon-text .title {
   margin-left: 40px;
+}
+.item_menu-collapsed.list-item.item__active .item-icon-text .title {
+  max-height: 44px;
+  overflow-x: hidden;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 :global(.body__menu-open) .list-item.item__active .item-icon-text .title {


### PR DESCRIPTION
For long labels, when the menu is collapsed and hovered, the main menu label overflows with the submenu items.

Before

<img width="288" alt="Screenshot 2023-04-03 at 12 49 40" src="https://user-images.githubusercontent.com/1110551/229489075-1974aff1-6c8a-47a8-973e-2b07679d31f5.png">

Due to limitations in how the navbar menu is implemented, we need a workaround to fix this edge case. We can set a max height for the main menu label to approx 2 lines, after which it gets truncated. This way we control the spacing with the submenu items.

The truncation is done using the [`-webkit-line-clamp`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp) CSS property, which is [supported by all browsers](https://caniuse.com/css-line-clamp).

After

<img width="283" alt="Screenshot 2023-04-03 at 12 46 32" src="https://user-images.githubusercontent.com/1110551/229489718-3cb4b11f-4e99-4d11-9098-10c262519995.png">
<img width="269" alt="Screenshot 2023-04-03 at 12 46 40" src="https://user-images.githubusercontent.com/1110551/229489721-9a1632d0-690d-40e9-9006-5f8870c5f251.png">
