### PR TITLE
feat: allow `TypedDocumentNode` as a type for query and mutation params in MC Apollo hooks

### DIFF
--- a/.changeset/giant-papayas-sit.md
+++ b/.changeset/giant-papayas-sit.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell-connectors': minor
+---
+
+Allow `TypedDocumentNode` as a type for query and mutation params in MC Apollo hooks

--- a/packages/application-shell-connectors/src/hooks/apollo-hooks/apollo-hooks.ts
+++ b/packages/application-shell-connectors/src/hooks/apollo-hooks/apollo-hooks.ts
@@ -5,9 +5,10 @@ import type {
   QueryTuple,
   MutationTuple,
   MutationHookOptions,
+  TypedDocumentNode,
+  DocumentNode,
 } from '@apollo/client';
 import { useQuery, useLazyQuery, useMutation } from '@apollo/client/react';
-import type { DocumentNode } from 'graphql';
 import type { TApolloContext } from '../../utils/apollo-context';
 
 type TQueryOptionsWithContext<
@@ -27,7 +28,7 @@ function useMcQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables
 >(
-  query: DocumentNode,
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: TQueryOptionsWithContext<TData, TVariables>
 ): QueryResult<TData, TVariables> {
   return useQuery<TData, TVariables>(query, options);
@@ -37,7 +38,7 @@ function useMcLazyQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables
 >(
-  query: DocumentNode,
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: TQueryOptionsWithContext<TData, TVariables>
 ): QueryTuple<TData, TVariables> {
   return useLazyQuery<TData, TVariables>(query, options);
@@ -47,7 +48,7 @@ function useMcMutation<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables
 >(
-  mutation: DocumentNode,
+  mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: TMutationOptionsWithContext<TData, TVariables>
 ): MutationTuple<TData, TVariables, TApolloContext> {
   return useMutation<TData, TVariables, TApolloContext>(mutation, options);


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

`useMcQuery`, `useMcLazyQuery` and `useMcMutation` accept a `TypedDocumentNode` as query/mutation param.

#### Description

The goal of this PR is to unblock projects where `@commercetools-frontend/application-shell-connectors` is used and start using [`TypedDocumentNode`](https://the-guild.dev/graphql/codegen/plugins/typescript/typed-document-node).
The idea is to test `TypedDocumentNode` in the Standalone Prices web app and check if it improves DX by reducing the amount of boilerplate code needed to use the hooks.
