### PR TITLE
docs: Fix formatting to avoid table content overflow

### DIFF
--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -63,81 +63,21 @@ const EntryPoint = () => (
 export default EntryPoint;
 ```
 
-### Properties original
+### Properties
 
-| Props                            | Type               |        Required        | Description                                                                                                                                                                                                                                                                                                                                                                      |
-| -------------------------------- | ------------------ | :---------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `applicationMessages`            | `object` or `func` |           ✅        | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).                                                                                                                                                                |
-| `environment`                  | `object`           |           ✅        | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).                                                                                                                                                                                                                                                                                                                                                       |
-| `children`                         | `node`             |           ✅        | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.                                                                                                                                                                                                                                    |
-| `render`                         | `func`             |            (*)       | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.                                                                                                                                                                                                                                  |
-| `apolloClient`         | `ApolloClient`           |                   | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).                                                                                                                                                                                                                                        |
+<Info>
 
+The properties with an * are required.
 
-### Properties with ChildSectionsNav
+</Info>
 
-<ChildSectionsNav parent="properties-with-childsectionsnav" />
-
-#### applicationMessages
-
-Type: `object` or `func` (Required)
-
-This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).
-
-#### environment
-
-Type: `object` (Required)
-
-The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).
-
-#### children
-
-Type: `node` (Required)
-
-Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.
-
-#### render
-
-Type: `func`
-
-The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.
-
-#### apolloClient
-
-Type: `ApolloClient`
-
-An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
-
-### Properties with Table+description
-
-| Name | Type | Required |
-|------|------|----------|
-| [applicationMessages](#applicationmessages) | `object` or `func` | Yes |
-| [environment](#environment) | `object` | Yes |
-| [children](#children) | `node` | Yes |
-| [render](#render) | `func` | No |
-| [apolloClient](#apolloClient) | `ApolloClient` | No |
-
-#### applicationMessages
-
-This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).
-
-#### environment
-
-The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).
-
-#### children
-
-Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.
-
-#### render
-
-The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.
-
-#### apolloClient
-
-An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
-
+| Name | Description |
+|------|------|
+| `applicationMessages` * of type `object` or `func` | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).  |
+| `environment` * of type `object` | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment). |
+| `children` * of type `node` | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup. |
+| `render` of type `func` | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use** the `children` prop to benefit from a simpler setup. |
+| `apolloClient` of type `ApolloClient` | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient). |
 
 ## ApplicationPageTitle
 
@@ -170,13 +110,15 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 ### Properties
 
-#### additionalParts
+<Info>
 
-Type: `string[]`
+The properties with an * are required.
 
-Required: ✅
+</Info>
 
-A list of parts to be prepended to the default page title, separated by `-`.
+| Props  |  Description |
+| ------ | ------------ |
+| `additionalParts` * of type `string[]` | A list of parts to be prepended to the default page title, separated by `-`. |
 
 
 # Hooks
@@ -495,114 +437,32 @@ describe('rendering', () => {
 
 ### Options
 
-<ChildSectionsNav parent="options" />
+| Argument              |                                                                                                                                                                                      | Description                                                                                                                                                                                                                                                                                                                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `locale` of type `String`      | Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.                                          |
+| `dataLocale` of type `String`                                                                                                                                                                                             | Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.                                                                                                                                                                                                                                                      |
+| `mocks` of type `Array`                                                                                                                                                                                                    | Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).                                                                                                                                                                              |
+| `apolloClient` of type  `ApolloClient`                                                                                                                                                                        | Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.                                                                                                  |
+| `route` of type `String`                                                                                                                                                                                          | The route the user is on, like `/test-project/products`. Defaults to `/`.                                                                                                                                                                                                                                                                                                          |
+| `disableAutomaticEntryPointRoutes` of type `Boolean`                                                                                                                                                                                               | Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.                                                                                                                                                                                                                                                                                                           |
+| `history` of type `Object`     |  By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object. |
+| `adapter` of type `Object`                                                                                                                                                                                          | The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).                                                                                                                                                                          |
+| `flags` of type `Object`                                                                                                                                                                                          | An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.                                                                                                                                                                            |
+| `environment` of type `Object`    | Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.                                                                                                                                                 |
+| `user`  of type `Object`      | Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.                                                                                                                                                                       |
+| `project` of type `Object`     | Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
 
-
-#### locale
-
-Type: `String`
-
-Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.
-
-
-#### dataLocale
-
-Type: `String`
-
-Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.
-
-
-#### mocks
-
-Type: `Array`
-
-Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).
-
-
-#### apolloClient
-
-Type: `ApolloClient`
-
-Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.
-
-
-#### route
-
-Type: `String`
-
-The route the user is on, like `/test-project/products`. Defaults to `/`.
-
-#### disableAutomaticEntryPointRoutes
-
-Type: `Boolean`
-
-Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.
-
-#### history
-
-Type: `Object`
-
-By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object.
-
-#### adapter
-
-Type: `Object`
-
-The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).
-
-#### flags
-
-Type: `Object`
-
-An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.
-
-#### environment
-
-Type: `Object`
-
-Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.
-
-#### user
-
-Type: `Object`
-
-Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.
-
-#### project
-
-Type: `Object`
-
-Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
 
 ### Return values
 
 Calling `renderApp` returns the same [Result](https://testing-library.com/docs/react-testing-library/api#render-result) object of React Testing Library, with the addition of the following fields:
 
-<ChildSectionsNav parent="return-values" />
-
-#### history
-
-Type: `Object`
-
-The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on.
-
-#### user
-
-Type: `Object`
-
-The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. The `user` object is not the same as `applicationContext.user` and can be `undefined` when no user is authenticated (when `options.user` was `null`).
-
-#### project
-
-Type: `Object`
-
-The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. The `project` object is not the same as `applicationContext.project` and can be `undefined` when no project was set (when `options.project` was `null`).
-
-#### environment
-
-Type: `Object`
-
-The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. The `environment` object is not the same as `applicationContext.environment` and can be `undefined` when no environment was set (when `options.environment` was `null`).
+| Field         | Description                                                                                                                                                                                                                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `history` of type `Object` | The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on.                                                                                                                                                                                          |
+| `user` of type `Object` | The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`).                                  |
+| `project` of type `Object` | The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`).                         |
+| `environment` of type `Object` | The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`). |
 
 ## renderAppWithRedux
 
