### PR TITLE
Added warnings to the `PageContentWide` component

### DIFF
--- a/.changeset/great-eggs-try.md
+++ b/.changeset/great-eggs-try.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-local/visual-testing-app': patch
+---
+
+Added warnings to the `page-content-wide' and tests update

--- a/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.tsx
+++ b/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.tsx
@@ -55,10 +55,33 @@ const Container = styled.div`
 
 function PageContentWide(props: TPageContentWide) {
   const [leftChild, rightChild] = Children.toArray(props.children);
+  const countChildren = Children.count(props.children);
+
+  // if there's 1 column and more than 1 child
+  const isColumnsOneAndMoreThanOneChild =
+    props.columns === '1' && countChildren > 1;
 
   useWarning(
-    props.columns !== '1' || !Boolean(rightChild),
-    'PageContentWide: This component only renders its first children when using a single column but you provided more that one.'
+    !isColumnsOneAndMoreThanOneChild,
+    'PageContentWide: This component has more than 1 child. Only the first child will be rendered.'
+  );
+
+  // if there's 1/1 or 2/1 columns and only 1 child
+  const isColumnsTwoAndOneChild =
+    (props.columns === '1/1' || props.columns === '2/1') && countChildren === 1;
+
+  useWarning(
+    !isColumnsTwoAndOneChild,
+    'PageContentWide: This component has only 1 child. The second child will be ignored.'
+  );
+
+  // if there's 1/1 or 2/1 columns and more than 2 children
+  const isColumnsTwoAndMoreThanTwoChildren =
+    (props.columns === '1/1' || props.columns === '2/1') && countChildren > 2;
+
+  useWarning(
+    !isColumnsTwoAndMoreThanTwoChildren,
+    'PageContentWide: This component has more than 2 children. Only the first 2 children will be rendered.'
   );
 
   return (

--- a/visual-testing-app/src/components/page-content-container-wide/page-content-container-wide.visualroute.tsx
+++ b/visual-testing-app/src/components/page-content-container-wide/page-content-container-wide.visualroute.tsx
@@ -38,18 +38,6 @@ export const Component = () => (
           ),
         },
         {
-          name: 'single column with several children',
-          path: 'single-column-with-several-children',
-          spec: (
-            <PageContentWide>
-              <Box />
-              <Box />
-              <Box />
-            </PageContentWide>
-          ),
-        },
-
-        {
           name: 'two columns 1/1',
           path: 'two-columns-half',
           spec: (
@@ -86,6 +74,38 @@ export const Component = () => (
             <PageContentWide columns="2/1" gapSize="10">
               <Box size="l" />
               <Box size="s" />
+            </PageContentWide>
+          ),
+        },
+        {
+          name: 'single column with several children',
+          path: 'single-column-with-several-children',
+          spec: (
+            <PageContentWide>
+              <Box />
+              <Box />
+              <Box />
+            </PageContentWide>
+          ),
+        },
+        {
+          name: 'two columns with one child',
+          path: 'two-columns-with-one-child',
+          spec: (
+            <PageContentWide columns="1/1">
+              <Box />
+            </PageContentWide>
+          ),
+        },
+        {
+          name: 'two columns with several children',
+          path: 'two-column-with-several-children',
+          spec: (
+            <PageContentWide columns="2/1">
+              <Box />
+              <Box />
+              <Box />
+              <Box />
             </PageContentWide>
           ),
         },


### PR DESCRIPTION
The `PageContentWide` doesn't throw a warning when more children are passed as props. 
For example if 3 are passed, it only renders first 2 children and it goes unnoticed that 3rd component is not rendered and why is that the case.

In this PR we cover 3 possible scenarios when the warning is shown:
1. There's 1 column and more than 1 child.
2. There's 1/1 or 2/1 columns and only 1 child.
3. There's 1/1 or 2/1 columns and more than 2 children.



This PR closes - https://github.com/commercetools/merchant-center-application-kit/issues/3126.
