### PR TITLE
Adjust Google Fonts loader url

### DIFF
--- a/.changeset/lazy-jokes-train.md
+++ b/.changeset/lazy-jokes-train.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Adjust Google Fonts loader URL. Removed "Open Sans" since we're not using it anymore.

--- a/.changeset/lazy-jokes-train.md
+++ b/.changeset/lazy-jokes-train.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/mc-html-template': patch
 ---
 
-Adjust Google Fonts loader URL. Removed "Open Sans" since we're not using it anymore.
+Adjust Google Fonts loader URL to not use the `slant` query parameter.

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -29,7 +29,7 @@
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="__CDN_URL__favicon_144x144px.png">
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,400;-10,500;0,400;0,500;0,600;0,700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10;-10,500;0;0,500;0,600;0,700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
     __APPLICATION_CSS_IMPORTS__
 

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -29,7 +29,7 @@
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="__CDN_URL__favicon_144x144px.png">
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10;-10,500;0;0,500;0,600;0,700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     __APPLICATION_CSS_IMPORTS__
 

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -29,7 +29,7 @@
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="__CDN_URL__favicon_144x144px.png">
 
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
     __APPLICATION_CSS_IMPORTS__
 

--- a/visual-testing-app/index.html
+++ b/visual-testing-app/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,400;-10,500;0,400;0,500;0,600;0,700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <title>App-Kit | Visual testing app</title>

--- a/visual-testing-app/index.html
+++ b/visual-testing-app/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
     <title>App-Kit | Visual testing app</title>

--- a/website-components-playground/index.html
+++ b/website-components-playground/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,400;-10,500;0,400;0,500;0,600;0,700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <title>App-Kit | Components Playground</title>

--- a/website-components-playground/index.html
+++ b/website-components-playground/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
     <title>App-Kit | Components Playground</title>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Adjust Google Fonts loader url.

#### Description

We've noticed some issues in the text styles of all Merchant Center applications that seems related to how fonts are loaded in the document.
We load fonts using [Google Fonts API v2](https://developers.google.com/fonts/docs/css2?hl=en).

It seems using the `slant` attribute somehow it's making fonts to fail loading the right ones based on the text styles so we're removing it from the loader URL. We didn't notice any downsides from removing this parameter.

Also, we are taking the opportunity to remove `Open Sans` from the loader URL since we're not using it anymore.
