### PR TITLE
test: prevent regressions with scrollable menu

### DIFF
--- a/.changeset/five-coats-thank.md
+++ b/.changeset/five-coats-thank.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix `role` of the `MenuItem` component

--- a/cypress/e2e/playground/application-shell.cy.ts
+++ b/cypress/e2e/playground/application-shell.cy.ts
@@ -63,8 +63,7 @@ describe('navigation menu', () => {
   });
   it('should show submenu on hover', () => {
     cy.findAllByText('Initial').should('exist');
-    cy.findByRole('menu')
-      .get('li')
+    cy.findAllByRole('menuitem')
       .first()
       .trigger('mouseover')
       .findByRole('link', { name: 'Echo Server' })

--- a/cypress/e2e/playground/application-shell.cy.ts
+++ b/cypress/e2e/playground/application-shell.cy.ts
@@ -61,4 +61,13 @@ describe('navigation menu', () => {
     );
     cy.percySnapshot();
   });
+  it('should show submenu on hover', () => {
+    cy.findAllByText('Initial').should('exist');
+    cy.findByRole('menu')
+      .get('li')
+      .first()
+      .trigger('mouseover')
+      .findByRole('link', { name: 'Echo Server' })
+      .should('be.visible');
+  });
 });

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -246,7 +246,7 @@ type MenuItemProps = {
 };
 const MenuItem = (props: MenuItemProps) => (
   <li
-    role="menu-item"
+    role="menuitem"
     className={classnames(styles['list-item'], {
       [styles.item__active]: props.isActive,
       [styles['item_menu__active']]: props.isMainMenuRouteActive ?? false,

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -412,6 +412,8 @@
     FIXME: Make the navbar scrollable in collapsed state.
     NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover 
   */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .fixed-menu {

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -412,8 +412,6 @@
     FIXME: Make the navbar scrollable in collapsed state.
     NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover 
   */
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 .fixed-menu {

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -408,6 +408,10 @@
 .scrollable-menu {
   flex: 1 1 0;
   padding-bottom: var(--faded-height);
+  /* 
+    FIXME: Make the navbar scrollable in collapsed state.
+    NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover 
+  */
 }
 
 .fixed-menu {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Having in mind [the regression we had yesterday](https://github.com/commercetools/merchant-center-application-kit/pull/3046) with the pop up submenu when the navbar is collapsed I thought about adding a test to prevent this in the future.

