### PR TITLE
fix(Navbar): proper sublist indentation when expanded

### DIFF
--- a/.changeset/wicked-terms-brake.md
+++ b/.changeset/wicked-terms-brake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Display sublist as block when expanded

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -408,6 +408,10 @@
   background-color: var(--background-color-for-navbar-when-active);
 }
 
+.sublist-expanded__active {
+  display: block;
+}
+
 .item-link:hover .sublist-collapsed-new__active,
 .item-link:hover .sublist-expanded-new__active {
   display: block;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Apologies for introducing the 🐛 [here](https://github.com/commercetools/merchant-center-application-kit/pull/3188) 🤦‍♂️ 

This PR overwrites styles from the upper rule:
```
.sublist-expanded__active,
.sublist-collapsed__active {
  opacity: 1;
  display: unset;
  text-align: left;
  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
  background-color: var(--background-color-for-navbar-when-active);
}

.sublist-expanded__active {
  display: block;
}
```
