### PR TITLE
fix(sentry): replace deprecated tracing library

### DIFF
--- a/.changeset/tame-lizards-walk.md
+++ b/.changeset/tame-lizards-walk.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-backend/loggers': patch
+'@commercetools-frontend/sentry': patch
+---
+
+Update Sentry dependencies, replace depreacted `@sentry/tracing` with `@sentry/browser`

--- a/packages-backend/loggers/package.json
+++ b/packages-backend/loggers/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@babel/runtime-corejs3": "^7.20.13",
-    "@sentry/node": "7.51.2",
+    "@sentry/node": "7.64.0",
     "@types/lodash": "^4.14.191",
     "@types/triple-beam": "1.3.2",
     "express-winston": "4.2.0",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -22,9 +22,9 @@
     "@babel/runtime-corejs3": "^7.20.13",
     "@commercetools-frontend/browser-history": "22.6.0",
     "@commercetools-frontend/constants": "22.6.0",
-    "@sentry/react": "7.51.2",
-    "@sentry/types": "7.51.2",
-    "@sentry/tracing": "7.51.2",
+    "@sentry/browser": "7.64.0",
+    "@sentry/react": "7.64.0",
+    "@sentry/types": "7.64.0",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.53",
     "prop-types": "15.8.1"

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing'; // Must import after `@sentry/react`
+// eslint-disable-next-line import/order
+import { BrowserTracing } from '@sentry/browser'; // Must import after `@sentry/react`
 import type { Extra, Extras, Event } from '@sentry/types';
 import history from '@commercetools-frontend/browser-history';
 import type { ApplicationWindow } from '@commercetools-frontend/constants';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,8 +825,8 @@ importers:
         specifier: ^7.20.13
         version: 7.20.13
       '@sentry/node':
-        specifier: 7.51.2
-        version: 7.51.2
+        specifier: 7.64.0
+        version: 7.64.0
       '@types/lodash':
         specifier: ^4.14.191
         version: 4.14.191
@@ -2545,15 +2545,15 @@ importers:
       '@commercetools-frontend/constants':
         specifier: 22.6.0
         version: link:../constants
+      '@sentry/browser':
+        specifier: 7.64.0
+        version: 7.64.0
       '@sentry/react':
-        specifier: 7.51.2
-        version: 7.51.2(react@17.0.2)
-      '@sentry/tracing':
-        specifier: 7.51.2
-        version: 7.51.2
+        specifier: 7.64.0
+        version: 7.64.0(react@17.0.2)
       '@sentry/types':
-        specifier: 7.51.2
-        version: 7.51.2
+        specifier: 7.64.0
+        version: 7.64.0
       '@types/prop-types':
         specifier: ^15.7.5
         version: 15.7.5
@@ -11926,16 +11926,6 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: false
 
