### PR TITLE
feat: add new size `16` to dialog components

### DIFF
--- a/.changeset/thirty-beans-occur.md
+++ b/.changeset/thirty-beans-occur.md
@@ -3,4 +3,4 @@
 '@commercetools-local/visual-testing-app': patch
 ---
 
-Introduced a new available size value (`xl`) for the `FormDialog`, `ConfirmationDialog`, and `InfoDialog` components.
+Introduced a new available size value (16) for the `FormDialog`, `ConfirmationDialog`, and `InfoDialog` components.

--- a/.changeset/thirty-beans-occur.md
+++ b/.changeset/thirty-beans-occur.md
@@ -3,4 +3,4 @@
 '@commercetools-local/visual-testing-app': patch
 ---
 
-Introduced a new available size value (`xl`) for the `FormDialog` component.
+Introduced a new available size value (`xl`) for the `FormDialog`, `ConfirmationDialog`, and `InfoDialog` components.

--- a/.changeset/thirty-beans-occur.md
+++ b/.changeset/thirty-beans-occur.md
@@ -3,4 +3,4 @@
 '@commercetools-local/visual-testing-app': patch
 ---
 
-introduce xl prop for FormDialog component
+Introduced a new available size value (`xl`) for the `FormDialog` component.

--- a/.changeset/thirty-beans-occur.md
+++ b/.changeset/thirty-beans-occur.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-local/visual-testing-app': patch
+---
+
+introduce xl prop for FormDialog component

--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.tsx
@@ -18,7 +18,7 @@ type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
   title: string;
-  size?: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size?: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
   zIndex?: number;
   children: ReactNode;
   labelSecondary: Label;

--- a/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/confirmation-dialog/confirmation-dialog.tsx
@@ -18,7 +18,7 @@ type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
   title: string;
-  size?: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size?: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 16 | 'scale';
   zIndex?: number;
   children: ReactNode;
   labelSecondary: Label;

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -18,7 +18,7 @@ type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
   title: string;
-  size?: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size?: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
   zIndex?: number;
   children: ReactNode;
   labelSecondary: Label;

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -18,7 +18,7 @@ type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
   title: string;
-  size?: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size?: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 16 | 'scale';
   zIndex?: number;
   children: ReactNode;
   labelSecondary: Label;

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.tsx
@@ -6,7 +6,7 @@ import DialogHeader from '../internals/dialog-header';
 type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
-  size?: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size?: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 16 | 'scale';
   zIndex?: number;
   title: string;
   children: ReactNode;

--- a/packages/application-components/src/components/dialogs/info-dialog/info-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/info-dialog/info-dialog.tsx
@@ -6,7 +6,7 @@ import DialogHeader from '../internals/dialog-header';
 type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
-  size?: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size?: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
   zIndex?: number;
   title: string;
   children: ReactNode;

