### PR TITLE
fix: styling issues with MainPageContent and Navbar

### DIFF
--- a/.changeset/fluffy-tables-notice.md
+++ b/.changeset/fluffy-tables-notice.md
@@ -1,5 +1,7 @@
 ---
 '@commercetools-frontend/application-components': patch
+'@commercetools-frontend/application-shell': patch
 ---
 
 Reverting MainPageContent style change due to breaking sticky DataTable styles.
+Fix for NavBar submenu title's `z-index`.

--- a/.changeset/fluffy-tables-notice.md
+++ b/.changeset/fluffy-tables-notice.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Reverting MainPageContent style change due to breaking sticky DataTable styles.

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -15,5 +15,6 @@ export const MainPageContent = styled.div`
   flex: 1;
   flex-basis: 0;
   overflow: auto;
+  // NOTE: do not change to "padding" as this breaks sticky DataTable styles
   margin: ${appKitDesignTokens.marginForPageContent};
 `;

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -15,5 +15,5 @@ export const MainPageContent = styled.div`
   flex: 1;
   flex-basis: 0;
   overflow: auto;
-  padding: ${appKitDesignTokens.marginForPageContent};
+  margin: ${appKitDesignTokens.marginForPageContent};
 `;

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -98,6 +98,7 @@
   transition: all 0.25s ease-in-out;
   text-align: left;
   text-decoration: none;
+  z-index: 1;
 }
 
 .expander {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR reverts MainPageContent styling changes due to breaking DataTable styles
<img width="1457" alt="Screenshot 2023-08-25 at 10 56 26" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/dcf01b1d-7f7b-4443-8c96-6eb8fe0c9567">

Also fixes `z-index` of Navbar's submenu title.
<img width="293" alt="Screenshot 2023-08-25 at 13 07 25" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/5d758bc1-c5a0-410f-be03-f15cedc4765e">

