### PR TITLE
`CustomPanel` new component

### DIFF
--- a/.changeset/lemon-horses-count.md
+++ b/.changeset/lemon-horses-count.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+New `CustomPanel` component. It will be used in the upcoming "Custom Views" feature.

--- a/packages/application-components/src/components/custom-views/custom-panel-container/custom-panel-container.tsx
+++ b/packages/application-components/src/components/custom-views/custom-panel-container/custom-panel-container.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { designTokens } from '@commercetools-uikit/design-system';
+import ModalPage from '../../modal-pages/internals/modal-page';
+
+type TCustoPanelContainerProps = {
+  title: string;
+  size: 'small' | 'large';
+  onClose: () => void;
+  children: ReactNode;
+};
+
+const ContentWrapper = styled.div`
+  padding: ${designTokens.spacing40} 40px;
+`;
+
+function CustomPanelContainer(props: TCustoPanelContainerProps) {
+  return (
+    <ModalPage
+      hidePathLabel
+      isOpen
+      onClose={props.onClose}
+      size={props.size}
+      title={props.title}
+    >
+      <ContentWrapper>{props.children}</ContentWrapper>
+    </ModalPage>
+  );
+}
+
+export default CustomPanelContainer;

--- a/packages/application-components/src/components/custom-views/custom-panel/custom-panel.tsx
+++ b/packages/application-components/src/components/custom-views/custom-panel/custom-panel.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { designTokens } from '@commercetools-uikit/design-system';
 import ModalPage from '../../modal-pages/internals/modal-page';
 
