### PR TITLE
fix(navbar): crashing Chrome tab with DevTools open

### DIFF
--- a/.changeset/pretty-glasses-kneel.md
+++ b/.changeset/pretty-glasses-kneel.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Resolve the issue of the Navbar causing Chrome tab crashes when DevTools are open

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -1442,7 +1442,7 @@ describe('With new navbar', () => {
       const groupId = submenuTooltip.getAttribute('aria-owns');
 
       // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-      const submenuContainer = container.querySelector(`#${groupId}`);
+      const submenuContainer = container.querySelector(`#group-${groupId}`);
       // The submenu container should not be expanded when the menu is not active.
       expect(submenuContainer).toHaveAttribute('aria-expanded', 'false');
 

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.tsx
@@ -224,7 +224,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
           />
         </MenuItemLink>
         <MenuGroup
-          id={props.menu.key}
+          id={`group-${props.menu.key}`}
           level={2}
           isActive={props.isActive}
           isExpanded={props.isMenuOpen}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

The issue was caused by [`aria-owns`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns) attribute value not referencing a valid id in DOM 🤯 
