### PR TITLE
Change <MainPageContent> style from margin to padding

### DIFF
--- a/.changeset/hungry-trees-vanish.md
+++ b/.changeset/hungry-trees-vanish.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+change MainPageContent style from margin to padding to avoid cutting off some styling features of it's child components.

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -15,5 +15,5 @@ export const MainPageContent = styled.div`
   flex: 1;
   flex-basis: 0;
   overflow: auto;
-  margin: ${appKitDesignTokens.marginForPageContent};
+  padding: ${appKitDesignTokens.marginForPageContent};
 `;


### PR DESCRIPTION
#### Summary

Change `MainPageContent` style from margin to padding to avoid cutting off some stylings from it's component's children

#### Description

The current styling from the `MainPageContent` used in the `CustomFormMainPage` has a margin property to space the container children from external contents but this seems like the property should be padding instead. The current margin property seems to cut of some of the features of the pagination dropdown box shadow. 

Before: 
<img width="259" alt="Screenshot 2023-08-23 at 10 12 25" src="https://github.com/commercetools/merchant-center-application-kit/assets/19975842/33fde529-229b-458b-b399-49ad966e9e6a">


After: 
<img width="248" alt="Screenshot 2023-08-23 at 10 15 16" src="https://github.com/commercetools/merchant-center-application-kit/assets/19975842/1e9e14f5-c88a-4309-a02e-18e6ba1f0145">


