### PR TITLE
fix: hidden submenu overflow

### DIFF
--- a/.changeset/stupid-dolphins-decide.md
+++ b/.changeset/stupid-dolphins-decide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Resolve the problem of a hidden menu with multiple items overflowing the layout

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -265,7 +265,7 @@
   z-index: -1;
   list-style: none;
   opacity: 0.01;
-  visibility: hidden;
+  display: none;
 }
 
 .sublist__inactive {
@@ -375,7 +375,7 @@
 .sublist-expanded__active,
 .sublist-collapsed__active {
   opacity: 1;
-  visibility: visible;
+  display: block;
   text-align: left;
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   background-color: var(--background-color-for-navbar-when-active);


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

The issue was identified by and solution was proposed by @jaikumar-tj.
Many thanks for that 🙇 

|  Before |  After | 
|---|---|
| <img width="348" alt="Screenshot 2023-08-23 at 18 21 27" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/b5b84fab-56e1-4f14-a5a7-1f4457495c18"> |  <img width="337" alt="Screenshot 2023-08-23 at 18 22 30" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/b618cfab-16c9-4167-90ac-897ecf14d1fc"> |

The root cause is hidden submenu not being removed from the visual flow due to `visibility: hidden`
<img width="224" alt="Screenshot 2023-08-23 at 18 25 19" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/5d6e6ec3-d04b-407e-bf58-ea7387ce20b5">

[Link to demo](https://mc-15223.mc-preview.europe-west1.gcp.escemo.com/test-with-big-data-44/welcome)

