### PR TITLE
`PageContentWide` warning fix

### DIFF
--- a/.changeset/old-sheep-thank.md
+++ b/.changeset/old-sheep-thank.md
@@ -2,4 +2,6 @@
 '@commercetools-frontend/application-components': patch
 ---
 
-Fix for the `PageContentWide` warning
+In version `22.3.3` we introduced a bug in the `PageContentWide` component leading to it sending warning messages to browser console log when correctly using it.
+
+We're now fixing that incorrect behaviour.

--- a/.changeset/old-sheep-thank.md
+++ b/.changeset/old-sheep-thank.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Fix for the `PageContentWide` warning

--- a/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.tsx
+++ b/packages/application-components/src/components/page-content-containers/page-content-wide/page-content-wide.tsx
@@ -57,13 +57,19 @@ function PageContentWide(props: TPageContentWide) {
   const [leftChild, rightChild] = Children.toArray(props.children);
   const childrenCount = Children.count(props.children);
 
+  const isOneColumnAndMoreThanOneChild =
+    props.columns === '1' && childrenCount > 1;
+
+  const isTwoColumnsAndMoreThanTwoChildren =
+    props.columns !== '1' && childrenCount > 2;
+
   useWarning(
-    props.columns === '1' && childrenCount > 1,
+    !isOneColumnAndMoreThanOneChild,
     'PageContentWide: This component only renders its first children when using a single column but you provided more than one.'
   );
 
   useWarning(
-    props.columns !== '1' && childrenCount > 2,
+    !isTwoColumnsAndMoreThanTwoChildren,
     'PageContentWide: This component only renders its first two children when using a two columns layout but you provided more than two.'
   );
 


### PR DESCRIPTION
FIX: The warning will be shown if the first param is `false` so we needed to adjust the condition.