--- a/packages/application-components/src/components/dialogs/internals/dialog-container.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-container.tsx
@@ -41,7 +41,7 @@ const getOverlayElement: ModalProps['overlayElement'] = (
 type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
-  size: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 16 | 'scale';
   zIndex?: number;
   title: string;
   children: ReactNode;

--- a/packages/application-components/src/components/dialogs/internals/dialog-container.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-container.tsx
@@ -41,7 +41,7 @@ const getOverlayElement: ModalProps['overlayElement'] = (
 type Props = {
   isOpen: boolean;
   onClose?: (event: SyntheticEvent) => void;
-  size: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
   zIndex?: number;
   title: string;
   children: ReactNode;

--- a/packages/application-components/src/components/dialogs/internals/dialog.styles.ts
+++ b/packages/application-components/src/components/dialogs/internals/dialog.styles.ts
@@ -3,7 +3,7 @@ import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-s
 import { designTokens as appKitDesignTokens } from '../../../theming';
 
 type StyleProps = {
-  size: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 16 | 'scale';
   zIndex?: number;
 };
 
@@ -25,10 +25,10 @@ const getConstraintForGridStyle = (size: StyleProps['size']) => {
       return uiKitDesignTokens.constraint12;
     case 13:
       return uiKitDesignTokens.constraint13;
+    case 16:
+      return uiKitDesignTokens.constraint16;
     case 'l':
       return appKitDesignTokens.widthForDialogAsLarge;
-    case 'xl':
-      return appKitDesignTokens.widthForDialogAsExtraLarge;
     case 'scale':
       return uiKitDesignTokens.constraintScale;
     default:

--- a/packages/application-components/src/components/dialogs/internals/dialog.styles.ts
+++ b/packages/application-components/src/components/dialogs/internals/dialog.styles.ts
@@ -3,7 +3,7 @@ import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-s
 import { designTokens as appKitDesignTokens } from '../../../theming';
 
 type StyleProps = {
-  size: 'm' | 'l' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
+  size: 'm' | 'l' | 'xl' | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 'scale';
   zIndex?: number;
 };
 
@@ -27,6 +27,8 @@ const getConstraintForGridStyle = (size: StyleProps['size']) => {
       return uiKitDesignTokens.constraint13;
     case 'l':
       return appKitDesignTokens.widthForDialogAsLarge;
+    case 'xl':
+      return appKitDesignTokens.widthForDialogAsExtraLarge;
     case 'scale':
       return uiKitDesignTokens.constraintScale;
     default:

--- a/packages/application-components/src/theming.ts
+++ b/packages/application-components/src/theming.ts
@@ -57,7 +57,6 @@ export const themesOverrides = {
     shadowForNavbar: 'none',
     widthForDialogAsMedium: uiKitDesignTokens.constraint9,
     widthForDialogAsLarge: uiKitDesignTokens.constraint13,
-    widthForDialogAsExtraLarge: uiKitDesignTokens.constraint16,
     widthForPageLayoutContentColumn: `calc(${uiKitDesignTokens.constraint16} / 2)`,
   },
 };

--- a/packages/application-components/src/theming.ts
+++ b/packages/application-components/src/theming.ts
@@ -57,6 +57,7 @@ export const themesOverrides = {
     shadowForNavbar: 'none',
     widthForDialogAsMedium: uiKitDesignTokens.constraint9,
     widthForDialogAsLarge: uiKitDesignTokens.constraint13,
+    widthForDialogAsExtraLarge: uiKitDesignTokens.constraint16,
     widthForPageLayoutContentColumn: `calc(${uiKitDesignTokens.constraint16} / 2)`,
   },
 };

--- a/visual-testing-app/src/components/confirmation-dialog/confirmation-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/confirmation-dialog/confirmation-dialog.visualroute.tsx
@@ -52,6 +52,13 @@ export const Component = () => (
       <ConfirmationDialogExample size="l" portalId="dialog-l" />
     </Spec>
     <Spec
+      label="ConfirmationDialog - Size xl"
+      size="l"
+      contentAlignment="center"
+    >
+      <ConfirmationDialogExample size="xl" portalId="dialog-xl" />
+    </Spec>
+    <Spec
       label="ConfirmationDialog - Size 7"
       size={7}
       contentAlignment="center"

--- a/visual-testing-app/src/components/confirmation-dialog/confirmation-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/confirmation-dialog/confirmation-dialog.visualroute.tsx
@@ -52,13 +52,6 @@ export const Component = () => (
       <ConfirmationDialogExample size="l" portalId="dialog-l" />
     </Spec>
     <Spec
-      label="ConfirmationDialog - Size xl"
-      size="l"
-      contentAlignment="center"
-    >
-      <ConfirmationDialogExample size="xl" portalId="dialog-xl" />
-    </Spec>
-    <Spec
       label="ConfirmationDialog - Size 7"
       size={7}
       contentAlignment="center"
@@ -106,6 +99,13 @@ export const Component = () => (
       contentAlignment="center"
     >
       <ConfirmationDialogExample size={13} portalId="dialog-13" />
+    </Spec>
+    <Spec
+      label="ConfirmationDialog - Size 16"
+      size={13}
+      contentAlignment="center"
+    >
+      <ConfirmationDialogExample size={16} portalId="dialog-16" />
     </Spec>
     <Spec
       label="ConfirmationDialog - Size Scale"

--- a/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
@@ -92,6 +92,9 @@ export const Component = () => (
     <Spec label="FormDialog - Size Scale" size="l" contentAlignment="center">
       <FormDialogExample size="scale" portalId="dialog-scale" />
     </Spec>
+    <Spec label="FormDialog - Size xl" size="l" contentAlignment="center">
+      <FormDialogExample size="xl" portalId="dialog-xl" />
+    </Spec>
     <Spec label="FormDialog - Default size" contentAlignment="center">
       <FormDialogExample portalId="dialog-default" />
     </Spec>

--- a/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
@@ -89,11 +89,11 @@ export const Component = () => (
     <Spec label="FormDialog - Size 13" size={13} contentAlignment="center">
       <FormDialogExample size={13} portalId="dialog-13" />
     </Spec>
+    <Spec label="FormDialog - Size 16" size={13} contentAlignment="center">
+      <FormDialogExample size={16} portalId="dialog-16" />
+    </Spec>
     <Spec label="FormDialog - Size Scale" size="l" contentAlignment="center">
       <FormDialogExample size="scale" portalId="dialog-scale" />
-    </Spec>
-    <Spec label="FormDialog - Size xl" size="l" contentAlignment="center">
-      <FormDialogExample size="xl" portalId="dialog-xl" />
     </Spec>
     <Spec label="FormDialog - Default size" contentAlignment="center">
       <FormDialogExample portalId="dialog-default" />

--- a/visual-testing-app/src/components/info-dialog/info-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/info-dialog/info-dialog.visualroute.tsx
@@ -51,9 +51,6 @@ export const Component = () => (
     >
       <InfoDialogExample size="l" portalId="dialog-l" />
     </Spec>
-    <Spec label="InfoDialog - Size xl" size="l" contentAlignment="center">
-      <InfoDialogExample size="xl" portalId="dialog-xl" />
-    </Spec>
     <Spec label="InfoDialog - Size 7" size={7} contentAlignment="center">
       <InfoDialogExample size={7} portalId="dialog-7" />
     </Spec>
@@ -74,6 +71,9 @@ export const Component = () => (
     </Spec>
     <Spec label="InfoDialog - Size 13" size={13} contentAlignment="center">
       <InfoDialogExample size={13} portalId="dialog-13" />
+    </Spec>
+    <Spec label="InfoDialog - Size 16" size={13} contentAlignment="center">
+      <InfoDialogExample size={16} portalId="dialog-16" />
     </Spec>
     <Spec label="InfoDialog - Size Scale" size="l" contentAlignment="center">
       <InfoDialogExample size="scale" portalId="dialog-scale" />

--- a/visual-testing-app/src/components/info-dialog/info-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/info-dialog/info-dialog.visualroute.tsx
@@ -51,6 +51,9 @@ export const Component = () => (
     >
       <InfoDialogExample size="l" portalId="dialog-l" />
     </Spec>
+    <Spec label="InfoDialog - Size xl" size="l" contentAlignment="center">
+      <InfoDialogExample size="xl" portalId="dialog-xl" />
+    </Spec>
     <Spec label="InfoDialog - Size 7" size={7} contentAlignment="center">
       <InfoDialogExample size={7} portalId="dialog-7" />
     </Spec>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary

![image](https://github.com/commercetools/merchant-center-application-kit/assets/15024562/cb39ad53-0fa9-4dfb-b62c-bcc101a9c43e)

This PR introduces an `xl` prop to the `FormDialog` component, which translates to a `784px` width. See [this discussion](https://commercetools.slack.com/archives/C03B6NKTA83/p1685023794530089) for context. 
