### PR TITLE
fix: remove peer dependency (regression)

### DIFF
--- a/packages/jest-stylelint-runner/package.json
+++ b/packages/jest-stylelint-runner/package.json
@@ -26,7 +26,6 @@
     "stylelint": "14.16.1"
   },
   "peerDependencies": {
-    "@commercetools-frontend/mc-scripts": "workspace:*",
     "postcss": "8.x",
     "stylelint": "14.x"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1885,9 +1885,6 @@ importers:
 
   packages/jest-stylelint-runner:
     dependencies:
-      '@commercetools-frontend/mc-scripts':
-        specifier: workspace:*
-        version: link:../mc-scripts
       create-jest-runner:
         specifier: 0.12.3
         version: 0.12.3


### PR DESCRIPTION
In #2976 (not sure why) I added a peer dep in the `jest-stylelint-runner` package. This causes changeset to consider it as a breaking change, which we don't want / need, so removing the peer dep should restore the normal behavior.