### PR TITLE
Grid columns fix

### DIFF
--- a/.changeset/twelve-windows-notice.md
+++ b/.changeset/twelve-windows-notice.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix the grid columns issue in new Navigation layout

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -232,9 +232,7 @@ export const ApplicationShellAuthenticated = (
                                 height: 100vh;
                                 display: grid;
                                 grid-template-rows: auto ${DIMENSIONS.header} 1fr;
-                                grid-template-columns:
-                                  minmax(${DIMENSIONS.navMenu}, auto)
-                                  1fr;
+                                grid-template-columns: min-content 1fr;
                               `}
                             >
                               <div


### PR DESCRIPTION
There's an issue with grid columns in new navigation layout in the MC account application.

Setting `grid-template-columns: min-content 1fr` specifies that the first column should be sized based on the minimum content width of its grid items instead of giving it a fixed value. 

This should fix the issue both for the MC account app and for navigation in the App-Kit.

Before
![Screenshot 2023-09-04 at 11 52 44](https://github.com/commercetools/merchant-center-application-kit/assets/52276952/68db6694-a657-4590-a0f3-7f3c47d6f479)

After
![Screenshot 2023-09-04 at 11 52 28](https://github.com/commercetools/merchant-center-application-kit/assets/52276952/bddaffdf-bf2e-44e9-b37b-446ec0ae41f8)
