### PR TITLE
Fix `renovate.json` and order of `packageRules`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,12 @@
       "groupName": "all svgr packages"
     },
     {
+      "groupName": "all Node.js updates",
+      "matchPackageNames": ["node"],
+      "excludePackageNames": ["calico/node", "kindest/node"],
+      "matchPackagePatterns": ["/node$"]
+    },
+    {
       "matchPackageNames": ["postcss-custom-properties"],
       "allowedVersions": "<=12.1.4"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,32 +3,32 @@
   "separateMajorMinor": true,
   "packageRules": [
     {
-      "sourceUrlPrefixes": ["https://github.com/commercetools/ui-kit"],
+      "packagePatterns": ["*"],
+      "updateTypes": ["minor", "patch"],
+      "groupName": "all dependencies",
+      "groupSlug": "all"
+    },
+    {
+      "matchSourceUrls": ["https://github.com/commercetools/ui-kit"],
       "groupName": "all ui-kit packages"
     },
     {
-      "sourceUrlPrefixes": [
+      "matchSourceUrls": [
         "https://github.com/commercetools/commercetools-docs-kit"
       ],
       "groupName": "all docs-kit packages"
     },
     {
-      "sourceUrlPrefixes": ["https://github.com/commercetools/test-data"],
+      "matchSourceUrls": ["https://github.com/commercetools/test-data"],
       "groupName": "all test-data packages"
     },
     {
-      "sourceUrlPrefixes": ["https://github.com/tdeekens/flopflip"],
+      "matchSourceUrls": ["https://github.com/tdeekens/flopflip"],
       "groupName": "all flopflip packages"
     },
     {
-      "sourceUrlPrefixes": ["https://github.com/gregberge/svgr"],
+      "matchSourceUrls": ["https://github.com/gregberge/svgr"],
       "groupName": "all svgr packages"
-    },
-    {
-      "packagePatterns": ["*"],
-      "updateTypes": ["minor", "patch"],
-      "groupName": "all dependencies",
-      "groupSlug": "all"
     },
     {
       "matchPackageNames": ["postcss-custom-properties"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,17 +10,20 @@
     },
     {
       "matchSourceUrls": ["https://github.com/commercetools/ui-kit"],
-      "groupName": "all ui-kit packages"
+      "groupName": "all ui-kit packages",
+      "schedule": ["after 10pm every weekday", "before 8am every weekday"]
     },
     {
       "matchSourceUrls": [
         "https://github.com/commercetools/commercetools-docs-kit"
       ],
-      "groupName": "all docs-kit packages"
+      "groupName": "all docs-kit packages",
+      "schedule": ["after 10pm every weekday", "before 8am every weekday"]
     },
     {
       "matchSourceUrls": ["https://github.com/commercetools/test-data"],
-      "groupName": "all test-data packages"
+      "groupName": "all test-data packages",
+      "schedule": ["after 10pm every weekday", "before 8am every weekday"]
     },
     {
       "matchSourceUrls": ["https://github.com/tdeekens/flopflip"],


### PR DESCRIPTION
#### Summary

As elsewhere applying similar fixes here:

1. The order matters for `packageRules`. You go from not important to important as they're evaluated in order and subsequent rules overwrite prior rules (Renovate docs)
2. `sourceUrlPrefixes` has not worked well elsewhere. We can use `matchSourceUrls` instead which works in all other repos
3. Isolate the update of our runtime in Node.js