### PR TITLE
Downgrade `graphql` dependency version

### DIFF
--- a/.changeset/fair-peas-pull.md
+++ b/.changeset/fair-peas-pull.md
@@ -1,0 +1,10 @@
+---
+'@commercetools-applications/merchant-center-template-starter-typescript': minor
+'@commercetools-frontend/application-shell-connectors': minor
+'@commercetools-applications/merchant-center-template-starter': minor
+'@commercetools-frontend/jest-preset-mc-app': minor
+'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/mc-scripts': minor
+---
+
+Downgrade `graphql` package to version `15.x`.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,6 +53,10 @@
     {
       "matchPackageNames": ["@types/react"],
       "allowedVersions": "<17.0.57"
+    },
+    {
+      "matchPackageNames": ["graphql"],
+      "allowedVersions": "<16"
     }
   ],
   "lockFileMaintenance": {

--- a/application-templates/starter-typescript/package.json
+++ b/application-templates/starter-typescript/package.json
@@ -75,7 +75,7 @@
     "eslint-formatter-pretty": "4.1.0",
     "eslint-plugin-graphql": "^4.0.0",
     "formik": "2.2.9",
-    "graphql": "^16.6.0",
+    "graphql": "^15.8.0",
     "graphql-tag": "^2.12.6",
     "jest": "29.5.0",
     "jest-runner-eslint": "2.0.0",

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -73,7 +73,7 @@
     "eslint-formatter-pretty": "4.1.0",
     "eslint-plugin-graphql": "^4.0.0",
     "formik": "2.2.9",
-    "graphql": "^16.6.0",
+    "graphql": "^15.8.0",
     "graphql-tag": "^2.12.6",
     "jest": "29.5.0",
     "jest-runner-eslint": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "eslint-formatter-pretty": "4.1.0",
     "eslint-plugin-graphql": "^4.0.0",
     "find-up": "5.0.0",
-    "graphql": "16.6.0",
+    "graphql": "15.8.0",
     "husky": "7.0.4",
     "jest": "29.5.0",
     "jest-each": "29.5.0",

--- a/packages/application-shell-connectors/package.json
+++ b/packages/application-shell-connectors/package.json
@@ -29,7 +29,7 @@
     "@types/lodash": "^4.14.191",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.53",
-    "graphql": "16.6.0",
+    "graphql": "15.8.0",
     "lodash": "4.17.21",
     "moment-timezone": "^0.5.40",
     "prop-types": "15.8.1",

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -86,7 +86,7 @@
     "debounce-async": "0.0.2",
     "downshift": "6.1.12",
     "fuse.js": "6.6.2",
-    "graphql": "16.6.0",
+    "graphql": "15.8.0",
     "history": "4.10.1",
     "is-retina": "1.0.3",
     "jwt-decode": "3.1.2",

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -404,11 +404,17 @@ describe('when loading user fails with an unauthorized graphql error', () => {
       graphql.query('FetchLoggedInUser', (req, res, ctx) =>
         res(
           ctx.errors([
-            new GraphQLError('User is not authorized', {
-              extensions: {
+            new GraphQLError(
+              'User is not authorized',
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              {
                 code: 'UNAUTHENTICATED',
-              },
-            }),
+              }
+            ),
           ])
         )
       )

--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -30,7 +30,7 @@
     "babel-preset-jest": "29.5.0",
     "colors": "1.4.0",
     "cosmiconfig": "7.1.0",
-    "graphql": "16.6.0",
+    "graphql": "15.8.0",
     "graphql-tag": "^2.12.6",
     "identity-obj-proxy": "3.0.0",
     "intl": "1.2.5",

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -76,7 +76,7 @@
     "dotenv": "16.0.3",
     "dotenv-expand": "8.0.3",
     "fs-extra": "10.1.0",
-    "graphql": "16.6.0",
+    "graphql": "15.8.0",
     "graphql-request": "5.2.0",
     "graphql-tag": "^2.12.6",
     "html-webpack-plugin": "5.5.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -45,7 +45,7 @@
     "@commercetools-uikit/text": "16.4.0",
     "@emotion/react": "11.11.0",
     "apollo-link-rest": "^0.9.0",
-    "graphql": "16.6.0",
+    "graphql": "15.8.0",
     "graphql-anywhere": "^4.2.8",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.40",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,22 +83,22 @@ importers:
         version: 6.1.1
       '@graphql-codegen/add':
         specifier: 3.2.3
-        version: 3.2.3(graphql@16.6.0)
+        version: 3.2.3(graphql@15.8.0)
       '@graphql-codegen/cli':
         specifier: 2.16.5
-        version: 2.16.5(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4)
+        version: 2.16.5(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4)
       '@graphql-codegen/introspection':
         specifier: 2.2.3
-        version: 2.2.3(graphql@16.6.0)
+        version: 2.2.3(graphql@15.8.0)
       '@graphql-codegen/typescript':
         specifier: 2.8.8
-        version: 2.8.8(graphql@16.6.0)
+        version: 2.8.8(graphql@15.8.0)
       '@graphql-codegen/typescript-graphql-files-modules':
         specifier: 2.2.1
-        version: 2.2.1(graphql@16.6.0)
+        version: 2.2.1(graphql@15.8.0)
       '@graphql-codegen/typescript-operations':
         specifier: 2.5.13
-        version: 2.5.13(graphql@16.6.0)
+        version: 2.5.13(graphql@15.8.0)
       '@manypkg/cli':
         specifier: 0.20.0
         version: 0.20.0
@@ -167,7 +167,7 @@ importers:
         version: 10.4.13(postcss@8.4.23)
       babel-plugin-import-graphql:
         specifier: ^2.8.1
-        version: 2.8.1(graphql-tag@2.12.6)(graphql@16.6.0)
+        version: 2.8.1(graphql-tag@2.12.6)(graphql@15.8.0)
       babel-plugin-transform-rename-import:
         specifier: ^2.3.0
         version: 2.3.0
@@ -194,13 +194,13 @@ importers:
         version: 4.1.0
       eslint-plugin-graphql:
         specifier: ^4.0.0
-        version: 4.0.0(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4)
+        version: 4.0.0(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4)
       find-up:
         specifier: 5.0.0
         version: 5.0.0
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 15.8.0
+        version: 15.8.0
       husky:
         specifier: 7.0.4
         version: 7.0.4
@@ -296,7 +296,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.7.14
-        version: 3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@babel/core':
         specifier: ^7.20.12
         version: 7.20.12
@@ -455,16 +455,16 @@ importers:
         version: 4.1.0
       eslint-plugin-graphql:
         specifier: ^4.0.0
-        version: 4.0.0(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4)
+        version: 4.0.0(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4)
       formik:
         specifier: 2.2.9
         version: 2.2.9(react@17.0.2)
       graphql:
-        specifier: ^16.6.0
-        version: 16.6.0
+        specifier: ^15.8.0
+        version: 15.8.0
       graphql-tag:
         specifier: ^2.12.6
-        version: 2.12.6(graphql@16.6.0)
+        version: 2.12.6(graphql@15.8.0)
       jest:
         specifier: 29.5.0
         version: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
@@ -512,7 +512,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.7.14
-        version: 3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@babel/core':
         specifier: ^7.20.12
         version: 7.20.12
@@ -674,16 +674,16 @@ importers:
         version: 4.1.0
       eslint-plugin-graphql:
         specifier: ^4.0.0
-        version: 4.0.0(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4)
+        version: 4.0.0(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4)
       formik:
         specifier: 2.2.9
         version: 2.2.9(react@17.0.2)
       graphql:
-        specifier: ^16.6.0
-        version: 16.6.0
+        specifier: ^15.8.0
+        version: 15.8.0
       graphql-tag:
         specifier: ^2.12.6
-        version: 2.12.6(graphql@16.6.0)
+        version: 2.12.6(graphql@15.8.0)
       jest:
         specifier: 29.5.0
         version: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
@@ -1291,8 +1291,8 @@ importers:
         specifier: 6.6.2
         version: 6.6.2
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 15.8.0
+        version: 15.8.0
       history:
         specifier: 4.10.1
         version: 4.10.1
@@ -1347,7 +1347,7 @@ importers:
     devDependencies:
       '@apollo/client':
         specifier: 3.7.14
-        version: 3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react':
         specifier: 12.1.5
         version: 12.1.5(react-dom@17.0.2)(react@17.0.2)
@@ -1421,8 +1421,8 @@ importers:
         specifier: 17.0.56
         version: 17.0.56
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 15.8.0
+        version: 15.8.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -1438,7 +1438,7 @@ importers:
     devDependencies:
       '@apollo/client':
         specifier: 3.7.14
-        version: 3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react':
         specifier: 12.1.5
         version: 12.1.5(react-dom@17.0.2)(react@17.0.2)
@@ -1840,11 +1840,11 @@ importers:
         specifier: 7.1.0
         version: 7.1.0
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 15.8.0
+        version: 15.8.0
       graphql-tag:
         specifier: ^2.12.6
-        version: 2.12.6(graphql@16.6.0)
+        version: 2.12.6(graphql@15.8.0)
       identity-obj-proxy:
         specifier: 3.0.0
         version: 3.0.0
@@ -2062,7 +2062,7 @@ importers:
         version: 0.5.10(react-refresh@0.14.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
       '@rollup/plugin-graphql':
         specifier: 2.0.3
-        version: 2.0.3(graphql@16.6.0)(rollup@2.79.1)
+        version: 2.0.3(graphql@15.8.0)(rollup@2.79.1)
       '@rollup/pluginutils':
         specifier: 5.0.2
         version: 5.0.2(rollup@2.79.1)
@@ -2124,14 +2124,14 @@ importers:
         specifier: 10.1.0
         version: 10.1.0
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 15.8.0
+        version: 15.8.0
       graphql-request:
         specifier: 5.2.0
-        version: 5.2.0(graphql@16.6.0)
+        version: 5.2.0(graphql@15.8.0)
       graphql-tag:
         specifier: ^2.12.6
-        version: 2.12.6(graphql@16.6.0)
+        version: 2.12.6(graphql@15.8.0)
       html-webpack-plugin:
         specifier: 5.5.1
         version: 5.5.1(webpack@5.82.1)
@@ -2684,13 +2684,13 @@ importers:
         version: 11.11.0(@types/react@17.0.56)(react@17.0.2)
       apollo-link-rest:
         specifier: ^0.9.0
-        version: 0.9.0(@apollo/client@3.7.14)(graphql@16.6.0)(qs@6.11.0)
+        version: 0.9.0(@apollo/client@3.7.14)(graphql@15.8.0)(qs@6.11.0)
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 15.8.0
+        version: 15.8.0
       graphql-anywhere:
         specifier: ^4.2.8
-        version: 4.2.8(graphql@16.6.0)
+        version: 4.2.8(graphql@15.8.0)
       moment:
         specifier: ^2.29.4
         version: 2.29.4
@@ -3084,7 +3084,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
 
-  /@apollo/client@3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2):
+  /@apollo/client@3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-BRvdkwq5PAXBkjXjboO12uksDm3nrZEqDi4xF97Fk3Mnaa0zDOEfJa7hoKTY9b9KA1EkeWv9BL3i7hSd4SfGBg==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -3102,12 +3102,12 @@ packages:
       subscriptions-transport-ws:
         optional: true
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       '@wry/context': 0.7.0
       '@wry/equality': 0.5.3
       '@wry/trie': 0.3.2
-      graphql: 16.6.0
-      graphql-tag: 2.12.6(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
       hoist-non-react-statics: 3.3.2
       optimism: 0.16.2
       prop-types: 15.8.1
@@ -3124,6 +3124,35 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.0.3
+    dev: false
+
+  /@ardatan/relay-compiler@12.0.0(graphql@15.8.0):
+    resolution: {integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==}
+    hasBin: true
+    peerDependencies:
+      graphql: '*'
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/generator': 7.21.5
+      '@babel/parser': 7.21.8
+      '@babel/runtime': 7.20.13
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
+      babel-preset-fbjs: 3.4.0(@babel/core@7.21.8)
+      chalk: 4.1.2
+      fb-watchman: 2.0.2
+      fbjs: 3.0.4
+      glob: 7.2.3
+      graphql: 15.8.0
+      immutable: 3.7.6
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      relay-runtime: 12.0.0
+      signedsource: 1.0.0
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: false
 
   /@ardatan/relay-compiler@12.0.0(graphql@16.6.0):
@@ -9542,6 +9571,16 @@ packages:
       html-entities: 2.3.3
       strip-ansi: 6.0.1
 
+  /@graphql-codegen/add@3.2.3(graphql@15.8.0):
+    resolution: {integrity: sha512-sQOnWpMko4JLeykwyjFTxnhqjd/3NOG2OyMuvK76Wnnwh8DRrNf2VEs2kmSvLl7MndMlOj7Kh5U154dVcvhmKQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.4.1
+    dev: false
+
   /@graphql-codegen/add@3.2.3(graphql@16.6.0):
     resolution: {integrity: sha512-sQOnWpMko4JLeykwyjFTxnhqjd/3NOG2OyMuvK76Wnnwh8DRrNf2VEs2kmSvLl7MndMlOj7Kh5U154dVcvhmKQ==}
     peerDependencies:
@@ -9551,7 +9590,7 @@ packages:
       graphql: 16.6.0
       tslib: 2.4.1
 
-  /@graphql-codegen/cli@2.16.5(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4):
+  /@graphql-codegen/cli@2.16.5(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4):
     resolution: {integrity: sha512-XYPIp+q7fB0xAGSAoRykiTe4oY80VU+z+dw5nuv4mLY0+pv7+pa2C6Nwhdw7a65lXOhFviBApWCCZeqd54SMnA==}
     hasBin: true
     peerDependencies:
@@ -9560,18 +9599,18 @@ packages:
       '@babel/generator': 7.21.5
       '@babel/template': 7.20.7
       '@babel/types': 7.21.5
-      '@graphql-codegen/core': 2.6.8(graphql@16.6.0)
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.6.0)
-      '@graphql-tools/apollo-engine-loader': 7.3.26(graphql@16.6.0)
-      '@graphql-tools/code-file-loader': 7.3.22(@babel/core@7.20.12)(graphql@16.6.0)
-      '@graphql-tools/git-loader': 7.2.21(@babel/core@7.20.12)(graphql@16.6.0)
-      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/graphql-file-loader': 7.5.17(graphql@16.6.0)
-      '@graphql-tools/json-file-loader': 7.4.18(graphql@16.6.0)
-      '@graphql-tools/load': 7.8.14(graphql@16.6.0)
-      '@graphql-tools/prisma-loader': 7.2.70(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/url-loader': 7.17.18(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-codegen/core': 2.6.8(graphql@15.8.0)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-tools/apollo-engine-loader': 7.3.26(graphql@15.8.0)
+      '@graphql-tools/code-file-loader': 7.3.22(@babel/core@7.20.12)(graphql@15.8.0)
+      '@graphql-tools/git-loader': 7.2.21(@babel/core@7.20.12)(graphql@15.8.0)
+      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/graphql-file-loader': 7.5.17(graphql@15.8.0)
+      '@graphql-tools/json-file-loader': 7.4.18(graphql@15.8.0)
+      '@graphql-tools/load': 7.8.14(graphql@15.8.0)
+      '@graphql-tools/prisma-loader': 7.2.70(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@whatwg-node/fetch': 0.6.9(@types/node@18.15.11)
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -9579,8 +9618,8 @@ packages:
       cosmiconfig-typescript-loader: 4.3.0(@types/node@18.15.11)(cosmiconfig@7.1.0)(ts-node@10.9.1)(typescript@5.0.4)
       debounce: 1.2.1
       detect-indent: 6.1.0
-      graphql: 16.6.0
-      graphql-config: 4.5.0(@types/node@18.15.11)(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-config: 4.5.0(@types/node@18.15.11)(graphql@15.8.0)
       inquirer: 8.2.5
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -9607,6 +9646,18 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@graphql-codegen/core@2.6.8(graphql@15.8.0):
+    resolution: {integrity: sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-tools/schema': 9.0.18(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.4.1
+    dev: false
+
   /@graphql-codegen/core@2.6.8(graphql@16.6.0):
     resolution: {integrity: sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==}
     peerDependencies:
@@ -9618,18 +9669,32 @@ packages:
       graphql: 16.6.0
       tslib: 2.4.1
 
-  /@graphql-codegen/introspection@2.2.3(graphql@16.6.0):
+  /@graphql-codegen/introspection@2.2.3(graphql@15.8.0):
     resolution: {integrity: sha512-iS0xhy64lapGCsBIBKFpAcymGW+A0LiLSGP9dPl6opZwU1bm/rsahkKvJnc+oCI/xfdQ3Q33zgUKOSCkqmM4Bw==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.6.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: false
+
+  /@graphql-codegen/plugin-helpers@2.7.2(graphql@15.8.0):
+    resolution: {integrity: sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/utils': 8.13.1(graphql@15.8.0)
+      change-case-all: 1.0.14
+      common-tags: 1.8.2
+      graphql: 15.8.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.4.1
     dev: false
 
   /@graphql-codegen/plugin-helpers@2.7.2(graphql@16.6.0):
@@ -9645,6 +9710,20 @@ packages:
       lodash: 4.17.21
       tslib: 2.4.1
 
+  /@graphql-codegen/plugin-helpers@3.1.2(graphql@15.8.0):
+    resolution: {integrity: sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 15.8.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.4.1
+    dev: false
+
   /@graphql-codegen/plugin-helpers@3.1.2(graphql@16.6.0):
     resolution: {integrity: sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==}
     peerDependencies:
@@ -9658,6 +9737,17 @@ packages:
       lodash: 4.17.21
       tslib: 2.4.1
 
+  /@graphql-codegen/schema-ast@2.6.1(graphql@15.8.0):
+    resolution: {integrity: sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.4.1
+    dev: false
+
   /@graphql-codegen/schema-ast@2.6.1(graphql@16.6.0):
     resolution: {integrity: sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==}
     peerDependencies:
@@ -9668,14 +9758,30 @@ packages:
       graphql: 16.6.0
       tslib: 2.4.1
 
-  /@graphql-codegen/typescript-graphql-files-modules@2.2.1(graphql@16.6.0):
+  /@graphql-codegen/typescript-graphql-files-modules@2.2.1(graphql@15.8.0):
     resolution: {integrity: sha512-E9k7AOZx4w4Qxll6tDbQKLJnriATowhrKobALaTcOG73SWtcZDDDitHjrm2DcV99XxlAFBV0J2ua/2r+nrvfvg==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.4.1
+    dev: false
+
+  /@graphql-codegen/typescript-operations@2.5.13(graphql@15.8.0):
+    resolution: {integrity: sha512-3vfR6Rx6iZU0JRt29GBkFlrSNTM6t+MSLF86ChvL4d/Jfo/JYAGuB3zNzPhirHYzJPCvLOAx2gy9ID1ltrpYiw==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-codegen/typescript': 2.8.8(graphql@15.8.0)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@15.8.0)
+      auto-bind: 4.0.0
+      graphql: 15.8.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: false
 
   /@graphql-codegen/typescript-operations@2.5.13(graphql@16.6.0):
@@ -9693,6 +9799,22 @@ packages:
       - encoding
       - supports-color
 
+  /@graphql-codegen/typescript@2.8.8(graphql@15.8.0):
+    resolution: {integrity: sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-codegen/schema-ast': 2.6.1(graphql@15.8.0)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@15.8.0)
+      auto-bind: 4.0.0
+      graphql: 15.8.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /@graphql-codegen/typescript@2.8.8(graphql@16.6.0):
     resolution: {integrity: sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==}
     peerDependencies:
@@ -9707,6 +9829,27 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  /@graphql-codegen/visitor-plugin-common@2.13.8(graphql@15.8.0):
+    resolution: {integrity: sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@15.8.0)
+      '@graphql-tools/optimize': 1.3.1(graphql@15.8.0)
+      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      dependency-graph: 0.11.0
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
+      parse-filepath: 1.0.2
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /@graphql-codegen/visitor-plugin-common@2.13.8(graphql@16.6.0):
     resolution: {integrity: sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==}
@@ -9728,53 +9871,53 @@ packages:
       - encoding
       - supports-color
 
-  /@graphql-tools/apollo-engine-loader@7.3.26(graphql@16.6.0):
+  /@graphql-tools/apollo-engine-loader@7.3.26(graphql@15.8.0):
     resolution: {integrity: sha512-h1vfhdJFjnCYn9b5EY1Z91JTF0KB3hHVJNQIsiUV2mpQXZdeOXQoaWeYEKaiI5R6kwBw5PP9B0fv3jfUIG8LyQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@whatwg-node/fetch': 0.8.4
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@graphql-tools/batch-execute@7.1.2(graphql@16.6.0):
+  /@graphql-tools/batch-execute@7.1.2(graphql@15.8.0):
     resolution: {integrity: sha512-IuR2SB2MnC2ztA/XeTMTfWcA0Wy7ZH5u+nDkDNLAdX+AaSyDnsQS35sCmHqG0VOGTl7rzoyBWLCKGwSJplgtwg==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
       dataloader: 2.0.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.2.0
       value-or-promise: 1.0.6
     dev: false
 
-  /@graphql-tools/batch-execute@8.5.19(graphql@16.6.0):
+  /@graphql-tools/batch-execute@8.5.19(graphql@15.8.0):
     resolution: {integrity: sha512-eqofTMYPygg9wVPdA+p8lk4NBpaPTcDut6SlnDk9IiYdY23Yfo6pY7mzZ3b27GugI7HDtB2OZUxzZJSGsk6Qew==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       dataloader: 2.2.2
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/code-file-loader@7.3.22(@babel/core@7.20.12)(graphql@16.6.0):
+  /@graphql-tools/code-file-loader@7.3.22(@babel/core@7.20.12)(graphql@15.8.0):
     resolution: {integrity: sha512-Dq38L0UTjWlGKaV8pTfOAHB/hhhNVuVOApBhpqMBSuE20B9vFslSWJvDXQzbCcSPNMAeuvq0JNjIeIec0O4qyw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 7.5.1(@babel/core@7.20.12)(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/graphql-tag-pluck': 7.5.1(@babel/core@7.20.12)(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       globby: 11.1.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       unixify: 1.0.0
     transitivePeerDependencies:
@@ -9797,46 +9940,46 @@ packages:
       - '@babel/core'
       - supports-color
 
-  /@graphql-tools/delegate@7.1.5(graphql@16.6.0):
+  /@graphql-tools/delegate@7.1.5(graphql@15.8.0):
     resolution: {integrity: sha512-bQu+hDd37e+FZ0CQGEEczmRSfQRnnXeUxI/0miDV+NV/zCbEdIJj5tYFNrKT03W6wgdqx8U06d8L23LxvGri/g==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
       '@ardatan/aggregate-error': 0.0.6
-      '@graphql-tools/batch-execute': 7.1.2(graphql@16.6.0)
-      '@graphql-tools/schema': 7.1.5(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
+      '@graphql-tools/batch-execute': 7.1.2(graphql@15.8.0)
+      '@graphql-tools/schema': 7.1.5(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
       dataloader: 2.0.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.2.0
       value-or-promise: 1.0.6
     dev: false
 
-  /@graphql-tools/delegate@9.0.31(graphql@16.6.0):
+  /@graphql-tools/delegate@9.0.31(graphql@15.8.0):
     resolution: {integrity: sha512-kQ08ssI9RMC3ENBCcwR/vP+IAvi5oWiyLBlydlS62N/UoIEHi1AgjT4dPkIlCXy/U/f2l6ETbsWCcdoN/2SQ7A==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/batch-execute': 8.5.19(graphql@16.6.0)
-      '@graphql-tools/executor': 0.0.17(graphql@16.6.0)
-      '@graphql-tools/schema': 9.0.18(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/batch-execute': 8.5.19(graphql@15.8.0)
+      '@graphql-tools/executor': 0.0.17(graphql@15.8.0)
+      '@graphql-tools/schema': 9.0.18(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       dataloader: 2.2.2
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/executor-graphql-ws@0.0.14(graphql@16.6.0):
+  /@graphql-tools/executor-graphql-ws@0.0.14(graphql@15.8.0):
     resolution: {integrity: sha512-P2nlkAsPZKLIXImFhj0YTtny5NQVGSsKnhi7PzXiaHSXc6KkzqbWZHKvikD4PObanqg+7IO58rKFpGXP7eeO+w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@repeaterjs/repeater': 3.0.4
       '@types/ws': 8.5.4
-      graphql: 16.6.0
-      graphql-ws: 5.12.1(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-ws: 5.12.1(graphql@15.8.0)
       isomorphic-ws: 5.0.0(ws@8.13.0)
       tslib: 2.5.0
       ws: 8.13.0
@@ -9845,17 +9988,17 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@graphql-tools/executor-http@0.1.9(@types/node@18.15.11)(graphql@16.6.0):
+  /@graphql-tools/executor-http@0.1.9(@types/node@18.15.11)(graphql@15.8.0):
     resolution: {integrity: sha512-tNzMt5qc1ptlHKfpSv9wVBVKCZ7gks6Yb/JcYJluxZIT4qRV+TtOFjpptfBU63usgrGVOVcGjzWc/mt7KhmmpQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@repeaterjs/repeater': 3.0.4
       '@whatwg-node/fetch': 0.8.4
       dset: 3.1.2
       extract-files: 11.0.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       meros: 1.2.1(@types/node@18.15.11)
       tslib: 2.5.0
       value-or-promise: 1.0.12
@@ -9863,14 +10006,14 @@ packages:
       - '@types/node'
     dev: false
 
-  /@graphql-tools/executor-legacy-ws@0.0.11(graphql@16.6.0):
+  /@graphql-tools/executor-legacy-ws@0.0.11(graphql@15.8.0):
     resolution: {integrity: sha512-4ai+NnxlNfvIQ4c70hWFvOZlSUN8lt7yc+ZsrwtNFbFPH/EroIzFMapAxM9zwyv9bH38AdO3TQxZ5zNxgBdvUw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@types/ws': 8.5.4
-      graphql: 16.6.0
+      graphql: 15.8.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
       tslib: 2.5.0
       ws: 8.13.0
@@ -9879,27 +10022,27 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@graphql-tools/executor@0.0.17(graphql@16.6.0):
+  /@graphql-tools/executor@0.0.17(graphql@15.8.0):
     resolution: {integrity: sha512-DVKyMclsNY8ei14FUrR4jn24VHB3EuFldD8yGWrcJ8cudSh47sknznvXN6q0ffqDeAf0IlZSaBCHrOTBqA7OfQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       '@repeaterjs/repeater': 3.0.4
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/git-loader@7.2.21(@babel/core@7.20.12)(graphql@16.6.0):
+  /@graphql-tools/git-loader@7.2.21(@babel/core@7.20.12)(graphql@15.8.0):
     resolution: {integrity: sha512-m9pZrhkc92iq7WRuZxA4NctNofQfhA34QoCLFCnm9krrvFUvzNZHhUvrfW5x3e63NTreu4+CFDPItBHeGZjoGA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 7.5.1(@babel/core@7.20.12)(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/graphql-tag-pluck': 7.5.1(@babel/core@7.20.12)(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
       is-glob: 4.0.3
       micromatch: 4.0.5
       tslib: 2.5.0
@@ -9909,17 +10052,17 @@ packages:
       - supports-color
     dev: false
 
-  /@graphql-tools/github-loader@7.3.28(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@16.6.0):
+  /@graphql-tools/github-loader@7.3.28(@babel/core@7.20.12)(@types/node@18.15.11)(graphql@15.8.0):
     resolution: {integrity: sha512-OK92Lf9pmxPQvjUNv05b3tnVhw0JRfPqOf15jZjyQ8BfdEUrJoP32b4dRQQem/wyRL24KY4wOfArJNqzpsbwCA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 0.1.9(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/graphql-tag-pluck': 7.5.1(@babel/core@7.20.12)(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/executor-http': 0.1.9(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/graphql-tag-pluck': 7.5.1(@babel/core@7.20.12)(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@whatwg-node/fetch': 0.8.4
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -9929,31 +10072,31 @@ packages:
       - supports-color
     dev: false
 
-  /@graphql-tools/graphql-file-loader@6.2.7(graphql@16.6.0):
+  /@graphql-tools/graphql-file-loader@6.2.7(graphql@15.8.0):
     resolution: {integrity: sha512-5k2SNz0W87tDcymhEMZMkd6/vs6QawDyjQXWtqkuLTBF3vxjxPD1I4dwHoxgWPIjjANhXybvulD7E+St/7s9TQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/import': 6.7.18(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/import': 6.7.18(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.1.0
     dev: false
 
-  /@graphql-tools/graphql-file-loader@7.5.17(graphql@16.6.0):
+  /@graphql-tools/graphql-file-loader@7.5.17(graphql@15.8.0):
     resolution: {integrity: sha512-hVwwxPf41zOYgm4gdaZILCYnKB9Zap7Ys9OhY1hbwuAuC4MMNY9GpUjoTU3CQc3zUiPoYStyRtUGkHSJZ3HxBw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/import': 6.7.18(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/import': 6.7.18(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       globby: 11.1.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       unixify: 1.0.0
     dev: false
 
-  /@graphql-tools/graphql-tag-pluck@7.5.1(@babel/core@7.20.12)(graphql@16.6.0):
+  /@graphql-tools/graphql-tag-pluck@7.5.1(@babel/core@7.20.12)(graphql@15.8.0):
     resolution: {integrity: sha512-TgKcSvs2sdFHMbUzyhR9bnYfwFHxqdpotX5Q0OcMmJkuieQe1q60+eEANWlCrjuEqr2giw528Ydq57MIWLKlNA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -9962,8 +10105,8 @@ packages:
       '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.20.12)
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.5.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -9986,54 +10129,66 @@ packages:
       - '@babel/core'
       - supports-color
 
-  /@graphql-tools/import@6.7.18(graphql@16.6.0):
+  /@graphql-tools/import@6.7.18(graphql@15.8.0):
     resolution: {integrity: sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
       resolve-from: 5.0.0
       tslib: 2.5.0
     dev: false
 
-  /@graphql-tools/json-file-loader@6.2.6(graphql@16.6.0):
+  /@graphql-tools/json-file-loader@6.2.6(graphql@15.8.0):
     resolution: {integrity: sha512-CnfwBSY5926zyb6fkDBHnlTblHnHI4hoBALFYXnrg0Ev4yWU8B04DZl/pBRUc459VNgO2x8/mxGIZj2hPJG1EA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.0.3
     dev: false
 
-  /@graphql-tools/json-file-loader@7.4.18(graphql@16.6.0):
+  /@graphql-tools/json-file-loader@7.4.18(graphql@15.8.0):
     resolution: {integrity: sha512-AJ1b6Y1wiVgkwsxT5dELXhIVUPs/u3VZ8/0/oOtpcoyO/vAeM5rOvvWegzicOOnQw8G45fgBRMkkRfeuwVt6+w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       globby: 11.1.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.5.0
       unixify: 1.0.0
     dev: false
 
-  /@graphql-tools/load@6.2.8(graphql@16.6.0):
+  /@graphql-tools/load@6.2.8(graphql@15.8.0):
     resolution: {integrity: sha512-JpbyXOXd8fJXdBh2ta0Q4w8ia6uK5FHzrTNmcvYBvflFuWly2LDTk2abbSl81zKkzswQMEd2UIYghXELRg8eTA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/merge': 6.2.14(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
+      '@graphql-tools/merge': 6.2.14(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
       globby: 11.0.3
-      graphql: 16.6.0
+      graphql: 15.8.0
       import-from: 3.0.0
       is-glob: 4.0.1
       p-limit: 3.1.0
       tslib: 2.2.0
       unixify: 1.0.0
       valid-url: 1.0.9
+    dev: false
+
+  /@graphql-tools/load@7.8.14(graphql@15.8.0):
+    resolution: {integrity: sha512-ASQvP+snHMYm+FhIaLxxFgVdRaM0vrN9wW2BKInQpktwWTXVyk+yP5nQUCEGmn0RTdlPKrffBaigxepkEAJPrg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/schema': 9.0.18(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
+      p-limit: 3.1.0
+      tslib: 2.5.0
     dev: false
 
   /@graphql-tools/load@7.8.14(graphql@16.6.0):
@@ -10047,15 +10202,25 @@ packages:
       p-limit: 3.1.0
       tslib: 2.5.0
 
-  /@graphql-tools/merge@6.2.14(graphql@16.6.0):
+  /@graphql-tools/merge@6.2.14(graphql@15.8.0):
     resolution: {integrity: sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/schema': 7.1.5(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/schema': 7.1.5(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.2.0
+    dev: false
+
+  /@graphql-tools/merge@8.4.1(graphql@15.8.0):
+    resolution: {integrity: sha512-hssnPpZ818mxgl5+GfyOOSnnflAxiaTn1A1AojZcIbh4J52sS1Q0gSuBR5VrnUDjuxiqoCotpXdAQl+K+U6KLQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.5.0
     dev: false
 
   /@graphql-tools/merge@8.4.1(graphql@16.6.0):
@@ -10067,6 +10232,15 @@ packages:
       graphql: 16.6.0
       tslib: 2.5.0
 
+  /@graphql-tools/optimize@1.3.1(graphql@15.8.0):
+    resolution: {integrity: sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.5.0
+    dev: false
+
   /@graphql-tools/optimize@1.3.1(graphql@16.6.0):
     resolution: {integrity: sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==}
     peerDependencies:
@@ -10075,21 +10249,21 @@ packages:
       graphql: 16.6.0
       tslib: 2.5.0
 
-  /@graphql-tools/prisma-loader@7.2.70(@types/node@18.15.11)(graphql@16.6.0):
+  /@graphql-tools/prisma-loader@7.2.70(@types/node@18.15.11)(graphql@15.8.0):
     resolution: {integrity: sha512-YcV1pScllv2uP+OSNsLOac7yccexa/AY6BoLIsCfrVmFQoo7KUlz3oPiyZ6eIbGYmU5fp3MWt3Wf0cL4WgAnlw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/url-loader': 7.17.18(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       '@types/js-yaml': 4.0.5
       '@types/json-stable-stringify': 1.0.34
       '@whatwg-node/fetch': 0.8.4
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.0.3
-      graphql: 16.6.0
-      graphql-request: 6.0.0(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-request: 6.0.0(graphql@15.8.0)
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       jose: 4.13.2
@@ -10107,6 +10281,20 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@graphql-tools/relay-operation-optimizer@6.5.18(graphql@15.8.0):
+    resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/relay-compiler': 12.0.0(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.6.0):
     resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
     peerDependencies:
@@ -10120,15 +10308,27 @@ packages:
       - encoding
       - supports-color
 
-  /@graphql-tools/schema@7.1.5(graphql@16.6.0):
+  /@graphql-tools/schema@7.1.5(graphql@15.8.0):
     resolution: {integrity: sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.2.0
       value-or-promise: 1.0.6
+    dev: false
+
+  /@graphql-tools/schema@9.0.18(graphql@15.8.0):
+    resolution: {integrity: sha512-Kckb+qoo36o5RSIVfBNU5XR5fOg4adNa1xuhhUgbQejDaI684tIJbTWwYbrDPVEGL/dqJJX3rrsq7RLufjNFoQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/merge': 8.4.1(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.5.0
+      value-or-promise: 1.0.12
     dev: false
 
   /@graphql-tools/schema@9.0.18(graphql@16.6.0):
@@ -10142,27 +10342,27 @@ packages:
       tslib: 2.5.0
       value-or-promise: 1.0.12
 
-  /@graphql-tools/url-loader@6.10.1(@types/node@18.15.11)(graphql@16.6.0):
+  /@graphql-tools/url-loader@6.10.1(@types/node@18.15.11)(graphql@15.8.0):
     resolution: {integrity: sha512-DSDrbhQIv7fheQ60pfDpGD256ixUQIR6Hhf9Z5bRjVkXOCvO5XrkwoWLiU7iHL81GB1r0Ba31bf+sl+D4nyyfw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/delegate': 7.1.5(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
-      '@graphql-tools/wrap': 7.0.8(graphql@16.6.0)
+      '@graphql-tools/delegate': 7.1.5(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
+      '@graphql-tools/wrap': 7.0.8(graphql@15.8.0)
       '@microsoft/fetch-event-source': 2.0.1
       '@types/websocket': 1.0.2
       abort-controller: 3.0.0
       cross-fetch: 3.1.4
       extract-files: 9.0.0
       form-data: 4.0.0
-      graphql: 16.6.0
-      graphql-ws: 4.9.0(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-ws: 4.9.0(graphql@15.8.0)
       is-promise: 4.0.0
       isomorphic-ws: 4.0.1(ws@7.4.5)
       lodash: 4.17.21
       meros: 1.1.4(@types/node@18.15.11)
-      subscriptions-transport-ws: 0.9.19(graphql@16.6.0)
+      subscriptions-transport-ws: 0.9.19(graphql@15.8.0)
       sync-fetch: 0.3.0
       tslib: 2.2.0
       valid-url: 1.0.9
@@ -10174,21 +10374,21 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@graphql-tools/url-loader@7.17.18(@types/node@18.15.11)(graphql@16.6.0):
+  /@graphql-tools/url-loader@7.17.18(@types/node@18.15.11)(graphql@15.8.0):
     resolution: {integrity: sha512-ear0CiyTj04jCVAxi7TvgbnGDIN2HgqzXzwsfcqiVg9cvjT40NcMlZ2P1lZDgqMkZ9oyLTV8Bw6j+SyG6A+xPw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/delegate': 9.0.31(graphql@16.6.0)
-      '@graphql-tools/executor-graphql-ws': 0.0.14(graphql@16.6.0)
-      '@graphql-tools/executor-http': 0.1.9(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/executor-legacy-ws': 0.0.11(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
-      '@graphql-tools/wrap': 9.4.2(graphql@16.6.0)
+      '@graphql-tools/delegate': 9.0.31(graphql@15.8.0)
+      '@graphql-tools/executor-graphql-ws': 0.0.14(graphql@15.8.0)
+      '@graphql-tools/executor-http': 0.1.9(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/executor-legacy-ws': 0.0.11(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      '@graphql-tools/wrap': 9.4.2(graphql@15.8.0)
       '@types/ws': 8.5.4
       '@whatwg-node/fetch': 0.8.4
-      graphql: 16.6.0
+      graphql: 15.8.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
       tslib: 2.5.0
       value-or-promise: 1.0.12
@@ -10200,15 +10400,24 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@graphql-tools/utils@7.10.0(graphql@16.6.0):
+  /@graphql-tools/utils@7.10.0(graphql@15.8.0):
     resolution: {integrity: sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
       '@ardatan/aggregate-error': 0.0.6
       camel-case: 4.1.2
-      graphql: 16.6.0
+      graphql: 15.8.0
       tslib: 2.2.0
+    dev: false
+
+  /@graphql-tools/utils@8.13.1(graphql@15.8.0):
+    resolution: {integrity: sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.5.0
     dev: false
 
   /@graphql-tools/utils@8.13.1(graphql@16.6.0):
@@ -10219,6 +10428,16 @@ packages:
       graphql: 16.6.0
       tslib: 2.5.0
 
+  /@graphql-tools/utils@9.2.1(graphql@15.8.0):
+    resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      graphql: 15.8.0
+      tslib: 2.5.0
+    dev: false
+
   /@graphql-tools/utils@9.2.1(graphql@16.6.0):
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
     peerDependencies:
@@ -10228,31 +10447,38 @@ packages:
       graphql: 16.6.0
       tslib: 2.5.0
 
-  /@graphql-tools/wrap@7.0.8(graphql@16.6.0):
+  /@graphql-tools/wrap@7.0.8(graphql@15.8.0):
     resolution: {integrity: sha512-1NDUymworsOlb53Qfh7fonDi2STvqCtbeE68ntKY9K/Ju/be2ZNxrFSbrBHwnxWcN9PjISNnLcAyJ1L5tCUyhg==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
-      '@graphql-tools/delegate': 7.1.5(graphql@16.6.0)
-      '@graphql-tools/schema': 7.1.5(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/delegate': 7.1.5(graphql@15.8.0)
+      '@graphql-tools/schema': 7.1.5(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.2.0
       value-or-promise: 1.0.6
     dev: false
 
-  /@graphql-tools/wrap@9.4.2(graphql@16.6.0):
+  /@graphql-tools/wrap@9.4.2(graphql@15.8.0):
     resolution: {integrity: sha512-DFcd9r51lmcEKn0JW43CWkkI2D6T9XI1juW/Yo86i04v43O9w2/k4/nx2XTJv4Yv+iXwUw7Ok81PGltwGJSDSA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/delegate': 9.0.31(graphql@16.6.0)
-      '@graphql-tools/schema': 9.0.18(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
-      graphql: 16.6.0
+      '@graphql-tools/delegate': 9.0.31(graphql@15.8.0)
+      '@graphql-tools/schema': 9.0.18(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
+      graphql: 15.8.0
       tslib: 2.5.0
       value-or-promise: 1.0.12
     dev: false
+
+  /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
 
   /@graphql-typed-document-node/core@3.2.0(graphql@16.6.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -11982,7 +12208,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-graphql@2.0.3(graphql@16.6.0)(rollup@2.79.1):
+  /@rollup/plugin-graphql@2.0.3(graphql@15.8.0)(rollup@2.79.1):
     resolution: {integrity: sha512-IuuELo+0t29adRuLVg8izBFiUXFSFw8BmezespscynRfvfXSOV0S7g8RzQt75VzP6KHHVmNmlAgz+8qlkLur3w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -11993,8 +12219,8 @@ packages:
         optional: true
     dependencies:
       '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
-      graphql: 16.6.0
-      graphql-tag: 2.12.6(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
       rollup: 2.79.1
     dev: false
 
@@ -14355,29 +14581,29 @@ packages:
     peerDependencies:
       '@apollo/client': ^3.0.0
     dependencies:
-      '@apollo/client': 3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2)
+      '@apollo/client': 3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
     dev: false
 
-  /apollo-link-rest@0.9.0(@apollo/client@3.7.14)(graphql@16.6.0)(qs@6.11.0):
+  /apollo-link-rest@0.9.0(@apollo/client@3.7.14)(graphql@15.8.0)(qs@6.11.0):
     resolution: {integrity: sha512-kuXjR56Y12w0TZcqwVaONKlipB6g3Ya1dAy4NMCaylPpNXq6tO+qzQFPUyDJC7B0JoJPIFjxPV2rAet4uGM4UQ==}
     peerDependencies:
       '@apollo/client': '>=3'
       graphql: '>=0.11'
       qs: '>=6'
     dependencies:
-      '@apollo/client': 3.7.14(graphql@16.6.0)(react-dom@17.0.2)(react@17.0.2)
-      graphql: 16.6.0
+      '@apollo/client': 3.7.14(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
+      graphql: 15.8.0
       qs: 6.11.0
     dev: false
 
-  /apollo-utilities@1.3.4(graphql@16.6.0):
+  /apollo-utilities@1.3.4(graphql@15.8.0):
     resolution: {integrity: sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       '@wry/equality': 0.1.11
       fast-json-stable-stringify: 2.1.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       ts-invariant: 0.4.4
       tslib: 1.14.1
     dev: false
@@ -14753,15 +14979,15 @@ packages:
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
 
-  /babel-plugin-import-graphql@2.8.1(graphql-tag@2.12.6)(graphql@16.6.0):
+  /babel-plugin-import-graphql@2.8.1(graphql-tag@2.12.6)(graphql@15.8.0):
     resolution: {integrity: sha512-j8Y0rWfMCd7Q63+hzCENrzbwYvQ9GfRbD3S50oHJ0SmEeRRVgLMxj+jXCBVLTFlmFLzY8UYVQQGx3FgrK3wajA==}
     engines: {node: '>= 4.x'}
     peerDependencies:
       graphql: '>=0.9.6'
       graphql-tag: ^2.1.0
     dependencies:
-      graphql: 16.6.0
-      graphql-tag: 2.12.6(graphql@16.6.0)
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -18052,15 +18278,15 @@ packages:
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  /eslint-plugin-graphql@4.0.0(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4):
+  /eslint-plugin-graphql@4.0.0(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4):
     resolution: {integrity: sha512-d5tQm24YkVvCEk29ZR5ScsgXqAGCjKlMS8lx3mS7FS/EKsWbkvXQImpvic03EpMIvNTBW5e+2xnHzXB/VHNZJw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       '@babel/runtime': 7.20.13
-      graphql: 16.6.0
-      graphql-config: 3.4.1(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4)
+      graphql: 15.8.0
+      graphql-config: 3.4.1(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4)
       lodash.flatten: 4.4.0
       lodash.without: 4.4.0
     transitivePeerDependencies:
@@ -20544,13 +20770,13 @@ packages:
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
-  /graphql-anywhere@4.2.8(graphql@16.6.0):
+  /graphql-anywhere@4.2.8(graphql@15.8.0):
     resolution: {integrity: sha512-bKeJJoY9JyWMAiz5isKrtYUdIUBOBiXUOrA9CQgs9Drh9itFtxhWndQH4UBuYfrMticum6Oj1uQ6iSvZk94cMQ==}
     peerDependencies:
       graphql: '>= 0.11.0'
     dependencies:
-      apollo-utilities: 1.3.4(graphql@16.6.0)
-      graphql: 16.6.0
+      apollo-utilities: 1.3.4(graphql@15.8.0)
+      graphql: 15.8.0
       ts-invariant: 0.3.3
       tslib: 2.5.0
     dev: false
@@ -20563,22 +20789,22 @@ packages:
       graphql: 16.6.0
       graphql-type-json: 0.3.2(graphql@16.6.0)
 
-  /graphql-config@3.4.1(@types/node@18.15.11)(graphql@16.6.0)(typescript@5.0.4):
+  /graphql-config@3.4.1(@types/node@18.15.11)(graphql@15.8.0)(typescript@5.0.4):
     resolution: {integrity: sha512-g9WyK4JZl1Ko++FSyE5Ir2g66njfxGzrDDhBOwnkoWf/t3TnnZG6BBkWP+pkqVJ5pqMJGPKHNrbew8jRxStjhw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.0)(typescript@5.0.4)
-      '@graphql-tools/graphql-file-loader': 6.2.7(graphql@16.6.0)
-      '@graphql-tools/json-file-loader': 6.2.6(graphql@16.6.0)
-      '@graphql-tools/load': 6.2.8(graphql@16.6.0)
-      '@graphql-tools/merge': 6.2.14(graphql@16.6.0)
-      '@graphql-tools/url-loader': 6.10.1(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/utils': 7.10.0(graphql@16.6.0)
+      '@graphql-tools/graphql-file-loader': 6.2.7(graphql@15.8.0)
+      '@graphql-tools/json-file-loader': 6.2.6(graphql@15.8.0)
+      '@graphql-tools/load': 6.2.8(graphql@15.8.0)
+      '@graphql-tools/merge': 6.2.14(graphql@15.8.0)
+      '@graphql-tools/url-loader': 6.10.1(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/utils': 7.10.0(graphql@15.8.0)
       cosmiconfig: 7.0.0
       cosmiconfig-toml-loader: 1.0.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       minimatch: 3.0.4
       string-env-interpolation: 1.0.1
     transitivePeerDependencies:
@@ -20589,7 +20815,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /graphql-config@4.5.0(@types/node@18.15.11)(graphql@16.6.0):
+  /graphql-config@4.5.0(@types/node@18.15.11)(graphql@15.8.0):
     resolution: {integrity: sha512-x6D0/cftpLUJ0Ch1e5sj1TZn6Wcxx4oMfmhaG9shM0DKajA9iR+j1z86GSTQ19fShbGvrSSvbIQsHku6aQ6BBw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -20599,14 +20825,14 @@ packages:
       cosmiconfig-toml-loader:
         optional: true
     dependencies:
-      '@graphql-tools/graphql-file-loader': 7.5.17(graphql@16.6.0)
-      '@graphql-tools/json-file-loader': 7.4.18(graphql@16.6.0)
-      '@graphql-tools/load': 7.8.14(graphql@16.6.0)
-      '@graphql-tools/merge': 8.4.1(graphql@16.6.0)
-      '@graphql-tools/url-loader': 7.17.18(@types/node@18.15.11)(graphql@16.6.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
+      '@graphql-tools/graphql-file-loader': 7.5.17(graphql@15.8.0)
+      '@graphql-tools/json-file-loader': 7.4.18(graphql@15.8.0)
+      '@graphql-tools/load': 7.8.14(graphql@15.8.0)
+      '@graphql-tools/merge': 8.4.1(graphql@15.8.0)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@18.15.11)(graphql@15.8.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       cosmiconfig: 8.0.0
-      graphql: 16.6.0
+      graphql: 15.8.0
       jiti: 1.17.1
       minimatch: 4.2.3
       string-env-interpolation: 1.0.1
@@ -20626,31 +20852,40 @@ packages:
     dependencies:
       graphql: 16.6.0
 
-  /graphql-request@5.2.0(graphql@16.6.0):
+  /graphql-request@5.2.0(graphql@15.8.0):
     resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
-      graphql: 16.6.0
+      graphql: 15.8.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /graphql-request@6.0.0(graphql@16.6.0):
+  /graphql-request@6.0.0(graphql@15.8.0):
     resolution: {integrity: sha512-2BmHTuglonjZvmNVw6ZzCfFlW/qkIPds0f+Qdi/Lvjsl3whJg2uvHmSvHnLWhUTEw6zcxPYAHiZoPvSVKOZ7Jw==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       cross-fetch: 3.1.5
-      graphql: 16.6.0
+      graphql: 15.8.0
     transitivePeerDependencies:
       - encoding
     dev: false
+
+  /graphql-tag@2.12.6(graphql@15.8.0):
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.5.0
 
   /graphql-tag@2.12.6(graphql@16.6.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -20668,23 +20903,27 @@ packages:
     dependencies:
       graphql: 16.6.0
 
-  /graphql-ws@4.9.0(graphql@16.6.0):
+  /graphql-ws@4.9.0(graphql@15.8.0):
     resolution: {integrity: sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==}
     engines: {node: '>=10'}
     peerDependencies:
       graphql: '>=0.11 <=15'
     dependencies:
-      graphql: 16.6.0
+      graphql: 15.8.0
     dev: false
 
-  /graphql-ws@5.12.1(graphql@16.6.0):
+  /graphql-ws@5.12.1(graphql@15.8.0):
     resolution: {integrity: sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==}
     engines: {node: '>=10'}
     peerDependencies:
       graphql: '>=0.11 <=16'
     dependencies:
-      graphql: 16.6.0
+      graphql: 15.8.0
     dev: false
+
+  /graphql@15.8.0:
+    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
+    engines: {node: '>= 10.x'}
 
   /graphql@16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
@@ -24756,7 +24995,7 @@ packages:
       chalk: 4.1.1
       chokidar: 3.5.3
       cookie: 0.4.2
-      graphql: 16.6.0
+      graphql: 15.8.0
       headers-polyfill: 3.1.2
       inquirer: 8.2.5
       is-node-process: 1.2.0
@@ -24792,7 +25031,7 @@ packages:
       chalk: 4.1.1
       chokidar: 3.5.3
       cookie: 0.4.2
-      graphql: 16.6.0
+      graphql: 15.8.0
       headers-polyfill: 3.1.2
       inquirer: 8.2.5
       is-node-process: 1.2.0
@@ -29161,7 +29400,7 @@ packages:
   /stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
-  /subscriptions-transport-ws@0.9.19(graphql@16.6.0):
+  /subscriptions-transport-ws@0.9.19(graphql@15.8.0):
     resolution: {integrity: sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==}
     deprecated: The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md
     peerDependencies:
@@ -29169,7 +29408,7 @@ packages:
     dependencies:
       backo2: 1.0.2
       eventemitter3: 3.1.2
-      graphql: 16.6.0
+      graphql: 15.8.0
       iterall: 1.3.0
       symbol-observable: 1.2.0
       ws: 7.5.9


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Downgrade `graphql` dependency version

#### Description

Some users using our `@commercetools-frontend/create-mc-app` to create a new Custom Application are experiencing problems when running the command because of a peer dependency miss match with the `graphql` package.

More info here: #3110 

Our starter templates rely on the [eslint-plugin-graphql](https://github.com/apollographql/eslint-plugin-graphql/tree/master) package to add static validation to graphql mutations and queries.
This package uses the `graphql` one as a peer dependency and the one we are currently using is `16.x` which [is not supported](https://github.com/apollographql/eslint-plugin-graphql/blob/master/package.json#L50) by the former.

We're downgrading our `graphql` version to the latest supported by the plugin (`v15`) as we don't want to loose that static check.

We also created [an issue](https://github.com/apollographql/eslint-plugin-graphql/issues/333) in the `eslint-plugin-graphql` repository asking for `graphql` `v16.x` version support.
