### PR TITLE
fix(Navbar): performance issues

### DIFF
--- a/.changeset/fast-students-look.md
+++ b/.changeset/fast-students-look.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix performance issues with the new Navbar

--- a/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
@@ -276,8 +276,9 @@ type MenuItemProps = {
   onMouseEnter?: MouseEventHandler<HTMLElement>;
   onMouseLeave?: MouseEventHandler<HTMLElement>;
   children: ReactNode;
+  identifier?: string;
 };
-const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
+const MenuItem = (props: MenuItemProps) => {
   return (
     <li
       role="menuitem"
@@ -289,9 +290,9 @@ const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
       onClick={props.onClick}
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
+      data-menuitem={props.identifier}
     >
       <div
-        ref={ref}
         className={
           props.hasSubmenu
             ? styles['item-link']
@@ -302,7 +303,7 @@ const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
       </div>
     </li>
   );
-});
+};
 
 MenuItem.displayName = 'MenuItem';
 

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { css } from '@emotion/react';
 import classnames from 'classnames';
+import snakeCase from 'lodash/snakeCase';
 import { FormattedMessage } from 'react-intl';
 import { matchPath, useLocation } from 'react-router-dom';
 import type { RouteComponentProps } from 'react-router-dom';
@@ -103,20 +104,23 @@ const getIsSubmenuRouteActive = (
 export const ApplicationMenu = (props: ApplicationMenuProps) => {
   const [submenuVerticalPosition, setSubmenuVerticalPosition] = useState(0);
   const [isSubmenuAboveMenuItem, setIsSubmenuAboveMenuItem] = useState(false);
-  const menuItemRef = useRef<HTMLDivElement>(null);
   const submenuRef = useRef<HTMLUListElement>(null);
 
   const hasSubmenu =
     Array.isArray(props.menu.submenu) && props.menu.submenu.length > 0;
 
-  const menuItemBoundingClientRect =
-    menuItemRef.current?.getBoundingClientRect();
-  const menuItemTop = menuItemBoundingClientRect?.top || 0;
-  const menuItemBottom = menuItemBoundingClientRect?.bottom || 0;
+  const menuItemIdentifier = snakeCase(props.menu.key);
 
   const callbackFn: IntersectionObserverCallback = useCallback(
     (entries) => {
+      const menuItemBoundingClientRect = document
+        .querySelector(`[data-menuitem="${menuItemIdentifier}"]`)
+        ?.getBoundingClientRect();
+      const menuItemTop = menuItemBoundingClientRect?.top || 0;
+      const menuItemBottom = menuItemBoundingClientRect?.bottom || 0;
+
       const [entry] = entries;
+
       const doesSubmenuFitWithinViewportBelowMenuItem =
         entry.boundingClientRect.height +
           (props.isMenuOpen ? menuItemTop : menuItemBottom) >
@@ -135,7 +139,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
         );
       }
     },
-    [menuItemBottom, menuItemTop, props.isMenuOpen]
+    [props.isMenuOpen, menuItemIdentifier]
   );
   useLayoutEffect(() => {
     const observer = new IntersectionObserver(callbackFn, {
@@ -152,8 +156,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
       }
     };
   }, [
-    menuItemBottom,
-    menuItemTop,
+    menuItemIdentifier,
     props.isMenuOpen,
     props.handleToggleItem,
     callbackFn,
@@ -193,7 +196,6 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
       namesOfMenuVisibilities={namesOfMenuVisibilitiesOfAllSubmenus}
     >
       <MenuItem
-        ref={menuItemRef}
         hasSubmenu={hasSubmenu}
         isActive={props.isActive}
         isMainMenuRouteActive={isMainMenuRouteActive}
@@ -201,6 +203,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
         onClick={props.handleToggleItem}
         onMouseEnter={props.handleToggleItem}
         onMouseLeave={props.shouldCloseMenuFly}
+        identifier={menuItemIdentifier}
       >
         {/* menu-item should be a link only if it doesn't contain a submenu */}
         {!hasSubmenu ? (

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -145,11 +145,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
     observerRef.current = new IntersectionObserver(callbackFn, {
       rootMargin: '-100% 0px 0px 0px', // we want to observe if the submenu crosses the bottom line of the viewport - therefore we set the root element top margin to -100% of the viewport height
     });
-    return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-      }
-    };
+    return () => observerRef.current?.disconnect();
   }, []);
 
   useLayoutEffect(() => {
@@ -160,11 +156,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
     if (observer && currentSubmenuRef) {
       observer.observe(currentSubmenuRef);
     }
-    return () => {
-      if (observer && currentSubmenuRef) {
-        observer.unobserve(currentSubmenuRef);
-      }
-    };
+    return () => observer?.disconnect();
   }, [
     menuItemIdentifier,
     props.isMenuOpen,

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -247,30 +247,7 @@ const useNavbarStateManager = (props: HookProps) => {
     );
   }, [state.activeItemIndex, state.isMenuOpen]);
 
