### PR TITLE
De fix border bottom nav radius issue when expander icon is hovered on.

### DIFF
--- a/.changeset/stupid-camels-allow.md
+++ b/.changeset/stupid-camels-allow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+fix issue with NavBar submenu having a border radius at the bottom when expander icon is hovered on, when navbar is collapsed.

--- a/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/navbar-new/menu-items.tsx
@@ -132,7 +132,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
   return (
     <li
       key="expander"
-      className={classnames(styles['list-item'], styles.expander, {
+      className={classnames(styles.expander, {
         [styles.hidden]: !props.isVisible,
       })}
     >

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
@@ -145,7 +145,6 @@
 
 .expander:hover {
   background-color: var(--color-primary-40);
-  cursor: pointer;
 }
 
 /* divider */
@@ -171,6 +170,7 @@
 
 .expand-icon:hover {
   background: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
 }
 
 .item--bottom {

--- a/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar-new/navbar.mod.css
@@ -143,6 +143,11 @@
   padding: var(--spacing-30) var(--spacing-25);
 }
 
+.expander:hover {
+  background-color: var(--color-primary-40);
+  cursor: pointer;
+}
+
 /* divider */
 .expander::before {
   content: '';


### PR DESCRIPTION
#### Summary

fix issue with NavBar submenu having a border radius at the bottom when expander icon is hovered on, when navbar is collapsed.

Issue:

https://github.com/commercetools/merchant-center-application-kit/assets/19975842/fef4228d-eadf-4921-85e6-7acbfc185fbb



Fix:

https://github.com/commercetools/merchant-center-application-kit/assets/19975842/26000701-2b9e-4c92-ba9a-86a89978c500



