### PR TITLE
fix(app-shell): Navbar's z-index in Safari

### DIFF
--- a/.changeset/slow-zoos-tap.md
+++ b/.changeset/slow-zoos-tap.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix issue with NavBar's `z-index` in Safari

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -96,7 +96,6 @@ export const MainContainer = styled.main<MainContainerProps>`
   min-width: 0;
   overflow-x: hidden;
   overflow-y: scroll;
-  z-index: -1;
 
   /*
     layout the children. There will always be the page and side notification

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -96,6 +96,7 @@ export const MainContainer = styled.main<MainContainerProps>`
   min-width: 0;
   overflow-x: hidden;
   overflow-y: scroll;
+  z-index: -1;
 
   /*
     layout the children. There will always be the page and side notification

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -4,6 +4,8 @@ import {
   MouseEventHandler,
   ReactNode,
   SyntheticEvent,
+  useRef,
+  useLayoutEffect,
 } from 'react';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -177,7 +179,29 @@ type MenuGroupProps = {
   hasSubmenu?: boolean;
   children?: ReactNode;
 };
+
+function agentHas(keyword: string) {
+  return navigator.userAgent.toLowerCase().search(keyword.toLowerCase()) > -1;
+}
+
+function isSafari() {
+  return (
+    // @ts-ignore
+    (!!window.ApplePaySetupFeature || !!window.safari) &&
+    agentHas('Safari') &&
+    !agentHas('Chrome') &&
+    !agentHas('CriOS')
+  );
+}
+
 const MenuGroup = (props: MenuGroupProps) => {
+  const menuGroupRef = useRef<HTMLUListElement>(null);
+  useLayoutEffect(() => {
+    if (isSafari() && menuGroupRef.current) {
+      // @ts-ignore
+      menuGroupRef.current.style.zIndex = 'unset';
+    }
+  });
   if (
     props.isExpanded &&
     ((props.level === 2 && !props.hasSubmenu) ||
@@ -216,6 +240,7 @@ const MenuGroup = (props: MenuGroupProps) => {
           [styles.sublist__inactive]: !isSublistActiveWhileIsMenuCollapsed,
         }
       )}
+      ref={menuGroupRef}
     >
       {props.children}
     </ul>
@@ -262,6 +287,16 @@ const menuItemLinkDefaultProps: Pick<MenuItemLinkProps, 'exactMatch'> = {
   exactMatch: false,
 };
 const MenuItemLink = (props: MenuItemLinkProps) => {
+  const menuItemLinkRef = useRef<HTMLAnchorElement>(null);
+  useLayoutEffect(() => {
+    if (isSafari() && menuItemLinkRef.current) {
+      const title = menuItemLinkRef.current.querySelector(`.${styles.title}`);
+      if (title) {
+        // @ts-ignore
+        title.style.zIndex = '1';
+      }
+    }
+  });
   const redirectTo = (targetUrl: string) => location.replace(targetUrl);
   if (props.linkTo) {
     return (
@@ -279,6 +314,7 @@ const MenuItemLink = (props: MenuItemLinkProps) => {
             props.onClick(event);
           }
         }}
+        ref={menuItemLinkRef}
       >
         {props.children}
       </NavLink>

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -4,8 +4,6 @@ import {
   MouseEventHandler,
   ReactNode,
   SyntheticEvent,
-  useRef,
-  useLayoutEffect,
 } from 'react';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -180,29 +178,7 @@ type MenuGroupProps = {
   children?: ReactNode;
 };
 
-function agentHas(keyword: string) {
-  return navigator.userAgent.toLowerCase().search(keyword.toLowerCase()) > -1;
-}
-
-function isSafari() {
-  return (
-    // @ts-ignore
-    (!!window.ApplePaySetupFeature || !!window.safari) &&
-    agentHas('Safari') &&
-    !agentHas('Chrome') &&
-    !agentHas('CriOS')
-  );
-}
-
 const MenuGroup = (props: MenuGroupProps) => {
-  // Fix for Navbar's z-index in Safari
-  const menuGroupRef = useRef<HTMLUListElement>(null);
-  useLayoutEffect(() => {
-    if (isSafari() && menuGroupRef.current) {
-      // @ts-ignore
-      menuGroupRef.current.style.zIndex = 'unset';
-    }
-  });
   if (
     props.isExpanded &&
     ((props.level === 2 && !props.hasSubmenu) ||
@@ -241,7 +217,6 @@ const MenuGroup = (props: MenuGroupProps) => {
           [styles.sublist__inactive]: !isSublistActiveWhileIsMenuCollapsed,
         }
       )}
-      ref={menuGroupRef}
     >
       {props.children}
     </ul>
@@ -288,17 +263,6 @@ const menuItemLinkDefaultProps: Pick<MenuItemLinkProps, 'exactMatch'> = {
   exactMatch: false,
 };
 const MenuItemLink = (props: MenuItemLinkProps) => {
-  // Fix for Navbar's z-index in Safari
-  const menuItemLinkRef = useRef<HTMLAnchorElement>(null);
-  useLayoutEffect(() => {
-    if (isSafari() && menuItemLinkRef.current) {
-      const title = menuItemLinkRef.current.querySelector(`.${styles.title}`);
-      if (title) {
-        // @ts-ignore
-        title.style.zIndex = '1';
-      }
-    }
-  });
   const redirectTo = (targetUrl: string) => location.replace(targetUrl);
   if (props.linkTo) {
     return (
@@ -316,7 +280,6 @@ const MenuItemLink = (props: MenuItemLinkProps) => {
             props.onClick(event);
           }
         }}
-        ref={menuItemLinkRef}
       >
         {props.children}
       </NavLink>

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -195,6 +195,7 @@ function isSafari() {
 }
 
 const MenuGroup = (props: MenuGroupProps) => {
+  // Fix for Navbar's z-index in Safari
   const menuGroupRef = useRef<HTMLUListElement>(null);
   useLayoutEffect(() => {
     if (isSafari() && menuGroupRef.current) {
@@ -287,6 +288,7 @@ const menuItemLinkDefaultProps: Pick<MenuItemLinkProps, 'exactMatch'> = {
   exactMatch: false,
 };
 const MenuItemLink = (props: MenuItemLinkProps) => {
+  // Fix for Navbar's z-index in Safari
   const menuItemLinkRef = useRef<HTMLAnchorElement>(null);
   useLayoutEffect(() => {
     if (isSafari() && menuItemLinkRef.current) {

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -13,6 +13,10 @@
   --width-left-navigation: 64px;
   --width-left-navigation-when-expanded: 245px;
   --width-left-navigation-sublist: 205px;
+
+  /* Active list item with icon text */
+  --left-list-item-icon-text-active: 46px;
+  --width-list-item-icon-text-active: 166px;
 }
 
 /* Left Nav */