@@ -636,31 +496,12 @@ In addition to the following options, the method accepts all options from `rende
 
 </Info>
 
-<ChildSectionsNav parent="options-1" />
-
-#### store
-
-Type: `Object`
-
-A custom redux store.
-
-#### storeState
-
-Type: `Object`
-
-Pass an initial state to the default Redux store.
-
-#### sdkMocks
-
-Type: `Array`
-
-Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md).
-
-#### mapNotificationToComponent
-
-Type: `Function`
-
-Pass a function to map a notification to a custom component.
+| Argument                             | Description                                                                                                                                                                                                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store` of type `Object`   | A custom redux store.                                                                                                                                                                                                                                          |
+| `storeState` of type `Object`   | Pass an initial state to the default Redux store.                                                                                                                                                                                                              |
+| `sdkMocks` of type `Array`    | Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
+| `mapNotificationToComponent` of type `Function` | Pass a function to map a notification to a custom component.                                                                                                                                                                                                   |
 
 
 <!-- ## renderHook -->

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -425,20 +425,115 @@ describe('rendering', () => {
 
 ### Options
 
-| Argument              | Type          | Concern                                                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                        |
-| --------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `locale`      | `String`      | Localization                                                                                                                                                                                       | Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.                                          |
-| `dataLocale`  | `String`      | Localization                                                                                                                                                                                       | Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.                                                                                                                                                                                                                                                      |
-| `mocks`       | `Array`       | Apollo                                                                                                                                                                                             | Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).                                                                                                                                                                              |
-| `apolloClient` | `ApolloClient`     | Apollo                                                                                                                                                                                             | Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.                                                                                                  |
-| `route`       | `String`      | Routing                                                                                                                                                                                            | The route the user is on, like `/test-project/products`. Defaults to `/`.                                                                                                                                                                                                                                                                                                          |
-| `disableAutomaticEntryPointRoutes`       | `Boolean`      | Routing                                                                                                                                                                                            | Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.                                                                                                                                                                                                                                                                                                           |
-| `history`     | `Object`      | Routing                                                                                                                                                                                            | By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object. |
-| `adapter`     | `Object`      | Feature Toggles                                                                                                                                                                                    | The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).                                                                                                                                                                          |
-| `flags`       | `Object`      | Feature Toggles                                                                                                                                                                                    | An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.                                                                                                                                                                            |
-| `environment` | `Object`      | [Runtime configuration](/api-reference/application-config#runtime-application-environment) | Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.                                                                                                                                                 |
-| `user`        | `Object`      | [Application Context](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell-connectors/src/components/application-context/README.md#user)        | Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.                                                                                                                                                                       |
-| `project`     | `Object`      | [Application Context](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell-connectors/src/components/application-context/README.md#project)     | Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
+<ChildSectionsNav parent="options" />
+
+
+#### `locale`
+
+`String`
+
+Localization
+
+Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.
+
+
+#### `dataLocale`
+
+`String`
+
+Localization
+
+Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.
+
+
+####  `mocks`
+
+`Array`
+
+Apollo
+
+Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).
+
+
+####  `apolloClient`
+
+`ApolloClient`
+
+Apollo
+
+Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.
+
+
+####  `route`
+
+`String`
+
+Routing
+
+The route the user is on, like `/test-project/products`. Defaults to `/`.
+
+
+####  `disableAutomaticEntryPointRoutes`
+
+`Boolean`
+
+Routing
+
+Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.
+
+
+####  `history`
+
+`Object`
+
+Routing
+
+By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object.
+
+
+#### `adapter`
+
+`Object`
+
+Feature Toggles
+
+The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).
+
+
+#### `flags`
+
+`Object`
+
+Feature Toggles
+
+An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.
+
+
+#### `environment`
+
+`Object`
+
+[Runtime configuration](/api-reference/application-config#runtime-application-environment)
+
+Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.
+
+
+#### `user`
+
+`Object`
+
+[Application Context](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell-connectors/src/components/application-context/README.md#user)
+
+Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.
+
+
+#### `project`
+
+`Object`
+
+[Application Context](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell-connectors/src/components/application-context/README.md#project)
+
+Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
 
 ### Return values
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -92,15 +92,6 @@ The render function is called when the `<ApplicationShell>` is ready to render t
 **ApolloClient** *(optional)* \
 An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
 
-
-| Name |
-| --- |
-| `applicationMessages` **object** or **func** <br/><br/>This is either an object containing all the translated messages, grouped by locale<br/>`{ en: { Welcome: "Welcome" }, de: { Welcome: "Wilkommen" } }`<br/>or a function that returns a Promise that resolves to such an object.<br/>The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).  |
-| `environment` **object** <br/><br/>The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment). |
-| `children` **node** <br/><br/>Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`.<br/>By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`.<br/>This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup. |
-| `render` *(optional)* **func** <br/><br/>The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized.<br/>It's **recommended to use** the `children` prop to benefit from a simpler setup. |
-| `apolloClient` *(optional)* **ApolloClient** <br/><br/>An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient). |
-
 ## ApplicationPageTitle
 
 <Info>
@@ -138,10 +129,6 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 **string[]**\
 A list of parts to be prepended to the default page title, separated by `-`.
-
-| Name |
-| ---- |
-| `additionalParts` **string[]** <br/><br/>A list of parts to be prepended to the default page title, separated by `-`. |
 
 
 # Hooks
@@ -523,23 +510,6 @@ Allows to set the `applicationContext.user`. The passed object gets merged with 
 Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
 
 
-
-| Name |
-| --- |
-| `locale` **string** <br/><br/>Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages. |
-| `dataLocale` **string** <br/><br/>Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s. |
-| `mocks` **mock[]** <br/><br/>Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/). |
-| `apolloClient` **ApolloClient** <br/><br/>Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`. |
-| `route` **string** <br/><br/>The route the user is on, like `/test-project/products`. Defaults to `/`. |
-| `disableAutomaticEntryPointRoutes` **boolean** <br/><br/>Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop. |
-| `history` **object** <br/><br/>By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object. |
-| `adapter` **object** <br/><br/>The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter). |
-| `flags` **object** <br/><br/>An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`. |
-| `environment` **object** <br/><br/>Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given. |
-| `user` **object** <br/><br/>Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated. |
-| `project` **object** <br/><br/>Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context. |
-
-
 ### Return values
 
 Calling `renderApp` returns the same [Result](https://testing-library.com/docs/react-testing-library/api#render-result) object of React Testing Library, with the addition of the following properties:
@@ -565,14 +535,6 @@ The `project` object used to configure `<ApplicationContextProvider>`, so the re
 
 **object**\
 The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`).
-
-
-| Name |
-| --- |
-| `history` **object** <br/><br/>The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on. |
-| `user` **object** <br/><br/>The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`). |
-| `project` **object** <br/><br/>The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`). |
-| `environment` **object** <br/><br/>The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`). |
 
 ## renderAppWithRedux
 
