### PR TITLE
docs: remove support policy section on maintenance guidelines page

### DIFF
--- a/website/src/content/maintenance-guidelines.mdx
+++ b/website/src/content/maintenance-guidelines.mdx
@@ -8,10 +8,6 @@ This page describes the different aspects of the support and maintenance recomme
 
 </Subtitle>
 
-# Support policy
-
-Please refer to the [commercetools HTTP API Contract](https://docs.commercetools.com/offering/api-contract).
-
 # Release process
 
 Tooling and packages related to Custom Applications are released and published to [Node Package Manager](https://www.npmjs.com) (NPM) following [Semantic Versioning](https://semver.org/) (SemVer).


### PR DESCRIPTION
### Summary

Remove the reference to the support policy on the Maintenance guidelines page. For more info: https://github.com/commercetools/commercetools-docs/issues/3606
