### PR TITLE
fix(Navbar): wrong submenu position on expand button click

### DIFF
--- a/.changeset/gold-countries-rhyme.md
+++ b/.changeset/gold-countries-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix wrong submenu position on menu expand button click

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -111,33 +111,36 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
 
   const menuItemIdentifier = snakeCase(props.menu.key);
 
-  const callbackFn: IntersectionObserverCallback = useCallback((entries) => {
-    const menuItemBoundingClientRect = document
-      .querySelector(`[data-menuitem="${menuItemIdentifier}"]`)
-      ?.getBoundingClientRect();
-    const menuItemTop = menuItemBoundingClientRect?.top || 0;
-    const menuItemBottom = menuItemBoundingClientRect?.bottom || 0;
+  const callbackFn: IntersectionObserverCallback = useCallback(
+    (entries) => {
+      const menuItemBoundingClientRect = document
+        .querySelector(`[data-menuitem="${menuItemIdentifier}"]`)
+        ?.getBoundingClientRect();
+      const menuItemTop = menuItemBoundingClientRect?.top || 0;
+      const menuItemBottom = menuItemBoundingClientRect?.bottom || 0;
 
-    const [entry] = entries;
+      const [entry] = entries;
 
-    const doesSubmenuFitWithinViewportBelowMenuItem =
-      entry.boundingClientRect.height +
-        (props.isMenuOpen ? menuItemTop : menuItemBottom) >
-      window.innerHeight;
-    // if the submenu does not fit at the bottom of the viewport (below the menu item)
-    if (doesSubmenuFitWithinViewportBelowMenuItem) {
-      setIsSubmenuAboveMenuItem(true);
-      setSubmenuVerticalPosition(
-        window.innerHeight - (props.isMenuOpen ? menuItemBottom : menuItemTop)
-      );
-      // show the submenu above the menu item
-    } else {
-      setIsSubmenuAboveMenuItem(false);
-      setSubmenuVerticalPosition(
-        props.isMenuOpen ? menuItemTop : menuItemBottom
-      );
-    }
-  }, []);
+      const doesSubmenuFitWithinViewportBelowMenuItem =
+        entry.boundingClientRect.height +
+          (props.isMenuOpen ? menuItemTop : menuItemBottom) >
+        window.innerHeight;
+      // if the submenu does not fit at the bottom of the viewport (below the menu item)
+      if (doesSubmenuFitWithinViewportBelowMenuItem) {
+        setIsSubmenuAboveMenuItem(true);
+        setSubmenuVerticalPosition(
+          window.innerHeight - (props.isMenuOpen ? menuItemBottom : menuItemTop)
+        );
+        // show the submenu above the menu item
+      } else {
+        setIsSubmenuAboveMenuItem(false);
+        setSubmenuVerticalPosition(
+          props.isMenuOpen ? menuItemTop : menuItemBottom
+        );
+      }
+    },
+    [menuItemIdentifier, props.isMenuOpen]
+  );
 
   const observerRef = useRef<IntersectionObserver | null>(null);
 
@@ -146,7 +149,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
       rootMargin: '-100% 0px 0px 0px', // we want to observe if the submenu crosses the bottom line of the viewport - therefore we set the root element top margin to -100% of the viewport height
     });
     return () => observerRef.current?.disconnect();
-  }, []);
+  }, [callbackFn, props.isMenuOpen]);
 
   useLayoutEffect(() => {
     const currentSubmenuRef = submenuRef.current;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Apologies, In #3247 a bug was introduced 🙈.  We need to make lifecycle of the Navbar dependent on `props.isMenuOpen`. Otherwise the `IntersectionObserver` callback is stale.

You can see it [here](https://mc.europe-west1.gcp.escemo.com/almond-40/welcome) after clicking expand button.
