### PR TITLE
docs: update top-menu status link 

### DIFF
--- a/website/src/content/concepts/merchant-center-api.mdx
+++ b/website/src/content/concepts/merchant-center-api.mdx
@@ -45,6 +45,7 @@ https://{mcService}.{region}.{cloudProvider}.commercetools.com
 | Europe (AWS, Frankfurt) | `mc-api.eu-central-1.aws.commercetools.com` |
 | North America (Google Cloud, Iowa) | `mc-api.us-central1.gcp.commercetools.com` |
 | North America (AWS, Ohio) | `mc-api.us-east-2.aws.commercetools.com` |
+| China (AWS, Ningxia) | `mc-api.cn-northwest-1.aws.commercetools.cn` |
 
 ## Cloud Identifiers
 
@@ -57,6 +58,7 @@ To make it easier to reference the Merchant Center API URL, for example in the [
 | Europe (AWS, Frankfurt) | `aws-fra` |
 | North America (Google Cloud, Iowa) | `gcp-us` |
 | North America (AWS, Ohio) | `aws-ohio` |
+| China (AWS, Ningxia) | `aws-cn` |
 
 # Authentication
 

--- a/website/src/data/top-side-menu.yaml
+++ b/website/src/data/top-side-menu.yaml
@@ -5,7 +5,7 @@
 - label: Support
   href: /../offering/support
 - label: Status
-  href: /../offering/status
+  href: https://status.commercetools.com
 - label: Offering
   href: /../offering/
 - label: Tech Blog


### PR DESCRIPTION
#### Summary

We recently changed the status homepage to: https://status.commercetools.com. This PR applies the same change on the status link on Custom Apps documentation website.