### PR TITLE
fix: use default value for `isForcedMenuOpen`

### DIFF
--- a/.changeset/rude-trains-allow.md
+++ b/.changeset/rude-trains-allow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix inconsistent Navbar behavior by using the default value for isForcedMenuOpen.

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -130,10 +130,12 @@ const useNavbarStateManager = (props: HookProps) => {
     ? isForcedMenuOpenDefaultValue
     : (JSON.parse(cachedIsForcedMenuOpen) as boolean);
 
-  window.localStorage.setItem(
-    STORAGE_KEYS.IS_FORCED_MENU_OPEN,
-    String(isForcedMenuOpen)
-  );
+  if (!cachedIsForcedMenuOpen) {
+    window.localStorage.setItem(
+      STORAGE_KEYS.IS_FORCED_MENU_OPEN,
+      String(isForcedMenuOpen)
+    );
+  }
 
   const [state, dispatch] = useReducer<
     (prevState: State, action: Action) => State

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -130,7 +130,7 @@ const useNavbarStateManager = (props: HookProps) => {
     ? isForcedMenuOpenDefaultValue
     : (JSON.parse(cachedIsForcedMenuOpen) as boolean);
 
-  if (!cachedIsForcedMenuOpen) {
+  if (isNil(cachedIsForcedMenuOpen)) {
     window.localStorage.setItem(
       STORAGE_KEYS.IS_FORCED_MENU_OPEN,
       String(isForcedMenuOpen)

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -132,7 +132,7 @@ const useNavbarStateManager = (props: HookProps) => {
 
   window.localStorage.setItem(
     STORAGE_KEYS.IS_FORCED_MENU_OPEN,
-    String(isForcedMenuOpenDefaultValue)
+    String(isForcedMenuOpen)
   );
 
   const [state, dispatch] = useReducer<

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -42,6 +42,8 @@ const getInitialState = (isForcedMenuOpen: boolean | null): State => ({
   isMenuOpen: isNil(isForcedMenuOpen) ? false : isForcedMenuOpen,
 });
 
+const isForcedMenuOpenDefaultValue = false;
+
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'setActiveItemIndex':
@@ -125,8 +127,13 @@ const useNavbarStateManager = (props: HookProps) => {
     STORAGE_KEYS.IS_FORCED_MENU_OPEN
   );
   const isForcedMenuOpen = isNil(cachedIsForcedMenuOpen)
-    ? null
+    ? isForcedMenuOpenDefaultValue
     : (JSON.parse(cachedIsForcedMenuOpen) as boolean);
+
+  window.localStorage.setItem(
+    STORAGE_KEYS.IS_FORCED_MENU_OPEN,
+    String(isForcedMenuOpenDefaultValue)
+  );
 
   const [state, dispatch] = useReducer<
     (prevState: State, action: Action) => State


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fixing inconsistencies in the Navbar's behavior. Check E2E tests now passing [here](https://github.com/commercetools/merchant-center-frontend/pull/15223)

For more context, currently the Navbar's behavior is somewhat inconsistent. For viewport widths below 1024 px until  `isForcedMenuOpen` is set by clicking the expand button, it sometimes renders with menu expanded and sometimes collapsed (some kind of race condition takes place).