-  const allInternalApplicationsNavbarMenu = [];
-
-  if (applicationsNavBarMenu) {
-    for (let i = 15; i > 0; i--) {
-      allInternalApplicationsNavbarMenu.push({
-        ...applicationsNavBarMenu[0],
-        key: applicationsNavBarMenu[0].key + i,
-        uriPath: applicationsNavBarMenu[0].uriPath + i,
-        submenu: applicationsNavBarMenu[0].submenu.map((submenu) => {
-          return {
-            ...submenu,
-            key: submenu.key + i,
-            uriPath: submenu.uriPath + i,
-          };
-        }),
-      });
-    }
-    allInternalApplicationsNavbarMenu.push({
-      key: applicationsNavBarMenu[0].key + 100,
-      uriPath: applicationsNavBarMenu[0].uriPath + 100,
-      labelAllLocales: applicationsNavBarMenu[0].labelAllLocales,
-      icon: applicationsNavBarMenu[0].icon,
-    });
-  }
+  const allInternalApplicationsNavbarMenu = applicationsNavBarMenu || [];
 
   return {
     ...state,

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -247,7 +247,30 @@ const useNavbarStateManager = (props: HookProps) => {
     );
   }, [state.activeItemIndex, state.isMenuOpen]);
 
-  const allInternalApplicationsNavbarMenu = applicationsNavBarMenu || [];
+  const allInternalApplicationsNavbarMenu = [];
+
+  if (applicationsNavBarMenu) {
+    for (let i = 15; i > 0; i--) {
+      allInternalApplicationsNavbarMenu.push({
+        ...applicationsNavBarMenu[0],
+        key: applicationsNavBarMenu[0].key + i,
+        uriPath: applicationsNavBarMenu[0].uriPath + i,
+        submenu: applicationsNavBarMenu[0].submenu.map((submenu) => {
+          return {
+            ...submenu,
+            key: submenu.key + i,
+            uriPath: submenu.uriPath + i,
+          };
+        }),
+      });
+    }
+    allInternalApplicationsNavbarMenu.push({
+      key: applicationsNavBarMenu[0].key + 100,
+      uriPath: applicationsNavBarMenu[0].uriPath + 100,
+      labelAllLocales: applicationsNavBarMenu[0].labelAllLocales,
+      icon: applicationsNavBarMenu[0].icon,
+    });
+  }
 
   return {
     ...state,


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
Create an instance of IntersectionObserver for each menu item only once (at first render) and reuse between re-renders.

We're comparing apples and oranges, but still the profiling results suggest it's at least making things a tad better.
I have no certainty it's the ultimate fix.
At least some garbage collection takes place over time and there are way less JS event listeners.
 
| Current prod (Welcome app) <br>Old Navbar <br> (that's our baseline) | Current staging (Welcome app) <br >New Navbar  |  Playground app in local prod mode (15 menu items) <br> New Navbar with changes from this PR |
|---|---|---|
|  <img width="401" alt="Screenshot 2023-10-04 at 15 29 51" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/4de9213c-5537-45b5-9484-fa39b4a3e4c1"> | <img width="398" alt="Screenshot 2023-10-04 at 15 29 44" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/d999d76f-befc-420c-ad98-60c5b4523c0d"> |  <img width="406" alt="Screenshot 2023-10-04 at 15 29 36" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/1b5f5c5c-b56d-41ab-a3ec-cf6bb7e58b31"> |