### PR TITLE
fix(cypress): hide redesign announcement

### DIFF
--- a/.changeset/quick-scissors-melt.md
+++ b/.changeset/quick-scissors-melt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/cypress': patch
+---
+
+Hide redesign announcement

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -236,6 +236,11 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
               STORAGE_KEYS.SESSION_SCOPE,
               sessionScope
             );
+            // Disable redesign announcement
+            win.localStorage.setItem(
+              'isNewDesignReleaseNotificationClosed',
+              'true'
+            );
 
             if (commandOptions.onBeforeLoad) {
               commandOptions.onBeforeLoad(win);


### PR DESCRIPTION
With the redesign turned on for GCP EU (where our e2e tests run) we have the announcement dialog popping up, which we need to hide.

To keeps things simple, we simply set the localstorage flag during the cypress login command.