### PR TITLE
fix(dev-auth): request / response compatibility

### DIFF
--- a/.changeset/yellow-moose-lie.md
+++ b/.changeset/yellow-moose-lie.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/mc-dev-authentication': patch
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Adjust the dev auth server compat with HTTP request / response options

--- a/packages/mc-dev-authentication/package.json
+++ b/packages/mc-dev-authentication/package.json
@@ -28,10 +28,10 @@
     "@babel/runtime-corejs3": "^7.20.13"
   },
   "devDependencies": {
-    "@commercetools-frontend/application-config": "workspace:*",
-    "@types/express": "^4.17.17",
+    "@commercetools-frontend/application-config": "22.6.0",
+    "@types/connect": "^3.4.35",
     "@tsconfig/node16": "^16.0.0",
-    "express": "4.18.2"
+    "connect": "^3.7.0"
   },
   "engines": {
     "node": "16.x || >=18.0.0"

--- a/packages/mc-dev-authentication/package.json
+++ b/packages/mc-dev-authentication/package.json
@@ -28,7 +28,7 @@
     "@babel/runtime-corejs3": "^7.20.13"
   },
   "devDependencies": {
-    "@commercetools-frontend/application-config": "22.6.0",
+    "@commercetools-frontend/application-config": "workspace:*",
     "@types/connect": "^3.4.35",
     "@tsconfig/node16": "^16.0.0",
     "connect": "^3.7.0"

--- a/packages/mc-dev-authentication/src/create-mc-dev-authentication-middleware.ts
+++ b/packages/mc-dev-authentication/src/create-mc-dev-authentication-middleware.ts
@@ -1,8 +1,9 @@
-import type { Request, Response, NextFunction } from 'express';
+import type { ServerResponse } from 'node:http';
+import type { IncomingMessage, NextFunction } from 'connect';
+// https://babeljs.io/blog/2017/09/11/zero-config-with-babel-macros
 import pages from /* preval */ './pages';
 import { logout } from './routes';
 import type { TCustomApplicationRuntimeConfig } from './types';
-// https://babeljs.io/blog/2017/09/11/zero-config-with-babel-macros
 
 const trimTrailingSlash = (value: string) => value.replace(/\/$/, '');
 
@@ -19,11 +20,15 @@ function createMcDevAuthenticationMiddleware(
     String(applicationConfig.env.disableAuthRoutesOfDevServer) === 'true' ||
     applicationConfig.env.servedByProxy;
 
-  return (request: Request, response: Response, next: NextFunction) => {
+  return (
+    request: IncomingMessage,
+    response: ServerResponse,
+    next: NextFunction
+  ) => {
     if (request.originalUrl === '/api/graphql') {
       response.statusCode = 404;
       response.setHeader('Content-Type', 'application/json');
-      response.send(
+      response.end(
         JSON.stringify({
           message: `This GraphQL endpoint is only available in production in the [Merchant Center Proxy Router](https://docs.commercetools.com/custom-applications/concepts/merchant-center-proxy-router). Please check that you are not calling this endpoint in development mode.`,
         })
@@ -38,11 +43,11 @@ function createMcDevAuthenticationMiddleware(
           'http://localhost'
         )
       ) {
-        if (request.originalUrl.startsWith('/login/authorize')) {
+        if (request.originalUrl?.startsWith('/login/authorize')) {
           if (isDevAuthenticationMiddlewareDisabled) {
             next();
           } else {
-            response.send(htmlLogin);
+            response.end(htmlLogin);
           }
           return;
         }
@@ -52,7 +57,7 @@ function createMcDevAuthenticationMiddleware(
         if (isDevAuthenticationMiddlewareDisabled) {
           next();
         } else {
-          response.send(htmlLogin);
+          response.end(htmlLogin);
         }
         return;
       }
@@ -62,7 +67,7 @@ function createMcDevAuthenticationMiddleware(
         if (isDevAuthenticationMiddlewareDisabled) {
           next();
         } else {
-          response.send(htmlLogout);
+          response.end(htmlLogout);
         }
         return;
       }

--- a/packages/mc-dev-authentication/src/routes/logout.ts
+++ b/packages/mc-dev-authentication/src/routes/logout.ts
@@ -1,7 +1,7 @@
-import type { Response } from 'express';
+import type { ServerResponse } from 'node:http';
 
 function logoutRoute(
-  response: Response,
+  response: ServerResponse,
   additionalCookieParameters: string[] = []
 ) {
   // NOTE: removing the cookie only works if your are running the MC API

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-custom-application.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-custom-application.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Connect } from 'vite';
+import type { Plugin } from 'vite';
 import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
 import { createMcDevAuthenticationMiddleware } from '@commercetools-frontend/mc-dev-authentication';
 import {
@@ -27,9 +27,7 @@ const vitePluginCustomApplication = (
 
         // Handle auth routes for internal local development.
         server.middlewares.use(
-          createMcDevAuthenticationMiddleware(
-            applicationConfig
-          ) as Connect.NextHandleFunction
+          createMcDevAuthenticationMiddleware(applicationConfig)
         );
       };
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1979,7 +1979,7 @@ importers:
         version: 7.20.13
     devDependencies:
       '@commercetools-frontend/application-config':
-        specifier: 22.6.0
+        specifier: workspace:*
         version: link:../application-config
       '@tsconfig/node16':
         specifier: ^16.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1979,17 +1979,17 @@ importers:
         version: 7.20.13
     devDependencies:
       '@commercetools-frontend/application-config':
-        specifier: workspace:*
+        specifier: 22.6.0
         version: link:../application-config
       '@tsconfig/node16':
         specifier: ^16.0.0
         version: 16.1.0
-      '@types/express':
-        specifier: ^4.17.17
-        version: 4.17.17
-      express:
-        specifier: 4.18.2
-        version: 4.18.2
+      '@types/connect':
+        specifier: ^3.4.35
+        version: 3.4.35
+      connect:
+        specifier: ^3.7.0
+        version: 3.7.0
 
   packages/mc-html-template:
     dependencies:
@@ -15990,6 +15990,18 @@ packages:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
 
+  /connect@3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
     dev: false
@@ -18865,6 +18877,21 @@ packages:
   /filter-obj@1.1.0:
     resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
     engines: {node: '>=0.10.0'}
+
+  /finalhandler@1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -25236,6 +25263,13 @@ packages:
       '@babel/runtime': 7.20.13
       '@babel/runtime-corejs3': 7.20.13
     dev: false
+
+  /on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: true
 
   /on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}


### PR DESCRIPTION
Fixes the issue when developing locally against local API that `response.send` is not a function.

I also refactored the types to use the ones from `connect`, as this is also what [Vite uses for its middlewares](https://vitejs.dev/guide/ssr.html#setting-up-the-dev-server)
<img width="716" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/1110551/cacacc50-e9b0-4dd6-98c5-283a037bea10">
