### PR TITLE
Fix: environment variable syntax typo

### DIFF
--- a/website/src/content/api-reference/application-config.mdx
+++ b/website/src/content/api-reference/application-config.mdx
@@ -671,7 +671,7 @@ You can also pass multiple references to the same value:
 ```json
 {
   "additionalEnv": {
-    "authorityUrl": "https://${env:IDP_URL}/${env.IDP_ID}"
+    "authorityUrl": "https://${env:IDP_URL}/${env:IDP_ID}"
   }
 }
 ```


### PR DESCRIPTION
Fix the environment variable usage syntax: replace `.` with `:`.