-  /@sentry-internal/tracing@7.51.2:
-    resolution: {integrity: sha512-OBNZn7C4CyocmlSMUPfkY9ORgab346vTHu5kX35PgW5XR51VD2nO5iJCFbyFcsmmRWyCJcZzwMNARouc2V4V8A==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/core': 7.51.2
-      '@sentry/types': 7.51.2
-      '@sentry/utils': 7.51.2
-      tslib: 1.14.1
-    dev: false
-
   /@sentry-internal/tracing@7.54.0:
     resolution: {integrity: sha512-JsyhZ0wWZ+VqbHJg+azqRGdYJDkcI5R9+pnkO6SzbzxrRewqMAIwzkpPee3oI7vG99uhMEkOkMjHu0nQGwkOQw==}
     engines: {node: '>=8'}
@@ -11946,16 +11936,14 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/browser@7.51.2:
-    resolution: {integrity: sha512-FQFEaTFbvYHPQE2emFjNoGSy+jXplwzoM/XEUBRjrGo62lf8BhMvWnPeG3H3UWPgrWA1mq0amvHRwXUkwofk0g==}
+  /@sentry-internal/tracing@7.64.0:
+    resolution: {integrity: sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry-internal/tracing': 7.51.2
-      '@sentry/core': 7.51.2
-      '@sentry/replay': 7.51.2
-      '@sentry/types': 7.51.2
-      '@sentry/utils': 7.51.2
-      tslib: 1.14.1
+      '@sentry/core': 7.64.0
+      '@sentry/types': 7.64.0
+      '@sentry/utils': 7.64.0
+      tslib: 2.5.0
     dev: false
 
   /@sentry/browser@7.54.0:
@@ -11970,13 +11958,16 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/core@7.51.2:
-    resolution: {integrity: sha512-p8ZiSBxpKe+rkXDMEcgmdoyIHM/1bhpINLZUFPiFH8vzomEr7sgnwRhyrU8y/ADnkPeNg/2YF3QpDpk0OgZJUA==}
+  /@sentry/browser@7.64.0:
+    resolution: {integrity: sha512-lB2IWUkZavEDclxfLBp554dY10ZNIEvlDZUWWathW+Ws2wRb6PNLtuPUNu12R7Q7z0xpkOLrM1kRNN0OdldgKA==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/types': 7.51.2
-      '@sentry/utils': 7.51.2
-      tslib: 1.14.1
+      '@sentry-internal/tracing': 7.64.0
+      '@sentry/core': 7.64.0
+      '@sentry/replay': 7.64.0
+      '@sentry/types': 7.64.0
+      '@sentry/utils': 7.64.0
+      tslib: 2.5.0
     dev: false
 
   /@sentry/core@7.54.0:
@@ -11988,43 +11979,43 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/node@7.51.2:
-    resolution: {integrity: sha512-qtZ2xNVR0ZW+OZWb0Xw0Cdh2QJXOJkXjK84CGC2P4Y6jWrt+GVvwMANPItLT6mAh+ITszTJ5Gk5HHFRpYme5EA==}
+  /@sentry/core@7.64.0:
+    resolution: {integrity: sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry-internal/tracing': 7.51.2
-      '@sentry/core': 7.51.2
-      '@sentry/types': 7.51.2
-      '@sentry/utils': 7.51.2
+      '@sentry/types': 7.64.0
+      '@sentry/utils': 7.64.0
+      tslib: 2.5.0
+    dev: false
+
+  /@sentry/node@7.64.0:
+    resolution: {integrity: sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/tracing': 7.64.0
+      '@sentry/core': 7.64.0
+      '@sentry/types': 7.64.0
+      '@sentry/utils': 7.64.0
       cookie: 0.4.2
       https-proxy-agent: 5.0.1
       lru_map: 0.3.3
-      tslib: 1.14.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@sentry/react@7.51.2(react@17.0.2):
-    resolution: {integrity: sha512-NiTbpiRaF7/2YnRONLqn8/bxT5UG+JN5MrR606ipxsl3ejF376VMLCHVvju6gJNw8mkrErEMkfxK+gGYqOdLEA==}
+  /@sentry/react@7.64.0(react@17.0.2):
+    resolution: {integrity: sha512-wOyJUQi7OoT1q+F/fVVv1fzbyO4OYbTu6m1DliLOGQPGEHPBsgPc722smPIExd1/rAMK/FxOuNN5oNhubH8nhg==}
     engines: {node: '>=8'}
     peerDependencies:
       react: 15.x || 16.x || 17.x || 18.x
     dependencies:
-      '@sentry/browser': 7.51.2
-      '@sentry/types': 7.51.2
-      '@sentry/utils': 7.51.2
+      '@sentry/browser': 7.64.0
+      '@sentry/types': 7.64.0
+      '@sentry/utils': 7.64.0
       hoist-non-react-statics: 3.3.2
       react: 17.0.2
-      tslib: 1.14.1
-    dev: false
-
-  /@sentry/replay@7.51.2:
-    resolution: {integrity: sha512-W8YnSxkK9LTUXDaYciM7Hn87u57AX9qvH8jGcxZZnvpKqHlDXOpSV8LRtBkARsTwgLgswROImSifY0ic0lyCWg==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@sentry/core': 7.51.2
-      '@sentry/types': 7.51.2
-      '@sentry/utils': 7.51.2
+      tslib: 2.5.0
     dev: false
 
   /@sentry/replay@7.54.0:
@@ -12036,16 +12027,13 @@ packages:
       '@sentry/utils': 7.54.0
     dev: false
 
-  /@sentry/tracing@7.51.2:
-    resolution: {integrity: sha512-qYl8TtwdEAtLBFSSTtHX6OpSGI73sgoPZhc3ZtF7+cLe29FRM5M6uyV7HhgIrxCstAx/5lZRlCWJabkIewGfFA==}
-    engines: {node: '>=8'}
+  /@sentry/replay@7.64.0:
+    resolution: {integrity: sha512-alaMCZDZhaAVmEyiUnszZnvfdbiZx5MmtMTGrlDd7tYq3K5OA9prdLqqlmfIJYBfYtXF3lD0iZFphOZQD+4CIw==}
+    engines: {node: '>=12'}
     dependencies:
-      '@sentry-internal/tracing': 7.51.2
-    dev: false
-
-  /@sentry/types@7.51.2:
-    resolution: {integrity: sha512-/hLnZVrcK7G5BQoD/60u9Qak8c9AvwV8za8TtYPJDUeW59GrqnqOkFji7RVhI7oH1OX4iBxV+9pAKzfYE6A6SA==}
-    engines: {node: '>=8'}
+      '@sentry/core': 7.64.0
+      '@sentry/types': 7.64.0
+      '@sentry/utils': 7.64.0
     dev: false
 
   /@sentry/types@7.54.0:
@@ -12053,12 +12041,9 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /@sentry/utils@7.51.2:
-    resolution: {integrity: sha512-EcjBU7qG4IG+DpIPvdgIBcdIofROMawKoRUNKraeKzH/waEYH9DzCaqp/mzc5/rPBhpDB4BShX9xDDSeH+8c0A==}
+  /@sentry/types@7.64.0:
+    resolution: {integrity: sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==}
     engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.51.2
-      tslib: 1.14.1
     dev: false
 
   /@sentry/utils@7.54.0:
@@ -12067,6 +12052,14 @@ packages:
     dependencies:
       '@sentry/types': 7.54.0
       tslib: 1.14.1
+    dev: false
+
+  /@sentry/utils@7.64.0:
+    resolution: {integrity: sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.64.0
+      tslib: 2.5.0
     dev: false
 
   /@sheerun/mutationobserver-shim@0.3.3:


### PR DESCRIPTION
I noticed that the `@sentry/tracing` library has been deprecated

<img width="607" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/1110551/c9da3078-2859-4f50-99d1-5a902b217ecf">
