### PR TITLE
fix: disable route permission check for `<CustomViewDevHost>`

### DIFF
--- a/.changeset/moody-mayflies-lie.md
+++ b/.changeset/moody-mayflies-lie.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Disable route check for `<CustomViewDevHost>`

--- a/packages/application-shell/src/components/custom-view-dev-host/custom-view-dev-host.tsx
+++ b/packages/application-shell/src/components/custom-view-dev-host/custom-view-dev-host.tsx
@@ -119,6 +119,7 @@ const CustomViewDevHost = (props: TCustomViewDevHost) => {
           <ApplicationShell
             environment={window.app}
             applicationMessages={props.applicationMessages}
+            disableRoutePermissionCheck
           >
             <LocalCustomViewLauncher environment={window.app} />
           </ApplicationShell>


### PR DESCRIPTION
When running the Custom View template locally, the application renders as a Custom Application (using the `<ApplicationShell>`). However, we need to disable the route permissions check as the computed permissions are based on the `customViewId` rather than the `entryPointUriPath`.