### PR TITLE
refactor(loggers): avoid using deprecated methods to parse client IP addresses

### DIFF
--- a/.changeset/many-dryers-camp.md
+++ b/.changeset/many-dryers-camp.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-backend/loggers': patch
+---
+
+Avoid using deprecated methods to parse client IP addresses

--- a/packages-backend/loggers/package.json
+++ b/packages-backend/loggers/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@tsconfig/node16": "^16.1.1",
+    "@types/express": "^4.17.17",
     "express": "4.18.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,6 +1077,9 @@ importers:
       '@tsconfig/node16':
         specifier: ^16.1.1
         version: 16.1.1
+      '@types/express':
+        specifier: ^4.17.17
+        version: 4.17.17
       express:
         specifier: 4.18.2
         version: 4.18.2


### PR DESCRIPTION
The `request.connection` has been [deprecated in Node since a long time](https://nodejs.org/api/http.html#requestconnection) in favor of `request.socket`.

When accessing `request.ip` or `request.ips` in Express, these methods attempt to resolve the `remoteAddress` using the deprecated `request.connection` (https://github.com/jshttp/forwarded/blob/af3830a175dbe316be3d943f505171c73853eb04/index.js#L46-L50).
Furthermore, the `request.socket` is not guaranteed to be defined as it can be `null` (see https://github.com/nodejs/node/issues/41011 and https://github.com/nodejs/undici/issues/1115).

This PR prevents using `request.ip` or `request.ips` to avoid the outdated implementation and instead attempts to parse these values manually, using the `x-forwarded-for` header.