@@ -349,8 +353,9 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   position: absolute;
-  left: 46px;
-  width: 166px;
+  /* `left` and `width` required for displaying focus indicator properly */
+  left: var(--left-list-item-icon-text-active);
+  width: var(--width-list-item-icon-text-active);
   z-index: 1;
 }
 

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -262,7 +262,6 @@
   background-color: var(--background-color-for-navbar);
   top: 0;
   left: 64px;
-  z-index: -1;
   list-style: none;
   opacity: 0.01;
   visibility: hidden;
@@ -317,10 +316,6 @@
 }
 
 .list-item.item__active .item-icon-text {
-  width: calc(
-    var(--width-left-navigation-sublist) + var(--width-left-navigation) -
-      var(--spacing-m) * 2
-  );
   justify-content: flex-start;
 }
 .list-item .icon-container {
@@ -353,6 +348,10 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  position: absolute;
+  left: 46px;
+  width: 166px;
+  z-index: 1;
 }
 
 :global(.body__menu-open) .list-item.item__active .item-icon-text .title {
@@ -408,9 +407,9 @@
 .scrollable-menu {
   flex: 1 1 0;
   padding-bottom: var(--faded-height);
-  /* 
+  /*
     FIXME: Make the navbar scrollable in collapsed state.
-    NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover 
+    NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover
   */
 }
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

|  Before |  After | 
|---|---|
|  ![2023-08-21 18 27 36](https://github.com/commercetools/merchant-center-application-kit/assets/49066275/8a6ed215-35e9-4904-95e7-10b5ba580c69) |  ![2023-08-21 18 28 36](https://github.com/commercetools/merchant-center-application-kit/assets/49066275/53a33a0d-3906-42ab-a8c3-1a1573a5779c) | 

#### Description

This PR aims at solving an issue with `z-index` of navbar in Safari.

I came a long way to arrive at this solution.
Unfortunately, due to the way we compile navbar CSS styles we can't easily add Safari-targeted styles to https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-shell/src/components/navbar/navbar.mod.css
because the respective [Safari-specific class names](https://stackoverflow.com/questions/16348489/is-there-a-way-to-apply-styles-to-safari-only) are edited by our post-css script.

I even attempted to add style rules to the compiled CSS file, but encountered challenges since we don't have access to the CSS module class names when appending the styles.

Hence, this is the approach I've come up with.

[Demo](https://mc-15223.mc-preview.europe-west1.gcp.escemo.com/adnan-nodejs-test-project/products) 
