### PR TITLE
fix: apply new design to oidc callback error page

### DIFF
--- a/.changeset/unlucky-worms-sniff.md
+++ b/.changeset/unlucky-worms-sniff.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix applying new design to error page when user authentication fails in local development

--- a/packages/application-shell/src/components/authenticated/oidc-callback-error-page.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback-error-page.tsx
@@ -1,13 +1,19 @@
 import styled from '@emotion/styled';
 import { useHistory } from 'react-router-dom';
-import { PublicPageLayout } from '@commercetools-frontend/application-components';
+import {
+  PublicPageLayout,
+  themesOverrides,
+} from '@commercetools-frontend/application-components';
 import FailedAuthenticationSVG from '@commercetools-frontend/assets/images/locked-diamond.svg';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import Card from '@commercetools-uikit/card';
 import Constraints from '@commercetools-uikit/constraints';
-import { customProperties } from '@commercetools-uikit/design-system';
+import {
+  ThemeProvider,
+  customProperties,
+} from '@commercetools-uikit/design-system';
 import FlatButton from '@commercetools-uikit/flat-button';
 import { AngleLeftIcon } from '@commercetools-uikit/icons';
 import { ContentNotification } from '@commercetools-uikit/notifications';
@@ -41,6 +47,10 @@ const AuthCallbackErrorPage = (props: TProps) => {
     >
       {({ locale, messages }) => (
         <ConfigureIntlProvider locale={locale} messages={messages}>
+          <ThemeProvider
+            theme="test"
+            themeOverrides={themesOverrides.default}
+          />
           <PublicPageLayout contentScale="wide">
             <Spacings.Inline justifyContent="center">
               <Constraints.Horizontal max={11}>


### PR DESCRIPTION
We forgot to apply the new design to the oidc callback error page, as it's rendered "outside" the main application shell rendering path.

<img width="757" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/1110551/b0229f40-d19b-4cb0-b231-a0f6468cc38f">
