### PR TITLE
[docs] Clarifying renderAppWithRedux props requirements

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -4,7 +4,7 @@ The website is available at https://docs.commercetools.com and is built using th
 
 ## Getting started
 
-To start the website in development mode, execute `yarn start`.
+To start the website in development mode, execute `pnpm start`.
 
 Please refer to the [Gatsby theme documentation](https://github.com/commercetools/commercetools-docs-kit) to how the website is configured and to work with it.
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -565,7 +565,7 @@ describe('rendering', () => {
 <Info>
 
 In addition to the following options, the method accepts all options from `renderApp`. 
-Please note that you can only pass one of `store`, `storeState`, or `sdkMocks`.
+Please note that it is not possible to pass either `storeState` or `sdkMocks` together with `store`.
 
 </Info>
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -565,7 +565,7 @@ describe('rendering', () => {
 <Info>
 
 In addition to the following options, the method accepts all options from `renderApp`. 
-Please note that you can only pass one of store, storeState or sdkMocks.
+Please note that you can only pass one of store, storeState, or sdkMocks.
 
 </Info>
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -564,7 +564,8 @@ describe('rendering', () => {
 
 <Info>
 
-In addition to the following options, the method accepts all options from `renderApp`.
+In addition to the following options, the method accepts all options from `renderApp`. 
+Please note that you can only pass one of store, storeState or sdkMocks.
 
 </Info>
 

--- a/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
+++ b/website/src/content/api-reference/commercetools-frontend-application-shell.mdx
@@ -565,7 +565,7 @@ describe('rendering', () => {
 <Info>
 
 In addition to the following options, the method accepts all options from `renderApp`. 
-Please note that you can only pass one of store, storeState, or sdkMocks.
+Please note that you can only pass one of `store`, `storeState`, or `sdkMocks`.
 
 </Info>
 


### PR DESCRIPTION
A couple weeks ago @ahmehri and I found that you could only provide one of store, storeState or sdkMocks to renderAppWithRedux testUtil function while debugging an integration test. We found this requirement in the code comments of test-utils but it wasn't in the documentation.

```
 invariant(
    !(store && storeState),
    '@commercetools-frontend/application-shell/test-utils: You provided both `store` and `storeState`. Please provide only one of them.'
  );
  invariant(
    !(store && sdkMocks.length > 0),
    '@commercetools-frontend/application-shell/test-utils: You provided both `store` and `sdkMocks`. Please provide only one of them.'
```

Also I changed the README to say that you need to use pnpm because I got an error when running it with yarn.