### PR TITLE
fix: fetch api polyfill

### DIFF
--- a/.changeset/nine-cows-add.md
+++ b/.changeset/nine-cows-add.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/jest-preset-mc-app": patch
+---
+
+Adds `Request` and `Response` from `node-fetch` as globals to the Jest preset.

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -8,6 +8,8 @@ global.window.app = {
 
 window.MutationObserver = MutationObserver;
 global.Headers = global.Headers || require('node-fetch').Headers;
+global.Request = global.Request || require('node-fetch').Request;
+global.Response = global.Response || require('node-fetch').Response;
 
 // Fix missing globals when `jsdom` is used in a test environment.
 // See https://github.com/jsdom/jsdom/issues/2524#issuecomment-1108991178.


### PR DESCRIPTION
This PR adds `Request` and `Response` to the Fetch API polyfill. Unfortunately `jsdom` [does not provide a way](https://github.com/jsdom/jsdom/issues/1724) to use Node native Fetch API, I used the same approach for the `Headers` class and also exported `Request` and `Response` from `node-fetch`.

This PR will allow running jest tests with `jsdom` env that relies on the Fetch API fixing https://github.com/commercetools/merchant-center-frontend/pull/15461

#### Notes:
In [setup-test-framework.js#L2](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/jest-preset-mc-app/setup-test-framework.js#L2) we are using the `unfetch/polyfill` to export the Fetch function and relying on `node-fetch` to export `Headers`, `Request` and `Response`. I tried to change `unfetch/polyfill` polyfill but unfortunately some tests in `merchant-center-frontend` started to fail.