### PR TITLE
docs: Add China region api url

### DIFF
--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -45,6 +45,7 @@ https://{mcService}.{region}.{cloudProvider}.commercetools.com
 | Europe (AWS, Frankfurt) | `mc-api.eu-central-1.aws.commercetools.com` |
 | North America (Google Cloud, Iowa) | `mc-api.us-central1.gcp.commercetools.com` |
 | North America (AWS, Ohio) | `mc-api.us-east-2.aws.commercetools.com` |
+| China (AWS, Ningxia) | `mc-api.cn-northwest-1.aws.commercetools.cn` |
 
 ## Cloud Identifiers
 
@@ -57,6 +58,7 @@ To make it easier to reference the Merchant Center API URL, for example in the [
 | Europe (AWS, Frankfurt) | `aws-fra` |
 | North America (Google Cloud, Iowa) | `gcp-us` |
 | North America (AWS, Ohio) | `aws-ohio` |
+| China (AWS, Ningxia) | `aws-cn` |
 
 # Authentication
 


### PR DESCRIPTION
#### Summary

Add the hostnames and cloud identifiers for the China region.


Related to: https://github.com/commercetools/commercetools-docs/pull/3300

⚠️ **Do not merge!** until the parent PR is ready and merged.
