### PR TITLE
Accept also React Element as a title type inside tabular detail page

### DIFF
--- a/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.tsx
+++ b/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.tsx
@@ -30,7 +30,7 @@ type TTabularDetailPageProps = {
   /**
    * The title of the page.
    */
-  title?: string;
+  title?: string | ReactElement;
   /**
    * The subtitle of the page.
    */


### PR DESCRIPTION
#### Summary

Accept not only `string` as a title for `Tabular Detail Page` but also `ReactElement`

#### Description

I need for a [PR](https://github.com/commercetools/merchant-center-frontend/pull/14587) the possibility to use a ReactElement to show a label component. 