### PR TITLE
test(components): define apollo provider

### DIFF
--- a/packages/application-components/package.json
+++ b/packages/application-components/package.json
@@ -71,7 +71,6 @@
   },
   "devDependencies": {
     "@apollo/client": "3.7.14",
-    "@commercetools-frontend/application-shell": "workspace:*",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",

--- a/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.spec.tsx
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.spec.tsx
@@ -1,9 +1,6 @@
 import { graphql } from 'msw';
 import { setupServer } from 'msw/node';
-import {
-  screen,
-  renderApp,
-} from '@commercetools-frontend/application-shell/test-utils';
+import { screen, renderComponent } from '../../../test-utils';
 import CustomViewsSelector from './custom-views-selector';
 
 const locators = {
@@ -75,7 +72,7 @@ describe('CustomViewsSelector', () => {
       )
     );
     const onCustomViewsResolved = jest.fn();
-    renderApp(
+    renderComponent(
       <CustomViewsSelector
         customViewLocatorCode={locators.productDetailsGeneral}
         onCustomViewsResolved={onCustomViewsResolved}
@@ -97,7 +94,7 @@ describe('CustomViewsSelector', () => {
   });
 
   it('should not render anything if no custom view locator code is provided', () => {
-    renderApp(<CustomViewsSelector />);
+    renderComponent(<CustomViewsSelector />);
     const label = screen.queryByText(/Custom Views/i);
     expect(label).not.toBeInTheDocument();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,9 +1268,6 @@ importers:
       '@apollo/client':
         specifier: 3.7.14
         version: 3.7.14(graphql@16.8.1)(react-dom@17.0.2)(react@17.0.2)
-      '@commercetools-frontend/application-shell':
-        specifier: workspace:*
-        version: link:../application-shell
       '@testing-library/dom':
         specifier: ^9.3.1
         version: 9.3.1


### PR DESCRIPTION
Follow up of #3255 

Using the `@commercetools-frontend/application-shell` as a dev dependency still causes a warning for a circular dependency (app-shell <--> app-components), even though we only use the test utils.

So let's get rid of the dependency again. However, we need to ensure the correct test-utils setup in the application-components package is correct. At the moment we only need to add the `<ApolloProvider>` in order to handle the graphql requests.

Apologies for the back and forth.

