### PR TITLE
Menu item as a clickable link

### DIFF
--- a/.changeset/big-mayflies-bake.md
+++ b/.changeset/big-mayflies-bake.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-shell': patch
 ---
 
-Navigation menu item is again clickable even if it has submenu.
+First level navigation menu items are clickable again even it they have submenu items.

--- a/.changeset/big-mayflies-bake.md
+++ b/.changeset/big-mayflies-bake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Navigation menu item is again clickable even if it has submenu.

--- a/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
@@ -290,14 +290,7 @@ const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
     >
-      <div
-        ref={ref}
-        className={
-          props.hasSubmenu
-            ? styles['item-link']
-            : styles['item-link-no-submenu']
-        }
-      >
+      <div ref={ref} className={styles['item-link']}>
         {props.children}
       </div>
     </li>

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
@@ -83,15 +83,9 @@
 .item-link {
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   color: var(--color-for-navbar-link);
-  padding: var(--spacing-25);
   width: var(--item-size);
   position: relative;
   display: block;
-}
-
-.item-link-no-submenu {
-  width: 100%;
-  height: 100%;
 }
 
 :global(.body__menu-open) .item-link {
@@ -425,8 +419,7 @@
 
 .item-link:hover .sublist-collapsed__active,
 .item-link:hover .sublist-collapsed__active__above,
-.item-link:hover .sublist-expanded__active,
-.item-link-no-submenu:hover .sublist-collapsed__active {
+.item-link:hover .sublist-expanded__active {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -442,9 +435,7 @@
 }
 
 .item-link:hover .sublist-collapsed__active.sublist-collapsed__empty,
-.item-link:hover .sublist-collapsed__active__above.sublist-collapsed__empty,
-.item-link-no-submenu:hover
-  .sublist-collapsed__active.sublist-collapsed__empty {
+.item-link:hover .sublist-collapsed__active__above.sublist-collapsed__empty {
   visibility: hidden;
 }
 

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -202,22 +202,11 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
         onMouseEnter={props.handleToggleItem}
         onMouseLeave={props.shouldCloseMenuFly}
       >
-        {/* menu-item should be a link only if it doesn't contain a submenu */}
-        {!hasSubmenu ? (
-          <MenuItemLink
-            linkTo={`/${props.projectKey}/${props.menu.uriPath}`}
-            useFullRedirectsForLinks={props.useFullRedirectsForLinks}
-            onClick={props.onMenuItemClick}
-          >
-            <ItemContainer
-              labelAllLocales={props.menu.labelAllLocales}
-              defaultLabel={props.menu.defaultLabel}
-              applicationLocale={props.applicationLocale}
-              icon={props.menu.icon}
-              isMenuOpen={props.isMenuOpen}
-            />
-          </MenuItemLink>
-        ) : (
+        <MenuItemLink
+          linkTo={`/${props.projectKey}/${props.menu.uriPath}`}
+          useFullRedirectsForLinks={props.useFullRedirectsForLinks}
+          onClick={props.onMenuItemClick}
+        >
           <ItemContainer
             labelAllLocales={props.menu.labelAllLocales}
             defaultLabel={props.menu.defaultLabel}
@@ -225,7 +214,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
             icon={props.menu.icon}
             isMenuOpen={props.isMenuOpen}
           />
-        )}
+        </MenuItemLink>
         <MenuGroup
           id={props.menu.key}
           level={2}


### PR DESCRIPTION
In previous work we disabled clicking on the menu item parent when it contained a submenu. 

This could lead to users reporting it as a bug, since it's not straightforward why some menu items are clickable and some not. 
But more importantly custom apps  can have different links from the parent menu item and the first submenu child, so it's a potentially a breaking change.

Therefore, we decided to have all menu items as links and clickable.
