### PR TITLE
Navigation footer part 1

### DIFF
--- a/.changeset/rich-parrots-visit.md
+++ b/.changeset/rich-parrots-visit.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Updating style of the navigation footer

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -124,6 +124,16 @@ type MenuExpanderProps = {
   isMenuOpen: boolean;
   isNewNavigationEnabled: boolean;
 };
+
+const getIcon = ({ isNewNavigationEnabled, isMenuOpen }: MenuExpanderProps) => {
+  const Icon = isNewNavigationEnabled
+    ? isMenuOpen
+      ? SidebarCollapseIcon
+      : SidebarExpandIcon
+    : ArrowRightIcon;
+  return <Icon color="surface" size="big" />;
+};
+
 const MenuExpander = (props: MenuExpanderProps) => {
   return (
     <li
@@ -142,19 +152,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
         })}
         data-testid="menu-expander"
       >
-        {/*
-          FIXME: define hover effect.
-          https://github.com/commercetools/merchant-center-frontend/issues/2216
-        */}
-        {props.isNewNavigationEnabled ? (
-          props.isMenuOpen ? (
-            <SidebarCollapseIcon color="surface" size="big" />
-          ) : (
-            <SidebarExpandIcon color="surface" size="big" />
-          )
-        ) : (
-          <ArrowRightIcon color="surface" size="big" />
-        )}
+        {getIcon(props)}
       </div>
     </li>
   );

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -21,7 +21,12 @@ import type {
 import MissingImageSvg from '@commercetools-frontend/assets/images/diagonal-line.svg';
 import { NO_VALUE_FALLBACK } from '@commercetools-frontend/constants';
 import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
-import { ArrowRightIcon, BackIcon } from '@commercetools-uikit/icons';
+import {
+  ArrowRightIcon,
+  BackIcon,
+  SidebarExpandIcon,
+  SidebarCollapseIcon,
+} from '@commercetools-uikit/icons';
 import InlineSvg from '@commercetools-uikit/icons/inline-svg';
 import type {
   TDataFence,
@@ -39,20 +44,6 @@ type TProjectPermissions = {
   actionRights: TNormalizedActionRights | null;
   dataFences: TNormalizedDataFences | null;
 };
-
-/*
-<DataMenu data={[]}>
-  <MenuGroup>
-    <MenuItem>
-      <MenuItemLink linkTo="/foo">(icon) Products</MenuItemLink>
-      <MenuGroup>
-        <MenuItemLink linkTo="/foo/new">Add product</MenuItemLink>
-      </MenuGroup>
-    </MenuItem>
-  </MenuGroup>
-  <MenuExpander/>
-</DataMenu>
-*/
 
 const HeartIcon = lazy(() => import('./legacy-icons/heart'));
 const PaperclipIcon = lazy(() => import('./legacy-icons/paperclip'));
@@ -131,42 +122,60 @@ type MenuExpanderProps = {
   isVisible: boolean;
   onClick: MouseEventHandler<HTMLDivElement>;
   isMenuOpen: boolean;
+  isNewNavigationEnabled: boolean;
 };
 const MenuExpander = (props: MenuExpanderProps) => {
   return (
     <li
       key="expander"
-      className={classnames(styles['list-item'], styles.expander, {
+      className={classnames(styles['list-item'], {
         [styles.hidden]: !props.isVisible,
+        [styles['expander-new']]: props.isNewNavigationEnabled,
+        [styles.expander]: !props.isNewNavigationEnabled,
       })}
     >
       <div
         onClick={props.onClick}
-        className={styles['expand-icon']}
+        className={classnames({
+          [styles['expand-icon']]: !props.isNewNavigationEnabled,
+          [styles['expand-icon-new']]: props.isNewNavigationEnabled,
+        })}
         data-testid="menu-expander"
       >
         {/*
           FIXME: define hover effect.
           https://github.com/commercetools/merchant-center-frontend/issues/2216
         */}
-        <ArrowRightIcon color="surface" size="big" />
+        {props.isNewNavigationEnabled ? (
+          props.isMenuOpen ? (
+            <SidebarCollapseIcon color="surface" size="big" />
+          ) : (
+            <SidebarExpandIcon color="surface" size="big" />
+          )
+        ) : (
+          <ArrowRightIcon color="surface" size="big" />
+        )}
       </div>
     </li>
   );
 };
 MenuExpander.displayName = 'MenuExpander';
 
-const Faded = styled.div`
+type FadedProps = {
+  isNewNavigationEnabled: boolean;
+};
+
+const Faded = styled.div<FadedProps>`
   position: absolute;
   top: -32px;
   height: 32px;
   width: 100%;
-  background: linear-gradient(
-    0deg,
-    ${appkitDesignTokens.backgroundColorForNavbar} 0%,
-    rgba(0, 0, 0, 0) 100%
-  );
   z-index: 1;
+
+  background: ${(props) =>
+    props.isNewNavigationEnabled
+      ? 'linear-gradient(180deg, rgba(0, 153, 135, 0.00) 0%, #009987 100%)'
+      : `linear-gradient(0deg, ${appkitDesignTokens.backgroundColorForNavbar} 0%, rgba(0, 0, 0, 0) 100%)`};
 `;
 
 type MenuGroupProps = {
@@ -257,6 +266,7 @@ type MenuItemProps = {
   onMouseEnter?: MouseEventHandler<HTMLElement>;
   onMouseLeave?: MouseEventHandler<HTMLElement>;
   children: ReactNode;
+  isNewNavigationEnabled?: boolean;
 };
 const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
   return (
@@ -267,6 +277,7 @@ const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
         [styles['item_menu__active']]: props.isMainMenuRouteActive ?? false,
         [styles['item_menu-collapsed']]: !props.isMenuOpen,
         [styles['item__no-submenu']]: !props.hasSubmenu,
+        [styles['list-item-new']]: props.isNewNavigationEnabled,
       })}
       onClick={props.onClick}
       onMouseEnter={props.onMouseEnter}

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -341,21 +341,6 @@
   display: none;
 }
 
-.sublist-new {
-  padding: var(--spacing-m) var(--spacing-l);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  font-weight: var(--font-weight-for-navbar-link);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  font-size: var(--font-size-for-navbar-link);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  background-color: var(--background-color-for-navbar);
-  left: 58px;
-  z-index: -1;
-  list-style: none;
-  position: fixed;
-  display: none;
-}
-
 .sublist__inactive {
   /* empty block */
 }

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -1,5 +1,6 @@
 :root {
   --expander-height: 50px;
+  --expander-size-new: 40px;
   --faded-height: 32px;
   --icon-size: 24px;
   --icon-container-offset: 4px;
@@ -64,6 +65,15 @@
   cursor: pointer;
 }
 
+.list-item-new {
+  background: var(--color-primary-30);
+  color: var(--color-surface);
+}
+
+.list-item:hover.list-item-new {
+  background: var(--color-primary);
+}
+
 .item-link {
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   color: var(--color-for-navbar-link);
@@ -120,6 +130,29 @@
   background-color: var(--background-color-for-navbar);
 }
 
+.expander-new {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  background: linear-gradient(
+    180deg,
+    var(--color-primary-30) 0%,
+    var(--color-primary-20) 100%
+  );
+  padding: 16px 12px;
+}
+
+/* divider */
+.expander-new::before {
+  content: '';
+  position: absolute;
+  top: 56px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.5);
+  width: calc(100% - 2 * var(--spacing-m));
+}
+
 .expand-icon {
   align-items: center;
   border-radius: 32px;
@@ -129,6 +162,20 @@
   justify-content: center;
   transform: translateX(0) rotateZ(0deg);
   width: var(--icon-size);
+}
+
+.expand-icon-new {
+  height: var(--expander-size-new);
+  width: var(--expander-size-new);
+  border-radius: var(--border-radius-4);
+  background: rgba(255, 255, 255, 0.2);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.expand-icon-new:hover {
+  background: rgba(255, 255, 255, 0.3);
 }
 
 .item--bottom {
@@ -276,6 +323,21 @@
   left: 64px;
   list-style: none;
   opacity: 0.01;
+  display: none;
+}
+
+.sublist-new {
+  padding: var(--spacing-m) var(--spacing-l);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  font-weight: var(--font-weight-for-navbar-link);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  font-size: var(--font-size-for-navbar-link);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  background-color: var(--background-color-for-navbar);
+  left: 58px;
+  z-index: -1;
+  list-style: none;
+  position: fixed;
   display: none;
 }
 

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -287,6 +287,7 @@ const NavBar = (props: TNavbarProps) => {
     allCustomApplicationsNavbarMenu,
   } = useNavbarStateManager({
     environment: props.environment,
+    isNewNavigationEnabled: props.isNewNavigationEnabled,
   });
   const useFullRedirectsForLinks = Boolean(
     props.environment.useFullRedirectsForLinks
@@ -381,7 +382,7 @@ const NavBar = (props: TNavbarProps) => {
               />
             );
           })}
-          <MenuItemDivider />
+          {!props.isNewNavigationEnabled && <MenuItemDivider />}
           {allCustomApplicationsNavbarMenu.map((menu) => {
             const menuType = 'scrollable';
             const itemIndex = `${menuType}-${menu.key}`;
@@ -407,7 +408,7 @@ const NavBar = (props: TNavbarProps) => {
           })}
         </div>
         <div className={styles['fixed-menu']}>
-          <Faded />
+          <Faded isNewNavigationEnabled={props.isNewNavigationEnabled} />
           <MenuItem
             hasSubmenu={false}
             isActive={false}
@@ -419,6 +420,7 @@ const NavBar = (props: TNavbarProps) => {
               isMenuOpen ? undefined : () => handleToggleItem('fixed-support')
             }
             onMouseLeave={isMenuOpen ? undefined : shouldCloseMenuFly}
+            isNewNavigationEnabled={props.isNewNavigationEnabled}
           >
             <a
               href={SUPPORT_PORTAL_URL}
@@ -446,6 +448,7 @@ const NavBar = (props: TNavbarProps) => {
             isVisible={isExpanderVisible}
             onClick={handleToggleMenu}
             isMenuOpen={isMenuOpen}
+            isNewNavigationEnabled={props.isNewNavigationEnabled}
           />
         </div>
       </MenuGroup>

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -23,6 +23,7 @@ import nonNullable from './non-nullable';
 
 type HookProps = {
   environment: TApplicationContext<{}>['environment'];
+  isNewNavigationEnabled: boolean;
 };
 type State = {
   activeItemIndex?: string;
@@ -135,7 +136,8 @@ const useNavbarStateManager = (props: HookProps) => {
   const checkSize = useCallback(
     throttle(() => {
       const shouldOpen = window.innerWidth > 1024;
-      const canExpandMenu = window.innerWidth > 918;
+      const canExpandMenu =
+        window.innerWidth > (props.isNewNavigationEnabled ? 1200 : 918);
 
       // If the screen is small, we should always keep the menu closed,
       // no matter the settings.

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -146,6 +146,11 @@ const useNavbarStateManager = (props: HookProps) => {
           // and resets the state to avoid conflicts
           dispatch({ type: 'reset' });
         }
+      } else if (isForcedMenuOpen) {
+        dispatch({
+          type: 'setIsMenuOpenAndMakeExpanderVisible',
+          payload: true,
+        });
       } else if (canExpandMenu && state.isExpanderVisible !== true) {
         dispatch({ type: 'setIsExpanderVisible' });
       } else if (isNil(isForcedMenuOpen) && state.isMenuOpen !== shouldOpen) {

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -10,7 +10,7 @@ import throttle from 'lodash/throttle';
 import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { STORAGE_KEYS } from '../../constants';
+import { STORAGE_KEYS, WINDOW_SIZES } from '../../constants';
 import { useMcQuery } from '../../hooks/apollo-hooks';
 import useApplicationsMenu from '../../hooks/use-applications-menu';
 import type { TNavbarMenu } from '../../types/generated/proxy';
@@ -135,9 +135,12 @@ const useNavbarStateManager = (props: HookProps) => {
 
   const checkSize = useCallback(
     throttle(() => {
-      const shouldOpen = window.innerWidth > 1024;
+      const shouldOpen = window.innerWidth > WINDOW_SIZES.STANDARD;
       const canExpandMenu =
-        window.innerWidth > (props.isNewNavigationEnabled ? 1200 : 918);
+        window.innerWidth >
+        (props.isNewNavigationEnabled
+          ? WINDOW_SIZES.WIDE
+          : WINDOW_SIZES.NARROW);
 
       // If the screen is small, we should always keep the menu closed,
       // no matter the settings.

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -5,6 +5,12 @@ export const DIMENSIONS = {
   navMenuExpanded: '245px',
 } as const;
 
+export const WINDOW_SIZES = {
+  NARROW: 918,
+  STANDARD: 1024,
+  WIDE: 1200,
+} as const;
+
 export const SUPPORTED_HEADERS = {
   ACCEPT: 'Accept',
   ACCEPT_VERSION: 'Accept-version',


### PR DESCRIPTION
**Footer requirements done with this PR:**
- Footer should be sticky on the bottom
- Imported new icons for expander
- New color tokens
- New divider
- Hover effect on the expander
- Change breakpoint when the expander is hidden (less than 1200 px)

Will be done later:
- Adjust width and spacings of the footer
- Add correct styling to 'Support' (will be done when changing `MenuItem` style)
- Space added so that the Faded component doesn’t hide the last `MenuItem` of the side nav

**Screenshots:**
![Screenshot 2023-08-31 at 09 31 10](https://github.com/commercetools/merchant-center-application-kit/assets/52276952/cc870b93-5a1e-41f3-8a7e-66b5457a6a3b)
![Screenshot 2023-08-31 at 09 31 03](https://github.com/commercetools/merchant-center-application-kit/assets/52276952/2b047bc6-3299-4878-8618-0192b04bde0a)
