### PR TITLE
refactor(ci): to use github app auth over long-lived credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,22 @@ jobs:
     timeout-minutes: 15
 
     steps:
+       # Get GitHub token via the CT Changesets App
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
-          # other workflows
+          # Pass a personal access token (using our `ct-changesets` app) to be able to trigger other workflows
+
           # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
@@ -38,7 +46,7 @@ jobs:
         run: echo "VALUE=$(./scripts/print_release_version.sh)" >> $GITHUB_OUTPUT
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Creating release pull request or publishing release to npm registry
         id: changesets
@@ -52,7 +60,7 @@ jobs:
           githubReleaseName: v${{ steps.release_version.outputs.VALUE }}
           githubTagName: v${{ steps.release_version.outputs.VALUE }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           SKIP_POSTINSTALL_DEV_SETUP: true
 
       # Publish canary releases only if the packages weren't published already
@@ -63,7 +71,7 @@ jobs:
           pnpm changeset version --snapshot canary
           pnpm changeset publish --tag canary
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Building Playground application
         if: steps.changesets.outputs.published != 'true' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This refactors the authentication for the GitHub PAT for releasing via Changesets from a long-lived static credential to a short-lived dynamic credential issues through a GitHub App.

More information can be found in internal documentation or repositories.