### PR TITLE
feat(app-shell, app-config): enable sending `application_id` claim

### DIFF
--- a/.changeset/six-bananas-sort.md
+++ b/.changeset/six-bananas-sort.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-frontend/application-config': minor
+'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/constants': minor
+'@commercetools-frontend/cypress': minor
+---
+
+Enable reading `applicationId` value from Custom Application config and sending it as a new `application_id` claim (when `team_id` claim is also provided)

--- a/packages/application-config/schema.json
+++ b/packages/application-config/schema.json
@@ -111,6 +111,9 @@
             },
             "teamId": {
               "type": "string"
+            },
+            "applicationId": {
+              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/packages/application-config/src/process-config.ts
+++ b/packages/application-config/src/process-config.ts
@@ -129,6 +129,7 @@ const processConfig = ({
                 ? undefined
                 : appConfig.env.development.initialProjectKey,
             teamId: appConfig.env.development?.teamId,
+            applicationId: appConfig.env.development?.applicationId,
             oAuthScopes: appConfig.oAuthScopes,
             additionalOAuthScopes: appConfig?.additionalOAuthScopes,
           }),

--- a/packages/application-config/src/schema.ts
+++ b/packages/application-config/src/schema.ts
@@ -65,6 +65,7 @@ export interface JSONSchemaForCustomApplicationConfigurationFiles {
        */
       initialProjectKey: string;
       teamId?: string;
+      applicationId?: string;
     };
     production: {
       /**

--- a/packages/application-config/test/fixtures/config-oidc.json
+++ b/packages/application-config/test/fixtures/config-oidc.json
@@ -4,7 +4,9 @@
   "cloudIdentifier": "gcp-eu",
   "env": {
     "development": {
-      "initialProjectKey": "project-key"
+      "initialProjectKey": "project-key",
+      "teamId": "teamId",
+      "applicationId": "app-id-123"
     },
     "production": {
       "applicationId": "app-id-123",

--- a/packages/application-config/test/process-config.spec.js
+++ b/packages/application-config/test/process-config.spec.js
@@ -1141,6 +1141,7 @@ describe('processing a config with OIDC', () => {
       env: {
         __DEVELOPMENT__: {
           oidc: {
+            applicationId: 'app-id-123',
             authorizeUrl:
               'https://mc.europe-west1.gcp.commercetools.com/login/authorize',
             initialProjectKey: 'project-key',
@@ -1148,6 +1149,7 @@ describe('processing a config with OIDC', () => {
               manage: ['manage_orders'],
               view: ['view_orders', 'view_states'],
             },
+            teamId: 'teamId',
             additionalOAuthScopes: [
               {
                 name: 'movies',

--- a/packages/application-shell/src/components/authenticated/has-cached-authentication-state.ts
+++ b/packages/application-shell/src/components/authenticated/has-cached-authentication-state.ts
@@ -51,6 +51,7 @@ const hasCachedAuthenticationState = (): boolean => {
         additionalOAuthScopes:
           window.app.__DEVELOPMENT__?.oidc?.additionalOAuthScopes,
         teamId: window.app.__DEVELOPMENT__?.oidc?.teamId,
+        applicationId: window.app.__DEVELOPMENT__?.oidc?.applicationId,
       });
       // Omit the project key from the check. This allows to switch projects
       // without having to log in again.

--- a/packages/application-shell/src/components/redirect-to-login/redirect-to-login.tsx
+++ b/packages/application-shell/src/components/redirect-to-login/redirect-to-login.tsx
@@ -60,6 +60,7 @@ const RedirectToLogin = () => {
       additionalOAuthScopes:
         window.app.__DEVELOPMENT__?.oidc?.additionalOAuthScopes,
       teamId: window.app.__DEVELOPMENT__?.oidc?.teamId,
+      applicationId: window.app.__DEVELOPMENT__?.oidc?.applicationId,
     });
 
     // Store session scopes, to be able to detect if requested scopes changed

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -56,6 +56,7 @@ export const OIDC_CLAIMS = {
   OPEN_ID: 'openid',
   PROJECT_KEY: 'project_key',
   TEAM_ID: 'team_id',
+  APPLICATION_ID: 'application_id',
   VIEW: 'view',
   MANAGE: 'manage',
 };

--- a/packages/application-shell/src/utils/oidc.ts
+++ b/packages/application-shell/src/utils/oidc.ts
@@ -7,6 +7,7 @@ type BuilOidcScopeOptions = {
   oAuthScopes?: ApplicationOidcForDevelopmentConfig['oAuthScopes'];
   additionalOAuthScopes?: ApplicationOidcForDevelopmentConfig['additionalOAuthScopes'];
   teamId?: ApplicationOidcForDevelopmentConfig['teamId'];
+  applicationId?: ApplicationOidcForDevelopmentConfig['applicationId'];
 };
 
 const buildOidcScope = (options: BuilOidcScopeOptions): string => {
@@ -44,9 +45,12 @@ const buildOidcScope = (options: BuilOidcScopeOptions): string => {
     });
   }
 
-  // Set the teamId
+  // Set the teamId and applicationId
   if (options.teamId) {
     claims.push(`${OIDC_CLAIMS.TEAM_ID}:${options.teamId}`);
+    if (options.applicationId) {
+      claims.push(`${OIDC_CLAIMS.APPLICATION_ID}:${options.applicationId}`);
+    }
   }
 
   return [

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -165,6 +165,7 @@ export type ApplicationOidcForDevelopmentConfig = {
   authorizeUrl: string;
   initialProjectKey?: string;
   teamId?: string;
+  applicationId?: string;
   oAuthScopes?: {
     view: string[];
     manage: string[];

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -196,6 +196,7 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
       additionalOAuthScopes:
         appConfig.__DEVELOPMENT__?.oidc?.additionalOAuthScopes,
       teamId: appConfig.__DEVELOPMENT__?.oidc?.teamId,
+      applicationId: appConfig.__DEVELOPMENT__?.oidc?.applicationId,
     });
     const userCredentials = commandOptions.login ?? {
       email: Cypress.env('LOGIN_EMAIL') || Cypress.env('LOGIN_USER'),


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Further changes needed to enable Custom App development for non-admins ([ref](https://github.com/commercetools/merchant-center-application-kit/issues/3122))
