### PR TITLE
refactor(Navbar): Show submenu and a tooltip when collapsed 

### DIFF
--- a/.changeset/warm-hairs-suffer.md
+++ b/.changeset/warm-hairs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Add tooltip to the new Navbar

--- a/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
@@ -200,6 +200,10 @@ const MenuGroup = (props: MenuGroupProps) => {
             isSublistActiveWhileIsMenuExpanded,
         },
         {
+          [styles['sublist-collapsed__empty']]:
+            isSublistActiveWhileIsMenuCollapsed && !props.hasSubmenu,
+        },
+        {
           [styles['sublist-collapsed__active']]:
             isSublistActiveWhileIsMenuCollapsed,
         },

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
@@ -6,6 +6,8 @@
   --icon-container-offset: 4px;
   --item-height: 56px;
   --item-width: 64px;
+  --sublist-new-indentantion: 58px;
+  --sublist-width: 253px;
   --submenu-margin: calc(
     var(--icon-size) + var(--spacing-m) + var(--icon-container-offset) + 4px
   );
@@ -220,24 +222,6 @@
   transition: max-height 0.25s ease-in;
 }
 
-:global(.body__menu-open) .title-copy {
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  font-weight: var(--font-weight-for-navbar-link);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  font-size: var(--font-size-for-navbar-link);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  color: var(--color-for-navbar-link);
-  text-decoration: none;
-  transition: all 0.15s ease;
-}
-
-:global(.body__menu-open) .title-copy:hover {
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  color: var(--color-for-navbar-link-when-hovered);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  font-weight: var(--font-weight-for-navbar-link-when-hovered);
-}
-
 /*  Second level menu */
 
 .sublist {
@@ -248,11 +232,22 @@
   font-size: var(--font-size-for-navbar-link);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   background-color: var(--background-color-for-navbar);
-  left: 58px;
+  left: var(--sublist-new-indentantion);
   z-index: -1;
   list-style: none;
   position: fixed;
   display: none;
+}
+
+/* This pseudo-element is required to enable smooth coursor movement from the main menu item to submenu items when tooltip is displayed */
+.sublist-collapsed__active::before {
+  content: '';
+  position: absolute;
+  display: block;
+  width: var(--sublist-width);
+  height: var(--item-height);
+  top: calc(-1 * var(--item-height));
+  left: calc(var(--sublist-new-indentantion) - var(--width-left-navigation));
 }
 
 .sublist__inactive {
@@ -372,17 +367,44 @@
   margin-left: 0;
 }
 
+.tooltip-container {
+  position: absolute;
+  top: calc(-1 * var(--item-height));
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: var(--item-height);
+  visibility: visible;
+}
+
+.tooltip {
+  padding: var(--spacing-10) calc(var(--spacing-20) + var(--spacing-10));
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  border-radius: var(--border-radius-4);
+  background: var(--color-accent-10);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.25);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  font-size: var(--font-size-for-navbar-link);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  line-height: var(--line-height-for-navbar-link);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  font-weight: var(--font-weight-for-navbar-link);
+  color: var(--color-surface);
+  max-height: var(--item-height);
+  visibility: inherit;
+}
+
 .sublist-expanded__active,
 .sublist-collapsed__active {
   opacity: 1;
-  display: unset;
+  display: none;
   text-align: left;
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   background-color: var(--background-color-for-navbar-when-active);
-}
-
-.sublist-expanded__active {
-  display: block;
 }
 
 .item-link:hover .sublist-collapsed__active,
@@ -395,11 +417,15 @@
   background-color: var(--color-surface);
   /* TODO: add design tokens instead hard-coded values */
   min-height: 50px;
-  width: 253px;
+  width: var(--sublist-width);
   border-radius: 8px;
   /* z-index value must be higher than AppBar's z-index */
   z-index: 20001;
   box-shadow: -2px 4px 25px 0 rgba(89, 89, 89, 0.5);