@@ -627,14 +589,6 @@ Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sd
 
 **func**\
 Pass a function to map a notification to a custom component.
-
-| Name |
-| --- |
-| `store` **object** <br/><br/>A custom redux store. |
-| `storeState` **object** <br/><br/>Pass an initial state to the default Redux store. |
-| `sdkMocks` **mock[]** <br/><br/>Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
-| `mapNotificationToComponent` **func** <br/><br/>Pass a function to map a notification to a custom component. |
-
 
 <!-- ## renderHook -->
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -65,6 +65,34 @@ export default EntryPoint;
 
 ### Properties
 
+<ChildSectionsNav parent="properties" />
+
+#### `applicationMessages`
+
+**object** or **func**\
+This is either an object containing all the translated messages, grouped by locale<br/>`{ en: { Welcome: "Welcome" }, de: { Welcome: "Wilkommen" } }`<br/>or a function that returns a Promise that resolves to such an object.<br/>The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).
+
+#### `environment`
+
+**object**\
+The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment). |
+
+#### `children`
+
+**node**\
+Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`.<br/>By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`.<br/>This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.
+
+#### `render`
+
+**func** *(optional)*\
+The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized.<br/>It's **recommended to use** the `children` prop to benefit from a simpler setup.
+
+#### `apolloClient`
+
+**ApolloClient** *(optional)* \
+An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
+
+
 | Name |
 | --- |
 | `applicationMessages` **object** or **func** <br/><br/>This is either an object containing all the translated messages, grouped by locale<br/>`{ en: { Welcome: "Welcome" }, de: { Welcome: "Wilkommen" } }`<br/>or a function that returns a Promise that resolves to such an object.<br/>The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).  |
