### PR TITLE
Updating style of navigation footer (part 1)

### DIFF
--- a/.changeset/dirty-tomatoes-jump.md
+++ b/.changeset/dirty-tomatoes-jump.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Updating style of the navigation footer

--- a/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
@@ -11,7 +11,6 @@ import { useFlagVariation } from '@flopflip/react-broadcast';
 import type { TFlagVariation } from '@flopflip/types';
 import classnames from 'classnames';
 import { NavLink } from 'react-router-dom';
-import { designTokens as appkitDesignTokens } from '@commercetools-frontend/application-components';
 import type {
   TNormalizedMenuVisibilities,
   TNormalizedPermissions,
@@ -21,7 +20,11 @@ import type {
 import MissingImageSvg from '@commercetools-frontend/assets/images/diagonal-line.svg';
 import { NO_VALUE_FALLBACK } from '@commercetools-frontend/constants';
 import { RestrictedByPermissions } from '@commercetools-frontend/permissions';
-import { ArrowRightIcon, BackIcon } from '@commercetools-uikit/icons';
+import {
+  BackIcon,
+  SidebarExpandIcon,
+  SidebarCollapseIcon,
+} from '@commercetools-uikit/icons';
 import InlineSvg from '@commercetools-uikit/icons/inline-svg';
 import type {
   TDataFence,
@@ -39,20 +42,6 @@ type TProjectPermissions = {
   actionRights: TNormalizedActionRights | null;
   dataFences: TNormalizedDataFences | null;
 };
-
-/*
-<DataMenu data={[]}>
-  <MenuGroup>
-    <MenuItem>
-      <MenuItemLink linkTo="/foo">(icon) Products</MenuItemLink>
-      <MenuGroup>
-        <MenuItemLink linkTo="/foo/new">Add product</MenuItemLink>
-      </MenuGroup>
-    </MenuItem>
-  </MenuGroup>
-  <MenuExpander/>
-</DataMenu>
-*/
 
 const HeartIcon = lazy(() => import('../legacy-icons/heart'));
 const PaperclipIcon = lazy(() => import('../legacy-icons/paperclip'));
@@ -132,6 +121,12 @@ type MenuExpanderProps = {
   onClick: MouseEventHandler<HTMLDivElement>;
   isMenuOpen: boolean;
 };
+
+const getIcon = ({ isMenuOpen }: MenuExpanderProps) => {
+  const Icon = isMenuOpen ? SidebarCollapseIcon : SidebarExpandIcon;
+  return <Icon color="surface" size="big" />;
+};
+
 const MenuExpander = (props: MenuExpanderProps) => {
   return (
     <li
@@ -145,11 +140,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
         className={styles['expand-icon']}
         data-testid="menu-expander"
       >
-        {/*
-          FIXME: define hover effect.
-          https://github.com/commercetools/merchant-center-frontend/issues/2216
-        */}
-        <ArrowRightIcon color="surface" size="big" />
+        {getIcon(props)}
       </div>
     </li>
   );
@@ -161,11 +152,7 @@ const Faded = styled.div`
   top: -32px;
   height: 32px;
   width: 100%;
-  background: linear-gradient(
-    0deg,
-    ${appkitDesignTokens.backgroundColorForNavbar} 0%,
-    rgba(0, 0, 0, 0) 100%
-  );
+  background: linear-gradient(180deg, rgba(0, 153, 135, 0) 0%, #009987 100%);
   z-index: 1;
 `;
 

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
@@ -1,5 +1,6 @@
 :root {
   --expander-height: 50px;
+  --expander-size: 40px;
   --faded-height: 32px;
   --icon-size: 24px;
   --icon-container-offset: 4px;
@@ -102,24 +103,41 @@
 }
 
 .expander {
-  border-top: 1px solid var(--color-neutral-40);
-  height: var(--expander-height);
   display: flex;
   align-items: center;
   justify-content: center;
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  background-color: var(--background-color-for-navbar);
+  background: linear-gradient(
+    180deg,
+    var(--color-primary-30) 0%,
+    var(--color-primary-20) 100%
+  );
+  padding: 16px 12px;
+}
+
+/* divider */
+.expander::before {
+  content: '';
+  position: absolute;
+  top: 56px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.5);
+  width: calc(100% - 2 * var(--spacing-m));
 }
 
 .expand-icon {
-  align-items: center;
-  border-radius: 32px;
-  cursor: pointer;
+  height: var(--expander-size);
+  width: var(--expander-size);
+  border-radius: var(--border-radius-4);
+  padding: var(--spacing-s);
+  background: rgba(255, 255, 255, 0.2);
   display: flex;
-  height: var(--icon-size);
   justify-content: center;
-  transform: translateX(0) rotateZ(0deg);
-  width: var(--icon-size);
+  align-items: center;
+}
+
+.expand-icon:hover {
+  background: rgba(255, 255, 255, 0.3);
 }
 
 .item--bottom {
@@ -128,8 +146,7 @@
 }
 
 .list-item:hover {
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  background-color: var(--background-color-for-navbar-when-hovered);
+  background: var(--color-primary);
 }
 
 .item__active .title {
@@ -198,11 +215,6 @@
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   color: var(--color-for-navbar-link-when-hovered);
 }
-
-:global(.body__menu-open) .expand-icon {
-  transform: translateX(0) rotateZ(180deg);
-}
-
 :global(.body__menu-open) .item__active {
   max-height: 500px;
   transition: max-height 0.25s ease-in;
@@ -224,12 +236,6 @@
   color: var(--color-for-navbar-link-when-hovered);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   font-weight: var(--font-weight-for-navbar-link-when-hovered);
-}
-
-:global(.body__menu-open) .expander {
-  min-height: 50px;
-  justify-content: flex-end;
-  padding: var(--spacing-m);
 }
 
 /*  Second level menu */

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -40,7 +40,6 @@ import {
   IconSwitcher,
   MenuGroup,
   MenuLabel,
-  MenuItemDivider,
   Faded,
   MenuExpander,
   NavBarLayout,
@@ -281,6 +280,7 @@ const NavBar = (props: TNavbarProps) => {
     allCustomApplicationsNavbarMenu,
   } = useNavbarStateManager({
     environment: props.environment,
+    newNavigation: true,
   });
   const useFullRedirectsForLinks = Boolean(
     props.environment.useFullRedirectsForLinks
@@ -361,7 +361,6 @@ const NavBar = (props: TNavbarProps) => {
               />
             );
           })}
-          <MenuItemDivider />
           {allCustomApplicationsNavbarMenu.map((menu) => {
             const menuType = 'scrollable';
             const itemIndex = `${menuType}-${menu.key}`;

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -10,7 +10,7 @@ import throttle from 'lodash/throttle';
 import type { TApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
 import { reportErrorToSentry } from '@commercetools-frontend/sentry';
-import { STORAGE_KEYS } from '../../constants';
+import { STORAGE_KEYS, WINDOW_SIZES } from '../../constants';
 import { useMcQuery } from '../../hooks/apollo-hooks';
 import useApplicationsMenu from '../../hooks/use-applications-menu';
 import type { TNavbarMenu } from '../../types/generated/proxy';
@@ -23,6 +23,7 @@ import nonNullable from './non-nullable';
 
 type HookProps = {
   environment: TApplicationContext<{}>['environment'];
+  newNavigation?: boolean;
 };
 type State = {
   activeItemIndex?: string;
@@ -143,8 +144,10 @@ const useNavbarStateManager = (props: HookProps) => {
 
   const checkSize = useCallback(
     throttle(() => {
-      const shouldOpen = window.innerWidth > 1024;
-      const canExpandMenu = window.innerWidth > 918;
+      const shouldOpen = window.innerWidth > WINDOW_SIZES.STANDARD;
+      const canExpandMenu =
+        window.innerWidth >
+        (props.newNavigation ? WINDOW_SIZES.WIDE : WINDOW_SIZES.NARROW);
 
       // If the screen is small, we should always keep the menu closed,
       // no matter the settings.
@@ -153,6 +156,11 @@ const useNavbarStateManager = (props: HookProps) => {
           // and resets the state to avoid conflicts
           dispatch({ type: 'reset' });
         }
+      } else if (isForcedMenuOpen) {
+        dispatch({
+          type: 'setIsMenuOpenAndMakeExpanderVisible',
+          payload: true,
+        });
       } else if (canExpandMenu && state.isExpanderVisible !== true) {
         dispatch({ type: 'setIsExpanderVisible' });
       } else if (isNil(isForcedMenuOpen) && state.isMenuOpen !== shouldOpen) {

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -5,6 +5,12 @@ export const DIMENSIONS = {
   navMenuExpanded: '245px',
 } as const;
 
+export const WINDOW_SIZES = {
+  NARROW: 918,
+  STANDARD: 1024,
+  WIDE: 1200,
+} as const;
+
 export const SUPPORTED_HEADERS = {
   ACCEPT: 'Accept',
   ACCEPT_VERSION: 'Accept-version',


### PR DESCRIPTION
Since now we have a [separate folders](https://github.com/commercetools/merchant-center-application-kit/pull/3198) for new and old navigation, I updated the changes from [previous footer PR](https://github.com/commercetools/merchant-center-application-kit/pull/3191) accordingly.

**The requirements done with this PR stay the same as the previous one:**

- Footer should be sticky on the bottom
- Imported new icons for expander
- New color tokens
- New divider
- Hover effect on the expander
- Change breakpoint when the expander is hidden (less than 1200 px)

**Will be done later:**

- Adjust width and spacings of the footer
- Add correct styling to 'Support' (will be done when changing MenuItem style)
- Space added so that the Faded component doesn’t hide the last MenuItem of the side nav
