### PR TITLE
fix: added missing cloud identifier

### DIFF
--- a/website/src/content/api-reference/application-config.mdx
+++ b/website/src/content/api-reference/application-config.mdx
@@ -187,6 +187,7 @@ Supported values are:
 * `gcp-us`
 * `aws-fra`
 * `aws-ohio`
+* `aws-cn`
 
 ```json
 {


### PR DESCRIPTION
#### Summary

Added missing cloud identifier for China environment (`aws-cn`) in the [application config page](https://docs.commercetools.com/custom-applications/api-reference/application-config#cloudidentifier) of docs