@@ -104,8 +132,15 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 ### Properties
 
-| Name  |
-| --- |
+<ChildSectionsNav parent="properties-1" />
+
+#### `additionalParts`
+
+**string[]**\
+A list of parts to be prepended to the default page title, separated by `-`.
+
+| Name |
+| ---- |
 | `additionalParts` **string[]** <br/><br/>A list of parts to be prepended to the default page title, separated by `-`. |
 
 
@@ -425,6 +460,70 @@ describe('rendering', () => {
 
 ### Options
 
+<ChildSectionsNav parent="options" />
+
+#### `locale`
+
+**string**\
+Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.
+
+#### `dataLocale`
+
+**string**\
+Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.
+
+#### `mocks`
+
+**mock[]**\
+Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).
+
+#### `apolloClient`
+
+**ApolloClient**\
+Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.
+
+#### `route`
+
+**string**\
+The route the user is on, like `/test-project/products`. Defaults to `/`.
+
+#### `disableAutomaticEntryPointRoutes`
+
+**boolean**\
+Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.
+
+#### `history`
+
+**object**\
+By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object.
+
+#### `adapter`
+
+**object**\
+The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).
+
+#### `flags`
+
+**object**\
+An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.
+
+#### `environment`
+
+**object**\
+Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.
+
+#### `user`
+
+**object**\
+Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.
+
+#### `project`
+
+**object**\
+Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
+
+
+
 | Name |
 | --- |
 | `locale` **string** <br/><br/>Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages. |
@@ -444,6 +543,29 @@ describe('rendering', () => {
 ### Return values
 
 Calling `renderApp` returns the same [Result](https://testing-library.com/docs/react-testing-library/api#render-result) object of React Testing Library, with the addition of the following properties:
+
+<ChildSectionsNav parent="return-values" />
+
+#### `history`
+
+**object**\
+The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on.
+
+#### `user`
+
+**object**\
+The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`).
+
+#### `project`
+
+**object**\
+The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`).
+
+#### `environment`
+
+**object**\
+The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`).
+
 
 | Name |
 | --- |
@@ -483,6 +605,28 @@ describe('rendering', () => {
 In addition to the following options, the method accepts all options from `renderApp`.
 
 </Info>
+
+<ChildSectionsNav parent="options-1" />
+
+#### `store`
+
+**object**\
+A custom redux store.
+
+#### `storeState`
+
+**object**\
+Pass an initial state to the default Redux store.
+
+#### `sdkMocks`
+
+**mock[]**\
+Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md).
+
+#### `mapNotificationToComponent`
+
+**func**\
+Pass a function to map a notification to a custom component.
 
 | Name |
 | --- |

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -508,12 +508,31 @@ Allows to set the `applicationContext.project`. The passed object gets merged wi
 
 Calling `renderApp` returns the same [Result](https://testing-library.com/docs/react-testing-library/api#render-result) object of React Testing Library, with the addition of the following fields:
 
-| Field         | Type     | Description                                                                                                                                                                                                                                                                                                       |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `history`     | `Object` | The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on.                                                                                                                                                                                          |
-| `user`        | `Object` | The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`).                                  |
-| `project`     | `Object` | The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`).                         |
-| `environment` | `Object` | The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`). |
+<ChildSectionsNav parent="return-values" />
+
+#### history
+
+Type: `Object`
+
+The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on.
+
+#### user
+
+Type: `Object`
+
+The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. The `user` object is not the same as `applicationContext.user` and can be `undefined` when no user is authenticated (when `options.user` was `null`).
+
+#### project
+
+Type: `Object`
+
+The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. The `project` object is not the same as `applicationContext.project` and can be `undefined` when no project was set (when `options.project` was `null`).
+
+#### environment
+
+Type: `Object`
+
+The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. The `environment` object is not the same as `applicationContext.environment` and can be `undefined` when no environment was set (when `options.environment` was `null`).
 
 ## renderAppWithRedux
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -10,7 +10,7 @@ React component that ties together all the main functionalities of the Custom Ap
 
 # Installation
 
-```
+```bash
 yarn add @commercetools-frontend/application-shell
 
 # or
@@ -20,7 +20,7 @@ npm --save install @commercetools-frontend/application-shell
 
 Additionally install the peer dependencies (if not present)
 
-```
+```bash
 yarn add @apollo/client react react-dom react-intl react-redux react-router-dom redux @testing-library/react @testing-library/react-hooks
 
 # or
@@ -65,13 +65,13 @@ export default EntryPoint;
 
 ### Properties
 
