### PR TITLE
chore: update typescript to v5

### DIFF
--- a/.changeset/moody-glasses-tell.md
+++ b/.changeset/moody-glasses-tell.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-applications/merchant-center-template-starter-typescript': patch
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/codemod': patch
+'@commercetools-local/playground': patch
+---
+
+Use TypeScript to v5

--- a/application-templates/starter-typescript/package.json
+++ b/application-templates/starter-typescript/package.json
@@ -90,7 +90,7 @@
     "react-redux": "7.2.9",
     "react-router-dom": "5.3.4",
     "redux": "4.2.1",
-    "typescript": "4.9.5"
+    "typescript": "5.0.4"
   },
   "resolutions": {
     "@emotion/react": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "stylelint-order": "5.0.0",
     "stylelint-value-no-unknown-custom-properties": "4.0.0",
     "tsc-files": "1.1.3",
-    "typescript": "4.9.5",
+    "typescript": "5.0.4",
     "vfile-message": "3.1.4"
   },
   "resolutions": {

--- a/packages/application-components/src/components/internals/page-header-title.tsx
+++ b/packages/application-components/src/components/internals/page-header-title.tsx
@@ -62,7 +62,7 @@ const Subtitle = (props: SubtitleProps) => {
   return (
     <SubtitleWrapper>
       <Text.Body
-        title={props.subtitle}
+        title={typeof props.subtitle === 'string' ? props.subtitle : undefined}
         truncate={props.truncate}
         tone={theme !== 'default' ? 'secondary' : undefined}
       >

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -32,7 +32,7 @@
     "@tsconfig/node16": "^1.0.3",
     "@types/jscodeshift": "0.11.6",
     "rimraf": "3.0.2",
-    "typescript": "4.9.5"
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": "14.x || >=16.0.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -61,6 +61,6 @@
     "dotenv-flow": "^3.2.0",
     "express": "4.18.2",
     "ts-node": "^10.9.1",
-    "typescript": "4.9.5"
+    "typescript": "5.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,7 +3695,7 @@ __metadata:
     react-redux: 7.2.9
     react-router-dom: 5.3.4
     redux: 4.2.1
-    typescript: 4.9.5
+    typescript: 5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4269,7 +4269,7 @@ __metadata:
     glob: 8.1.0
     jscodeshift: 0.14.0
     rimraf: 3.0.2
-    typescript: 4.9.5
+    typescript: 5.0.4
   bin:
     mc-codemod: ./bin/mc-codemod.js
   languageName: unknown
@@ -4747,7 +4747,7 @@ __metadata:
     react-intl: ^5.25.1
     react-router-dom: 5.3.4
     ts-node: ^10.9.1
-    typescript: 4.9.5
+    typescript: 5.0.4
     vercel: 24.2.5
   languageName: unknown
   linkType: soft
@@ -28197,7 +28197,7 @@ __metadata:
     stylelint-order: 5.0.0
     stylelint-value-no-unknown-custom-properties: 4.0.0
     tsc-files: 1.1.3
-    typescript: 4.9.5
+    typescript: 5.0.4
     vfile-message: 3.1.4
   languageName: unknown
   linkType: soft
@@ -36557,13 +36557,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:5.0.4":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
@@ -36597,13 +36597,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+"typescript@patch:typescript@5.0.4#~builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
No breaking changes are expected for us.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-rc/#breaking-changes-and-deprecations