### PR TITLE
feat(packages-backend/loggers): support to not unset from field

### DIFF
--- a/.changeset/mighty-donkeys-sip.md
+++ b/.changeset/mighty-donkeys-sip.md
@@ -2,15 +2,15 @@
 "@commercetools-backend/loggers": minor
 ---
 
-Support to not unset the original field when rewriting logs.
+Add support to optionally preserve the original field when rewriting log fields with `rewriteFieldsFormatter`.
 
-When rewriting a field you can use the `unsetFromField` option and set it to `false`. For example:
+When rewriting a field you can use the `preserveFromField` option and set it to `true`. For example:
 
 ```js
 {
   from: 'meta.req.statusCode',
   to: 'meta.req.status_code',
-  unsetFromField: false,
+  preserveFromField: true,
 }
 ```
 

--- a/.changeset/mighty-donkeys-sip.md
+++ b/.changeset/mighty-donkeys-sip.md
@@ -1,0 +1,17 @@
+---
+"@commercetools-backend/loggers": minor
+---
+
+Support to not unset the original field when rewriting logs.
+
+When rewriting a field you can use the `unsetFromField` option and set it to `false`. For example:
+
+```js
+{
+  from: 'meta.req.statusCode',
+  to: 'meta.req.status_code',
+  unsetFromField: false,
+}
+```
+
+Would add a field `meta.req.status_code` while keeping the original `meta.req.statusCode`. This can be helpful when gracefully migrating fields.

--- a/packages-backend/loggers/src/formatters/rewrite-fields.ts
+++ b/packages-backend/loggers/src/formatters/rewrite-fields.ts
@@ -9,16 +9,31 @@ type TRewriteField = {
   from: string;
   to: string;
   replaceValue?: (value: unknown) => unknown;
+  unsetFromField?: boolean;
 };
 type TRewriteFieldsFormatterOption = {
   fields: TRewriteField[];
 };
 
+const defaultRewriteField: TRewriteField = {
+  unsetFromField: true,
+};
 function rewriteField(info: TransformableInfo, field: TRewriteField) {
-  const val = getIn(info, field.from);
-  if (val) {
-    unsetIn(info, field.from);
-    setIn(info, field.to, field.replaceValue ? field.replaceValue(val) : val);
+  const mergedRewriteField = { ...defaultRewriteField, ...field };
+  const fromFieldValue = getIn(info, mergedRewriteField.from);
+
+  if (fromFieldValue) {
+    if (mergedRewriteField.unsetFromField) {
+      unsetIn(info, mergedRewriteField.from);
+    }
+
+    setIn(
+      info,
+      mergedRewriteField.to,
+      mergedRewriteField.replaceValue
+        ? mergedRewriteField.replaceValue(fromFieldValue)
+        : fromFieldValue
+    );
   }
 }
 

--- a/packages-backend/loggers/src/formatters/rewrite-fields.ts
+++ b/packages-backend/loggers/src/formatters/rewrite-fields.ts
@@ -15,7 +15,7 @@ type TRewriteFieldsFormatterOption = {
   fields: TRewriteField[];
 };
 
-const defaultRewriteField: TRewriteField = {
+const defaultRewriteField: Partial<TRewriteField> = {
   unsetFromField: true,
 };
 function rewriteField(info: TransformableInfo, field: TRewriteField) {

--- a/packages-backend/loggers/src/formatters/rewrite-fields.ts
+++ b/packages-backend/loggers/src/formatters/rewrite-fields.ts
@@ -9,30 +9,25 @@ type TRewriteField = {
   from: string;
   to: string;
   replaceValue?: (value: unknown) => unknown;
-  unsetFromField?: boolean;
+  preserveFromField?: boolean;
 };
 type TRewriteFieldsFormatterOption = {
   fields: TRewriteField[];
 };
 
-const defaultRewriteField: Partial<TRewriteField> = {
-  unsetFromField: true,
-};
 function rewriteField(info: TransformableInfo, field: TRewriteField) {
-  const mergedRewriteField = { ...defaultRewriteField, ...field };
-  const fromFieldValue = getIn(info, mergedRewriteField.from);
+  const fromFieldValue = getIn(info, field.from);
+  const preserveFromField = field.preserveFromField ?? false;
 
   if (fromFieldValue) {
-    if (mergedRewriteField.unsetFromField) {
-      unsetIn(info, mergedRewriteField.from);
+    if (!preserveFromField) {
+      unsetIn(info, field.from);
     }
 
     setIn(
       info,
-      mergedRewriteField.to,
-      mergedRewriteField.replaceValue
-        ? mergedRewriteField.replaceValue(fromFieldValue)
-        : fromFieldValue
+      field.to,
+      field.replaceValue ? field.replaceValue(fromFieldValue) : fromFieldValue
     );
   }
 }

--- a/packages-backend/loggers/src/loggers.spec.ts
+++ b/packages-backend/loggers/src/loggers.spec.ts
@@ -26,6 +26,7 @@ describe('application logger', () => {
         meta: { req: { headers: { Accept: 'application/json' } } },
       });
       // Note: that both only headersJsonString is present
+      // @ts-ignore
       expect(console._stdout.write.mock.lastCall).toMatchInlineSnapshot(`
         [
           "{"level":"info","message":"Test log","meta":{"req":{"headersJsonString":"{\\"Accept\\":\\"application/json\\"}"}}}
@@ -60,6 +61,7 @@ describe('application logger', () => {
       });
 
       // Note: that both headers and headersJsonString are present
+      // @ts-ignore
       expect(console._stdout.write.mock.lastCall).toMatchInlineSnapshot(`
         [
           "{"level":"info","message":"Test log","meta":{"req":{"headers":{"Accept":"application/json"},"headersJsonString":"{\\"Accept\\":\\"application/json\\"}"}}}
@@ -112,6 +114,7 @@ describe('application logger', () => {
       },
     });
     // Note that authorization is REDACTED in both headers and headersJsonString
+    // @ts-ignore
     expect(console._stdout.write.mock.lastCall).toMatchInlineSnapshot(`
       [
         "{"level":"info","message":"Test log","meta":{"req":{"headers":{"authorization":"[REDACTED]"},"headersJsonString":"{\\"authorization\\":\\"[REDACTED]\\"}"}}}

--- a/packages-backend/loggers/src/loggers.spec.ts
+++ b/packages-backend/loggers/src/loggers.spec.ts
@@ -47,7 +47,7 @@ describe('application logger', () => {
               {
                 from: 'meta.req.headers',
                 to: 'meta.req.headersJsonString',
-                unsetFromField: false,
+                preserveFromField: true,
                 replaceValue: (value) => {
                   return JSON.stringify(value);
                 },


### PR DESCRIPTION
#### Summary

In 90% of the cases you intend to unset the from field when rewriting log field. In the other 10% however you may want to keep the from field.

This use case particularly holds when you want to gracefully migrate fields logged from an old to a new field without breaking dashboards in logging tools.

The process there would be to:

1. Rewrite a field to a new field
2. Keep the old field (feature here)
3. Keep logs ingesting for a while
4. Update all dashboards and saved queries in the logging tool
5. Unset the old from field

Internally this use case is needed when migrating to standardized logging field names