-| Props                            | Type               |        Required         | Default | Description                                                                                                                                                                                                                                                                                                                                                                      |
-| -------------------------------- | ------------------ | :---------------------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `applicationMessages`            | `object` or `func` |           ✅            | -       | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).                                                                                                                                                                |
-| `environment`                  | `object`           |           ✅            | -       | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).                                                                                                                                                                                                                                                                                                                                                       |
-| `children`                         | `node`             |           ✅ (*)            | -       | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.                                                                                                                                                                                                                                    |
-| `render`                         | `func`             |            (*)           | -       | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.                                                                                                                                                                                                                                  |
-| `apolloClient`         | `ApolloClient`           |                       | -       | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).                                                                                                                                                                                                                                        |
+| Props                            | Type               |        Required        | Description                                                                                                                                                                                                                                                                                                                                                                      |
+| -------------------------------- | ------------------ | :---------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `applicationMessages`            | `object` or `func` |           ✅        | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).                                                                                                                                                                |
+| `environment`                  | `object`           |           ✅        | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).                                                                                                                                                                                                                                                                                                                                                       |
+| `children`                         | `node`             |           ✅        | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.                                                                                                                                                                                                                                    |
+| `render`                         | `func`             |            (*)       | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.                                                                                                                                                                                                                                  |
+| `apolloClient`         | `ApolloClient`           |                   | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).                                                                                                                                                                                                                                        |
 
 
 ## ApplicationPageTitle
@@ -105,9 +105,9 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 ### Properties
 
-| Props | Type | Required | Default |  Description |
-| --- | --- | :---: | --- | --- |
-| `additionalParts` | `array` of `string` | ✅ | - | A list of parts to be prepended to the default page title, separated by `-`. |
+| Props | Type | Required|  Description |
+| --- | --- | :---: | --- |
+| `additionalParts` | `array` of `string` | ✅ | A list of parts to be prepended to the default page title, separated by `-`. |
 
 # Hooks
 
@@ -428,110 +428,79 @@ describe('rendering', () => {
 <ChildSectionsNav parent="options" />
 
 
-#### `locale`
+#### locale
 
-`String`
-
-Localization
+Type: `String`
 
 Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.
 
 
-#### `dataLocale`
+#### dataLocale
 
-`String`
-
-Localization
+Type: `String`
 
 Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.
 
 
-####  `mocks`
+#### mocks
 
-`Array`
-
-Apollo
+Type: `Array`
 
 Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).
 
 
-####  `apolloClient`
+#### apolloClient
 
-`ApolloClient`
-
-Apollo
+Type: `ApolloClient`
 
 Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.
 
 
-####  `route`
+#### route
 
-`String`
-
-Routing
+Type: `String`
 
 The route the user is on, like `/test-project/products`. Defaults to `/`.
 
+#### disableAutomaticEntryPointRoutes
 
-####  `disableAutomaticEntryPointRoutes`
-
-`Boolean`
-
-Routing
+Type: `Boolean`
 
 Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.
 
+#### history
 
-####  `history`
-
-`Object`
-
-Routing
+Type: `Object`
 
 By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object.
 
+#### adapter
 
-#### `adapter`
-
-`Object`
-
-Feature Toggles
+Type: `Object`
 
 The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).
 
+#### flags
 
-#### `flags`
-
-`Object`
-
-Feature Toggles
+Type: `Object`
 
 An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.
 
+#### environment
 
