### PR TITLE
Fix Navigation menu E2E tests

### DIFF
--- a/cypress/e2e/playground/application-shell.cy.ts
+++ b/cypress/e2e/playground/application-shell.cy.ts
@@ -38,6 +38,7 @@ describe('when user is authenticated', () => {
 
 describe('navigation menu', () => {
   beforeEach(() => {
+    cy.viewport(1250, 800);
     cy.loginToMerchantCenter({
       entryPointUriPath: ENTRY_POINT_APP_KIT_PLAYGROUND,
       initialRoute: URL_APP_KIT_PLAYGROUND,

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -41,6 +41,7 @@
     "@commercetools-frontend/application-shell": "22.8.2",
     "@manypkg/get-packages": "1.1.3",
     "@types/semver": "^7.5.1",
+    "cypress-real-events": "1.10.3",
     "semver": "7.5.2",
     "uuid": "9.0.0"
   },

--- a/packages/cypress/src/add-commands/index.ts
+++ b/packages/cypress/src/add-commands/index.ts
@@ -1,3 +1,5 @@
+import { Matcher } from '@testing-library/dom';
+import 'cypress-real-events';
 import {
   loginByForm,
   loginByOidc,
@@ -32,4 +34,16 @@ Cypress.Commands.add('loginByOidc', (commandOptions: CommandLoginOptions) => {
   );
 
   loginByOidc(commandOptions);
+});
+
+Cypress.Commands.add('hover', { prevSubject: true }, (subject: JQuery) => {
+  cy.wrap(subject).realHover();
+});
+
+Cypress.Commands.add('navigationMenuHover', (textMatcher: Matcher) => {
+  cy.findByTestId('left-navigation')
+    .findByText(textMatcher)
+    .parents('[role="menuitem"]')
+    .first()
+    .realHover();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1899,6 +1899,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.1
         version: 7.5.1
+      cypress-real-events:
+        specifier: 1.10.3
+        version: 1.10.3(cypress@12.12.0)
       semver:
         specifier: 7.5.2
         version: 7.5.2
@@ -6360,6 +6363,7 @@ packages:
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+    requiresBuild: true
 
   /@commercetools-community-kit/i18n@0.3.0:
     resolution: {integrity: sha512-EPxsJaNXUYwY6Q9gjyKOymzhlSNAhTur415yX25d6S/GA6sG0yWx+/WRKCr/AqSKOskv8SGpj8+tMyPFO6AeNQ==}
@@ -17419,6 +17423,14 @@ packages:
     dependencies:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
+    dev: false
+
+  /cypress-real-events@1.10.3(cypress@12.12.0):
+    resolution: {integrity: sha512-YN3fn+CJIAM638sE6uMvv2/n3PsWowdd0rOiN6ZoyezNAMyENfuQHvccLKZpN+apGfQZYetCml6QXLYgDid2fg==}
+    peerDependencies:
+      cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x
+    dependencies:
+      cypress: 12.12.0
     dev: false
 
   /cypress@12.12.0:


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

There were a couple of tests failing after enabling the new navigation menu.

#### Description

The trickiest one is was a test expecting the submenu links to be visible after hovering a navigation menu item (when collapsed) since we now control that behaviour with CSS and [Cypress does not support real `hover` events](https://docs.cypress.io/api/commands/hover#__docusaurus_skipToContent_fallback).

I've tries the alternatives suggested in their docs but had no luck so I decided to use [this package](https://github.com/dmtrKovalenko/cypress-real-events/) which adds a some custom commands for interacting with DOM elements using real events.

Since we will need to also update the E2E tests in consuming apps, I've added a couple of custom commands to our cypress exported package so we use a standard API to deal with this behaviour and it's under our control.
