### PR TITLE
docs: fix broken links to MC SSO

### DIFF
--- a/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell-connectors.mdx
@@ -72,7 +72,7 @@ The information about the logged in user.
 }
 ```
 
-If the user logged into the Merchant Center using [Single Sign-On](https://docs.commercetools.com/merchant-center/single-sign-on-beta), we expose an additional property `idTokenUserInfo` which contains some of the user info claims (OpenID Connect) from the user's Identity Provider.
+If the user logged into the Merchant Center using [Single Sign-On](https://docs.commercetools.com/merchant-center/single-sign-on), we expose an additional property `idTokenUserInfo` which contains some of the user info claims (OpenID Connect) from the user's Identity Provider.
 
 ```json highlightedLines="14-22"
 {

--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -93,7 +93,7 @@ The session token `mcAccessToken` is granted upon user login and is stored in a 
 The Merchant Center API provides two endpoints for authenticating a user:
 
 - `/tokens`: for normal login using `email` and `password`.
-- `/tokens/sso`: for login using an `idToken` from an SSO workflow (see [Single Sign-On](https://docs.commercetools.com/merchant-center/single-sign-on-beta)).
+- `/tokens/sso`: for login using an `idToken` from an SSO workflow (see [Single Sign-On](https://docs.commercetools.com/merchant-center/single-sign-on)).
 
 <Info>
 

--- a/website/src/releases/2023-02/support-sso-login-local-development.mdx
+++ b/website/src/releases/2023-02/support-sso-login-local-development.mdx
@@ -8,6 +8,6 @@ topics:
   - Development
 ---
 
-When developing a Custom Application locally, you are prompted to authorize your user via the login form. From now on, it is possible to log into the Merchant Center using [Single Sign-On](https://docs.commercetools.com/merchant-center/single-sign-on-beta) for local development as well.
+When developing a Custom Application locally, you are prompted to authorize your user via the login form. From now on, it is possible to log into the Merchant Center using [Single Sign-On](https://docs.commercetools.com/merchant-center/single-sign-on) for local development as well.
 
 As always, if you have questions or feedback, you can open a [support ticket](https://support.commercetools.com).


### PR DESCRIPTION
## Summary

Fix the broken link to MC SSO because we remove `beta` from the URL.