### PR TITLE
Alternative to fix `NavBar` unexpected behaviour in Safari

### DIFF
--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -4,8 +4,6 @@ import {
   MouseEventHandler,
   ReactNode,
   SyntheticEvent,
-  useRef,
-  useLayoutEffect,
 } from 'react';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -180,29 +178,7 @@ type MenuGroupProps = {
   children?: ReactNode;
 };
 
-function agentHas(keyword: string) {
-  return navigator.userAgent.toLowerCase().search(keyword.toLowerCase()) > -1;
-}
-
-function isSafari() {
-  return (
-    // @ts-ignore
-    (!!window.ApplePaySetupFeature || !!window.safari) &&
-    agentHas('Safari') &&
-    !agentHas('Chrome') &&
-    !agentHas('CriOS')
-  );
-}
-
 const MenuGroup = (props: MenuGroupProps) => {
-  // Fix for Navbar's z-index in Safari
-  const menuGroupRef = useRef<HTMLUListElement>(null);
-  useLayoutEffect(() => {
-    if (isSafari() && menuGroupRef.current) {
-      // @ts-ignore
-      menuGroupRef.current.style.zIndex = 'unset';
-    }
-  });
   if (
     props.isExpanded &&
     ((props.level === 2 && !props.hasSubmenu) ||
@@ -241,7 +217,6 @@ const MenuGroup = (props: MenuGroupProps) => {
           [styles.sublist__inactive]: !isSublistActiveWhileIsMenuCollapsed,
         }
       )}
-      ref={menuGroupRef}
     >
       {props.children}
     </ul>
@@ -288,17 +263,6 @@ const menuItemLinkDefaultProps: Pick<MenuItemLinkProps, 'exactMatch'> = {
   exactMatch: false,
 };
 const MenuItemLink = (props: MenuItemLinkProps) => {
-  // Fix for Navbar's z-index in Safari
-  const menuItemLinkRef = useRef<HTMLAnchorElement>(null);
-  useLayoutEffect(() => {
-    if (isSafari() && menuItemLinkRef.current) {
-      const title = menuItemLinkRef.current.querySelector(`.${styles.title}`);
-      if (title) {
-        // @ts-ignore
-        title.style.zIndex = '1';
-      }
-    }
-  });
   const redirectTo = (targetUrl: string) => location.replace(targetUrl);
   if (props.linkTo) {
     return (
@@ -316,7 +280,6 @@ const MenuItemLink = (props: MenuItemLinkProps) => {
             props.onClick(event);
           }
         }}
-        ref={menuItemLinkRef}
       >
         {props.children}
       </NavLink>

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -262,7 +262,6 @@
   background-color: var(--background-color-for-navbar);
   top: 0;
   left: 64px;
-  z-index: -1;
   list-style: none;
   opacity: 0.01;
   visibility: hidden;
@@ -317,10 +316,6 @@
 }
 
 .list-item.item__active .item-icon-text {
-  width: calc(
-    var(--width-left-navigation-sublist) + var(--width-left-navigation) -
-      var(--spacing-m) * 2
-  );
   justify-content: flex-start;
 }
 .list-item .icon-container {
@@ -353,6 +348,10 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  position: absolute;
+  left: 46px;
+  width: 166px;
+  z-index: 1;
 }
 
 :global(.body__menu-open) .list-item.item__active .item-icon-text .title {
@@ -408,9 +407,9 @@
 .scrollable-menu {
   flex: 1 1 0;
   padding-bottom: var(--faded-height);
-  /* 
+  /*
     FIXME: Make the navbar scrollable in collapsed state.
-    NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover 
+    NOTE: do not use `overflow-x: hidden; overflow-y: auto;` as this prevents submenus from showing up on hover
   */
 }
 


### PR DESCRIPTION
…ri behaviour

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Alternative to fix `NavBar` unexpected behaviour in Safari.

#### Description

Here I'm trying to refactor the styles to avoid User-Agent sniffing.

Maybe this is not the most elegant solution but it seems to work in Safari, Chrome an Firefox. 
Also, this would be a temporary fix anyway until we implement the new scrolling behaviour for the navbar.