-#### `environment`
-
-`Object`
-
-[Runtime configuration](/api-reference/application-config#runtime-application-environment)
+Type: `Object`
 
 Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.
 
+#### user
 
-#### `user`
-
-`Object`
-
-[Application Context](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell-connectors/src/components/application-context/README.md#user)
+Type: `Object`
 
 Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.
 
+#### project
 
-#### `project`
-
-`Object`
-
-[Application Context](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell-connectors/src/components/application-context/README.md#project)
+Type: `Object`
 
 Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
 
@@ -578,12 +547,12 @@ In addition to the following options, the method accepts all options from `rende
 
 </Info>
 
-| Argument                             | Type       | Concern | Description                                                                                                                                                                                                                                                    |
-| ------------------------------------ | ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `store`                      | `Object`   | Redux   | A custom redux store.                                                                                                                                                                                                                                          |
-| `storeState`                 | `Object`   | Redux   | Pass an initial state to the default Redux store.                                                                                                                                                                                                              |
-| `sdkMocks`                   | `Array`    | Redux   | Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
-| `mapNotificationToComponent` | `Function` | Redux   | Pass a function to map a notification to a custom component.                                                                                                                                                                                                   |
+| Argument                             | Type       | Description                                                                                                                                                                                                                                                    |
+| ------------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store`                      | `Object`   | A custom redux store.                                                                                                                                                                                                                                          |
+| `storeState`                 | `Object`   | Pass an initial state to the default Redux store.                                                                                                                                                                                                              |
+| `sdkMocks`                   | `Array`    | Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
+| `mapNotificationToComponent` | `Function` | Pass a function to map a notification to a custom component.                                                                                                                                                                                                   |
 
 <!-- ## renderHook -->
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -65,13 +65,43 @@ export default EntryPoint;
 
 ### Properties
 
-| Props                            | Type               |        Required        | Description                                                                                                                                                                                                                                                                                                                                                                      |
-| -------------------------------- | ------------------ | :---------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `applicationMessages`            | `object` or `func` |           ✅        | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).                                                                                                                                                                |
-| `environment`                  | `object`           |           ✅        | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).                                                                                                                                                                                                                                                                                                                                                       |
-| `children`                         | `node`             |           ✅        | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.                                                                                                                                                                                                                                    |
-| `render`                         | `func`             |            (*)       | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.                                                                                                                                                                                                                                  |
-| `apolloClient`         | `ApolloClient`           |                   | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).                                                                                                                                                                                                                                        |
+
+
+#### applicationMessages
+
+Type: `object` or `func`
+
+Required: ✅
+
+This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).
+
+#### environment
+
+Type: `object`
+
+Required: ✅
+
+The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).
+
+#### children
+
+Type: `node`
+
+Required: ✅
+
+Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.
+
+#### render
+
+Type: `func`
+
+The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.
+
+#### apolloClient
+
+Type: `ApolloClient`
+
+An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
 
 
 ## ApplicationPageTitle

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -63,31 +63,36 @@ const EntryPoint = () => (
 export default EntryPoint;
 ```
 
-### Properties
+### Properties original
 
-<ChildSectionsNav parent="properties" />
+| Props                            | Type               |        Required        | Description                                                                                                                                                                                                                                                                                                                                                                      |
+| -------------------------------- | ------------------ | :---------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `applicationMessages`            | `object` or `func` |           ✅        | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).                                                                                                                                                                |
+| `environment`                  | `object`           |           ✅        | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).                                                                                                                                                                                                                                                                                                                                                       |
+| `children`                         | `node`             |           ✅        | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.                                                                                                                                                                                                                                    |
+| `render`                         | `func`             |            (*)       | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.                                                                                                                                                                                                                                  |
+| `apolloClient`         | `ApolloClient`           |                   | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).                                                                                                                                                                                                                                        |
+
+
+### Properties with ChildSectionsNav
+
+<ChildSectionsNav parent="properties-with-childsectionsnav" />
 
 #### applicationMessages
 
-Type: `object` or `func`
-
-Required: ✅
+Type: `object` or `func` (Required)
 
 This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).
 
 #### environment
 
-Type: `object`
-
-Required: ✅
+Type: `object` (Required)
 
 The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).
 
 #### children
 
-Type: `node`
-
-Required: ✅
+Type: `node` (Required)
 
 Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.
 
@@ -100,6 +105,36 @@ The render function is called when the `<ApplicationShell>` is ready to render t
 #### apolloClient
 
 Type: `ApolloClient`
+
+An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
+
+### Properties with Table+description
+
+| Name | Type | Required |
+|------|------|----------|
+| [applicationMessages](#applicationmessages) | `object` or `func` | Yes |
+| [environment](#environment) | `object` | Yes |
+| [children](#children) | `node` | Yes |
+| [render](#render) | `func` | No |
+| [apolloClient](#apolloClient) | `ApolloClient` | No |
+
+#### applicationMessages
+
+This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).
+
+#### environment
+
+The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment).
+
+#### children
+
+Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup.
+
+#### render
+
+The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use the `children`** prop to benefit from a simpler setup.
+
+#### apolloClient
 
 An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient).
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -65,7 +65,7 @@ export default EntryPoint;
 
 ### Properties
 
-
+<ChildSectionsNav parent="properties" />
 
 #### applicationMessages
 
@@ -135,9 +135,14 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 ### Properties
 
-| Props | Type | Required|  Description |
-| --- | --- | :---: | --- |
-| `additionalParts` | `array` of `string` | ✅ | A list of parts to be prepended to the default page title, separated by `-`. |
+#### additionalParts
+
+Type: `string[]`
+
+Required: ✅
+
+A list of parts to be prepended to the default page title, separated by `-`.
+
 
 # Hooks
 
@@ -596,12 +601,32 @@ In addition to the following options, the method accepts all options from `rende
 
 </Info>
 
-| Argument                             | Type       | Description                                                                                                                                                                                                                                                    |
-| ------------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `store`                      | `Object`   | A custom redux store.                                                                                                                                                                                                                                          |
-| `storeState`                 | `Object`   | Pass an initial state to the default Redux store.                                                                                                                                                                                                              |
-| `sdkMocks`                   | `Array`    | Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
-| `mapNotificationToComponent` | `Function` | Pass a function to map a notification to a custom component.                                                                                                                                                                                                   |
+<ChildSectionsNav parent="options-1" />
+
+#### store
+
+Type: `Object`
+
+A custom redux store.
+
+#### storeState
+
+Type: `Object`
+
+Pass an initial state to the default Redux store.
+
+#### sdkMocks
+
+Type: `Array`
+
+Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md).
+
+#### mapNotificationToComponent
+
+Type: `Function`
+
+Pass a function to map a notification to a custom component.
+
 
 <!-- ## renderHook -->
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -65,19 +65,13 @@ export default EntryPoint;
 
 ### Properties
 
