### PR TITLE
fix(create-mc-app): run `npm install` cmd with `--legacy-peer-deps` option

### DIFF
--- a/.changeset/fresh-lizards-remain.md
+++ b/.changeset/fresh-lizards-remain.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Run `npm install` command with `--legacy-peer-deps` option

--- a/packages/create-mc-app/src/tasks/install-dependencies.ts
+++ b/packages/create-mc-app/src/tasks/install-dependencies.ts
@@ -1,17 +1,17 @@
 import execa from 'execa';
 import type { ListrTask } from 'listr2';
 import type { TCliTaskOptions } from '../types';
-import { getPreferredPackageManager } from '../utils';
+import { getInstallCommand } from '../utils';
 
 function installDependencies(options: TCliTaskOptions): ListrTask {
   return {
     title: 'Installing dependencies (this might take a while)',
     task: () => {
-      const packageManager = getPreferredPackageManager(options);
+      const installCommand = getInstallCommand(options);
 
       // TODO: we could check for min yarn/npm versions
       // See https://github.com/facebook/create-react-app/blob/0f4781e8507249ce29a9ac1409fece67c1a53c38/packages/create-react-app/createReactApp.js#L225-L254
-      return execa(packageManager, ['install'], {
+      return execa.command(installCommand, {
         cwd: options.projectDirectoryPath,
         encoding: 'utf-8',
       });

--- a/packages/create-mc-app/src/utils.ts
+++ b/packages/create-mc-app/src/utils.ts
@@ -27,6 +27,17 @@ const getPreferredPackageManager = (
   return 'npm';
 };
 
+const getInstallCommand = (options: TCliTaskOptions): string => {
+  const packageManager = getPreferredPackageManager(options);
+
+  switch (packageManager) {
+    case 'npm':
+      return 'npm install --legacy-peer-deps';
+    default:
+      return `${packageManager} install`;
+  }
+};
+
 const slugify = (name: string) => name.toLowerCase().replace(/_/gi, '-');
 
 const upperFirst = (value: string) =>
@@ -54,4 +65,5 @@ export {
   upperFirst,
   resolveFilePathByExtension,
   getPreferredPackageManager,
+  getInstallCommand,
 };


### PR DESCRIPTION
Fixes #3110 

Refers to comment https://github.com/commercetools/merchant-center-application-kit/pull/3134#issuecomment-1637648922

