### PR TITLE
fix: add special format for DuplicateField error

### DIFF
--- a/.changeset/four-seas-do.md
+++ b/.changeset/four-seas-do.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/react-notifications': patch
+---
+
+Adds special formatted message for `DuplicateField` errors

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
@@ -94,6 +94,20 @@ describe('render', () => {
       screen.getByText(/"duplicateValueContent" is already in use/i)
     ).toBeInTheDocument();
   });
+  it('should show message for DuplicateField', () => {
+    const error = {
+      extensions: { code: 'DuplicateField' },
+      message: 'message-content',
+      field: 'key',
+      duplicateValue: 'duplicateValueContent',
+    };
+    renderMessage(<ApiErrorMessage error={error} />);
+    expect(
+      screen.getByText(
+        'The value for the field "key" has already been used. Please choose another value for this field.'
+      )
+    ).toBeInTheDocument();
+  });
   it('should show message for DuplicateAttributeValue', () => {
     const error = {
       extensions: { code: 'DuplicateAttributeValue' },

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
@@ -142,14 +142,15 @@ function getSpecialFormattedMessageByErrorCode(
     return intl.formatMessage(messages.Forbidden);
 
   if (extensionErrorCode === 'DuplicateField') {
-    if (error.field === 'slug')
+    if (error.field === 'slug') {
       return intl.formatMessage(messages.DuplicateSlug, {
         slugValue: error.duplicateValue,
       });
-    else
+    } else {
       return intl.formatMessage(messages.DuplicateField, {
         field: error.field,
       });
+    }
   }
 
   // Try to match the error with a custom error message

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.tsx
@@ -141,10 +141,16 @@ function getSpecialFormattedMessageByErrorCode(
   if (extensionErrorCode === 'insufficient_scope')
     return intl.formatMessage(messages.Forbidden);
 
-  if (extensionErrorCode === 'DuplicateField' && error.field === 'slug')
-    return intl.formatMessage(messages.DuplicateSlug, {
-      slugValue: error.duplicateValue,
-    });
+  if (extensionErrorCode === 'DuplicateField') {
+    if (error.field === 'slug')
+      return intl.formatMessage(messages.DuplicateSlug, {
+        slugValue: error.duplicateValue,
+      });
+    else
+      return intl.formatMessage(messages.DuplicateField, {
+        field: error.field,
+      });
+  }
 
   // Try to match the error with a custom error message
   if (


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

`useShowApiErrorNotification` from `@commercetools-frontend/actions-global` is not properly formatting `DuplicateField` errors.

<!-- provide a short summary of your changes -->

#### Description

The following (broken) message is rendered in Standalone Prices web app when rendering a `DuplicateField` error with the `useShowApiErrorNotification` hook.

![Screenshot 2023-04-25 at 17 51 41](https://user-images.githubusercontent.com/13467563/234333283-d3d7cf94-445e-4aeb-8435-7d8f93abe3a2.png)

<!-- provide some context -->
