### PR TITLE
test(setupFilesAfterEnv): do not fail on console when not on CI

### DIFF
--- a/packages/jest-preset-mc-app/setup-test-framework.js
+++ b/packages/jest-preset-mc-app/setup-test-framework.js
@@ -65,10 +65,10 @@ function shouldNotThrowWarnings(...messages) {
 }
 
 failOnConsole({
-  shouldFailOnLog: true,
-  shouldFailOnInfo: true,
-  shouldFailOnWarn: true,
-  shouldFailOnError: true,
+  shouldFailOnLog: process.env.CI,
+  shouldFailOnInfo: process.env.CI,
+  shouldFailOnWarn: process.env.CI,
+  shouldFailOnError: process.env.CI,
   silenceMessage: (message) => {
     if (!process.env.CI) {
       return false;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

Fix the regression introduced in https://github.com/commercetools/merchant-center-application-kit/pull/2820.

#### Description

<!-- provide some context -->

In https://github.com/commercetools/merchant-center-application-kit/pull/2820, a developer experience regression has been introduced.

Before, debugging tests locally by adding `console.log` won’t fail the test, the output will remain clean and compact and include only the expected log output, in addition to other positive error logs.

But now, the output is cluttered with these false-positive “Expected test not to call console.log()” errors, making the debug experience worse.

The solution is to restore the old state, i.e. to not fail on console when tests are not running on CI.

<details>
<summary>Screenshots</summary>

<img width="951" alt="CleanShot 2023-05-17 at 16 44 55@2x" src="https://github.com/commercetools/merchant-center-application-kit/assets/3668245/c10e6c5c-e598-4a1a-aad5-89e0a18f8647">
<img width="958" alt="CleanShot 2023-05-17 at 16 44 03@2x" src="https://github.com/commercetools/merchant-center-application-kit/assets/3668245/d0b6500e-2bd3-45cb-9c0a-de1a163148d3">
</details>

#### Future Improvements

Allow this config, `shouldFailOnLog` etc, to be overridden at the consumer level.