-type TCustoPanelContainerProps = {
+type TCustomPanelProps = {
   title: string;
   size: 'small' | 'large';
   onClose: () => void;
@@ -14,7 +14,7 @@ const ContentWrapper = styled.div`
   padding: ${designTokens.spacing40} 40px;
 `;
 
-function CustomPanelContainer(props: TCustoPanelContainerProps) {
+function CustomPanel(props: TCustomPanelProps) {
   return (
     <ModalPage
       hidePathLabel
@@ -28,4 +28,4 @@ function CustomPanelContainer(props: TCustoPanelContainerProps) {
   );
 }
 
-export default CustomPanelContainer;
+export default CustomPanel;

--- a/packages/application-components/src/components/custom-views/custom-panel/index.ts
+++ b/packages/application-components/src/components/custom-views/custom-panel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './custom-panel';

--- a/packages/application-components/src/components/modal-pages/internals/modal-page-top-bar.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page-top-bar.tsx
@@ -50,12 +50,17 @@ type Props = {
   color: 'surface' | 'neutral';
   currentPathLabel?: string;
   previousPathLabel: Label;
+  hidePathLabel?: boolean;
   onClose: (event: SyntheticEvent) => void;
   children?: never;
 };
-const defaultProps: Pick<Props, 'color' | 'previousPathLabel'> = {
+const defaultProps: Pick<
+  Props,
+  'color' | 'previousPathLabel' | 'hidePathLabel'
+> = {
   color: 'surface',
   previousPathLabel: messages.back,
+  hidePathLabel: false,
 };
 
 const ModalPageTopBar = (props: Props) => {
@@ -97,16 +102,18 @@ const ModalPageTopBar = (props: Props) => {
           }
         `}
       >
-        <FlatButton
-          tone="primary"
-          label={
-            typeof props.previousPathLabel === 'string'
-              ? props.previousPathLabel
-              : intl.formatMessage(props.previousPathLabel)
-          }
-          icon={<AngleLeftIcon size="medium" color="primary" />}
-          onClick={props.onClose}
-        />
+        {!props.hidePathLabel && (
+          <FlatButton
+            tone="primary"
+            label={
+              typeof props.previousPathLabel === 'string'
+                ? props.previousPathLabel
+                : intl.formatMessage(props.previousPathLabel)
+            }
+            icon={<AngleLeftIcon size="medium" color="primary" />}
+            onClick={props.onClose}
+          />
+        )}
         {props.currentPathLabel && (
           <>
             <Text.Detail as="span">/</Text.Detail>

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
@@ -5,6 +5,7 @@ export const TRANSITION_DURATION = 200;
 
 type StyleProps = {
   zIndex?: number;
+  size?: 'small' | 'large';
 };
 
 export const getContainerStyles = (_props: StyleProps): SerializedStyles => css`
@@ -12,7 +13,7 @@ export const getContainerStyles = (_props: StyleProps): SerializedStyles => css`
   top: 0;
   right: 0;
   height: 100%;
-  width: 100%;
+  width: ${_props.size === 'small' ? '562px !important' : '100%'};
   display: flex;
   flex-direction: column;
   background-color: ${customProperties.colorSurface};

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
@@ -13,7 +13,7 @@ export const getContainerStyles = (_props: StyleProps): SerializedStyles => css`
   top: 0;
   right: 0;
   height: 100%;
-  width: ${_props.size === 'small' ? '562px !important' : '100%'};
+  width: ${_props.size === 'small' ? '600px !important' : '100%'};
   display: flex;
   flex-direction: column;
   background-color: ${customProperties.colorSurface};

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
@@ -81,10 +81,16 @@ type Props = {
   topBarColor?: 'surface' | 'neutral';
   currentPathLabel?: string;
   previousPathLabel?: Label;
+  hidePathLabel?: boolean;
+  size?: 'small' | 'large';
 };
-const defaultProps: Pick<Props, 'getParentSelector' | 'shouldDelayOnClose'> = {
+const defaultProps: Pick<
+  Props,
+  'getParentSelector' | 'shouldDelayOnClose' | 'size'
+> = {
   getParentSelector: getDefaultParentSelector,
   shouldDelayOnClose: true,
+  size: 'large',
 };
 
 const ModalPage = (props: Props) => {
@@ -156,6 +162,7 @@ const ModalPage = (props: Props) => {
             onClose={handleClose}
             currentPathLabel={props.currentPathLabel}
             previousPathLabel={props.previousPathLabel}
+            hidePathLabel={props.hidePathLabel}
           />
           {props.children}
         </Modal>

--- a/packages/application-components/src/index.ts
+++ b/packages/application-components/src/index.ts
@@ -42,7 +42,7 @@ export type { TPageContentWide } from './components/page-content-containers/page
 export { default as PageContentFull } from './components/page-content-containers/page-content-full';
 export type { TPageContentFull } from './components/page-content-containers/page-content-full';
 
-export { default as CustomPanelContainer } from './components/custom-views/custom-panel/custom-panel';
+export { default as CustomPanel } from './components/custom-views/custom-panel/custom-panel';
 
 // Utilities
 export { default as PortalsContainer } from './components/portals-container';

--- a/packages/application-components/src/index.ts
+++ b/packages/application-components/src/index.ts
@@ -42,7 +42,7 @@ export type { TPageContentWide } from './components/page-content-containers/page
 export { default as PageContentFull } from './components/page-content-containers/page-content-full';
 export type { TPageContentFull } from './components/page-content-containers/page-content-full';
 
-export { default as CustomPanelContainer } from './components/custom-views/custom-panel-container/custom-panel-container';
+export { default as CustomPanelContainer } from './components/custom-views/custom-panel/custom-panel';
 
 // Utilities
 export { default as PortalsContainer } from './components/portals-container';

--- a/packages/application-components/src/index.ts
+++ b/packages/application-components/src/index.ts
@@ -42,6 +42,8 @@ export type { TPageContentWide } from './components/page-content-containers/page
 export { default as PageContentFull } from './components/page-content-containers/page-content-full';
 export type { TPageContentFull } from './components/page-content-containers/page-content-full';
 
+export { default as CustomPanelContainer } from './components/custom-views/custom-panel-container/custom-panel-container';
+
 // Utilities
 export { default as PortalsContainer } from './components/portals-container';
 export { default as useModalState } from './hooks/use-modal-state';

--- a/packages/application-components/src/index.ts
+++ b/packages/application-components/src/index.ts
@@ -42,7 +42,8 @@ export type { TPageContentWide } from './components/page-content-containers/page
 export { default as PageContentFull } from './components/page-content-containers/page-content-full';
 export type { TPageContentFull } from './components/page-content-containers/page-content-full';
 
-export { default as CustomPanel } from './components/custom-views/custom-panel/custom-panel';
+// Custom views
+export { default as CustomPanel } from './components/custom-views/custom-panel';
 
 // Utilities
 export { default as PortalsContainer } from './components/portals-container';

--- a/playground/custom-application-config.mjs
+++ b/playground/custom-application-config.mjs
@@ -74,7 +74,13 @@ const config = {
       permissions: [PERMISSIONS.View],
       defaultLabel: 'Formatters',
       labelAllLocales: [],
-    }
+    },
+    {
+      uriPath: 'custom-panel',
+      permissions: [PERMISSIONS.View],
+      defaultLabel: 'Custom Panel',
+      labelAllLocales: [],
+    },
   ],
 };
 

--- a/playground/src/components/custom-views/custom-panel-demo.jsx
+++ b/playground/src/components/custom-views/custom-panel-demo.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { CustomPanelContainer } from '@commercetools-frontend/application-components';
+import SecondaryButton from '@commercetools-uikit/secondary-button';
+import Spacings from '@commercetools-uikit/spacings';
+import Text from '@commercetools-uikit/text';
+
+function CustomPanelDemo() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [panelSize, setPanelSize] = useState('');
+  return (
+    <Spacings.Inset>
+      <Spacings.Stack scale="l">
+        <Text.Headline as="h1">Custom Views - Custom Panel</Text.Headline>
+
+        <Spacings.Stack scale="m">
+          <Spacings.Inline>
+            <SecondaryButton
+              label="Open large Custom Panel"
+              onClick={() => {
+                setPanelSize('large');
+                setIsOpen(true);
+              }}
+            />
+          </Spacings.Inline>
+
+          <Spacings.Inline>
+            <SecondaryButton
+              label="Open small Custom Panel"
+              onClick={() => {
+                setPanelSize('small');
+                setIsOpen(true);
+              }}
+            />
+          </Spacings.Inline>
+        </Spacings.Stack>
+
+        {isOpen && (
+          <CustomPanelContainer
+            title="Custom Panel"
+            size={panelSize}
+            onClose={() => setIsOpen(false)}
+          >
+            <p>This is the extension content</p>
+          </CustomPanelContainer>
+        )}
+      </Spacings.Stack>
+    </Spacings.Inset>
+  );
+}
+
+export default CustomPanelDemo;

--- a/playground/src/components/custom-views/custom-panel-demo.jsx
+++ b/playground/src/components/custom-views/custom-panel-demo.jsx
@@ -8,7 +8,6 @@ import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 
 function CustomPanelDemo() {
-  // const [isOpen, setIsOpen] = useState(false);
   const { isModalOpen, openModal, closeModal } = useModalState();
   const [panelSize, setPanelSize] = useState('');
   return (

--- a/playground/src/components/custom-views/custom-panel-demo.jsx
+++ b/playground/src/components/custom-views/custom-panel-demo.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CustomPanelContainer } from '@commercetools-frontend/application-components';
+import { CustomPanel } from '@commercetools-frontend/application-components';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
@@ -35,13 +35,13 @@ function CustomPanelDemo() {
         </Spacings.Stack>
 
         {isOpen && (
-          <CustomPanelContainer
+          <CustomPanel
             title="Custom Panel"
             size={panelSize}
             onClose={() => setIsOpen(false)}
           >
             <p>This is the Custom Panel content</p>
-          </CustomPanelContainer>
+          </CustomPanel>
         )}
       </Spacings.Stack>
     </Spacings.Inset>

--- a/playground/src/components/custom-views/custom-panel-demo.jsx
+++ b/playground/src/components/custom-views/custom-panel-demo.jsx
@@ -40,7 +40,7 @@ function CustomPanelDemo() {
             size={panelSize}
             onClose={() => setIsOpen(false)}
           >
-            <p>This is the extension content</p>
+            <p>This is the Custom Panel content</p>
           </CustomPanelContainer>
         )}
       </Spacings.Stack>

--- a/playground/src/components/custom-views/custom-panel-demo.jsx
+++ b/playground/src/components/custom-views/custom-panel-demo.jsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
-import { CustomPanel } from '@commercetools-frontend/application-components';
+import {
+  CustomPanel,
+  useModalState,
+} from '@commercetools-frontend/application-components';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 
 function CustomPanelDemo() {
-  const [isOpen, setIsOpen] = useState(false);
+  // const [isOpen, setIsOpen] = useState(false);
+  const { isModalOpen, openModal, closeModal } = useModalState();
   const [panelSize, setPanelSize] = useState('');
   return (
     <Spacings.Inset>
@@ -18,7 +22,7 @@ function CustomPanelDemo() {
               label="Open large Custom Panel"
               onClick={() => {
                 setPanelSize('large');
-                setIsOpen(true);
+                openModal();
               }}
             />
           </Spacings.Inline>
@@ -28,17 +32,17 @@ function CustomPanelDemo() {
               label="Open small Custom Panel"
               onClick={() => {
                 setPanelSize('small');
-                setIsOpen(true);
+                openModal();
               }}
             />
           </Spacings.Inline>
         </Spacings.Stack>
 
-        {isOpen && (
+        {isModalOpen && (
           <CustomPanel
             title="Custom Panel"
             size={panelSize}
-            onClose={() => setIsOpen(false)}
+            onClose={() => closeModal()}
           >
             <p>This is the Custom Panel content</p>
           </CustomPanel>

--- a/playground/src/components/custom-views/index.js
+++ b/playground/src/components/custom-views/index.js
@@ -1,0 +1,5 @@
+import { lazy } from 'react';
+
+export const CustomPanelDemo = lazy(() =>
+  import('./custom-panel-demo' /* webpackChunkName: "custom-panel-demo" */)
+);

--- a/playground/src/routes.jsx
+++ b/playground/src/routes.jsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { Route, Switch, useRouteMatch, useHistory } from 'react-router-dom';
+import { CustomPanelDemo } from './components/custom-views';
 import EchoServer from './components/echo-server';
 import FormattersDemo from './components/formatters-demo';
 import NotificationsPlayground from './components/notifications-playground';
@@ -29,6 +30,9 @@ const ApplicationRoutes = () => {
       </Route>
       <Route path={`${match.path}/formatters`}>
         <FormattersDemo />
+      </Route>
+      <Route path={`${match.path}/custom-panel`}>
+        <CustomPanelDemo />
       </Route>
       <Route>
         <StateMachinesList goToStateMachineDetail={goToStateMachineDetail}>

--- a/visual-testing-app/src/components/custom-panel/custom-panel.visualroute.tsx
+++ b/visual-testing-app/src/components/custom-panel/custom-panel.visualroute.tsx
@@ -1,14 +1,14 @@
 import { Route, Switch } from 'react-router-dom';
-import { CustomPanelContainer } from '@commercetools-frontend/application-components';
+import { CustomPanel } from '@commercetools-frontend/application-components';
 import { Suite, NestedPages } from '../../test-utils';
 
 export const routePath = '/custom-views/custom-panel';
 
 function TestComponent({ size }: { size: 'small' | 'large' }) {
   return (
-    <CustomPanelContainer onClose={() => {}} size={size} title="Custom Panel">
+    <CustomPanel onClose={() => {}} size={size} title="Custom Panel">
       <p>This is the panel content ({size})</p>
-    </CustomPanelContainer>
+    </CustomPanel>
   );
 }
 

--- a/visual-testing-app/src/components/custom-panel/custom-panel.visualroute.tsx
+++ b/visual-testing-app/src/components/custom-panel/custom-panel.visualroute.tsx
@@ -1,0 +1,43 @@
+import { Route, Switch } from 'react-router-dom';
+import { CustomPanelContainer } from '@commercetools-frontend/application-components';
+import { Suite, NestedPages } from '../../test-utils';
+
+export const routePath = '/custom-views/custom-panel';
+
+function TestComponent({ size }: { size: 'small' | 'large' }) {
+  return (
+    <CustomPanelContainer onClose={() => {}} size={size} title="Custom Panel">
+      <p>This is the panel content ({size})</p>
+    </CustomPanelContainer>
+  );
+}
+
+const Content = () => (
+  <Switch>
+    <Route path={`${routePath}/custom-panel-large`}>
+      <TestComponent size="large" />
+    </Route>
+    <Route path={`${routePath}/custom-panel-small`}>
+      <TestComponent size="small" />
+    </Route>
+  </Switch>
+);
+
+export const Component = () => (
+  <Suite>
+    <NestedPages
+      title="Custom Views -> Custom Panel"
+      basePath={routePath}
+      pages={[
+        {
+          path: 'custom-panel-large',
+          spec: <Content />,
+        },
+        {
+          path: 'custom-panel-small',
+          spec: <Content />,
+        },
+      ]}
+    />
+  </Suite>
+);

--- a/visual-testing-app/src/components/custom-panel/custom-panel.visualspec.ts
+++ b/visual-testing-app/src/components/custom-panel/custom-panel.visualspec.ts
@@ -1,0 +1,17 @@
+import percySnapshot from '@percy/puppeteer';
+import { HOST } from '../../constants';
+
+describe.each`
+  path
+  ${'custom-panel-large'}
+  ${'custom-panel-small'}
+`('CustomPanel $path', ({ path }) => {
+  beforeAll(async () => {
+    await page.goto(`${HOST}/custom-views/custom-panel/${path}`);
+  });
+
+  it('renders page', async () => {
+    await page.waitForSelector('text/This is the panel content');
+    await percySnapshot(page, `CustomPanel/${path}`);
+  });
+});


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR introduces a new component (`CustomPanel`) which will be used in the context of the **Custom Views** project.

#### Description

I thought about two strategies to implement this new component which will contain the customer's custom views when they select to use a sidebar panel.

![image](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/674f4783-9ac4-4349-a2c1-87be628c4c4d)

The first one is try to reuse the same component we use for our modal page components.
This is easier as we don't need to implement everything from the scratch but maybe the transition is not the exact one expected (need to confirm this point). Also, we're extending our current shared `ModalPage` component to include new use cases, making it a little more complex.

The second one is to implement a brand new component.
This one takes a little more time since we need to build everything (maybe we can search for a package that implements the behaviour of this component) but allows us to control every aspect.

In this PR I'm first going for the first option but I'm not 100% satisfied with this approach.
Please let me know your thoughts about it.


Anyway, I would like to have at least a basic implementation available so we can focus in the rest components which are more relevant.
We can come back to this one as a follow-up later so we don't block the rest of the work.