-<Info>
-
-The properties with an * are required.
-
-</Info>
-
-| Name | Description |
-|------|------|
-| `applicationMessages` * of type `object` or `func` | This is either an object containing all the translated messages, grouped by locale (`{ "en": { "Welcome": "Welcome" }, "de": { "Welcome": "Wilkommen" }}`), or a function that returns a Promise that resolves to such an object. The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).  |
-| `environment` * of type `object` | The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment). |
-| `children` * of type `node` | Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`. By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`. This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup. |
-| `render` of type `func` | The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized. It's **recommended to use** the `children` prop to benefit from a simpler setup. |
-| `apolloClient` of type `ApolloClient` | An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient). |
+| Name |
+| --- |
+| `applicationMessages` **object** or **func** <br/><br/>This is either an object containing all the translated messages, grouped by locale<br/>`{ en: { Welcome: "Welcome" }, de: { Welcome: "Wilkommen" } }`<br/>or a function that returns a Promise that resolves to such an object.<br/>The function is called with a `locale` parameter. See [Importing translations](/development/translations#importing-translations).  |
+| `environment` **object** <br/><br/>The application runtime environment, which is exposed in `window.app`. See [Runtime configuration](/api-reference/application-config#runtime-application-environment). |
+| `children` **node** <br/><br/>Instead of using the `render` prop, render your application component as children of `<ApplicationShell>`.<br/>By doing so, the `<ApplicationShell>` pre-configures the main application routes according to the `entryPointUriPath` defined in the `custom-application-config.json`.<br/>This is an opt-int behavior as a replacement of the `render` prop, to simplify the entry point setup. |
+| `render` *(optional)* **func** <br/><br/>The render function is called when the `<ApplicationShell>` is ready to render the actual application. This is the case when the required data (user, project) has been fetched and the application context has been initialized.<br/>It's **recommended to use** the `children` prop to benefit from a simpler setup. |
+| `apolloClient` *(optional)* **ApolloClient** <br/><br/>An optional instance of [ApolloClient](https://www.apollographql.com/docs/react/) to be used instead of the default one. This is usually the case when you need to configure the Apollo cache. See [`createApolloClient`](#createapolloclient). |
 
 ## ApplicationPageTitle
 
@@ -110,15 +104,9 @@ Please refer to the [Mapping guidelines](/development/human-readable-page-title#
 
 ### Properties
 
-<Info>
-
-The properties with an * are required.
-
-</Info>
-
-| Props  |  Description |
-| ------ | ------------ |
-| `additionalParts` * of type `string[]` | A list of parts to be prepended to the default page title, separated by `-`. |
+| Name  |
+| --- |
+| `additionalParts` **string[]** <br/><br/>A list of parts to be prepended to the default page title, separated by `-`. |
 
 
 # Hooks
@@ -437,32 +425,32 @@ describe('rendering', () => {
 
 ### Options
 
-| Argument              |                                                                                                                                                                                      | Description                                                                                                                                                                                                                                                                                                                                                                        |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `locale` of type `String`      | Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages.                                          |
-| `dataLocale` of type `String`                                                                                                                                                                                             | Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s.                                                                                                                                                                                                                                                      |
-| `mocks` of type `Array`                                                                                                                                                                                                    | Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/).                                                                                                                                                                              |
-| `apolloClient` of type  `ApolloClient`                                                                                                                                                                        | Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`.                                                                                                  |
-| `route` of type `String`                                                                                                                                                                                          | The route the user is on, like `/test-project/products`. Defaults to `/`.                                                                                                                                                                                                                                                                                                          |
-| `disableAutomaticEntryPointRoutes` of type `Boolean`                                                                                                                                                                                               | Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop.                                                                                                                                                                                                                                                                                                           |
-| `history` of type `Object`     |  By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object. |
-| `adapter` of type `Object`                                                                                                                                                                                          | The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter).                                                                                                                                                                          |
-| `flags` of type `Object`                                                                                                                                                                                          | An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`.                                                                                                                                                                            |
-| `environment` of type `Object`    | Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given.                                                                                                                                                 |
-| `user`  of type `Object`      | Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated.                                                                                                                                                                       |
-| `project` of type `Object`     | Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context.
+| Name |
+| --- |
+| `locale` **string** <br/><br/>Determines the UI language and number format. Is used to configure `<IntlProvider>`. Only _core_ messages will be available during tests, no matter the `locale`. The locale can be a full [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), although the Merchant Center is currently only available in a limited set of languages. |
+| `dataLocale` **string** <br/><br/>Sets the locale which is used to display [`LocalizedString`](https://docs.commercetools.com/api/types#localizedstring)s. |
+| `mocks` **mock[]** <br/><br/>Allows mocking requests made with Apollo. `mocks` is forwarded as the `mocks` argument to [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). If `mocks` is not provided or is an empty array, the Apollo `MockedProvider` is not used. This is an opt-in functionality, as the default behavior is to mock requests using [Mock Service Worker](https://mswjs.io/). |
+| `apolloClient` **ApolloClient** <br/><br/>Pass a custom instance of Apollo client, useful when your Custom Application has some custom cache policies. You can use the exported function `createApolloClient` of `@commercetools-frontend/application-shell`. |
+| `route` **string** <br/><br/>The route the user is on, like `/test-project/products`. Defaults to `/`. |
+| `disableAutomaticEntryPointRoutes` **boolean** <br/><br/>Pass `true` if you are using the `render` prop for the `<ApplicationShell>` instead of the `children` prop. |
+| `history` **object** <br/><br/>By default a memory-history is generated which has the provided `route` set as its initial history entry. It's possible to pass a custom history as well. In that case, we recommend using the factory function `createEnhancedHistory` from the `@commercetools-frontend/browser-history` package, as it contains the enhanced `location` with the parsed `query` object. |
+| `adapter` **object** <br/><br/>The [FlopFlip](https://github.com/tdeekens/flopflip) adapter to use when configuring `flopflip`. Defaults to [`memoryAdapter`](https://github.com/tdeekens/flopflip/tree/master/packages/memory-adapter). |
+| `flags` **object** <br/><br/>An object whose keys are feature-toggle keys and whose values are their toggle state. Use this to test your component with different feature toggle combinations. Example: `{ betaUserProfile: true }`. |
+| `environment` **object** <br/><br/>Allows to set the `applicationContext.environment`. The passed object gets merged with the tests default environment. Pass `null` to completely remove the `environment`, which renders the `ui` as if no `environment` was given. |
+| `user` **object** <br/><br/>Allows to set the `applicationContext.user`. The passed object gets merged with the test's default user. Pass `null` to completely remove the `user`, which renders the `ui` as if no user was authenticated. |
+| `project` **object** <br/><br/>Allows to set the `applicationContext.project`. The passed object gets merged with the tests default project. Pass `null` to completely remove the `project` which renders the `ui` outside of a project context. |
 
 
 ### Return values
 
-Calling `renderApp` returns the same [Result](https://testing-library.com/docs/react-testing-library/api#render-result) object of React Testing Library, with the addition of the following fields:
+Calling `renderApp` returns the same [Result](https://testing-library.com/docs/react-testing-library/api#render-result) object of React Testing Library, with the addition of the following properties:
 
-| Field         | Description                                                                                                                                                                                                                                                                                                       |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `history` of type `Object` | The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on.                                                                                                                                                                                          |
-| `user` of type `Object` | The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`).                                  |
-| `project` of type `Object` | The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`).                         |
-| `environment` of type `Object` | The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`). |
+| Name |
+| --- |
+| `history` **object** <br/><br/>The history created by `renderApp` which is passed to the router. It can be used to simulate location changes and so on. |
+| `user` **object** <br/><br/>The `user` object used to configure `<ApplicationContextProvider>`, so the result of merging the default user with `options.user`. Note that this is not the same as `applicationContext.user`. Can be `undefined` when no user is authenticated (when `options.user` was `null`). |
+| `project` **object** <br/><br/>The `project` object used to configure `<ApplicationContextProvider>`, so the result of merging the default project with `options.project`. Note that this is not the same as `applicationContext.project`. Can be `undefined` when no project was set (when `options.project` was `null`). |
+| `environment` **object** <br/><br/>The `environment` object used to configure `<ApplicationContextProvider>`, so the result of merging the default environment with `options.environment`. Note that this is not the same as `applicationContext.environment`. Can be `undefined` when no environment was set (when `options.environment` was `null`). |
 
 ## renderAppWithRedux
 
@@ -496,12 +484,12 @@ In addition to the following options, the method accepts all options from `rende
 
 </Info>
 
-| Argument                             | Description                                                                                                                                                                                                                                                    |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `store` of type `Object`   | A custom redux store.                                                                                                                                                                                                                                          |
-| `storeState` of type `Object`   | Pass an initial state to the default Redux store.                                                                                                                                                                                                              |
-| `sdkMocks` of type `Array`    | Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
-| `mapNotificationToComponent` of type `Function` | Pass a function to map a notification to a custom component.                                                                                                                                                                                                   |
+| Name |
+| --- |
+| `store` **object** <br/><br/>A custom redux store. |
+| `storeState` **object** <br/><br/>Pass an initial state to the default Redux store. |
+| `sdkMocks` **mock[]** <br/><br/>Allows mocking requests made with `@commercetools-frontend/sdk` (Redux). The `sdkMocks` is forwarded as `mocks` to the [SDK `test-utils`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/sdk/src/test-utils/README.md). |
+| `mapNotificationToComponent` **func** <br/><br/>Pass a function to map a notification to a custom component. |
 
 
 <!-- ## renderHook -->


### PR DESCRIPTION
#### Summary

As pointed out by peers, the table on [@/application-shell](https://docs.commercetools.com/custom-applications/api-reference/commercetools-frontend-application-shell#options) page overflows it's parent container. Moreover, the content makes the table look sparse as the `description` column is densely packed.

#### Description

As a solution, we'll reformat the tables on this page for better readability and fix the overflow issues as a result.

**Preview**: https://appkit-pr-3045.commercetools.vercel.app/custom-applications/api-reference/commercetools-frontend-application-shell