+}
+
+.item-link:hover .sublist-collapsed__active.sublist-collapsed__empty {
+  visibility: hidden;
 }
 
 .item-link:hover .sublist-expanded__active {

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
@@ -6,7 +6,7 @@
   --icon-container-offset: 4px;
   --item-height: 56px;
   --item-width: 64px;
-  --sublist-new-indentantion: 58px;
+  --sublist-indentantion: 58px;
   --sublist-width: 253px;
   --submenu-margin: calc(
     var(--icon-size) + var(--spacing-m) + var(--icon-container-offset) + 4px
@@ -232,7 +232,7 @@
   font-size: var(--font-size-for-navbar-link);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   background-color: var(--background-color-for-navbar);
-  left: var(--sublist-new-indentantion);
+  left: var(--sublist-indentantion);
   z-index: -1;
   list-style: none;
   position: fixed;
@@ -247,7 +247,7 @@
   width: var(--sublist-width);
   height: var(--item-height);
   top: calc(-1 * var(--item-height));
-  left: calc(var(--sublist-new-indentantion) - var(--width-left-navigation));
+  left: calc(var(--sublist-indentantion) - var(--width-left-navigation));
 }
 
 .sublist__inactive {

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@commercetools-frontend/application-shell-connectors';
 import { SUPPORT_PORTAL_URL } from '@commercetools-frontend/constants';
 import { SupportIcon } from '@commercetools-uikit/icons';
+import { DIMENSIONS } from '../../../constants';
 import type { TFetchProjectQuery } from '../../../types/generated/mc';
 import type { TNavbarMenu, TBaseMenu } from '../../../types/generated/proxy';
 import messages from '../messages';
@@ -48,8 +49,6 @@ import NavBarSkeleton from './navbar-skeleton';
 import compiledStyles from /* preval */ './navbar.styles';
 
 const styles = compiledStyles.jsonMap;
-
-const menuItemHeightInPx = 56;
 
 type TProjectPermissions = {
   permissions: TNormalizedPermissions | null;
@@ -106,7 +105,9 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
   // We need to calculate the vertical position of the menu item to be able to
   // position the submenu correctly.
   const verticalPosition =
-    topPosition - props.scrollTop + (props.isMenuOpen ? 0 : menuItemHeightInPx);
+    topPosition -
+    props.scrollTop +
+    (props.isMenuOpen ? 0 : parseInt(DIMENSIONS.navMenuItemHeight));
 
   useEffect(() => {
     if (elementRef.current != null) {

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -49,6 +49,8 @@ import compiledStyles from /* preval */ './navbar.styles';
 
 const styles = compiledStyles.jsonMap;
 
+const menuItemHeightInPx = 56;
+
 type TProjectPermissions = {
   permissions: TNormalizedPermissions | null;
   actionRights: TNormalizedActionRights | null;
@@ -103,7 +105,8 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
 
   // We need to calculate the vertical position of the menu item to be able to
   // position the submenu correctly.
-  const verticalPosition = topPosition - props.scrollTop;
+  const verticalPosition =
+    topPosition - props.scrollTop + (props.isMenuOpen ? 0 : menuItemHeightInPx);
 
   useEffect(() => {
     if (elementRef.current != null) {
@@ -201,6 +204,20 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
           hasSubmenu={hasSubmenu}
           verticalPosition={verticalPosition}
         >
+          {!props.isMenuOpen && (
+            <div className={styles['tooltip-container']}>
+              <div
+                className={styles['tooltip']}
+                aria-owns={`group-${props.menu.key}`}
+              >
+                <MenuLabel
+                  labelAllLocales={props.menu.labelAllLocales}
+                  defaultLabel={props.menu.defaultLabel}
+                  applicationLocale={props.applicationLocale}
+                />
+              </div>
+            </div>
+          )}
           {hasSubmenu
             ? props.menu.submenu.map((submenu: TSubmenuWithDefaultLabel) => (
                 <RestrictedMenuItem

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -3,6 +3,7 @@ export const DIMENSIONS = {
   headerItemDivider: '24px',
   navMenu: '64px',
   navMenuExpanded: '245px',
+  navMenuItemHeight: '56px',
 } as const;
 
 export const WINDOW_SIZES = {


### PR DESCRIPTION
#### Summary

This PR adds a tooltip with the app name in the collapsed mode of the navbar.

![2023-08-31 10 26 24](https://github.com/commercetools/merchant-center-application-kit/assets/49066275/a117faae-962a-482a-8d98-67313a93b905)

It is deployed [here](https://mc-15303.mc-preview.europe-west1.gcp.escemo.com/main-navigation-test/welcome).

Please note that for now the submenu pops up on click when the navbar is expanded. I assumed the correct behaviour (submenu showing up on hover) will be part of [this](https://commercetools.atlassian.net/browse/SHIELD-884) ticket.

