### PR TITLE
feat(mc-scripts): support custom views in the `config:sync` command

### DIFF
--- a/.changeset/thick-papayas-wave.md
+++ b/.changeset/thick-papayas-wave.md
@@ -1,0 +1,10 @@
+---
+'@commercetools-frontend/application-shell-connectors': minor
+'@commercetools-frontend/application-components': minor
+'@commercetools-frontend/application-config': minor
+'@commercetools-frontend/application-shell': minor
+'@commercetools-frontend/mc-scripts': minor
+'@commercetools-frontend/constants': minor
+---
+
+Enhance the functionality of the `mc-scripts config:sync` command to support custom views.

--- a/@types-extensions/graphql-settings/index.d.ts
+++ b/@types-extensions/graphql-settings/index.d.ts
@@ -34,6 +34,14 @@ declare module '*/create-custom-application.settings.graphql' {
   export default defaultDocument;
 }
 
+declare module '*/create-custom-view.settings.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+  export const CreateCustomViewFromCli: DocumentNode;
+
+  export default defaultDocument;
+}
+
 declare module '*/fetch-custom-application.settings.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
@@ -42,10 +50,26 @@ declare module '*/fetch-custom-application.settings.graphql' {
   export default defaultDocument;
 }
 
+declare module '*/fetch-custom-view.settings.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+  export const FetchCustomViewFromCli: DocumentNode;
+
+  export default defaultDocument;
+}
+
 declare module '*/update-custom-application.settings.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   export const UpdateCustomApplicationFromCli: DocumentNode;
+
+  export default defaultDocument;
+}
+
+declare module '*/update-custom-view.settings.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+  export const UpdateCustomViewFromCli: DocumentNode;
 
   export default defaultDocument;
 }

--- a/packages/application-components/src/types/generated/settings.ts
+++ b/packages/application-components/src/types/generated/settings.ts
@@ -673,6 +673,7 @@ export type TMutation = {
   activateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activateDashboardView?: Maybe<TDashboardView>;
   activateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activateOrderDetailView?: Maybe<TOrderDetailView>;
   activateOrdersListView?: Maybe<TOrdersListView>;
   activateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   activatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -690,6 +691,7 @@ export type TMutation = {
   createCustomersSearchListMyView: TCustomersSearchListMyView;
   createDashboardView: TDashboardView;
   createDiscountCodesCustomView: TDiscountsCustomView;
+  createOrderDetailView: TOrderDetailView;
   createOrdersListView: TOrdersListView;
   createPimSearchListView: TPimSearchListView;
   createProductDiscountsCustomView: TDiscountsCustomView;
@@ -702,6 +704,7 @@ export type TMutation = {
   deactivateCustomersSearchListMyView?: Maybe<TOrdersListView>;
   deactivateDashboardView?: Maybe<TDashboardView>;
   deactivateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deactivateOrderDetailView?: Maybe<TOrderDetailView>;
   deactivateOrdersListView?: Maybe<TOrdersListView>;
   deactivateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   deactivatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -709,6 +712,7 @@ export type TMutation = {
   deactivateProductTypeAttributesView?: Maybe<TProductTypeAttributesView>;
   deactivateProjectSettingsStoresView?: Maybe<TProjectSettingsStoresView>;
   deleteAllDashboardViews: Array<TDashboardView>;
+  deleteAllOrderDetailViews: Array<TOrderDetailView>;
   deleteAllOrdersListViews: Array<TOrdersListView>;
   deleteBusinessUnitsListMyView?: Maybe<TBusinessUnitsListMyView>;
   deleteCartDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -719,6 +723,7 @@ export type TMutation = {
   deleteCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   deleteDashboardView?: Maybe<TDashboardView>;
   deleteDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deleteOrderDetailView?: Maybe<TOrderDetailView>;
   deleteOrdersListView?: Maybe<TOrdersListView>;
   deletePimSearchListView?: Maybe<TPimSearchListView>;
   deleteProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -748,6 +753,7 @@ export type TMutation = {
   updateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   updateDashboardView?: Maybe<TDashboardView>;
   updateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  updateOrderDetailView?: Maybe<TOrderDetailView>;
   updateOrdersListView?: Maybe<TOrdersListView>;
   updatePimSearchListView?: Maybe<TPimSearchListView>;
   updateProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -785,6 +791,11 @@ export type TMutation_ActivateDashboardViewArgs = {
 
 
 export type TMutation_ActivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_ActivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -884,6 +895,11 @@ export type TMutation_CreateDiscountCodesCustomViewArgs = {
 };
 
 
+export type TMutation_CreateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+};
+
+
 export type TMutation_CreateOrdersListViewArgs = {
   data: TOrdersListViewInput;
 };
@@ -940,6 +956,11 @@ export type TMutation_DeactivateDashboardViewArgs = {
 
 
 export type TMutation_DeactivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_DeactivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1018,6 +1039,11 @@ export type TMutation_DeleteDashboardViewArgs = {
 
 
 export type TMutation_DeleteDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_DeleteOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1191,6 +1217,12 @@ export type TMutation_UpdateDiscountCodesCustomViewArgs = {
 };
 
 
+export type TMutation_UpdateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+  id: Scalars['ID'];
+};
+
+
 export type TMutation_UpdateOrdersListViewArgs = {
   data: TOrdersListViewInput;
   id: Scalars['ID'];
@@ -1342,6 +1374,27 @@ export type TOidcSsoConfigDataInput = {
   teamIdForNewUsers: Scalars['String'];
 };
 
+export type TOrderDetailView = {
+  __typename?: 'OrderDetailView';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  nameAllLocales?: Maybe<Array<TLocalizedField>>;
+  projectKey: Scalars['String'];
+  table?: Maybe<TTable>;
+  updatedAt: Scalars['DateTime'];
+  userId: Scalars['String'];
+};
+
+export type TOrderDetailViewInput = {
+  nameAllLocales: Array<TLocalizedFieldCreateInput>;
+  table?: InputMaybe<TOrderDetailViewTableInput>;
+};
+
+export type TOrderDetailViewTableInput = {
+  visibleColumns: Array<Scalars['String']>;
+};
+
 export enum TOrderStatesVisibility {
   HideOrderState = 'HideOrderState',
   HidePaymentState = 'HidePaymentState',
@@ -1412,6 +1465,14 @@ export type TOrganizationExtension = {
 export type TOrganizationExtensionForCustomApplication = {
   __typename?: 'OrganizationExtensionForCustomApplication';
   application: TRestrictedCustomApplicationForOrganization;
+  id: Scalars['ID'];
+  organizationId: Scalars['String'];
+  organizationName?: Maybe<Scalars['String']>;
+};
+
+export type TOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TRestrictedCustomViewForOrganization>;
   id: Scalars['ID'];
   organizationId: Scalars['String'];
   organizationName?: Maybe<Scalars['String']>;
@@ -1556,6 +1617,7 @@ export type TQuery = {
   activeCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activeDashboardView?: Maybe<TDashboardView>;
   activeDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activeOrderDetailView?: Maybe<TOrderDetailView>;
   activeOrdersListView?: Maybe<TOrdersListView>;
   activePimSearchListView?: Maybe<TPimSearchListView>;
   activeProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1593,10 +1655,13 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  orderDetailView?: Maybe<TOrderDetailView>;
+  orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
   ordersListViews: Array<Maybe<TOrdersListView>>;
   organizationExtension?: Maybe<TOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TPimSearchListView>;
   pimSearchListViews: Array<Maybe<TPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1704,6 +1769,11 @@ export type TQuery_MyCustomApplicationsArgs = {
 };
 
 
+export type TQuery_OrderDetailViewArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type TQuery_OrdersListViewArgs = {
   id: Scalars['ID'];
 };
@@ -1716,6 +1786,11 @@ export type TQuery_OrganizationExtensionArgs = {
 
 export type TQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String'];
+};
+
+
+export type TQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String'];
 };
 
 
@@ -1963,7 +2038,8 @@ export type TSampleDataImportMetadata = {
 };
 
 export enum TSampleDatasets {
-  Fashion = 'FASHION'
+  Fashion = 'FASHION',
+  Goodstore = 'GOODSTORE'
 }
 
 export type TSort = {
@@ -2073,12 +2149,27 @@ export type TCreateCustomApplicationFromCliMutationVariables = Exact<{
 
 export type TCreateCustomApplicationFromCliMutation = { __typename?: 'Mutation', createCustomApplication?: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string } | null };
 
+export type TCreateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+}>;
+
+
+export type TCreateCustomViewFromCliMutation = { __typename?: 'Mutation', createCustomView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string } | null };
+
 export type TFetchCustomApplicationFromCliQueryVariables = Exact<{
   entryPointUriPath: Scalars['String'];
 }>;
 
 
 export type TFetchCustomApplicationFromCliQuery = { __typename?: 'Query', organizationExtensionForCustomApplication?: { __typename?: 'OrganizationExtensionForCustomApplication', organizationId: string, application: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string, entryPointUriPath: string, name: string, description?: string | null, url: string, icon: string, permissions: Array<{ __typename?: 'CustomApplicationPermission', name: string, oAuthScopes: Array<string> }>, mainMenuLink: { __typename?: 'CustomApplicationMenuLink', defaultLabel: string, permissions: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }> }, submenuLinks: Array<{ __typename?: 'CustomApplicationSubmenuLink', uriPath: string, defaultLabel: string, permissions: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }> }> } } | null };
+
+export type TFetchCustomViewFromCliQueryVariables = Exact<{
+  customViewId: Scalars['String'];
+}>;
+
+
+export type TFetchCustomViewFromCliQuery = { __typename?: 'Query', organizationExtensionForCustomView?: { __typename?: 'OrganizationExtensionForCustomView', organizationId: string, customView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string, defaultLabel: string, url: string, type: TCustomViewType, locators: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }>, typeSettings?: { __typename?: 'CustomViewTypeSettings', size?: TCustomViewSize | null } | null, permissions: Array<{ __typename?: 'CustomViewPermission', name: string, oAuthScopes: Array<string> }> } | null } | null };
 
 export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
   organizationId: Scalars['String'];
@@ -2088,3 +2179,12 @@ export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
 
 
 export type TUpdateCustomApplicationFromCliMutation = { __typename?: 'Mutation', updateCustomApplication?: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string } | null };
+
+export type TUpdateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+  customViewId: Scalars['String'];
+}>;
+
+
+export type TUpdateCustomViewFromCliMutation = { __typename?: 'Mutation', updateCustomView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string } | null };

--- a/packages/application-config/src/generated/settings.ts
+++ b/packages/application-config/src/generated/settings.ts
@@ -679,6 +679,7 @@ export type TMutation = {
   activateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activateDashboardView?: Maybe<TDashboardView>;
   activateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activateOrderDetailView?: Maybe<TOrderDetailView>;
   activateOrdersListView?: Maybe<TOrdersListView>;
   activateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   activatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -696,6 +697,7 @@ export type TMutation = {
   createCustomersSearchListMyView: TCustomersSearchListMyView;
   createDashboardView: TDashboardView;
   createDiscountCodesCustomView: TDiscountsCustomView;
+  createOrderDetailView: TOrderDetailView;
   createOrdersListView: TOrdersListView;
   createPimSearchListView: TPimSearchListView;
   createProductDiscountsCustomView: TDiscountsCustomView;
@@ -708,6 +710,7 @@ export type TMutation = {
   deactivateCustomersSearchListMyView?: Maybe<TOrdersListView>;
   deactivateDashboardView?: Maybe<TDashboardView>;
   deactivateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deactivateOrderDetailView?: Maybe<TOrderDetailView>;
   deactivateOrdersListView?: Maybe<TOrdersListView>;
   deactivateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   deactivatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -715,6 +718,7 @@ export type TMutation = {
   deactivateProductTypeAttributesView?: Maybe<TProductTypeAttributesView>;
   deactivateProjectSettingsStoresView?: Maybe<TProjectSettingsStoresView>;
   deleteAllDashboardViews: Array<TDashboardView>;
+  deleteAllOrderDetailViews: Array<TOrderDetailView>;
   deleteAllOrdersListViews: Array<TOrdersListView>;
   deleteBusinessUnitsListMyView?: Maybe<TBusinessUnitsListMyView>;
   deleteCartDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -725,6 +729,7 @@ export type TMutation = {
   deleteCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   deleteDashboardView?: Maybe<TDashboardView>;
   deleteDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deleteOrderDetailView?: Maybe<TOrderDetailView>;
   deleteOrdersListView?: Maybe<TOrdersListView>;
   deletePimSearchListView?: Maybe<TPimSearchListView>;
   deleteProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -754,6 +759,7 @@ export type TMutation = {
   updateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   updateDashboardView?: Maybe<TDashboardView>;
   updateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  updateOrderDetailView?: Maybe<TOrderDetailView>;
   updateOrdersListView?: Maybe<TOrdersListView>;
   updatePimSearchListView?: Maybe<TPimSearchListView>;
   updateProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -785,6 +791,10 @@ export type TMutation_ActivateDashboardViewArgs = {
 };
 
 export type TMutation_ActivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_ActivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -866,6 +876,10 @@ export type TMutation_CreateDiscountCodesCustomViewArgs = {
   data: TDiscountsCustomViewInput;
 };
 
+export type TMutation_CreateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+};
+
 export type TMutation_CreateOrdersListViewArgs = {
   data: TOrdersListViewInput;
 };
@@ -911,6 +925,10 @@ export type TMutation_DeactivateDashboardViewArgs = {
 };
 
 export type TMutation_DeactivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_DeactivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -974,6 +992,10 @@ export type TMutation_DeleteDashboardViewArgs = {
 };
 
 export type TMutation_DeleteDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_DeleteOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1115,6 +1137,11 @@ export type TMutation_UpdateDashboardViewArgs = {
 
 export type TMutation_UpdateDiscountCodesCustomViewArgs = {
   data: TDiscountsCustomViewInput;
+  id: Scalars['ID'];
+};
+
+export type TMutation_UpdateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
   id: Scalars['ID'];
 };
 
@@ -1262,6 +1289,27 @@ export type TOidcSsoConfigDataInput = {
   teamIdForNewUsers: Scalars['String'];
 };
 
+export type TOrderDetailView = {
+  __typename?: 'OrderDetailView';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  nameAllLocales?: Maybe<Array<TLocalizedField>>;
+  projectKey: Scalars['String'];
+  table?: Maybe<TTable>;
+  updatedAt: Scalars['DateTime'];
+  userId: Scalars['String'];
+};
+
+export type TOrderDetailViewInput = {
+  nameAllLocales: Array<TLocalizedFieldCreateInput>;
+  table?: InputMaybe<TOrderDetailViewTableInput>;
+};
+
+export type TOrderDetailViewTableInput = {
+  visibleColumns: Array<Scalars['String']>;
+};
+
 export enum TOrderStatesVisibility {
   HideOrderState = 'HideOrderState',
   HidePaymentState = 'HidePaymentState',
@@ -1332,6 +1380,14 @@ export type TOrganizationExtension = {
 export type TOrganizationExtensionForCustomApplication = {
   __typename?: 'OrganizationExtensionForCustomApplication';
   application: TRestrictedCustomApplicationForOrganization;
+  id: Scalars['ID'];
+  organizationId: Scalars['String'];
+  organizationName?: Maybe<Scalars['String']>;
+};
+
+export type TOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TRestrictedCustomViewForOrganization>;
   id: Scalars['ID'];
   organizationId: Scalars['String'];
   organizationName?: Maybe<Scalars['String']>;
@@ -1473,6 +1529,7 @@ export type TQuery = {
   activeCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activeDashboardView?: Maybe<TDashboardView>;
   activeDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activeOrderDetailView?: Maybe<TOrderDetailView>;
   activeOrdersListView?: Maybe<TOrdersListView>;
   activePimSearchListView?: Maybe<TPimSearchListView>;
   activeProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1510,10 +1567,13 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  orderDetailView?: Maybe<TOrderDetailView>;
+  orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
   ordersListViews: Array<Maybe<TOrdersListView>>;
   organizationExtension?: Maybe<TOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TPimSearchListView>;
   pimSearchListViews: Array<Maybe<TPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1604,6 +1664,10 @@ export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
 };
 
+export type TQuery_OrderDetailViewArgs = {
+  id: Scalars['ID'];
+};
+
 export type TQuery_OrdersListViewArgs = {
   id: Scalars['ID'];
 };
@@ -1614,6 +1678,10 @@ export type TQuery_OrganizationExtensionArgs = {
 
 export type TQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String'];
+};
+
+export type TQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String'];
 };
 
 export type TQuery_PimSearchListViewArgs = {
@@ -1854,6 +1922,7 @@ export type TSampleDataImportMetadata = {
 
 export enum TSampleDatasets {
   Fashion = 'FASHION',
+  Goodstore = 'GOODSTORE',
 }
 
 export type TSort = {
@@ -2061,6 +2130,19 @@ export type TCreateCustomApplicationFromCliMutation = {
   } | null;
 };
 
+export type TCreateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+}>;
+
+export type TCreateCustomViewFromCliMutation = {
+  __typename?: 'Mutation';
+  createCustomView?: {
+    __typename?: 'RestrictedCustomViewForOrganization';
+    id: string;
+  } | null;
+};
+
 export type TFetchCustomApplicationFromCliQueryVariables = Exact<{
   entryPointUriPath: Scalars['String'];
 }>;
@@ -2108,6 +2190,40 @@ export type TFetchCustomApplicationFromCliQuery = {
   } | null;
 };
 
+export type TFetchCustomViewFromCliQueryVariables = Exact<{
+  customViewId: Scalars['String'];
+}>;
+
+export type TFetchCustomViewFromCliQuery = {
+  __typename?: 'Query';
+  organizationExtensionForCustomView?: {
+    __typename?: 'OrganizationExtensionForCustomView';
+    organizationId: string;
+    customView?: {
+      __typename?: 'RestrictedCustomViewForOrganization';
+      id: string;
+      defaultLabel: string;
+      url: string;
+      type: TCustomViewType;
+      locators: Array<string>;
+      labelAllLocales: Array<{
+        __typename?: 'LocalizedField';
+        locale: string;
+        value: string;
+      }>;
+      typeSettings?: {
+        __typename?: 'CustomViewTypeSettings';
+        size?: TCustomViewSize | null;
+      } | null;
+      permissions: Array<{
+        __typename?: 'CustomViewPermission';
+        name: string;
+        oAuthScopes: Array<string>;
+      }>;
+    } | null;
+  } | null;
+};
+
 export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
   organizationId: Scalars['String'];
   data: TCustomApplicationDraftDataInput;
@@ -2118,6 +2234,20 @@ export type TUpdateCustomApplicationFromCliMutation = {
   __typename?: 'Mutation';
   updateCustomApplication?: {
     __typename?: 'RestrictedCustomApplicationForOrganization';
+    id: string;
+  } | null;
+};
+
+export type TUpdateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+  customViewId: Scalars['String'];
+}>;
+
+export type TUpdateCustomViewFromCliMutation = {
+  __typename?: 'Mutation';
+  updateCustomView?: {
+    __typename?: 'RestrictedCustomViewForOrganization';
     id: string;
   } | null;
 };

--- a/packages/application-shell-connectors/src/types/generated/settings.ts
+++ b/packages/application-shell-connectors/src/types/generated/settings.ts
@@ -673,6 +673,7 @@ export type TMutation = {
   activateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activateDashboardView?: Maybe<TDashboardView>;
   activateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activateOrderDetailView?: Maybe<TOrderDetailView>;
   activateOrdersListView?: Maybe<TOrdersListView>;
   activateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   activatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -690,6 +691,7 @@ export type TMutation = {
   createCustomersSearchListMyView: TCustomersSearchListMyView;
   createDashboardView: TDashboardView;
   createDiscountCodesCustomView: TDiscountsCustomView;
+  createOrderDetailView: TOrderDetailView;
   createOrdersListView: TOrdersListView;
   createPimSearchListView: TPimSearchListView;
   createProductDiscountsCustomView: TDiscountsCustomView;
@@ -702,6 +704,7 @@ export type TMutation = {
   deactivateCustomersSearchListMyView?: Maybe<TOrdersListView>;
   deactivateDashboardView?: Maybe<TDashboardView>;
   deactivateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deactivateOrderDetailView?: Maybe<TOrderDetailView>;
   deactivateOrdersListView?: Maybe<TOrdersListView>;
   deactivateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   deactivatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -709,6 +712,7 @@ export type TMutation = {
   deactivateProductTypeAttributesView?: Maybe<TProductTypeAttributesView>;
   deactivateProjectSettingsStoresView?: Maybe<TProjectSettingsStoresView>;
   deleteAllDashboardViews: Array<TDashboardView>;
+  deleteAllOrderDetailViews: Array<TOrderDetailView>;
   deleteAllOrdersListViews: Array<TOrdersListView>;
   deleteBusinessUnitsListMyView?: Maybe<TBusinessUnitsListMyView>;
   deleteCartDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -719,6 +723,7 @@ export type TMutation = {
   deleteCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   deleteDashboardView?: Maybe<TDashboardView>;
   deleteDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deleteOrderDetailView?: Maybe<TOrderDetailView>;
   deleteOrdersListView?: Maybe<TOrdersListView>;
   deletePimSearchListView?: Maybe<TPimSearchListView>;
   deleteProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -748,6 +753,7 @@ export type TMutation = {
   updateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   updateDashboardView?: Maybe<TDashboardView>;
   updateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  updateOrderDetailView?: Maybe<TOrderDetailView>;
   updateOrdersListView?: Maybe<TOrdersListView>;
   updatePimSearchListView?: Maybe<TPimSearchListView>;
   updateProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -785,6 +791,11 @@ export type TMutation_ActivateDashboardViewArgs = {
 
 
 export type TMutation_ActivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_ActivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -884,6 +895,11 @@ export type TMutation_CreateDiscountCodesCustomViewArgs = {
 };
 
 
+export type TMutation_CreateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+};
+
+
 export type TMutation_CreateOrdersListViewArgs = {
   data: TOrdersListViewInput;
 };
@@ -940,6 +956,11 @@ export type TMutation_DeactivateDashboardViewArgs = {
 
 
 export type TMutation_DeactivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_DeactivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1018,6 +1039,11 @@ export type TMutation_DeleteDashboardViewArgs = {
 
 
 export type TMutation_DeleteDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_DeleteOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1191,6 +1217,12 @@ export type TMutation_UpdateDiscountCodesCustomViewArgs = {
 };
 
 
+export type TMutation_UpdateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+  id: Scalars['ID'];
+};
+
+
 export type TMutation_UpdateOrdersListViewArgs = {
   data: TOrdersListViewInput;
   id: Scalars['ID'];
@@ -1342,6 +1374,27 @@ export type TOidcSsoConfigDataInput = {
   teamIdForNewUsers: Scalars['String'];
 };
 
+export type TOrderDetailView = {
+  __typename?: 'OrderDetailView';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  nameAllLocales?: Maybe<Array<TLocalizedField>>;
+  projectKey: Scalars['String'];
+  table?: Maybe<TTable>;
+  updatedAt: Scalars['DateTime'];
+  userId: Scalars['String'];
+};
+
+export type TOrderDetailViewInput = {
+  nameAllLocales: Array<TLocalizedFieldCreateInput>;
+  table?: InputMaybe<TOrderDetailViewTableInput>;
+};
+
+export type TOrderDetailViewTableInput = {
+  visibleColumns: Array<Scalars['String']>;
+};
+
 export enum TOrderStatesVisibility {
   HideOrderState = 'HideOrderState',
   HidePaymentState = 'HidePaymentState',
@@ -1412,6 +1465,14 @@ export type TOrganizationExtension = {
 export type TOrganizationExtensionForCustomApplication = {
   __typename?: 'OrganizationExtensionForCustomApplication';
   application: TRestrictedCustomApplicationForOrganization;
+  id: Scalars['ID'];
+  organizationId: Scalars['String'];
+  organizationName?: Maybe<Scalars['String']>;
+};
+
+export type TOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TRestrictedCustomViewForOrganization>;
   id: Scalars['ID'];
   organizationId: Scalars['String'];
   organizationName?: Maybe<Scalars['String']>;
@@ -1556,6 +1617,7 @@ export type TQuery = {
   activeCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activeDashboardView?: Maybe<TDashboardView>;
   activeDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activeOrderDetailView?: Maybe<TOrderDetailView>;
   activeOrdersListView?: Maybe<TOrdersListView>;
   activePimSearchListView?: Maybe<TPimSearchListView>;
   activeProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1593,10 +1655,13 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  orderDetailView?: Maybe<TOrderDetailView>;
+  orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
   ordersListViews: Array<Maybe<TOrdersListView>>;
   organizationExtension?: Maybe<TOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TPimSearchListView>;
   pimSearchListViews: Array<Maybe<TPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1704,6 +1769,11 @@ export type TQuery_MyCustomApplicationsArgs = {
 };
 
 
+export type TQuery_OrderDetailViewArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type TQuery_OrdersListViewArgs = {
   id: Scalars['ID'];
 };
@@ -1716,6 +1786,11 @@ export type TQuery_OrganizationExtensionArgs = {
 
 export type TQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String'];
+};
+
+
+export type TQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String'];
 };
 
 
@@ -1963,7 +2038,8 @@ export type TSampleDataImportMetadata = {
 };
 
 export enum TSampleDatasets {
-  Fashion = 'FASHION'
+  Fashion = 'FASHION',
+  Goodstore = 'GOODSTORE'
 }
 
 export type TSort = {
@@ -2073,12 +2149,27 @@ export type TCreateCustomApplicationFromCliMutationVariables = Exact<{
 
 export type TCreateCustomApplicationFromCliMutation = { __typename?: 'Mutation', createCustomApplication?: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string } | null };
 
+export type TCreateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+}>;
+
+
+export type TCreateCustomViewFromCliMutation = { __typename?: 'Mutation', createCustomView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string } | null };
+
 export type TFetchCustomApplicationFromCliQueryVariables = Exact<{
   entryPointUriPath: Scalars['String'];
 }>;
 
 
 export type TFetchCustomApplicationFromCliQuery = { __typename?: 'Query', organizationExtensionForCustomApplication?: { __typename?: 'OrganizationExtensionForCustomApplication', organizationId: string, application: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string, entryPointUriPath: string, name: string, description?: string | null, url: string, icon: string, permissions: Array<{ __typename?: 'CustomApplicationPermission', name: string, oAuthScopes: Array<string> }>, mainMenuLink: { __typename?: 'CustomApplicationMenuLink', defaultLabel: string, permissions: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }> }, submenuLinks: Array<{ __typename?: 'CustomApplicationSubmenuLink', uriPath: string, defaultLabel: string, permissions: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }> }> } } | null };
+
+export type TFetchCustomViewFromCliQueryVariables = Exact<{
+  customViewId: Scalars['String'];
+}>;
+
+
+export type TFetchCustomViewFromCliQuery = { __typename?: 'Query', organizationExtensionForCustomView?: { __typename?: 'OrganizationExtensionForCustomView', organizationId: string, customView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string, defaultLabel: string, url: string, type: TCustomViewType, locators: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }>, typeSettings?: { __typename?: 'CustomViewTypeSettings', size?: TCustomViewSize | null } | null, permissions: Array<{ __typename?: 'CustomViewPermission', name: string, oAuthScopes: Array<string> }> } | null } | null };
 
 export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
   organizationId: Scalars['String'];
@@ -2088,3 +2179,12 @@ export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
 
 
 export type TUpdateCustomApplicationFromCliMutation = { __typename?: 'Mutation', updateCustomApplication?: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string } | null };
+
+export type TUpdateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+  customViewId: Scalars['String'];
+}>;
+
+
+export type TUpdateCustomViewFromCliMutation = { __typename?: 'Mutation', updateCustomView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string } | null };

--- a/packages/application-shell/src/types/generated/settings.ts
+++ b/packages/application-shell/src/types/generated/settings.ts
@@ -673,6 +673,7 @@ export type TMutation = {
   activateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activateDashboardView?: Maybe<TDashboardView>;
   activateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activateOrderDetailView?: Maybe<TOrderDetailView>;
   activateOrdersListView?: Maybe<TOrdersListView>;
   activateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   activatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -690,6 +691,7 @@ export type TMutation = {
   createCustomersSearchListMyView: TCustomersSearchListMyView;
   createDashboardView: TDashboardView;
   createDiscountCodesCustomView: TDiscountsCustomView;
+  createOrderDetailView: TOrderDetailView;
   createOrdersListView: TOrdersListView;
   createPimSearchListView: TPimSearchListView;
   createProductDiscountsCustomView: TDiscountsCustomView;
@@ -702,6 +704,7 @@ export type TMutation = {
   deactivateCustomersSearchListMyView?: Maybe<TOrdersListView>;
   deactivateDashboardView?: Maybe<TDashboardView>;
   deactivateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deactivateOrderDetailView?: Maybe<TOrderDetailView>;
   deactivateOrdersListView?: Maybe<TOrdersListView>;
   deactivateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   deactivatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -709,6 +712,7 @@ export type TMutation = {
   deactivateProductTypeAttributesView?: Maybe<TProductTypeAttributesView>;
   deactivateProjectSettingsStoresView?: Maybe<TProjectSettingsStoresView>;
   deleteAllDashboardViews: Array<TDashboardView>;
+  deleteAllOrderDetailViews: Array<TOrderDetailView>;
   deleteAllOrdersListViews: Array<TOrdersListView>;
   deleteBusinessUnitsListMyView?: Maybe<TBusinessUnitsListMyView>;
   deleteCartDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -719,6 +723,7 @@ export type TMutation = {
   deleteCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   deleteDashboardView?: Maybe<TDashboardView>;
   deleteDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deleteOrderDetailView?: Maybe<TOrderDetailView>;
   deleteOrdersListView?: Maybe<TOrdersListView>;
   deletePimSearchListView?: Maybe<TPimSearchListView>;
   deleteProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -748,6 +753,7 @@ export type TMutation = {
   updateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   updateDashboardView?: Maybe<TDashboardView>;
   updateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  updateOrderDetailView?: Maybe<TOrderDetailView>;
   updateOrdersListView?: Maybe<TOrdersListView>;
   updatePimSearchListView?: Maybe<TPimSearchListView>;
   updateProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -785,6 +791,11 @@ export type TMutation_ActivateDashboardViewArgs = {
 
 
 export type TMutation_ActivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_ActivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -884,6 +895,11 @@ export type TMutation_CreateDiscountCodesCustomViewArgs = {
 };
 
 
+export type TMutation_CreateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+};
+
+
 export type TMutation_CreateOrdersListViewArgs = {
   data: TOrdersListViewInput;
 };
@@ -940,6 +956,11 @@ export type TMutation_DeactivateDashboardViewArgs = {
 
 
 export type TMutation_DeactivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_DeactivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1018,6 +1039,11 @@ export type TMutation_DeleteDashboardViewArgs = {
 
 
 export type TMutation_DeleteDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type TMutation_DeleteOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1191,6 +1217,12 @@ export type TMutation_UpdateDiscountCodesCustomViewArgs = {
 };
 
 
+export type TMutation_UpdateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+  id: Scalars['ID'];
+};
+
+
 export type TMutation_UpdateOrdersListViewArgs = {
   data: TOrdersListViewInput;
   id: Scalars['ID'];
@@ -1342,6 +1374,27 @@ export type TOidcSsoConfigDataInput = {
   teamIdForNewUsers: Scalars['String'];
 };
 
+export type TOrderDetailView = {
+  __typename?: 'OrderDetailView';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  nameAllLocales?: Maybe<Array<TLocalizedField>>;
+  projectKey: Scalars['String'];
+  table?: Maybe<TTable>;
+  updatedAt: Scalars['DateTime'];
+  userId: Scalars['String'];
+};
+
+export type TOrderDetailViewInput = {
+  nameAllLocales: Array<TLocalizedFieldCreateInput>;
+  table?: InputMaybe<TOrderDetailViewTableInput>;
+};
+
+export type TOrderDetailViewTableInput = {
+  visibleColumns: Array<Scalars['String']>;
+};
+
 export enum TOrderStatesVisibility {
   HideOrderState = 'HideOrderState',
   HidePaymentState = 'HidePaymentState',
@@ -1412,6 +1465,14 @@ export type TOrganizationExtension = {
 export type TOrganizationExtensionForCustomApplication = {
   __typename?: 'OrganizationExtensionForCustomApplication';
   application: TRestrictedCustomApplicationForOrganization;
+  id: Scalars['ID'];
+  organizationId: Scalars['String'];
+  organizationName?: Maybe<Scalars['String']>;
+};
+
+export type TOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TRestrictedCustomViewForOrganization>;
   id: Scalars['ID'];
   organizationId: Scalars['String'];
   organizationName?: Maybe<Scalars['String']>;
@@ -1556,6 +1617,7 @@ export type TQuery = {
   activeCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activeDashboardView?: Maybe<TDashboardView>;
   activeDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activeOrderDetailView?: Maybe<TOrderDetailView>;
   activeOrdersListView?: Maybe<TOrdersListView>;
   activePimSearchListView?: Maybe<TPimSearchListView>;
   activeProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1593,10 +1655,13 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  orderDetailView?: Maybe<TOrderDetailView>;
+  orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
   ordersListViews: Array<Maybe<TOrdersListView>>;
   organizationExtension?: Maybe<TOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TPimSearchListView>;
   pimSearchListViews: Array<Maybe<TPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1704,6 +1769,11 @@ export type TQuery_MyCustomApplicationsArgs = {
 };
 
 
+export type TQuery_OrderDetailViewArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type TQuery_OrdersListViewArgs = {
   id: Scalars['ID'];
 };
@@ -1716,6 +1786,11 @@ export type TQuery_OrganizationExtensionArgs = {
 
 export type TQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String'];
+};
+
+
+export type TQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String'];
 };
 
 
@@ -1963,7 +2038,8 @@ export type TSampleDataImportMetadata = {
 };
 
 export enum TSampleDatasets {
-  Fashion = 'FASHION'
+  Fashion = 'FASHION',
+  Goodstore = 'GOODSTORE'
 }
 
 export type TSort = {
@@ -2073,12 +2149,27 @@ export type TCreateCustomApplicationFromCliMutationVariables = Exact<{
 
 export type TCreateCustomApplicationFromCliMutation = { __typename?: 'Mutation', createCustomApplication?: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string } | null };
 
+export type TCreateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+}>;
+
+
+export type TCreateCustomViewFromCliMutation = { __typename?: 'Mutation', createCustomView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string } | null };
+
 export type TFetchCustomApplicationFromCliQueryVariables = Exact<{
   entryPointUriPath: Scalars['String'];
 }>;
 
 
 export type TFetchCustomApplicationFromCliQuery = { __typename?: 'Query', organizationExtensionForCustomApplication?: { __typename?: 'OrganizationExtensionForCustomApplication', organizationId: string, application: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string, entryPointUriPath: string, name: string, description?: string | null, url: string, icon: string, permissions: Array<{ __typename?: 'CustomApplicationPermission', name: string, oAuthScopes: Array<string> }>, mainMenuLink: { __typename?: 'CustomApplicationMenuLink', defaultLabel: string, permissions: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }> }, submenuLinks: Array<{ __typename?: 'CustomApplicationSubmenuLink', uriPath: string, defaultLabel: string, permissions: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }> }> } } | null };
+
+export type TFetchCustomViewFromCliQueryVariables = Exact<{
+  customViewId: Scalars['String'];
+}>;
+
+
+export type TFetchCustomViewFromCliQuery = { __typename?: 'Query', organizationExtensionForCustomView?: { __typename?: 'OrganizationExtensionForCustomView', organizationId: string, customView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string, defaultLabel: string, url: string, type: TCustomViewType, locators: Array<string>, labelAllLocales: Array<{ __typename?: 'LocalizedField', locale: string, value: string }>, typeSettings?: { __typename?: 'CustomViewTypeSettings', size?: TCustomViewSize | null } | null, permissions: Array<{ __typename?: 'CustomViewPermission', name: string, oAuthScopes: Array<string> }> } | null } | null };
 
 export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
   organizationId: Scalars['String'];
@@ -2088,3 +2179,12 @@ export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
 
 
 export type TUpdateCustomApplicationFromCliMutation = { __typename?: 'Mutation', updateCustomApplication?: { __typename?: 'RestrictedCustomApplicationForOrganization', id: string } | null };
+
+export type TUpdateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+  customViewId: Scalars['String'];
+}>;
+
+
+export type TUpdateCustomViewFromCliMutation = { __typename?: 'Mutation', updateCustomView?: { __typename?: 'RestrictedCustomViewForOrganization', id: string } | null };

--- a/packages/constants/src/generated/settings.ts
+++ b/packages/constants/src/generated/settings.ts
@@ -679,6 +679,7 @@ export type TMutation = {
   activateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activateDashboardView?: Maybe<TDashboardView>;
   activateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activateOrderDetailView?: Maybe<TOrderDetailView>;
   activateOrdersListView?: Maybe<TOrdersListView>;
   activateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   activatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -696,6 +697,7 @@ export type TMutation = {
   createCustomersSearchListMyView: TCustomersSearchListMyView;
   createDashboardView: TDashboardView;
   createDiscountCodesCustomView: TDiscountsCustomView;
+  createOrderDetailView: TOrderDetailView;
   createOrdersListView: TOrdersListView;
   createPimSearchListView: TPimSearchListView;
   createProductDiscountsCustomView: TDiscountsCustomView;
@@ -708,6 +710,7 @@ export type TMutation = {
   deactivateCustomersSearchListMyView?: Maybe<TOrdersListView>;
   deactivateDashboardView?: Maybe<TDashboardView>;
   deactivateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deactivateOrderDetailView?: Maybe<TOrderDetailView>;
   deactivateOrdersListView?: Maybe<TOrdersListView>;
   deactivateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   deactivatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -715,6 +718,7 @@ export type TMutation = {
   deactivateProductTypeAttributesView?: Maybe<TProductTypeAttributesView>;
   deactivateProjectSettingsStoresView?: Maybe<TProjectSettingsStoresView>;
   deleteAllDashboardViews: Array<TDashboardView>;
+  deleteAllOrderDetailViews: Array<TOrderDetailView>;
   deleteAllOrdersListViews: Array<TOrdersListView>;
   deleteBusinessUnitsListMyView?: Maybe<TBusinessUnitsListMyView>;
   deleteCartDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -725,6 +729,7 @@ export type TMutation = {
   deleteCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   deleteDashboardView?: Maybe<TDashboardView>;
   deleteDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deleteOrderDetailView?: Maybe<TOrderDetailView>;
   deleteOrdersListView?: Maybe<TOrdersListView>;
   deletePimSearchListView?: Maybe<TPimSearchListView>;
   deleteProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -754,6 +759,7 @@ export type TMutation = {
   updateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   updateDashboardView?: Maybe<TDashboardView>;
   updateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  updateOrderDetailView?: Maybe<TOrderDetailView>;
   updateOrdersListView?: Maybe<TOrdersListView>;
   updatePimSearchListView?: Maybe<TPimSearchListView>;
   updateProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -785,6 +791,10 @@ export type TMutation_ActivateDashboardViewArgs = {
 };
 
 export type TMutation_ActivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_ActivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -866,6 +876,10 @@ export type TMutation_CreateDiscountCodesCustomViewArgs = {
   data: TDiscountsCustomViewInput;
 };
 
+export type TMutation_CreateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+};
+
 export type TMutation_CreateOrdersListViewArgs = {
   data: TOrdersListViewInput;
 };
@@ -911,6 +925,10 @@ export type TMutation_DeactivateDashboardViewArgs = {
 };
 
 export type TMutation_DeactivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_DeactivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -974,6 +992,10 @@ export type TMutation_DeleteDashboardViewArgs = {
 };
 
 export type TMutation_DeleteDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_DeleteOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1115,6 +1137,11 @@ export type TMutation_UpdateDashboardViewArgs = {
 
 export type TMutation_UpdateDiscountCodesCustomViewArgs = {
   data: TDiscountsCustomViewInput;
+  id: Scalars['ID'];
+};
+
+export type TMutation_UpdateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
   id: Scalars['ID'];
 };
 
@@ -1262,6 +1289,27 @@ export type TOidcSsoConfigDataInput = {
   teamIdForNewUsers: Scalars['String'];
 };
 
+export type TOrderDetailView = {
+  __typename?: 'OrderDetailView';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  nameAllLocales?: Maybe<Array<TLocalizedField>>;
+  projectKey: Scalars['String'];
+  table?: Maybe<TTable>;
+  updatedAt: Scalars['DateTime'];
+  userId: Scalars['String'];
+};
+
+export type TOrderDetailViewInput = {
+  nameAllLocales: Array<TLocalizedFieldCreateInput>;
+  table?: InputMaybe<TOrderDetailViewTableInput>;
+};
+
+export type TOrderDetailViewTableInput = {
+  visibleColumns: Array<Scalars['String']>;
+};
+
 export enum TOrderStatesVisibility {
   HideOrderState = 'HideOrderState',
   HidePaymentState = 'HidePaymentState',
@@ -1332,6 +1380,14 @@ export type TOrganizationExtension = {
 export type TOrganizationExtensionForCustomApplication = {
   __typename?: 'OrganizationExtensionForCustomApplication';
   application: TRestrictedCustomApplicationForOrganization;
+  id: Scalars['ID'];
+  organizationId: Scalars['String'];
+  organizationName?: Maybe<Scalars['String']>;
+};
+
+export type TOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TRestrictedCustomViewForOrganization>;
   id: Scalars['ID'];
   organizationId: Scalars['String'];
   organizationName?: Maybe<Scalars['String']>;
@@ -1473,6 +1529,7 @@ export type TQuery = {
   activeCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activeDashboardView?: Maybe<TDashboardView>;
   activeDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activeOrderDetailView?: Maybe<TOrderDetailView>;
   activeOrdersListView?: Maybe<TOrdersListView>;
   activePimSearchListView?: Maybe<TPimSearchListView>;
   activeProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1510,10 +1567,13 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  orderDetailView?: Maybe<TOrderDetailView>;
+  orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
   ordersListViews: Array<Maybe<TOrdersListView>>;
   organizationExtension?: Maybe<TOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TPimSearchListView>;
   pimSearchListViews: Array<Maybe<TPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1604,6 +1664,10 @@ export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
 };
 
+export type TQuery_OrderDetailViewArgs = {
+  id: Scalars['ID'];
+};
+
 export type TQuery_OrdersListViewArgs = {
   id: Scalars['ID'];
 };
@@ -1614,6 +1678,10 @@ export type TQuery_OrganizationExtensionArgs = {
 
 export type TQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String'];
+};
+
+export type TQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String'];
 };
 
 export type TQuery_PimSearchListViewArgs = {
@@ -1854,6 +1922,7 @@ export type TSampleDataImportMetadata = {
 
 export enum TSampleDatasets {
   Fashion = 'FASHION',
+  Goodstore = 'GOODSTORE',
 }
 
 export type TSort = {
@@ -2061,6 +2130,19 @@ export type TCreateCustomApplicationFromCliMutation = {
   } | null;
 };
 
+export type TCreateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+}>;
+
+export type TCreateCustomViewFromCliMutation = {
+  __typename?: 'Mutation';
+  createCustomView?: {
+    __typename?: 'RestrictedCustomViewForOrganization';
+    id: string;
+  } | null;
+};
+
 export type TFetchCustomApplicationFromCliQueryVariables = Exact<{
   entryPointUriPath: Scalars['String'];
 }>;
@@ -2108,6 +2190,40 @@ export type TFetchCustomApplicationFromCliQuery = {
   } | null;
 };
 
+export type TFetchCustomViewFromCliQueryVariables = Exact<{
+  customViewId: Scalars['String'];
+}>;
+
+export type TFetchCustomViewFromCliQuery = {
+  __typename?: 'Query';
+  organizationExtensionForCustomView?: {
+    __typename?: 'OrganizationExtensionForCustomView';
+    organizationId: string;
+    customView?: {
+      __typename?: 'RestrictedCustomViewForOrganization';
+      id: string;
+      defaultLabel: string;
+      url: string;
+      type: TCustomViewType;
+      locators: Array<string>;
+      labelAllLocales: Array<{
+        __typename?: 'LocalizedField';
+        locale: string;
+        value: string;
+      }>;
+      typeSettings?: {
+        __typename?: 'CustomViewTypeSettings';
+        size?: TCustomViewSize | null;
+      } | null;
+      permissions: Array<{
+        __typename?: 'CustomViewPermission';
+        name: string;
+        oAuthScopes: Array<string>;
+      }>;
+    } | null;
+  } | null;
+};
+
 export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
   organizationId: Scalars['String'];
   data: TCustomApplicationDraftDataInput;
@@ -2118,6 +2234,20 @@ export type TUpdateCustomApplicationFromCliMutation = {
   __typename?: 'Mutation';
   updateCustomApplication?: {
     __typename?: 'RestrictedCustomApplicationForOrganization';
+    id: string;
+  } | null;
+};
+
+export type TUpdateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+  customViewId: Scalars['String'];
+}>;
+
+export type TUpdateCustomViewFromCliMutation = {
+  __typename?: 'Mutation';
+  updateCustomView?: {
+    __typename?: 'RestrictedCustomViewForOrganization';
     id: string;
   } | null;
 };

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -111,6 +111,7 @@
     "webpackbar": "5.0.2"
   },
   "devDependencies": {
+    "@commercetools-test-data/custom-view": "^6.4.1",
     "@tsconfig/node16": "^16.1.1",
     "@types/fs-extra": "^11.0.1",
     "@types/lodash": "^4.14.198",

--- a/packages/mc-scripts/src/commands/config-sync.ts
+++ b/packages/mc-scripts/src/commands/config-sync.ts
@@ -44,14 +44,10 @@ const getMcUrlLink = ({
   return customEntityLink;
 };
 
-const checkIfCustomApplicationConfigData = (
-  localCustomEntityData: CustomApplicationData | CustomViewData
-): localCustomEntityData is CustomApplicationData => {
-  return (
-    (localCustomEntityData as CustomApplicationData).entryPointUriPath !==
-    undefined
-  );
-};
+const isCustomViewData = (
+  data: CustomApplicationData | CustomViewData
+): data is CustomViewData =>
+  (data as CustomApplicationData).entryPointUriPath === undefined;
 
 type TCreateOrUpdateCustomApplication = {
   mcApiUrl: string;
@@ -352,7 +348,6 @@ async function createOrUpdateCustomView({
       mcApiUrl,
       organizationId,
       data,
-      customViewId,
     });
 
     // This check is technically not necessary, as the `graphql-request` client
@@ -474,22 +469,18 @@ async function run(options: TCliCommandConfigSyncOptions) {
     );
   }
 
-  const isCustomApplicationConfigData = checkIfCustomApplicationConfigData(
-    localCustomEntityData
-  );
-
-  if (isCustomApplicationConfigData) {
-    createOrUpdateCustomApplication({
-      mcApiUrl,
-      localCustomEntityData,
-      applicationIdentifier,
-      options,
-    });
-  } else {
+  if (isCustomViewData(localCustomEntityData)) {
     createOrUpdateCustomView({
       mcApiUrl,
       localCustomEntityData,
       customViewId: customViewId || localCustomEntityData.id,
+      options,
+    });
+  } else {
+    createOrUpdateCustomApplication({
+      mcApiUrl,
+      localCustomEntityData,
+      applicationIdentifier,
       options,
     });
   }

--- a/packages/mc-scripts/src/commands/config-sync.ts
+++ b/packages/mc-scripts/src/commands/config-sync.ts
@@ -24,14 +24,24 @@ import {
 
 const credentialsStorage = new CredentialsStorage();
 
-const getMcUrlLink = (
-  mcApiUrl: string,
-  organizationId: string,
-  customEntityId: string
-) => {
+type TGetMcUrlLink = {
+  mcApiUrl: string;
+  organizationId: string;
+  customEntityId: string;
+  isCustomView?: boolean;
+};
+
+const getMcUrlLink = ({
+  mcApiUrl,
+  organizationId,
+  customEntityId,
+  isCustomView,
+}: TGetMcUrlLink) => {
   const mcUrl = mcApiUrl.replace('mc-api', 'mc');
-  const customAppLink = `${mcUrl}/account/organizations/${organizationId}/custom-applications/owned/${customEntityId}`;
-  return customAppLink;
+  const customEntityLink = `${mcUrl}/account/organizations/${organizationId}/custom-${
+    isCustomView ? 'views' : 'applications'
+  }/owned/${customEntityId}`;
+  return customEntityLink;
 };
 
 const checkIfCustomApplicationConfigData = (
@@ -152,11 +162,11 @@ async function createOrUpdateCustomApplication({
       throw new Error('Failed to create the Custom Application.');
     }
 
-    const customAppLink = getMcUrlLink(
+    const customAppLink = getMcUrlLink({
       mcApiUrl,
       organizationId,
-      createdCustomApplication.id
-    );
+      customEntityId: createdCustomApplication.id,
+    });
     console.log(
       chalk.green(
         `Custom Application created.\nPlease update the "env.production.applicationId" field in your local Custom Application config file with the following value: "${chalk.green(
@@ -172,11 +182,11 @@ async function createOrUpdateCustomApplication({
     return;
   }
 
-  const customAppLink = getMcUrlLink(
+  const customAppLink = getMcUrlLink({
     mcApiUrl,
-    fetchedCustomApplication.organizationId,
-    fetchedCustomApplication.application.id
-  );
+    organizationId: fetchedCustomApplication.organizationId,
+    customEntityId: fetchedCustomApplication.application.id,
+  });
 
   const configDiff = getCustomApplicationConfigDiff(
     fetchedCustomApplication.application as CustomApplicationData,
@@ -353,11 +363,12 @@ async function createOrUpdateCustomView({
       throw new Error('Failed to create the Custom View.');
     }
 
-    const customViewLink = getMcUrlLink(
+    const customViewLink = getMcUrlLink({
       mcApiUrl,
       organizationId,
-      createdCustomView.id
-    );
+      customEntityId: createdCustomView.id,
+      isCustomView: true,
+    });
     console.log(
       chalk.green(
         `Custom View created.\nPlease update the "env.production.customViewId" field in your local Custom View config file with the following value: "${chalk.green(
@@ -373,11 +384,12 @@ async function createOrUpdateCustomView({
     return;
   }
 
-  const customViewLink = getMcUrlLink(
+  const customViewLink = getMcUrlLink({
     mcApiUrl,
-    fetchedCustomView.organizationId,
-    fetchedCustomView.customView.id
-  );
+    organizationId: fetchedCustomView.organizationId,
+    customEntityId: fetchedCustomView?.customView?.id || '',
+    isCustomView: true,
+  });
 
   const configDiff = getCustomViewConfigDiff(
     fetchedCustomView.customView as unknown as CustomViewData,
@@ -434,7 +446,7 @@ async function createOrUpdateCustomView({
     mcApiUrl,
     organizationId: fetchedCustomView.organizationId,
     data: omit(localCustomEntityData, ['id']),
-    customViewId: fetchedCustomView.customView.id,
+    customViewId: fetchedCustomView?.customView?.id || '',
   });
 
   console.log(chalk.green(`Custom View updated.`));

--- a/packages/mc-scripts/src/commands/config-sync.ts
+++ b/packages/mc-scripts/src/commands/config-sync.ts
@@ -256,6 +256,7 @@ type TCreateOrUpdateCustomView = {
   localCustomEntityData: CustomViewData;
   customViewId: string;
   options: TCliCommandConfigSyncOptions;
+  applicationIdentifier: string;
 };
 
 async function createOrUpdateCustomView({
@@ -263,16 +264,19 @@ async function createOrUpdateCustomView({
   localCustomEntityData,
   customViewId,
   options,
+  applicationIdentifier,
 }: TCreateOrUpdateCustomView) {
   const fetchedCustomView = await fetchCustomView({
     mcApiUrl,
     customViewId,
+    applicationIdentifier,
   });
 
   if (!fetchedCustomView) {
     const userOrganizations = await fetchUserOrganizations({
       mcApiUrl,
       customViewId,
+      applicationIdentifier,
     });
 
     let organizationId: string, organizationName: string;
@@ -348,6 +352,7 @@ async function createOrUpdateCustomView({
       mcApiUrl,
       organizationId,
       data,
+      applicationIdentifier,
     });
 
     // This check is technically not necessary, as the `graphql-request` client
@@ -442,6 +447,7 @@ async function createOrUpdateCustomView({
     organizationId: fetchedCustomView.organizationId,
     data: omit(localCustomEntityData, ['id']),
     customViewId: fetchedCustomView?.customView?.id || '',
+    applicationIdentifier,
   });
 
   console.log(chalk.green(`Custom View updated.`));
@@ -473,6 +479,7 @@ async function run(options: TCliCommandConfigSyncOptions) {
     createOrUpdateCustomView({
       mcApiUrl,
       localCustomEntityData,
+      applicationIdentifier,
       customViewId: customViewId || localCustomEntityData.id,
       options,
     });

--- a/packages/mc-scripts/src/generated/settings.ts
+++ b/packages/mc-scripts/src/generated/settings.ts
@@ -679,6 +679,7 @@ export type TMutation = {
   activateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activateDashboardView?: Maybe<TDashboardView>;
   activateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activateOrderDetailView?: Maybe<TOrderDetailView>;
   activateOrdersListView?: Maybe<TOrdersListView>;
   activateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   activatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -696,6 +697,7 @@ export type TMutation = {
   createCustomersSearchListMyView: TCustomersSearchListMyView;
   createDashboardView: TDashboardView;
   createDiscountCodesCustomView: TDiscountsCustomView;
+  createOrderDetailView: TOrderDetailView;
   createOrdersListView: TOrdersListView;
   createPimSearchListView: TPimSearchListView;
   createProductDiscountsCustomView: TDiscountsCustomView;
@@ -708,6 +710,7 @@ export type TMutation = {
   deactivateCustomersSearchListMyView?: Maybe<TOrdersListView>;
   deactivateDashboardView?: Maybe<TDashboardView>;
   deactivateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deactivateOrderDetailView?: Maybe<TOrderDetailView>;
   deactivateOrdersListView?: Maybe<TOrdersListView>;
   deactivateOrganizationExtensionOidcSsoConfig?: Maybe<TOrganizationExtension>;
   deactivatePimSearchListView?: Maybe<TPimSearchListView>;
@@ -715,6 +718,7 @@ export type TMutation = {
   deactivateProductTypeAttributesView?: Maybe<TProductTypeAttributesView>;
   deactivateProjectSettingsStoresView?: Maybe<TProjectSettingsStoresView>;
   deleteAllDashboardViews: Array<TDashboardView>;
+  deleteAllOrderDetailViews: Array<TOrderDetailView>;
   deleteAllOrdersListViews: Array<TOrdersListView>;
   deleteBusinessUnitsListMyView?: Maybe<TBusinessUnitsListMyView>;
   deleteCartDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -725,6 +729,7 @@ export type TMutation = {
   deleteCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   deleteDashboardView?: Maybe<TDashboardView>;
   deleteDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  deleteOrderDetailView?: Maybe<TOrderDetailView>;
   deleteOrdersListView?: Maybe<TOrdersListView>;
   deletePimSearchListView?: Maybe<TPimSearchListView>;
   deleteProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -754,6 +759,7 @@ export type TMutation = {
   updateCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   updateDashboardView?: Maybe<TDashboardView>;
   updateDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  updateOrderDetailView?: Maybe<TOrderDetailView>;
   updateOrdersListView?: Maybe<TOrdersListView>;
   updatePimSearchListView?: Maybe<TPimSearchListView>;
   updateProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -785,6 +791,10 @@ export type TMutation_ActivateDashboardViewArgs = {
 };
 
 export type TMutation_ActivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_ActivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -866,6 +876,10 @@ export type TMutation_CreateDiscountCodesCustomViewArgs = {
   data: TDiscountsCustomViewInput;
 };
 
+export type TMutation_CreateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
+};
+
 export type TMutation_CreateOrdersListViewArgs = {
   data: TOrdersListViewInput;
 };
@@ -911,6 +925,10 @@ export type TMutation_DeactivateDashboardViewArgs = {
 };
 
 export type TMutation_DeactivateDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_DeactivateOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -974,6 +992,10 @@ export type TMutation_DeleteDashboardViewArgs = {
 };
 
 export type TMutation_DeleteDiscountCodesCustomViewArgs = {
+  id: Scalars['ID'];
+};
+
+export type TMutation_DeleteOrderDetailViewArgs = {
   id: Scalars['ID'];
 };
 
@@ -1115,6 +1137,11 @@ export type TMutation_UpdateDashboardViewArgs = {
 
 export type TMutation_UpdateDiscountCodesCustomViewArgs = {
   data: TDiscountsCustomViewInput;
+  id: Scalars['ID'];
+};
+
+export type TMutation_UpdateOrderDetailViewArgs = {
+  data: TOrderDetailViewInput;
   id: Scalars['ID'];
 };
 
@@ -1262,6 +1289,27 @@ export type TOidcSsoConfigDataInput = {
   teamIdForNewUsers: Scalars['String'];
 };
 
+export type TOrderDetailView = {
+  __typename?: 'OrderDetailView';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive?: Maybe<Scalars['Boolean']>;
+  nameAllLocales?: Maybe<Array<TLocalizedField>>;
+  projectKey: Scalars['String'];
+  table?: Maybe<TTable>;
+  updatedAt: Scalars['DateTime'];
+  userId: Scalars['String'];
+};
+
+export type TOrderDetailViewInput = {
+  nameAllLocales: Array<TLocalizedFieldCreateInput>;
+  table?: InputMaybe<TOrderDetailViewTableInput>;
+};
+
+export type TOrderDetailViewTableInput = {
+  visibleColumns: Array<Scalars['String']>;
+};
+
 export enum TOrderStatesVisibility {
   HideOrderState = 'HideOrderState',
   HidePaymentState = 'HidePaymentState',
@@ -1332,6 +1380,14 @@ export type TOrganizationExtension = {
 export type TOrganizationExtensionForCustomApplication = {
   __typename?: 'OrganizationExtensionForCustomApplication';
   application: TRestrictedCustomApplicationForOrganization;
+  id: Scalars['ID'];
+  organizationId: Scalars['String'];
+  organizationName?: Maybe<Scalars['String']>;
+};
+
+export type TOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TRestrictedCustomViewForOrganization>;
   id: Scalars['ID'];
   organizationId: Scalars['String'];
   organizationName?: Maybe<Scalars['String']>;
@@ -1473,6 +1529,7 @@ export type TQuery = {
   activeCustomersSearchListMyView?: Maybe<TCustomersSearchListMyView>;
   activeDashboardView?: Maybe<TDashboardView>;
   activeDiscountCodesCustomView?: Maybe<TDiscountsCustomView>;
+  activeOrderDetailView?: Maybe<TOrderDetailView>;
   activeOrdersListView?: Maybe<TOrdersListView>;
   activePimSearchListView?: Maybe<TPimSearchListView>;
   activeProductDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1510,10 +1567,13 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  orderDetailView?: Maybe<TOrderDetailView>;
+  orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
   ordersListViews: Array<Maybe<TOrdersListView>>;
   organizationExtension?: Maybe<TOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TPimSearchListView>;
   pimSearchListViews: Array<Maybe<TPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TDiscountsCustomView>;
@@ -1604,6 +1664,10 @@ export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
 };
 
+export type TQuery_OrderDetailViewArgs = {
+  id: Scalars['ID'];
+};
+
 export type TQuery_OrdersListViewArgs = {
   id: Scalars['ID'];
 };
@@ -1614,6 +1678,10 @@ export type TQuery_OrganizationExtensionArgs = {
 
 export type TQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String'];
+};
+
+export type TQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String'];
 };
 
 export type TQuery_PimSearchListViewArgs = {
@@ -1854,6 +1922,7 @@ export type TSampleDataImportMetadata = {
 
 export enum TSampleDatasets {
   Fashion = 'FASHION',
+  Goodstore = 'GOODSTORE',
 }
 
 export type TSort = {
@@ -2061,6 +2130,19 @@ export type TCreateCustomApplicationFromCliMutation = {
   } | null;
 };
 
+export type TCreateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+}>;
+
+export type TCreateCustomViewFromCliMutation = {
+  __typename?: 'Mutation';
+  createCustomView?: {
+    __typename?: 'RestrictedCustomViewForOrganization';
+    id: string;
+  } | null;
+};
+
 export type TFetchCustomApplicationFromCliQueryVariables = Exact<{
   entryPointUriPath: Scalars['String'];
 }>;
@@ -2108,6 +2190,40 @@ export type TFetchCustomApplicationFromCliQuery = {
   } | null;
 };
 
+export type TFetchCustomViewFromCliQueryVariables = Exact<{
+  customViewId: Scalars['String'];
+}>;
+
+export type TFetchCustomViewFromCliQuery = {
+  __typename?: 'Query';
+  organizationExtensionForCustomView?: {
+    __typename?: 'OrganizationExtensionForCustomView';
+    organizationId: string;
+    customView?: {
+      __typename?: 'RestrictedCustomViewForOrganization';
+      id: string;
+      defaultLabel: string;
+      url: string;
+      type: TCustomViewType;
+      locators: Array<string>;
+      labelAllLocales: Array<{
+        __typename?: 'LocalizedField';
+        locale: string;
+        value: string;
+      }>;
+      typeSettings?: {
+        __typename?: 'CustomViewTypeSettings';
+        size?: TCustomViewSize | null;
+      } | null;
+      permissions: Array<{
+        __typename?: 'CustomViewPermission';
+        name: string;
+        oAuthScopes: Array<string>;
+      }>;
+    } | null;
+  } | null;
+};
+
 export type TUpdateCustomApplicationFromCliMutationVariables = Exact<{
   organizationId: Scalars['String'];
   data: TCustomApplicationDraftDataInput;
@@ -2118,6 +2234,20 @@ export type TUpdateCustomApplicationFromCliMutation = {
   __typename?: 'Mutation';
   updateCustomApplication?: {
     __typename?: 'RestrictedCustomApplicationForOrganization';
+    id: string;
+  } | null;
+};
+
+export type TUpdateCustomViewFromCliMutationVariables = Exact<{
+  organizationId: Scalars['String'];
+  data: TCustomViewDraftDataInput;
+  customViewId: Scalars['String'];
+}>;
+
+export type TUpdateCustomViewFromCliMutation = {
+  __typename?: 'Mutation';
+  updateCustomView?: {
+    __typename?: 'RestrictedCustomViewForOrganization';
     id: string;
   } | null;
 };

--- a/packages/mc-scripts/src/utils/create-custom-view.settings.graphql
+++ b/packages/mc-scripts/src/utils/create-custom-view.settings.graphql
@@ -1,0 +1,8 @@
+mutation CreateCustomViewFromCli(
+  $organizationId: String!
+  $data: CustomViewDraftDataInput!
+) {
+  createCustomView(organizationId: $organizationId, data: $data) {
+    id
+  }
+}

--- a/packages/mc-scripts/src/utils/fetch-custom-view.settings.graphql
+++ b/packages/mc-scripts/src/utils/fetch-custom-view.settings.graphql
@@ -1,0 +1,23 @@
+query FetchCustomViewFromCli($customViewId: String!) {
+  organizationExtensionForCustomView(customViewId: $customViewId) {
+    organizationId
+    customView {
+      id
+      defaultLabel
+      labelAllLocales {
+        locale
+        value
+      }
+      url
+      type
+      typeSettings {
+        size
+      }
+      locators
+      permissions {
+        name
+        oAuthScopes
+      }
+    }
+  }
+}

--- a/packages/mc-scripts/src/utils/get-config-diff.spec.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.spec.ts
@@ -1,4 +1,4 @@
-import getConfigDiff from './get-config-diff';
+import { getCustomApplicationConfigDiff } from './get-config-diff';
 
 const createTestConfig = (customConfig = {}) => ({
   id: 'id',
@@ -19,7 +19,9 @@ const createTestConfig = (customConfig = {}) => ({
 
 describe('when there are no changes', () => {
   it('should display no diff', () => {
-    expect(getConfigDiff(createTestConfig(), createTestConfig())).toBe('');
+    expect(
+      getCustomApplicationConfigDiff(createTestConfig(), createTestConfig())
+    ).toBe('');
   });
 });
 describe('when there are changes', () => {
@@ -30,7 +32,8 @@ describe('when there are changes', () => {
       url: 'https://updated-test.com',
       icon: '<svg><path fill="#ffffff"></path></svg>',
     });
-    expect(getConfigDiff(createTestConfig(), newConfig)).toMatchInlineSnapshot(`
+    expect(getCustomApplicationConfigDiff(createTestConfig(), newConfig))
+      .toMatchInlineSnapshot(`
       "name changed: <color-red>test name</color-red> => <color-green>updated test name</color-green>
       description changed: <color-red>test description</color-red> => <color-green>updated description</color-green>
       url changed: <color-red>https://test.com</color-red> => <color-green>https://updated-test.com</color-green>
@@ -41,7 +44,9 @@ describe('when there are changes', () => {
     const newConfig = createTestConfig({
       description: undefined,
     });
-    expect(getConfigDiff(createTestConfig(), newConfig)).toMatchInlineSnapshot(
+    expect(
+      getCustomApplicationConfigDiff(createTestConfig(), newConfig)
+    ).toMatchInlineSnapshot(
       `"description removed: <color-red>test description</color-red>"`
     );
   });
@@ -90,7 +95,8 @@ describe('when there are changes', () => {
       ],
     });
 
-    expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+    expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+      .toMatchInlineSnapshot(`
       "permissions changed
         "viewMyTestApp" changed
           oauth scope added: <color-green>view_channel</color-green>
@@ -124,7 +130,8 @@ describe('when there are changes', () => {
         },
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "mainMenuLink changed
           permissions changed
             applied permission added: <color-green>ViewMyTestApp</color-green>"
@@ -147,7 +154,8 @@ describe('when there are changes', () => {
         },
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "mainMenuLink changed
           permissions changed
             applied permission removed: <color-red>ViewMyTestApp</color-red>"
@@ -170,7 +178,8 @@ describe('when there are changes', () => {
         },
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "mainMenuLink changed
           labelAllLocales changed
             locale added: <color-green>de</color-green>"
@@ -193,7 +202,8 @@ describe('when there are changes', () => {
         },
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "mainMenuLink changed
           labelAllLocales changed
             locale removed: <color-red>de</color-red>"
@@ -234,7 +244,8 @@ describe('when there are changes', () => {
         },
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "mainMenuLink changed
           defaultLabel changed: <color-red>Avengers</color-red> => <color-green>Justice League</color-green>
           permissions changed
@@ -270,7 +281,8 @@ describe('when there are changes', () => {
         ],
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "submenuLink changed
           menu link added: <color-green>my-test-app/new</color-green>"
       `);
@@ -296,7 +308,8 @@ describe('when there are changes', () => {
         submenuLinks: [],
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "submenuLink changed
           menu link removed: <color-red>my-test-app/new</color-red>"
       `);
@@ -342,7 +355,8 @@ describe('when there are changes', () => {
         ],
       });
 
-      expect(getConfigDiff(oldConfig, newConfig)).toMatchInlineSnapshot(`
+      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
         "submenuLink changed
           menu link "my-test-app/new" changed
             defaultLabel changed: <color-red>New Avenger</color-red> => <color-green>Add Avenger</color-green>

--- a/packages/mc-scripts/src/utils/get-config-diff.spec.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.spec.ts
@@ -1,3 +1,4 @@
+import { TCustomViewType, TCustomViewSize } from '../generated/settings';
 import {
   getCustomApplicationConfigDiff,
   getCustomViewConfigDiff,
@@ -29,9 +30,9 @@ const createTestCustomViewConfig = (customConfig = {}) => ({
     'products.product_variant_details.images',
     'customers.customer_details.custom_fields',
   ],
-  type: 'CustomPanel',
+  type: TCustomViewType.CustomPanel,
   typeSettings: {
-    size: 'LARGE',
+    size: TCustomViewSize.Large,
   },
   permissions: [],
   labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
@@ -501,15 +502,11 @@ describe('Custom View Config Diff', () => {
     });
 
     it('should display diff for "typeSettings"', () => {
-      const oldConfig = createTestCustomViewConfig({
-        typeSettings: {
-          size: 'LARGE',
-        },
-      });
+      const oldConfig = createTestCustomViewConfig();
 
       const newConfig = createTestCustomViewConfig({
         typeSettings: {
-          size: 'SMALL',
+          size: TCustomViewSize.Small,
         },
       });
 

--- a/packages/mc-scripts/src/utils/get-config-diff.spec.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.spec.ts
@@ -1,6 +1,9 @@
-import { getCustomApplicationConfigDiff } from './get-config-diff';
+import {
+  getCustomApplicationConfigDiff,
+  getCustomViewConfigDiff,
+} from './get-config-diff';
 
-const createTestConfig = (customConfig = {}) => ({
+const createTestCustomApplicationConfig = (customConfig = {}) => ({
   id: 'id',
   entryPointUriPath: 'my-test-app',
   name: 'test name',
@@ -17,356 +20,542 @@ const createTestConfig = (customConfig = {}) => ({
   ...customConfig,
 });
 
-describe('when there are no changes', () => {
-  it('should display no diff', () => {
-    expect(
-      getCustomApplicationConfigDiff(createTestConfig(), createTestConfig())
-    ).toBe('');
-  });
+const createTestCustomViewConfig = (customConfig = {}) => ({
+  id: 'id',
+  defaultLabel: 'test name',
+  description: 'test description',
+  url: 'https://test.com',
+  locators: [
+    'products.product_variant_details.images',
+    'customers.customer_details.custom_fields',
+  ],
+  type: 'CustomPanel',
+  typeSettings: {
+    size: 'LARGE',
+  },
+  permissions: [],
+  labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
+  ...customConfig,
 });
-describe('when there are changes', () => {
-  it('should display diff if "name", "description", "icon", "url" changed', () => {
-    const newConfig = createTestConfig({
-      name: 'updated test name',
-      description: 'updated description',
-      url: 'https://updated-test.com',
-      icon: '<svg><path fill="#ffffff"></path></svg>',
-    });
-    expect(getCustomApplicationConfigDiff(createTestConfig(), newConfig))
-      .toMatchInlineSnapshot(`
-      "name changed: <color-red>test name</color-red> => <color-green>updated test name</color-green>
-      description changed: <color-red>test description</color-red> => <color-green>updated description</color-green>
-      url changed: <color-red>https://test.com</color-red> => <color-green>https://updated-test.com</color-green>
-      icon changed: <color-red><svg><path fill="#000000"></path></svg></color-red> => <color-green><svg><path fill="#ffffff"></path></svg></color-green>"
-    `);
-  });
-  it('should display diff if "description" is removed', () => {
-    const newConfig = createTestConfig({
-      description: undefined,
-    });
-    expect(
-      getCustomApplicationConfigDiff(createTestConfig(), newConfig)
-    ).toMatchInlineSnapshot(
-      `"description removed: <color-red>test description</color-red>"`
-    );
-  });
 
-  it('should display diff for "permissions"', () => {
-    const oldConfig = createTestConfig({
-      permissions: [
-        {
-          name: 'viewMyTestApp',
-          oAuthScopes: ['view_products', 'view_customers'],
-        },
-        { name: 'manageMyTestApp', oAuthScopes: ['manage_product'] },
-        {
-          name: 'viewMyTestAppMovies',
-          oAuthScopes: ['view_products'],
-        },
-        { name: 'manageMyTestAppMovies', oAuthScopes: [] },
-        {
-          name: 'viewMyTestAppMerch',
-          oAuthScopes: ['view_channels'],
-        },
-        { name: 'manageMyTestAppMerch', oAuthScopes: [] },
-      ],
-    });
-
-    const newConfig = createTestConfig({
-      permissions: [
-        {
-          name: 'viewMyTestApp',
-          oAuthScopes: ['view_products', 'view_channel'],
-        },
-        {
-          name: 'manageMyTestApp',
-          oAuthScopes: ['manage_product', 'manage_channel'],
-        },
-        {
-          name: 'viewMyTestAppMovies',
-          oAuthScopes: ['view_products', 'view_channel'],
-        },
-        { name: 'manageMyTestAppMovies', oAuthScopes: [] },
-        {
-          name: 'viewMyTestAppCharacters',
-          oAuthScopes: ['view_channels'],
-        },
-        { name: 'manageMyTestAppCharacters', oAuthScopes: [] },
-      ],
-    });
-
-    expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-      .toMatchInlineSnapshot(`
-      "permissions changed
-        "viewMyTestApp" changed
-          oauth scope added: <color-green>view_channel</color-green>
-          oauth scope removed: <color-red>view_customers</color-red>
-        "manageMyTestApp" changed
-          oauth scope added: <color-green>manage_channel</color-green>
-        "viewMyTestAppMovies" changed
-          oauth scope added: <color-green>view_channel</color-green>
-        "<color-green>viewMyTestAppCharacters</color-green>" was added
-        "<color-green>manageMyTestAppCharacters</color-green>" was added
-        "<color-red>viewMyTestAppMerch</color-red>" was removed
-        "<color-red>manageMyTestAppMerch</color-red>" was removed"
-    `);
-  });
-
-  describe('for "mainMenuLink"', () => {
-    it('should display diff for "mainMenuLink" when assigning new permissions', () => {
-      const oldConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: [],
-          labelAllLocales: [],
-        },
-      });
-
-      const newConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: ['ViewMyTestApp'],
-          labelAllLocales: [],
-        },
-      });
-
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-        .toMatchInlineSnapshot(`
-        "mainMenuLink changed
-          permissions changed
-            applied permission added: <color-green>ViewMyTestApp</color-green>"
-      `);
-    });
-    it('should display diff for "mainMenuLink" when removing permissions', () => {
-      const oldConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: ['ViewMyTestApp'],
-          labelAllLocales: [],
-        },
-      });
-
-      const newConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: [],
-          labelAllLocales: [],
-        },
-      });
-
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-        .toMatchInlineSnapshot(`
-        "mainMenuLink changed
-          permissions changed
-            applied permission removed: <color-red>ViewMyTestApp</color-red>"
-      `);
-    });
-    it('should display diff for "mainMenuLink" when assigning new labels', () => {
-      const oldConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: [],
-          labelAllLocales: [],
-        },
-      });
-
-      const newConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: [],
-          labelAllLocales: [{ locale: 'de', value: 'Die Avengers' }],
-        },
-      });
-
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-        .toMatchInlineSnapshot(`
-        "mainMenuLink changed
-          labelAllLocales changed
-            locale added: <color-green>de</color-green>"
-      `);
-    });
-    it('should display diff for "mainMenuLink" when removing labels', () => {
-      const oldConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: [],
-          labelAllLocales: [{ locale: 'de', value: 'Die Avengers' }],
-        },
-      });
-
-      const newConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: [],
-          labelAllLocales: [],
-        },
-      });
-
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-        .toMatchInlineSnapshot(`
-        "mainMenuLink changed
-          labelAllLocales changed
-            locale removed: <color-red>de</color-red>"
-      `);
-    });
-    it('should display multiple diff for changes of existing "mainMenuLink"', () => {
-      const oldConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Avengers',
-          permissions: ['ViewMyTestApp'],
-          labelAllLocales: [
-            {
-              locale: 'de',
-              value: 'Die Avengers',
-            },
-            {
-              locale: 'en',
-              value: 'The Avengers',
-            },
-          ],
-        },
-      });
-
-      const newConfig = createTestConfig({
-        mainMenuLink: {
-          defaultLabel: 'Justice League',
-          permissions: ['ManageMyTestApp'],
-          labelAllLocales: [
-            {
-              locale: 'de',
-              value: 'Die Justice League',
-            },
-            {
-              locale: 'it',
-              value: 'La Justice League',
-            },
-          ],
-        },
-      });
-
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-        .toMatchInlineSnapshot(`
-        "mainMenuLink changed
-          defaultLabel changed: <color-red>Avengers</color-red> => <color-green>Justice League</color-green>
-          permissions changed
-            applied permission added: <color-green>ManageMyTestApp</color-green>
-            applied permission removed: <color-red>ViewMyTestApp</color-red>
-          labelAllLocales changed
-            locale "de" changed: <color-red>Die Avengers</color-red> => <color-green>Die Justice League</color-green>
-            locale added: <color-green>it</color-green>
-            locale removed: <color-red>en</color-red>"
-      `);
+describe('Custom Application Config Diff', () => {
+  describe('when there are no changes', () => {
+    it('should display no diff', () => {
+      expect(
+        getCustomApplicationConfigDiff(
+          createTestCustomApplicationConfig(),
+          createTestCustomApplicationConfig()
+        )
+      ).toBe('');
     });
   });
-
-  describe('for "submenuLinks"', () => {
-    it('should display diff for "submenuLinks" when adding a new menu link', () => {
-      const oldConfig = createTestConfig({
-        submenuLinks: [],
+  describe('when there are changes', () => {
+    it('should display diff if "name", "description", "icon", "url" changed', () => {
+      const newConfig = createTestCustomApplicationConfig({
+        name: 'updated test name',
+        description: 'updated description',
+        url: 'https://updated-test.com',
+        icon: '<svg><path fill="#ffffff"></path></svg>',
       });
+      expect(
+        getCustomApplicationConfigDiff(
+          createTestCustomApplicationConfig(),
+          newConfig
+        )
+      ).toMatchInlineSnapshot(`
+        "name changed: <color-red>test name</color-red> => <color-green>updated test name</color-green>
+        description changed: <color-red>test description</color-red> => <color-green>updated description</color-green>
+        url changed: <color-red>https://test.com</color-red> => <color-green>https://updated-test.com</color-green>
+        icon changed: <color-red><svg><path fill="#000000"></path></svg></color-red> => <color-green><svg><path fill="#ffffff"></path></svg></color-green>"
+      `);
+    });
+    it('should display diff if "description" is removed', () => {
+      const newConfig = createTestCustomApplicationConfig({
+        description: undefined,
+      });
+      expect(
+        getCustomApplicationConfigDiff(
+          createTestCustomApplicationConfig(),
+          newConfig
+        )
+      ).toMatchInlineSnapshot(
+        `"description removed: <color-red>test description</color-red>"`
+      );
+    });
 
-      const newConfig = createTestConfig({
-        submenuLinks: [
+    it('should display diff for "permissions"', () => {
+      const oldConfig = createTestCustomApplicationConfig({
+        permissions: [
           {
-            uriPath: 'my-test-app/new',
-            defaultLabel: 'New Avenger',
-            permissions: ['ManageMyTestApp'],
-            labelAllLocales: [
-              {
-                locale: 'de',
-                value: 'Neu Avenger',
-              },
-            ],
+            name: 'viewMyTestApp',
+            oAuthScopes: ['view_products', 'view_customers'],
           },
+          { name: 'manageMyTestApp', oAuthScopes: ['manage_product'] },
+          {
+            name: 'viewMyTestAppMovies',
+            oAuthScopes: ['view_products'],
+          },
+          { name: 'manageMyTestAppMovies', oAuthScopes: [] },
+          {
+            name: 'viewMyTestAppMerch',
+            oAuthScopes: ['view_channels'],
+          },
+          { name: 'manageMyTestAppMerch', oAuthScopes: [] },
+        ],
+      });
+
+      const newConfig = createTestCustomApplicationConfig({
+        permissions: [
+          {
+            name: 'viewMyTestApp',
+            oAuthScopes: ['view_products', 'view_channel'],
+          },
+          {
+            name: 'manageMyTestApp',
+            oAuthScopes: ['manage_product', 'manage_channel'],
+          },
+          {
+            name: 'viewMyTestAppMovies',
+            oAuthScopes: ['view_products', 'view_channel'],
+          },
+          { name: 'manageMyTestAppMovies', oAuthScopes: [] },
+          {
+            name: 'viewMyTestAppCharacters',
+            oAuthScopes: ['view_channels'],
+          },
+          { name: 'manageMyTestAppCharacters', oAuthScopes: [] },
         ],
       });
 
       expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
         .toMatchInlineSnapshot(`
-        "submenuLink changed
-          menu link added: <color-green>my-test-app/new</color-green>"
+        "permissions changed
+          "viewMyTestApp" changed
+            oauth scope added: <color-green>view_channel</color-green>
+            oauth scope removed: <color-red>view_customers</color-red>
+          "manageMyTestApp" changed
+            oauth scope added: <color-green>manage_channel</color-green>
+          "viewMyTestAppMovies" changed
+            oauth scope added: <color-green>view_channel</color-green>
+          "<color-green>viewMyTestAppCharacters</color-green>" was added
+          "<color-green>manageMyTestAppCharacters</color-green>" was added
+          "<color-red>viewMyTestAppMerch</color-red>" was removed
+          "<color-red>manageMyTestAppMerch</color-red>" was removed"
       `);
     });
-    it('should display diff for "submenuLinks" when removing a menu link', () => {
-      const oldConfig = createTestConfig({
-        submenuLinks: [
-          {
-            uriPath: 'my-test-app/new',
-            defaultLabel: 'New Avenger',
-            permissions: ['ManageMyTestApp'],
-            labelAllLocales: [
-              {
-                locale: 'de',
-                value: 'Neu Avenger',
-              },
-            ],
+
+    describe('for "mainMenuLink"', () => {
+      it('should display diff for "mainMenuLink" when assigning new permissions', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: [],
+            labelAllLocales: [],
           },
-        ],
-      });
+        });
 
-      const newConfig = createTestConfig({
-        submenuLinks: [],
-      });
+        const newConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: ['ViewMyTestApp'],
+            labelAllLocales: [],
+          },
+        });
 
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
-        .toMatchInlineSnapshot(`
-        "submenuLink changed
-          menu link removed: <color-red>my-test-app/new</color-red>"
-      `);
-    });
-    it('should display multiple diff for changes of existing "submenuLinks"', () => {
-      const oldConfig = createTestConfig({
-        submenuLinks: [
-          {
-            uriPath: 'my-test-app/new',
-            defaultLabel: 'New Avenger',
-            permissions: ['ManageMyTestApp'],
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "mainMenuLink changed
+            permissions changed
+              applied permission added: <color-green>ViewMyTestApp</color-green>"
+        `);
+      });
+      it('should display diff for "mainMenuLink" when removing permissions', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: ['ViewMyTestApp'],
+            labelAllLocales: [],
+          },
+        });
+
+        const newConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: [],
+            labelAllLocales: [],
+          },
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "mainMenuLink changed
+            permissions changed
+              applied permission removed: <color-red>ViewMyTestApp</color-red>"
+        `);
+      });
+      it('should display diff for "mainMenuLink" when assigning new labels', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: [],
+            labelAllLocales: [],
+          },
+        });
+
+        const newConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: [],
+            labelAllLocales: [{ locale: 'de', value: 'Die Avengers' }],
+          },
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "mainMenuLink changed
+            labelAllLocales changed
+              locale added: <color-green>de</color-green>"
+        `);
+      });
+      it('should display diff for "mainMenuLink" when removing labels', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: [],
+            labelAllLocales: [{ locale: 'de', value: 'Die Avengers' }],
+          },
+        });
+
+        const newConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: [],
+            labelAllLocales: [],
+          },
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "mainMenuLink changed
+            labelAllLocales changed
+              locale removed: <color-red>de</color-red>"
+        `);
+      });
+      it('should display multiple diff for changes of existing "mainMenuLink"', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Avengers',
+            permissions: ['ViewMyTestApp'],
             labelAllLocales: [
               {
                 locale: 'de',
-                value: 'Neu Avenger',
+                value: 'Die Avengers',
               },
               {
                 locale: 'en',
-                value: 'Add Avenger',
+                value: 'The Avengers',
               },
             ],
           },
-        ],
-      });
+        });
 
-      const newConfig = createTestConfig({
-        submenuLinks: [
-          {
-            uriPath: 'my-test-app/new',
-            defaultLabel: 'Add Avenger',
-            permissions: [],
+        const newConfig = createTestCustomApplicationConfig({
+          mainMenuLink: {
+            defaultLabel: 'Justice League',
+            permissions: ['ManageMyTestApp'],
             labelAllLocales: [
               {
                 locale: 'de',
-                value: 'Avenger hinzufügen',
+                value: 'Die Justice League',
               },
               {
                 locale: 'it',
-                value: 'Nuovo Avenger',
+                value: 'La Justice League',
               },
             ],
           },
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "mainMenuLink changed
+            defaultLabel changed: <color-red>Avengers</color-red> => <color-green>Justice League</color-green>
+            permissions changed
+              applied permission added: <color-green>ManageMyTestApp</color-green>
+              applied permission removed: <color-red>ViewMyTestApp</color-red>
+            labelAllLocales changed
+              locale "de" changed: <color-red>Die Avengers</color-red> => <color-green>Die Justice League</color-green>
+              locale added: <color-green>it</color-green>
+              locale removed: <color-red>en</color-red>"
+        `);
+      });
+    });
+
+    describe('for "submenuLinks"', () => {
+      it('should display diff for "submenuLinks" when adding a new menu link', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          submenuLinks: [],
+        });
+
+        const newConfig = createTestCustomApplicationConfig({
+          submenuLinks: [
+            {
+              uriPath: 'my-test-app/new',
+              defaultLabel: 'New Avenger',
+              permissions: ['ManageMyTestApp'],
+              labelAllLocales: [
+                {
+                  locale: 'de',
+                  value: 'Neu Avenger',
+                },
+              ],
+            },
+          ],
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "submenuLink changed
+            menu link added: <color-green>my-test-app/new</color-green>"
+        `);
+      });
+      it('should display diff for "submenuLinks" when removing a menu link', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          submenuLinks: [
+            {
+              uriPath: 'my-test-app/new',
+              defaultLabel: 'New Avenger',
+              permissions: ['ManageMyTestApp'],
+              labelAllLocales: [
+                {
+                  locale: 'de',
+                  value: 'Neu Avenger',
+                },
+              ],
+            },
+          ],
+        });
+
+        const newConfig = createTestCustomApplicationConfig({
+          submenuLinks: [],
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "submenuLink changed
+            menu link removed: <color-red>my-test-app/new</color-red>"
+        `);
+      });
+      it('should display multiple diff for changes of existing "submenuLinks"', () => {
+        const oldConfig = createTestCustomApplicationConfig({
+          submenuLinks: [
+            {
+              uriPath: 'my-test-app/new',
+              defaultLabel: 'New Avenger',
+              permissions: ['ManageMyTestApp'],
+              labelAllLocales: [
+                {
+                  locale: 'de',
+                  value: 'Neu Avenger',
+                },
+                {
+                  locale: 'en',
+                  value: 'Add Avenger',
+                },
+              ],
+            },
+          ],
+        });
+
+        const newConfig = createTestCustomApplicationConfig({
+          submenuLinks: [
+            {
+              uriPath: 'my-test-app/new',
+              defaultLabel: 'Add Avenger',
+              permissions: [],
+              labelAllLocales: [
+                {
+                  locale: 'de',
+                  value: 'Avenger hinzufügen',
+                },
+                {
+                  locale: 'it',
+                  value: 'Nuovo Avenger',
+                },
+              ],
+            },
+          ],
+        });
+
+        expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+          .toMatchInlineSnapshot(`
+          "submenuLink changed
+            menu link "my-test-app/new" changed
+              defaultLabel changed: <color-red>New Avenger</color-red> => <color-green>Add Avenger</color-green>
+              permissions changed
+                applied permission removed: <color-red>ManageMyTestApp</color-red>
+              labelAllLocales changed
+                locale "de" changed: <color-red>Neu Avenger</color-red> => <color-green>Avenger hinzufügen</color-green>
+                locale added: <color-green>it</color-green>
+                locale removed: <color-red>en</color-red>"
+        `);
+      });
+    });
+  });
+});
+describe('Custom View Config Diff', () => {
+  describe('when there are no changes', () => {
+    it('should display no diff', () => {
+      expect(
+        getCustomViewConfigDiff(
+          createTestCustomViewConfig(),
+          createTestCustomViewConfig()
+        )
+      ).toBe('');
+    });
+  });
+  describe('when there are changes', () => {
+    it('should display diff if "defaultLabel", "description", "url" changed', () => {
+      const newConfig = createTestCustomViewConfig({
+        defaultLabel: 'updated test name',
+        description: 'updated description',
+        url: 'https://updated-test.com',
+      });
+      expect(getCustomViewConfigDiff(createTestCustomViewConfig(), newConfig))
+        .toMatchInlineSnapshot(`
+        "defaultLabel changed: <color-red>test name</color-red> => <color-green>updated test name</color-green>
+        description changed: <color-red>test description</color-red> => <color-green>updated description</color-green>
+        url changed: <color-red>https://test.com</color-red> => <color-green>https://updated-test.com</color-green>"
+      `);
+    });
+    it('should display diff if "description" is removed', () => {
+      const newConfig = createTestCustomViewConfig({
+        description: undefined,
+      });
+      expect(
+        getCustomViewConfigDiff(createTestCustomViewConfig(), newConfig)
+      ).toMatchInlineSnapshot(
+        `"description removed: <color-red>test description</color-red>"`
+      );
+    });
+
+    it('should display diff for "permissions"', () => {
+      const oldConfig = createTestCustomViewConfig({
+        permissions: [
+          {
+            name: 'viewMyTestView',
+            oAuthScopes: ['view_products', 'view_customers'],
+          },
+          { name: 'manageMyTestView', oAuthScopes: ['manage_product'] },
+          {
+            name: 'viewMyTestViewMovies',
+            oAuthScopes: ['view_products'],
+          },
+          { name: 'manageMyTestViewMovies', oAuthScopes: [] },
+          {
+            name: 'viewMyTestViewMerch',
+            oAuthScopes: ['view_channels'],
+          },
+          { name: 'manageMyTestViewMerch', oAuthScopes: [] },
         ],
       });
 
-      expect(getCustomApplicationConfigDiff(oldConfig, newConfig))
+      const newConfig = createTestCustomViewConfig({
+        permissions: [
+          {
+            name: 'viewMyTestView',
+            oAuthScopes: ['view_products', 'view_channel'],
+          },
+          {
+            name: 'manageMyTestView',
+            oAuthScopes: ['manage_product', 'manage_channel'],
+          },
+          {
+            name: 'viewMyTestViewMovies',
+            oAuthScopes: ['view_products', 'view_channel'],
+          },
+          { name: 'manageMyTestViewMovies', oAuthScopes: [] },
+          {
+            name: 'viewMyTestViewCharacters',
+            oAuthScopes: ['view_channels'],
+          },
+          { name: 'manageMyTestViewCharacters', oAuthScopes: [] },
+        ],
+      });
+
+      expect(getCustomViewConfigDiff(oldConfig, newConfig))
         .toMatchInlineSnapshot(`
-        "submenuLink changed
-          menu link "my-test-app/new" changed
-            defaultLabel changed: <color-red>New Avenger</color-red> => <color-green>Add Avenger</color-green>
-            permissions changed
-              applied permission removed: <color-red>ManageMyTestApp</color-red>
-            labelAllLocales changed
-              locale "de" changed: <color-red>Neu Avenger</color-red> => <color-green>Avenger hinzufügen</color-green>
-              locale added: <color-green>it</color-green>
-              locale removed: <color-red>en</color-red>"
+        "permissions changed
+          "viewMyTestView" changed
+            oauth scope added: <color-green>view_channel</color-green>
+            oauth scope removed: <color-red>view_customers</color-red>
+          "manageMyTestView" changed
+            oauth scope added: <color-green>manage_channel</color-green>
+          "viewMyTestViewMovies" changed
+            oauth scope added: <color-green>view_channel</color-green>
+          "<color-green>viewMyTestViewCharacters</color-green>" was added
+          "<color-green>manageMyTestViewCharacters</color-green>" was added
+          "<color-red>viewMyTestViewMerch</color-red>" was removed
+          "<color-red>manageMyTestViewMerch</color-red>" was removed"
       `);
+    });
+
+    it('should display diff for "typeSettings"', () => {
+      const oldConfig = createTestCustomViewConfig({
+        typeSettings: {
+          size: 'LARGE',
+        },
+      });
+
+      const newConfig = createTestCustomViewConfig({
+        typeSettings: {
+          size: 'SMALL',
+        },
+      });
+
+      expect(getCustomViewConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
+          "type settings changed
+            size changed: <color-red>LARGE</color-red> => <color-green>SMALL</color-green>"
+        `);
+    });
+
+    it('should display diff for "labelAllLocales"', () => {
+      const oldConfig = createTestCustomViewConfig({
+        labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
+      });
+
+      const newConfig = createTestCustomViewConfig({
+        labelAllLocales: [
+          { locale: 'en', value: 'custom-view-en' },
+          { locale: 'de', value: 'custom-view-de' },
+        ],
+      });
+
+      expect(getCustomViewConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
+          "labelAllLocales changed
+            locale "en" changed: <color-red>custom-view</color-red> => <color-green>custom-view-en</color-green>
+            locale added: <color-green>de</color-green>"
+        `);
+    });
+
+    it('should display diff for "locators"', () => {
+      const oldConfig = createTestCustomViewConfig();
+
+      const newConfig = createTestCustomViewConfig({
+        locators: [
+          'customers.customer_details.custom_fields',
+          'customers.customer_details.another_one',
+        ],
+      });
+
+      expect(getCustomViewConfigDiff(oldConfig, newConfig))
+        .toMatchInlineSnapshot(`
+        "locators changed
+          locators added: <color-green>customers.customer_details.another_one</color-green>
+          locators removed: <color-red>products.product_variant_details.images</color-red>"
+        `);
     });
   });
 });

--- a/packages/mc-scripts/src/utils/get-config-diff.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import {
   sanitizeSvg,
   type CustomApplicationData,
+  type CustomViewData,
 } from '@commercetools-frontend/application-config';
 
 // Since not all terminal supports colors, to make things more consistent for testing purposes,
@@ -20,8 +21,8 @@ const green = (str: string) => {
 const indent = (indentLevel: number) => '  '.repeat(indentLevel);
 
 type TGetStringDiffParams = {
-  previousValue?: string;
-  nextValue?: string;
+  previousValue?: string | null;
+  nextValue?: string | null;
   label: string;
   indentLevel?: number;
 };
@@ -202,6 +203,40 @@ const getLabelAllLocalesDiff = ({
   return null;
 };
 
+type TTypeSettings = CustomViewData['typeSettings'];
+type TTypeSettingsDiffParams = {
+  previousValue: TTypeSettings;
+  nextValue: TTypeSettings;
+};
+
+const getTypeSettingsDiff = ({
+  previousValue,
+  nextValue,
+}: TTypeSettingsDiffParams) => {
+  const nonNullablePreviousValue = previousValue || {};
+  const nonNullableNextValue = nextValue || {};
+  const indentLevel = 1;
+  const typeSettingsDiff: string[] = [
+    `${indent(indentLevel - 1)}type settings changed`,
+  ];
+
+  Object.keys(nonNullablePreviousValue).forEach((key) => {
+    const typeSettingDiff = getStringDiff({
+      previousValue: nonNullablePreviousValue[key as keyof TTypeSettings],
+      nextValue: nonNullableNextValue[key as keyof TTypeSettings],
+      label: key,
+      indentLevel,
+    });
+    if (typeSettingDiff) {
+      typeSettingsDiff.push(typeSettingDiff);
+    }
+  });
+
+  if (typeSettingsDiff.length > 1) return typeSettingsDiff.join('\n');
+
+  return null;
+};
+
 type TMainMenuLink = CustomApplicationData['mainMenuLink'];
 type TGetMainMenuLinkDiffParams = {
   previousValue: TMainMenuLink;
@@ -357,7 +392,7 @@ const getSubmenuLinksDiff = ({
 
 // Compute diff changes of the Custom Application config.
 // NOTE: Only known keys are evaluated.
-const getConfigDiff = (
+export const getCustomApplicationConfigDiff = (
   oldConfig: CustomApplicationData,
   newConfig: CustomApplicationData
 ) => {
@@ -436,4 +471,91 @@ const getConfigDiff = (
   return diff.join('\n');
 };
 
-export default getConfigDiff;
+// Compute diff changes of the Custom Application config.
+// NOTE: Only known keys are evaluated.
+export const getCustomViewConfigDiff = (
+  oldConfig: CustomViewData,
+  newConfig: CustomViewData
+) => {
+  const diff: string[] = [];
+
+  // Default Label
+  const nameDiff = getStringDiff({
+    previousValue: oldConfig.defaultLabel,
+    nextValue: newConfig.defaultLabel,
+    label: 'defaultLabel',
+  });
+  if (nameDiff) {
+    diff.push(nameDiff);
+  }
+
+  // Description
+  const descriptionDiff = getStringDiff({
+    previousValue: oldConfig.description,
+    nextValue: newConfig.description,
+    label: 'description',
+  });
+  if (descriptionDiff) {
+    diff.push(descriptionDiff);
+  }
+
+  // URL
+  const urlDiff = getStringDiff({
+    previousValue: oldConfig.url,
+    nextValue: newConfig.url,
+    label: 'url',
+  });
+  if (urlDiff) {
+    diff.push(urlDiff);
+  }
+
+  // Type
+  const typeDiff = getStringDiff({
+    previousValue: oldConfig.type,
+    nextValue: newConfig.type,
+    label: 'type',
+  });
+  if (typeDiff) {
+    diff.push(typeDiff);
+  }
+
+  // Permissions
+  const permissionsDiff = getPermissionsDiff({
+    previousValue: oldConfig.permissions,
+    nextValue: newConfig.permissions,
+  });
+  if (permissionsDiff) {
+    diff.push(permissionsDiff);
+  }
+
+  // Label All Locales
+  const labelsDiff = getLabelAllLocalesDiff({
+    previousValue: oldConfig.labelAllLocales,
+    nextValue: newConfig.labelAllLocales,
+    indentLevel: 3,
+  });
+  if (labelsDiff) {
+    diff.push(labelsDiff);
+  }
+
+  // Type settings
+  const typeSettingsDiff = getTypeSettingsDiff({
+    previousValue: oldConfig.typeSettings,
+    nextValue: newConfig.typeSettings,
+  });
+  if (typeSettingsDiff) {
+    diff.push(typeSettingsDiff);
+  }
+
+  // Locators
+  const locatorsDiff = getArrayDiff({
+    previousValue: oldConfig.locators,
+    nextValue: newConfig.locators,
+    label: 'locators',
+  });
+  if (locatorsDiff) {
+    diff.push(locatorsDiff);
+  }
+
+  return diff.join('\n');
+};

--- a/packages/mc-scripts/src/utils/get-config-diff.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.ts
@@ -500,13 +500,13 @@ export const getCustomViewConfigDiff = (
   const diff: string[] = [];
 
   // Default Label
-  const nameDiff = getStringDiff({
+  const defaultLabelDiff = getStringDiff({
     previousValue: oldConfig.defaultLabel,
     nextValue: newConfig.defaultLabel,
     label: 'defaultLabel',
   });
-  if (nameDiff) {
-    diff.push(nameDiff);
+  if (defaultLabelDiff) {
+    diff.push(defaultLabelDiff);
   }
 
   // Description

--- a/packages/mc-scripts/src/utils/get-config-diff.ts
+++ b/packages/mc-scripts/src/utils/get-config-diff.ts
@@ -237,6 +237,26 @@ const getTypeSettingsDiff = ({
   return null;
 };
 
+type TLocatorsDiffParams = {
+  previousValue: CustomViewData['locators'];
+  nextValue: CustomViewData['locators'];
+};
+const getLocatorsDiff = ({ previousValue, nextValue }: TLocatorsDiffParams) => {
+  const diff: string[] = [];
+
+  const locatorsDiff = getArrayDiff({
+    previousValue: previousValue,
+    nextValue: nextValue,
+    label: 'locators',
+    indentLevel: 1,
+  });
+  if (locatorsDiff) {
+    diff.push('locators changed');
+    diff.push(locatorsDiff);
+  }
+  return diff.join('\n');
+};
+
 type TMainMenuLink = CustomApplicationData['mainMenuLink'];
 type TGetMainMenuLinkDiffParams = {
   previousValue: TMainMenuLink;
@@ -471,7 +491,7 @@ export const getCustomApplicationConfigDiff = (
   return diff.join('\n');
 };
 
-// Compute diff changes of the Custom Application config.
+// Compute diff changes of the Custom View config.
 // NOTE: Only known keys are evaluated.
 export const getCustomViewConfigDiff = (
   oldConfig: CustomViewData,
@@ -532,7 +552,7 @@ export const getCustomViewConfigDiff = (
   const labelsDiff = getLabelAllLocalesDiff({
     previousValue: oldConfig.labelAllLocales,
     nextValue: newConfig.labelAllLocales,
-    indentLevel: 3,
+    indentLevel: 1,
   });
   if (labelsDiff) {
     diff.push(labelsDiff);
@@ -548,10 +568,9 @@ export const getCustomViewConfigDiff = (
   }
 
   // Locators
-  const locatorsDiff = getArrayDiff({
+  const locatorsDiff = getLocatorsDiff({
     previousValue: oldConfig.locators,
     nextValue: newConfig.locators,
-    label: 'locators',
   });
   if (locatorsDiff) {
     diff.push(locatorsDiff);

--- a/packages/mc-scripts/src/utils/graphql-requests.spec.ts
+++ b/packages/mc-scripts/src/utils/graphql-requests.spec.ts
@@ -23,9 +23,9 @@ beforeAll(() =>
 afterAll(() => mockServer.close());
 
 const mcApiUrl = 'https://mc-api.europe-west1.gcp.commercetools.com';
-const applicationIdentifier = '__local:test-custom-app';
 
 describe('fetch user organizations', () => {
+  const applicationIdentifier = '__local:test-custom-app';
   beforeEach(() => {
     mockServer.use(
       graphql.query('FetchMyOrganizationsFromCli', (_req, res, ctx) => {
@@ -56,6 +56,7 @@ describe('fetch user organizations', () => {
 });
 
 describe('Custom Applications', () => {
+  const applicationIdentifier = '__local:test-custom-app';
   describe('fetch custom application data', () => {
     beforeEach(() => {
       mockServer.use(
@@ -223,6 +224,7 @@ describe('Custom Applications', () => {
 });
 describe('Custom Views', () => {
   const customViewId = 'custom-view-id';
+  const applicationIdentifier = '__local:@@custom-view-host@@';
   describe('fetch custom view data', () => {
     beforeEach(() => {
       mockServer.use(
@@ -247,11 +249,11 @@ describe('Custom Views', () => {
                   permissions: [
                     {
                       oAuthScopes: ['view_products', 'view_customers'],
-                      name: 'viewTestCustomView',
+                      name: 'view',
                     },
                     {
                       oAuthScopes: [],
-                      name: 'manageTestCustomView',
+                      name: 'manage',
                     },
                   ],
                   labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
@@ -266,6 +268,7 @@ describe('Custom Views', () => {
       const organizationExtensionForCustomView = await fetchCustomView({
         customViewId,
         mcApiUrl,
+        applicationIdentifier,
       });
       expect(organizationExtensionForCustomView?.customView?.id).toEqual(
         customViewId
@@ -298,11 +301,11 @@ describe('Custom Views', () => {
                 permissions: [
                   {
                     oAuthScopes: ['view_products', 'view_customers'],
-                    name: 'viewNewTestCustomView',
+                    name: 'view',
                   },
                   {
                     oAuthScopes: [],
-                    name: 'manageNewTestCustomView',
+                    name: 'manage',
                   },
                 ],
               },
@@ -330,15 +333,16 @@ describe('Custom Views', () => {
           permissions: [
             {
               oAuthScopes: ['view_products', 'view_customers'],
-              name: 'viewNewTestCustomView',
+              name: 'view',
             },
             {
               oAuthScopes: [],
-              name: 'manageNewTestCustomView',
+              name: 'manage',
             },
           ],
           labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
         },
+        applicationIdentifier,
       });
       expect(createdCustomViewData?.id).toEqual(customViewId);
     });
@@ -378,15 +382,16 @@ describe('Custom Views', () => {
           permissions: [
             {
               oAuthScopes: ['view_products', 'view_customers'],
-              name: 'viewNewTestCustomView',
+              name: 'view',
             },
             {
               oAuthScopes: [],
-              name: 'manageNewTestCustomView',
+              name: 'manage',
             },
           ],
           labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
         },
+        applicationIdentifier,
       });
       expect(updatedCustomAppsData?.id).toEqual(customViewId);
     });

--- a/packages/mc-scripts/src/utils/graphql-requests.spec.ts
+++ b/packages/mc-scripts/src/utils/graphql-requests.spec.ts
@@ -1,6 +1,11 @@
 import { graphql } from 'msw';
+import {
+  CustomView,
+  CustomViewPermission,
+  type TCustomViewGraphql,
+} from '@commercetools-test-data/custom-view';
 import { setupServer } from 'msw/node';
-import { TCustomViewType, TCustomViewSize } from '../generated/settings';
+import type { TCustomViewDraftDataInput } from '../generated/settings';
 import {
   createCustomApplication,
   updateCustomApplication,
@@ -225,6 +230,11 @@ describe('Custom Applications', () => {
 describe('Custom Views', () => {
   const customViewId = 'custom-view-id';
   const applicationIdentifier = '__local:@@custom-view-host@@';
+  const customView: TCustomViewGraphql = CustomView.random()
+    .id(customViewId)
+    .defaultLabel('Avengers')
+    .permissions([CustomViewPermission.presets.ViewOnlyPermissions()])
+    .buildGraphql();
   describe('fetch custom view data', () => {
     beforeEach(() => {
       mockServer.use(
@@ -233,31 +243,7 @@ describe('Custom Views', () => {
             ctx.data({
               organizationExtensionForCustomView: {
                 organizationId: 'organization-id',
-                customView: {
-                  id: customViewId,
-                  url: 'https://test.com',
-                  defaultLabel: 'Test name',
-                  description: 'Test description',
-                  type: 'CustomPanel',
-                  typeSettings: {
-                    size: 'SMALL',
-                  },
-                  locators: [
-                    'products.product_variant_details.images',
-                    'customers.customer_details.custom_fields',
-                  ],
-                  permissions: [
-                    {
-                      oAuthScopes: ['view_products', 'view_customers'],
-                      name: 'view',
-                    },
-                    {
-                      oAuthScopes: [],
-                      name: 'manage',
-                    },
-                  ],
-                  labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
-                },
+                customView,
               },
             })
           );
@@ -285,30 +271,7 @@ describe('Custom Views', () => {
         graphql.mutation('CreateCustomViewFromCli', (_req, res, ctx) => {
           return res(
             ctx.data({
-              createCustomView: {
-                id: customViewId,
-                url: 'https://test.com',
-                defaultLabel: 'New Test name',
-                description: 'Test description',
-                locators: [
-                  'products.product_variant_details.images',
-                  'customers.customer_details.custom_fields',
-                ],
-                type: 'CustomPanel',
-                typeSettings: {
-                  size: 'LARGE',
-                },
-                permissions: [
-                  {
-                    oAuthScopes: ['view_products', 'view_customers'],
-                    name: 'view',
-                  },
-                  {
-                    oAuthScopes: [],
-                    name: 'manage',
-                  },
-                ],
-              },
+              createCustomView: customView,
             })
           );
         })
@@ -318,30 +281,7 @@ describe('Custom Views', () => {
       const createdCustomViewData = await createCustomView({
         mcApiUrl,
         organizationId: 'organization-id',
-        data: {
-          url: 'https://test.com',
-          defaultLabel: 'New Test name',
-          description: 'Test description',
-          locators: [
-            'products.product_variant_details.images',
-            'customers.customer_details.custom_fields',
-          ],
-          type: TCustomViewType['CustomPanel'],
-          typeSettings: {
-            size: TCustomViewSize.Large,
-          },
-          permissions: [
-            {
-              oAuthScopes: ['view_products', 'view_customers'],
-              name: 'view',
-            },
-            {
-              oAuthScopes: [],
-              name: 'manage',
-            },
-          ],
-          labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
-        },
+        data: customView as TCustomViewDraftDataInput,
         applicationIdentifier,
       });
       expect(createdCustomViewData?.id).toEqual(customViewId);
@@ -367,30 +307,7 @@ describe('Custom Views', () => {
         mcApiUrl,
         organizationId: 'organization-id',
         customViewId,
-        data: {
-          url: 'https://test.com',
-          defaultLabel: 'New Test name',
-          description: 'Test description',
-          locators: [
-            'products.product_variant_details.images',
-            'customers.customer_details.custom_fields',
-          ],
-          type: TCustomViewType['CustomPanel'],
-          typeSettings: {
-            size: TCustomViewSize.Small,
-          },
-          permissions: [
-            {
-              oAuthScopes: ['view_products', 'view_customers'],
-              name: 'view',
-            },
-            {
-              oAuthScopes: [],
-              name: 'manage',
-            },
-          ],
-          labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
-        },
+        data: customView as TCustomViewDraftDataInput,
         applicationIdentifier,
       });
       expect(updatedCustomAppsData?.id).toEqual(customViewId);

--- a/packages/mc-scripts/src/utils/graphql-requests.spec.ts
+++ b/packages/mc-scripts/src/utils/graphql-requests.spec.ts
@@ -1,9 +1,13 @@
 import { graphql } from 'msw';
 import { setupServer } from 'msw/node';
+import { TCustomViewType, TCustomViewSize } from '../generated/settings';
 import {
   createCustomApplication,
   updateCustomApplication,
   fetchCustomApplication,
+  createCustomView,
+  updateCustomView,
+  fetchCustomView,
   fetchUserOrganizations,
 } from './graphql-requests';
 
@@ -20,171 +24,6 @@ afterAll(() => mockServer.close());
 
 const mcApiUrl = 'https://mc-api.europe-west1.gcp.commercetools.com';
 const applicationIdentifier = '__local:test-custom-app';
-
-describe('fetch custom application data', () => {
-  beforeEach(() => {
-    mockServer.use(
-      graphql.query('FetchCustomApplicationFromCli', (_req, res, ctx) => {
-        return res(
-          ctx.data({
-            organizationExtensionForCustomApplication: {
-              organizationId: 'organization-id',
-              application: {
-                id: 'application-id',
-                url: 'https://test.com',
-                name: 'Test name',
-                description: 'Test description',
-                entryPointUriPath: 'test-custom-app',
-                icon: '<svg><path fill="#000000"></path></svg>',
-                submenuLinks: [],
-                mainMenuLink: [],
-                permissions: [
-                  {
-                    oAuthScopes: ['view_products', 'view_customers'],
-                    name: 'viewTestCustomApp',
-                  },
-                  {
-                    oAuthScopes: [],
-                    name: 'manageTestCustomApp',
-                  },
-                ],
-              },
-            },
-          })
-        );
-      })
-    );
-  });
-  it('should match returned data', async () => {
-    const organizationExtensionForCustomApplication =
-      await fetchCustomApplication({
-        entryPointUriPath: 'test-custom-app',
-        mcApiUrl,
-        applicationIdentifier,
-      });
-    expect(
-      organizationExtensionForCustomApplication?.application.entryPointUriPath
-    ).toEqual('test-custom-app');
-    expect(organizationExtensionForCustomApplication?.application.id).toEqual(
-      'application-id'
-    );
-    expect(organizationExtensionForCustomApplication?.organizationId).toEqual(
-      'organization-id'
-    );
-  });
-});
-
-describe('register custom application', () => {
-  beforeEach(() => {
-    mockServer.use(
-      graphql.mutation('CreateCustomApplicationFromCli', (_req, res, ctx) => {
-        return res(
-          ctx.data({
-            createCustomApplication: {
-              id: 'application-id',
-              url: 'https://test.com',
-              name: 'New Test name',
-              description: 'Test description',
-              entryPointUriPath: 'new-test-custom-app',
-              icon: '<svg><path fill="#000000"></path></svg>',
-              submenuLinks: [],
-              mainMenuLink: [],
-              permissions: [
-                {
-                  oAuthScopes: ['view_products', 'view_customers'],
-                  name: 'viewNewTestCustomApp',
-                },
-                {
-                  oAuthScopes: [],
-                  name: 'manageNewTestCustomApp',
-                },
-              ],
-            },
-          })
-        );
-      })
-    );
-  });
-  it('should match returned data', async () => {
-    const createdCustomAppsData = await createCustomApplication({
-      mcApiUrl,
-      organizationId: 'organization-id',
-      data: {
-        url: 'https://test.com',
-        name: 'New Test name',
-        description: 'Test description',
-        entryPointUriPath: 'new-test-custom-app',
-        icon: '<svg><path fill="#000000"></path></svg>',
-        submenuLinks: [],
-        mainMenuLink: {
-          defaultLabel: 'Test',
-          labelAllLocales: [],
-          permissions: [],
-        },
-        permissions: [
-          {
-            oAuthScopes: ['view_products', 'view_customers'],
-            name: 'viewNewTestCustomApp',
-          },
-          {
-            oAuthScopes: [],
-            name: 'manageNewTestCustomApp',
-          },
-        ],
-      },
-      applicationIdentifier,
-    });
-    expect(createdCustomAppsData?.id).toEqual('application-id');
-  });
-});
-
-describe('update custom application', () => {
-  beforeEach(() => {
-    mockServer.use(
-      graphql.mutation('UpdateCustomApplicationFromCli', (_req, res, ctx) => {
-        return res(
-          ctx.data({
-            updateCustomApplication: {
-              id: 'application-id',
-            },
-          })
-        );
-      })
-    );
-  });
-  it('should match returned data', async () => {
-    const updatedCustomAppsData = await updateCustomApplication({
-      mcApiUrl,
-      organizationId: 'organization-id',
-      applicationId: 'application-id',
-      data: {
-        url: 'https://test.com',
-        name: 'New Test name',
-        description: 'Test description',
-        entryPointUriPath: 'new-test-custom-app',
-        icon: '<svg><path fill="#000000"></path></svg>',
-        submenuLinks: [],
-        mainMenuLink: {
-          defaultLabel: 'Test',
-          labelAllLocales: [],
-          permissions: [],
-        },
-        permissions: [
-          {
-            oAuthScopes: ['view_products', 'view_customers'],
-            name: 'viewNewTestCustomApp',
-          },
-          {
-            oAuthScopes: [],
-            name: 'manageNewTestCustomApp',
-          },
-        ],
-      },
-      applicationIdentifier,
-    });
-    expect(updatedCustomAppsData?.id).toEqual('application-id');
-  });
-});
 
 describe('fetch user organizations', () => {
   beforeEach(() => {
@@ -213,5 +52,343 @@ describe('fetch user organizations', () => {
     });
     expect(data.results[0].id).toEqual('test-organization-id');
     expect(data.results[0].name).toEqual('test-organization-name');
+  });
+});
+
+describe('Custom Applications', () => {
+  describe('fetch custom application data', () => {
+    beforeEach(() => {
+      mockServer.use(
+        graphql.query('FetchCustomApplicationFromCli', (_req, res, ctx) => {
+          return res(
+            ctx.data({
+              organizationExtensionForCustomApplication: {
+                organizationId: 'organization-id',
+                application: {
+                  id: 'application-id',
+                  url: 'https://test.com',
+                  name: 'Test name',
+                  description: 'Test description',
+                  entryPointUriPath: 'test-custom-app',
+                  icon: '<svg><path fill="#000000"></path></svg>',
+                  submenuLinks: [],
+                  mainMenuLink: [],
+                  permissions: [
+                    {
+                      oAuthScopes: ['view_products', 'view_customers'],
+                      name: 'viewTestCustomApp',
+                    },
+                    {
+                      oAuthScopes: [],
+                      name: 'manageTestCustomApp',
+                    },
+                  ],
+                },
+              },
+            })
+          );
+        })
+      );
+    });
+    it('should match returned data', async () => {
+      const organizationExtensionForCustomApplication =
+        await fetchCustomApplication({
+          entryPointUriPath: 'test-custom-app',
+          mcApiUrl,
+          applicationIdentifier,
+        });
+      expect(
+        organizationExtensionForCustomApplication?.application.entryPointUriPath
+      ).toEqual('test-custom-app');
+      expect(organizationExtensionForCustomApplication?.application.id).toEqual(
+        'application-id'
+      );
+      expect(organizationExtensionForCustomApplication?.organizationId).toEqual(
+        'organization-id'
+      );
+    });
+  });
+
+  describe('register custom application', () => {
+    beforeEach(() => {
+      mockServer.use(
+        graphql.mutation('CreateCustomApplicationFromCli', (_req, res, ctx) => {
+          return res(
+            ctx.data({
+              createCustomApplication: {
+                id: 'application-id',
+                url: 'https://test.com',
+                name: 'New Test name',
+                description: 'Test description',
+                entryPointUriPath: 'new-test-custom-app',
+                icon: '<svg><path fill="#000000"></path></svg>',
+                submenuLinks: [],
+                mainMenuLink: [],
+                permissions: [
+                  {
+                    oAuthScopes: ['view_products', 'view_customers'],
+                    name: 'viewNewTestCustomApp',
+                  },
+                  {
+                    oAuthScopes: [],
+                    name: 'manageNewTestCustomApp',
+                  },
+                ],
+              },
+            })
+          );
+        })
+      );
+    });
+    it('should match returned data', async () => {
+      const createdCustomAppsData = await createCustomApplication({
+        mcApiUrl,
+        organizationId: 'organization-id',
+        data: {
+          url: 'https://test.com',
+          name: 'New Test name',
+          description: 'Test description',
+          entryPointUriPath: 'new-test-custom-app',
+          icon: '<svg><path fill="#000000"></path></svg>',
+          submenuLinks: [],
+          mainMenuLink: {
+            defaultLabel: 'Test',
+            labelAllLocales: [],
+            permissions: [],
+          },
+          permissions: [
+            {
+              oAuthScopes: ['view_products', 'view_customers'],
+              name: 'viewNewTestCustomApp',
+            },
+            {
+              oAuthScopes: [],
+              name: 'manageNewTestCustomApp',
+            },
+          ],
+        },
+        applicationIdentifier,
+      });
+      expect(createdCustomAppsData?.id).toEqual('application-id');
+    });
+  });
+
+  describe('update custom application', () => {
+    beforeEach(() => {
+      mockServer.use(
+        graphql.mutation('UpdateCustomApplicationFromCli', (_req, res, ctx) => {
+          return res(
+            ctx.data({
+              updateCustomApplication: {
+                id: 'application-id',
+              },
+            })
+          );
+        })
+      );
+    });
+    it('should match returned data', async () => {
+      const updatedCustomAppsData = await updateCustomApplication({
+        mcApiUrl,
+        organizationId: 'organization-id',
+        applicationId: 'application-id',
+        data: {
+          url: 'https://test.com',
+          name: 'New Test name',
+          description: 'Test description',
+          entryPointUriPath: 'new-test-custom-app',
+          icon: '<svg><path fill="#000000"></path></svg>',
+          submenuLinks: [],
+          mainMenuLink: {
+            defaultLabel: 'Test',
+            labelAllLocales: [],
+            permissions: [],
+          },
+          permissions: [
+            {
+              oAuthScopes: ['view_products', 'view_customers'],
+              name: 'viewNewTestCustomApp',
+            },
+            {
+              oAuthScopes: [],
+              name: 'manageNewTestCustomApp',
+            },
+          ],
+        },
+        applicationIdentifier,
+      });
+      expect(updatedCustomAppsData?.id).toEqual('application-id');
+    });
+  });
+});
+describe('Custom Views', () => {
+  const customViewId = 'custom-view-id';
+  describe('fetch custom view data', () => {
+    beforeEach(() => {
+      mockServer.use(
+        graphql.query('FetchCustomViewFromCli', (_req, res, ctx) => {
+          return res(
+            ctx.data({
+              organizationExtensionForCustomView: {
+                organizationId: 'organization-id',
+                customView: {
+                  id: customViewId,
+                  url: 'https://test.com',
+                  defaultLabel: 'Test name',
+                  description: 'Test description',
+                  type: 'CustomPanel',
+                  typeSettings: {
+                    size: 'SMALL',
+                  },
+                  locators: [
+                    'products.product_variant_details.images',
+                    'customers.customer_details.custom_fields',
+                  ],
+                  permissions: [
+                    {
+                      oAuthScopes: ['view_products', 'view_customers'],
+                      name: 'viewTestCustomView',
+                    },
+                    {
+                      oAuthScopes: [],
+                      name: 'manageTestCustomView',
+                    },
+                  ],
+                  labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
+                },
+              },
+            })
+          );
+        })
+      );
+    });
+    it('should match returned data', async () => {
+      const organizationExtensionForCustomView = await fetchCustomView({
+        customViewId,
+        mcApiUrl,
+      });
+      expect(organizationExtensionForCustomView?.customView?.id).toEqual(
+        customViewId
+      );
+      expect(organizationExtensionForCustomView?.organizationId).toEqual(
+        'organization-id'
+      );
+    });
+  });
+
+  describe('register custom view', () => {
+    beforeEach(() => {
+      mockServer.use(
+        graphql.mutation('CreateCustomViewFromCli', (_req, res, ctx) => {
+          return res(
+            ctx.data({
+              createCustomView: {
+                id: customViewId,
+                url: 'https://test.com',
+                defaultLabel: 'New Test name',
+                description: 'Test description',
+                locators: [
+                  'products.product_variant_details.images',
+                  'customers.customer_details.custom_fields',
+                ],
+                type: 'CustomPanel',
+                typeSettings: {
+                  size: 'LARGE',
+                },
+                permissions: [
+                  {
+                    oAuthScopes: ['view_products', 'view_customers'],
+                    name: 'viewNewTestCustomView',
+                  },
+                  {
+                    oAuthScopes: [],
+                    name: 'manageNewTestCustomView',
+                  },
+                ],
+              },
+            })
+          );
+        })
+      );
+    });
+    it('should match returned data', async () => {
+      const createdCustomViewData = await createCustomView({
+        mcApiUrl,
+        organizationId: 'organization-id',
+        data: {
+          url: 'https://test.com',
+          defaultLabel: 'New Test name',
+          description: 'Test description',
+          locators: [
+            'products.product_variant_details.images',
+            'customers.customer_details.custom_fields',
+          ],
+          type: TCustomViewType['CustomPanel'],
+          typeSettings: {
+            size: TCustomViewSize.Large,
+          },
+          permissions: [
+            {
+              oAuthScopes: ['view_products', 'view_customers'],
+              name: 'viewNewTestCustomView',
+            },
+            {
+              oAuthScopes: [],
+              name: 'manageNewTestCustomView',
+            },
+          ],
+          labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
+        },
+      });
+      expect(createdCustomViewData?.id).toEqual(customViewId);
+    });
+  });
+
+  describe('update custom view', () => {
+    beforeEach(() => {
+      mockServer.use(
+        graphql.mutation('UpdateCustomViewFromCli', (_req, res, ctx) => {
+          return res(
+            ctx.data({
+              updateCustomView: {
+                id: customViewId,
+              },
+            })
+          );
+        })
+      );
+    });
+    it('should match returned data', async () => {
+      const updatedCustomAppsData = await updateCustomView({
+        mcApiUrl,
+        organizationId: 'organization-id',
+        customViewId,
+        data: {
+          url: 'https://test.com',
+          defaultLabel: 'New Test name',
+          description: 'Test description',
+          locators: [
+            'products.product_variant_details.images',
+            'customers.customer_details.custom_fields',
+          ],
+          type: TCustomViewType['CustomPanel'],
+          typeSettings: {
+            size: TCustomViewSize.Small,
+          },
+          permissions: [
+            {
+              oAuthScopes: ['view_products', 'view_customers'],
+              name: 'viewNewTestCustomView',
+            },
+            {
+              oAuthScopes: [],
+              name: 'manageNewTestCustomView',
+            },
+          ],
+          labelAllLocales: [{ locale: 'en', value: 'custom-view' }],
+        },
+      });
+      expect(updatedCustomAppsData?.id).toEqual(customViewId);
+    });
   });
 });

--- a/packages/mc-scripts/src/utils/graphql-requests.ts
+++ b/packages/mc-scripts/src/utils/graphql-requests.ts
@@ -40,6 +40,7 @@ type TFetchCustomApplicationOptions = {
 type TFetchCustomViewOptions = {
   mcApiUrl: string;
   customViewId: string;
+  applicationIdentifier: string;
 };
 type TUpdateCustomApplicationOptions = {
   mcApiUrl: string;
@@ -53,6 +54,7 @@ type TUpdateCustomViewOptions = {
   customViewId: string;
   organizationId: string;
   data: TCustomViewDraftDataInput;
+  applicationIdentifier: string;
 };
 type TCreateCustomApplicationOptions = {
   mcApiUrl: string;
@@ -64,10 +66,11 @@ type TCreateCustomViewOptions = {
   mcApiUrl: string;
   organizationId: string;
   data: TCustomViewDraftDataInput;
+  applicationIdentifier: string;
 };
 type TFetchUserOrganizationsOptions = {
   mcApiUrl: string;
-  applicationIdentifier?: string;
+  applicationIdentifier: string;
   customViewId?: string;
 };
 
@@ -175,6 +178,7 @@ const fetchCustomApplication = async ({
 const fetchCustomView = async ({
   mcApiUrl,
   customViewId,
+  applicationIdentifier,
 }: TFetchCustomViewOptions) => {
   const customViewData = await requestWithTokenRetry<
     TFetchCustomViewFromCliQuery,
@@ -184,6 +188,7 @@ const fetchCustomView = async ({
     mcApiUrl,
     headers: {
       'x-custom-view-id': customViewId,
+      'x-application-id': applicationIdentifier,
       'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
     },
   });
@@ -220,6 +225,7 @@ const updateCustomView = async ({
   organizationId,
   data,
   customViewId,
+  applicationIdentifier,
 }: TUpdateCustomViewOptions) => {
   const updatedCustomViewData = await requestWithTokenRetry<
     TUpdateCustomViewFromCliMutation,
@@ -233,6 +239,7 @@ const updateCustomView = async ({
     mcApiUrl,
     headers: {
       'x-custom-view-id': customViewId,
+      'x-application-id': applicationIdentifier,
       'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
     },
   });
@@ -266,6 +273,7 @@ const createCustomView = async ({
   mcApiUrl,
   organizationId,
   data,
+  applicationIdentifier,
 }: TCreateCustomViewOptions) => {
   const createdCustomViewData = await requestWithTokenRetry<
     TCreateCustomViewFromCliMutation,
@@ -277,6 +285,7 @@ const createCustomView = async ({
     },
     mcApiUrl,
     headers: {
+      'x-application-id': applicationIdentifier,
       'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
     },
   });
@@ -294,9 +303,7 @@ const fetchUserOrganizations = async ({
   >(FetchMyOrganizationsFromCli, {
     mcApiUrl,
     headers: {
-      ...(applicationIdentifier && {
-        'x-application-id': applicationIdentifier,
-      }),
+      'x-application-id': applicationIdentifier,
       ...(customViewId && {
         'x-custom-view-id': customViewId,
       }),

--- a/packages/mc-scripts/src/utils/graphql-requests.ts
+++ b/packages/mc-scripts/src/utils/graphql-requests.ts
@@ -64,7 +64,6 @@ type TCreateCustomViewOptions = {
   mcApiUrl: string;
   organizationId: string;
   data: TCustomViewDraftDataInput;
-  customViewId: string;
 };
 type TFetchUserOrganizationsOptions = {
   mcApiUrl: string;
@@ -267,7 +266,6 @@ const createCustomView = async ({
   mcApiUrl,
   organizationId,
   data,
-  customViewId,
 }: TCreateCustomViewOptions) => {
   const createdCustomViewData = await requestWithTokenRetry<
     TCreateCustomViewFromCliMutation,
@@ -279,7 +277,6 @@ const createCustomView = async ({
     },
     mcApiUrl,
     headers: {
-      'x-custom-view-id': customViewId,
       'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
     },
   });

--- a/packages/mc-scripts/src/utils/graphql-requests.ts
+++ b/packages/mc-scripts/src/utils/graphql-requests.ts
@@ -9,23 +9,37 @@ import type {
 import type {
   TCreateCustomApplicationFromCliMutation,
   TCreateCustomApplicationFromCliMutationVariables,
+  TCreateCustomViewFromCliMutation,
+  TCreateCustomViewFromCliMutationVariables,
   TCustomApplicationDraftDataInput,
+  TCustomViewDraftDataInput,
   TFetchCustomApplicationFromCliQuery,
   TFetchCustomApplicationFromCliQueryVariables,
+  TFetchCustomViewFromCliQuery,
+  TFetchCustomViewFromCliQueryVariables,
   TUpdateCustomApplicationFromCliMutation,
   TUpdateCustomApplicationFromCliMutationVariables,
+  TUpdateCustomViewFromCliMutation,
+  TUpdateCustomViewFromCliMutationVariables,
 } from '../generated/settings';
 import CreateCustomApplicationFromCli from './create-custom-application.settings.graphql';
+import CreateCustomViewFromCli from './create-custom-view.settings.graphql';
 import CredentialsStorage from './credentials-storage';
 import FetchCustomApplicationFromCli from './fetch-custom-application.settings.graphql';
+import FetchCustomViewFromCli from './fetch-custom-view.settings.graphql';
 import FetchMyOrganizationsFromCli from './fetch-user-organizations.core.graphql';
 import UpdateCustomApplicationFromCli from './update-custom-application.settings.graphql';
+import UpdateCustomViewFromCli from './update-custom-view.settings.graphql';
 import userAgent from './user-agent';
 
 type TFetchCustomApplicationOptions = {
   mcApiUrl: string;
   entryPointUriPath: string;
   applicationIdentifier: string;
+};
+type TFetchCustomViewOptions = {
+  mcApiUrl: string;
+  customViewId: string;
 };
 type TUpdateCustomApplicationOptions = {
   mcApiUrl: string;
@@ -34,15 +48,28 @@ type TUpdateCustomApplicationOptions = {
   data: TCustomApplicationDraftDataInput;
   applicationIdentifier: string;
 };
+type TUpdateCustomViewOptions = {
+  mcApiUrl: string;
+  customViewId: string;
+  organizationId: string;
+  data: TCustomViewDraftDataInput;
+};
 type TCreateCustomApplicationOptions = {
   mcApiUrl: string;
   organizationId: string;
   data: TCustomApplicationDraftDataInput;
   applicationIdentifier: string;
 };
+type TCreateCustomViewOptions = {
+  mcApiUrl: string;
+  organizationId: string;
+  data: TCustomViewDraftDataInput;
+  customViewId: string;
+};
 type TFetchUserOrganizationsOptions = {
   mcApiUrl: string;
-  applicationIdentifier: string;
+  applicationIdentifier?: string;
+  customViewId?: string;
 };
 
 const credentialsStorage = new CredentialsStorage();
@@ -146,6 +173,24 @@ const fetchCustomApplication = async ({
   return customAppData.organizationExtensionForCustomApplication;
 };
 
+const fetchCustomView = async ({
+  mcApiUrl,
+  customViewId,
+}: TFetchCustomViewOptions) => {
+  const customViewData = await requestWithTokenRetry<
+    TFetchCustomViewFromCliQuery,
+    TFetchCustomViewFromCliQueryVariables
+  >(FetchCustomViewFromCli, {
+    variables: { customViewId },
+    mcApiUrl,
+    headers: {
+      'x-custom-view-id': customViewId,
+      'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
+    },
+  });
+  return customViewData.organizationExtensionForCustomView;
+};
+
 const updateCustomApplication = async ({
   mcApiUrl,
   applicationId,
@@ -171,6 +216,30 @@ const updateCustomApplication = async ({
   return updatedCustomAppsData.updateCustomApplication;
 };
 
+const updateCustomView = async ({
+  mcApiUrl,
+  organizationId,
+  data,
+  customViewId,
+}: TUpdateCustomViewOptions) => {
+  const updatedCustomViewData = await requestWithTokenRetry<
+    TUpdateCustomViewFromCliMutation,
+    TUpdateCustomViewFromCliMutationVariables
+  >(UpdateCustomViewFromCli, {
+    variables: {
+      organizationId,
+      customViewId,
+      data,
+    },
+    mcApiUrl,
+    headers: {
+      'x-custom-view-id': customViewId,
+      'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
+    },
+  });
+  return updatedCustomViewData.updateCustomView;
+};
+
 const createCustomApplication = async ({
   mcApiUrl,
   organizationId,
@@ -194,9 +263,33 @@ const createCustomApplication = async ({
   return createdCustomAppData.createCustomApplication;
 };
 
+const createCustomView = async ({
+  mcApiUrl,
+  organizationId,
+  data,
+  customViewId,
+}: TCreateCustomViewOptions) => {
+  const createdCustomViewData = await requestWithTokenRetry<
+    TCreateCustomViewFromCliMutation,
+    TCreateCustomViewFromCliMutationVariables
+  >(CreateCustomViewFromCli, {
+    variables: {
+      organizationId,
+      data,
+    },
+    mcApiUrl,
+    headers: {
+      'x-custom-view-id': customViewId,
+      'x-graphql-target': GRAPHQL_TARGETS.SETTINGS_SERVICE,
+    },
+  });
+  return createdCustomViewData.createCustomView;
+};
+
 const fetchUserOrganizations = async ({
   mcApiUrl,
   applicationIdentifier,
+  customViewId,
 }: TFetchUserOrganizationsOptions) => {
   const userOrganizations = await requestWithTokenRetry<
     TFetchMyOrganizationsFromCliQuery,
@@ -204,7 +297,12 @@ const fetchUserOrganizations = async ({
   >(FetchMyOrganizationsFromCli, {
     mcApiUrl,
     headers: {
-      'x-application-id': applicationIdentifier,
+      ...(applicationIdentifier && {
+        'x-application-id': applicationIdentifier,
+      }),
+      ...(customViewId && {
+        'x-custom-view-id': customViewId,
+      }),
       'x-graphql-target': GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
     },
   });
@@ -213,7 +311,10 @@ const fetchUserOrganizations = async ({
 
 export {
   fetchCustomApplication,
+  fetchCustomView,
   updateCustomApplication,
   createCustomApplication,
   fetchUserOrganizations,
+  createCustomView,
+  updateCustomView,
 };

--- a/packages/mc-scripts/src/utils/update-custom-view.settings.graphql
+++ b/packages/mc-scripts/src/utils/update-custom-view.settings.graphql
@@ -1,0 +1,13 @@
+mutation UpdateCustomViewFromCli(
+  $organizationId: String!
+  $data: CustomViewDraftDataInput!
+  $customViewId: String!
+) {
+  updateCustomView(
+    organizationId: $organizationId
+    data: $data
+    customViewId: $customViewId
+  ) {
+    id
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2493,6 +2493,9 @@ importers:
         specifier: 5.0.2
         version: 5.0.2(webpack@5.82.1)
     devDependencies:
+      '@commercetools-test-data/custom-view':
+        specifier: ^6.4.1
+        version: 6.4.1
       '@tsconfig/node16':
         specifier: ^16.1.1
         version: 16.1.1
@@ -3847,7 +3850,6 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
-    dev: false
 
   /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.17):
     resolution: {integrity: sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==}
@@ -3876,7 +3878,6 @@ packages:
       resolve: 1.22.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
@@ -3925,19 +3926,6 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.22.17
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.15
-
-  /@babel/helper-module-transforms@7.22.17(@babel/core@7.23.0):
-    resolution: {integrity: sha512-XouDDhQESrLHTpnBtCKExJdyY4gJCdrvH2Pyv8r8kovX2U8G0dRUOT45T9XlbLtuu9CLXP15eusnkprhoPV5iQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.23.0
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -4006,7 +3994,6 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.17
-    dev: false
 
   /@babel/helper-replace-supers@7.22.9(@babel/core@7.22.17):
     resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
@@ -4131,7 +4118,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-Hyph9LseGvAeeXzikV88bczhsrLrIZqDPxO+sSmAunMPaGrBGhfMWzCPYTtiW9t+HzSE2wtV8e5cc5P6r1xMDQ==}
@@ -4154,7 +4140,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.17):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -4189,6 +4174,17 @@ packages:
       '@babel/plugin-syntax-do-expressions': 7.22.5(@babel/core@7.22.17)
     dev: false
 
+  /@babel/plugin-proposal-do-expressions@7.22.5(@babel/core@7.23.0):
+    resolution: {integrity: sha512-Qh6Sbkt6xCRbHykDc709db/EQB4RJlmaW3ENuvzzi7G6GKeDNQHx81P0OdI9oEXhhHEJvLRzIr08m8HNCJWS8g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-do-expressions': 7.22.5(@babel/core@7.23.0)
+    dev: true
+
   /@babel/plugin-proposal-export-default-from@7.22.17(@babel/core@7.22.17):
     resolution: {integrity: sha512-cop/3quQBVvdz6X5SJC6AhUv3C9DrVTM06LUEXimEdWAhCSyOJIr9NiZDU9leHZ0/aiG0Sh7Zmvaku5TWYNgbA==}
     engines: {node: '>=6.9.0'}
@@ -4199,6 +4195,17 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.22.5(@babel/core@7.22.17)
     dev: false
+
+  /@babel/plugin-proposal-export-default-from@7.22.17(@babel/core@7.23.0):
+    resolution: {integrity: sha512-cop/3quQBVvdz6X5SJC6AhUv3C9DrVTM06LUEXimEdWAhCSyOJIr9NiZDU9leHZ0/aiG0Sh7Zmvaku5TWYNgbA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-export-default-from': 7.22.5(@babel/core@7.23.0)
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.22.17):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -4313,7 +4320,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.0
-    dev: false
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.17):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -4381,7 +4387,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-do-expressions@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-60pOTgQGY00/Kiozrtu286Aqg50IxDy/jIHhlMzXjYTs1Q8lbeOgqC9NLidtqfBNwdX6bZCT6FJ2i5xzt+JKzw==}
@@ -4392,6 +4397,16 @@ packages:
       '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
+
+  /@babel/plugin-syntax-do-expressions@7.22.5(@babel/core@7.23.0):
+    resolution: {integrity: sha512-60pOTgQGY00/Kiozrtu286Aqg50IxDy/jIHhlMzXjYTs1Q8lbeOgqC9NLidtqfBNwdX6bZCT6FJ2i5xzt+JKzw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.17):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -4408,7 +4423,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-export-default-from@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-ODAqWWXB/yReh/jVQDag/3/tl6lgBueQkk/TcfW/59Oykm4c8a55XloX0CTk2k2VJiFWMgHby9xNX29IbCv9dQ==}
@@ -4419,6 +4433,16 @@ packages:
       '@babel/core': 7.22.17
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
+
+  /@babel/plugin-syntax-export-default-from@7.22.5(@babel/core@7.23.0):
+    resolution: {integrity: sha512-ODAqWWXB/yReh/jVQDag/3/tl6lgBueQkk/TcfW/59Oykm4c8a55XloX0CTk2k2VJiFWMgHby9xNX29IbCv9dQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.17):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -4435,7 +4459,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-flow@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==}
@@ -4483,7 +4506,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==}
@@ -4502,7 +4524,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.22.17):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -4685,7 +4706,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -4743,7 +4763,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
@@ -4786,7 +4805,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.17(@babel/core@7.23.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
@@ -4809,7 +4827,6 @@ packages:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.17(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
@@ -4866,7 +4883,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.22.17):
     resolution: {integrity: sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==}
@@ -4889,7 +4905,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-classes@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==}
@@ -4982,7 +4997,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
@@ -5001,7 +5015,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.22.17):
     resolution: {integrity: sha512-g/21plo58sfteWjaO0ZNVb+uEOkJNjAaHhbejrnBmu011l/eNDScmkbjCC3l4FKb10ViaGU4aOkFznSu2zRHgA==}
@@ -5022,7 +5035,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
@@ -5043,7 +5055,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.22.17):
     resolution: {integrity: sha512-xa7aad7q7OiT8oNZ1mU7NrISjlSkVdMbNxn9IuLZyL9AJEhs1Apba3I+u5riX1dIkdptP5EKDG5XDPByWxtehw==}
@@ -5064,7 +5075,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-tujNbZdxdG0/54g/oua8ISToaXTFBf8EnSb5PgQSciIXWOWKX3S4+JR7ZE9ol8FZwf9kxitzkGQ+QWeov/mCiA==}
@@ -5146,7 +5156,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
@@ -5185,7 +5194,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
@@ -5222,9 +5230,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-module-transforms': 7.22.17(@babel/core@7.23.0)
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-jWL4eh90w0HQOTKP2MoXXUpVxilxsB2Vl4ji69rSjS3EcZ/v4sBmn+A3NpepuJzBhOaEBbR7udonlHHn5DWidg==}
@@ -5244,7 +5251,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-module-transforms': 7.22.17(@babel/core@7.23.0)
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
@@ -5268,10 +5275,9 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.22.17(@babel/core@7.23.0)
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.15
-    dev: false
 
   /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
@@ -5290,9 +5296,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-module-transforms': 7.22.17(@babel/core@7.23.0)
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
@@ -5313,7 +5318,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
@@ -5332,7 +5336,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.22.17):
     resolution: {integrity: sha512-YZWOw4HxXrotb5xsjMJUDlLgcDXSfO9eCmdl1bgW4+/lAGdkjaEvOnQ4p5WKKdUgSzO39dgPl0pTnfxm0OAXcg==}
@@ -5353,7 +5356,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.22.17):
     resolution: {integrity: sha512-3dzU4QGPsILdJbASKhF/V2TVP+gJya1PsueQCxIPCEcerqF21oEcrob4mzjsp2Py/1nLfF5m+xYNMDpmA8vffg==}
@@ -5374,7 +5376,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-fEB+I1+gAmfAyxZcX1+ZUwLeAuuf8VIg67CTznZE0MqVFumWkh8xWtn58I4dxdVf080wn7gzWoF8vndOViJe9Q==}
@@ -5401,7 +5402,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
@@ -5442,7 +5442,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-optional-chaining@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-ngQ2tBhq5vvSJw2Q2Z9i7ealNkpDMU0rGWnHPKqRZO0tzZ5tlaoz4hDvhXioOoaE0X2vfNss1djwg0DXlfu30A==}
@@ -5465,7 +5464,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-parameters@7.22.15(@babel/core@7.12.9):
     resolution: {integrity: sha512-hjk7qKIqhyzhhUvRT683TYQOFa/4cQKwQy7ALvTpODswN40MljzNDa0YldevS6tGbxwaEKVn502JmY0dP7qEtQ==}
@@ -5514,7 +5512,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-private-property-in-object@7.22.11(@babel/core@7.22.17):
     resolution: {integrity: sha512-sSCbqZDBKHetvjSwpyWzhuHkmW5RummxJBVbYLkGkaiTOWGxml7SXt0iWa03bzxFIx7wOj3g/ILRd0RcJKBeSQ==}
@@ -5539,7 +5536,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
@@ -5614,7 +5610,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==}
@@ -5658,7 +5653,7 @@ packages:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.0
 
   /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==}
@@ -5679,7 +5674,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.22.17):
     resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
@@ -5700,7 +5694,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
-    dev: false
 
   /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
@@ -5719,7 +5712,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-runtime@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-tEVLhk8NRZSmwQ0DJtxxhTrCht1HVo8VaMzYT4w6lwyKBuHsgoioAUA7/6eT2fRfc5/23fuGdlwIxXhRVgWr4g==}
@@ -5736,6 +5728,23 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/plugin-transform-runtime@7.22.15(@babel/core@7.23.0):
+    resolution: {integrity: sha512-tEVLhk8NRZSmwQ0DJtxxhTrCht1HVo8VaMzYT4w6lwyKBuHsgoioAUA7/6eT2fRfc5/23fuGdlwIxXhRVgWr4g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.0)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.0)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
@@ -5792,7 +5801,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
@@ -5829,7 +5837,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==}
@@ -5873,7 +5880,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==}
@@ -5894,7 +5900,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
@@ -5915,7 +5920,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.17):
     resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==}
@@ -5936,7 +5940,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/preset-env@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-tZFHr54GBkHk6hQuVA8w4Fmq+MSPsfvMG0vPnOYyTnJpyfMqybL8/MbNCPRT9zc2KBO2pe4tq15g6Uno4Jpoag==}
@@ -6117,7 +6120,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-flow@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-dB5aIMqpkgbTfN5vDdTRPzjqtWiZcRESNR88QYnoPR+bmdYoluOzMX9tQerTv0XzSgZYctPfO1oc0N5zdog1ew==}
@@ -6148,9 +6150,8 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/types': 7.22.17
+      '@babel/types': 7.23.0
       esutils: 2.0.3
-    dev: false
 
   /@babel/preset-react@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-Csy1IJ2uEh/PecCBXXoZGAZBeCATTuePzCSB7dLYWS0vOEj6CNpjxIhW4duWwZodBNueH7QO14WbGn8YyeuN9w==}
@@ -6179,7 +6180,6 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.0)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.0)
       '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.23.0)
-    dev: false
 
   /@babel/preset-typescript@7.22.15(@babel/core@7.22.17):
     resolution: {integrity: sha512-HblhNmh6yM+cU4VwbBRpxFhxsTdfS1zsvH9W+gEjD0ARV9+8B4sNfpI6GuhePti84nuvhiwKS539jKPFHskA9A==}
@@ -6221,6 +6221,20 @@ packages:
       pirates: 4.0.5
       source-map-support: 0.5.21
     dev: false
+
+  /@babel/register@7.22.15(@babel/core@7.23.0):
+    resolution: {integrity: sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.0
+      clone-deep: 4.0.1
+      find-cache-dir: 2.1.0
+      make-dir: 2.1.0
+      pirates: 4.0.5
+      source-map-support: 0.5.21
+    dev: true
 
   /@babel/regjsgen@0.8.0:
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
@@ -6829,6 +6843,73 @@ packages:
       shelljs: 0.8.5
     dev: false
 
+  /@commercetools-frontend/application-config@22.11.0:
+    resolution: {integrity: sha512-duD29RMllJYDi65jn+52TdYE4Mudnb3g0YQ2gbFJkltKazME+jEYyS0/xnx01A/AW043LkbpdGA1XPnfMb0CcA==}
+    engines: {node: 16.x || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/register': 7.22.15(@babel/core@7.23.0)
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+      '@commercetools-frontend/babel-preset-mc-app': 22.11.0
+      '@commercetools-frontend/constants': 22.11.0
+      '@types/dompurify': 2.4.0
+      '@types/lodash': 4.14.198
+      '@types/react': 17.0.56
+      ajv: 8.12.0
+      core-js: 3.32.2
+      cosmiconfig: 7.1.0
+      dompurify: 2.4.7
+      jsdom: 21.1.2
+      lodash: 4.17.21
+      omit-empty-es: 1.1.3
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@commercetools-frontend/babel-preset-mc-app@22.11.0:
+    resolution: {integrity: sha512-IplxlUuKl9wMDUpsd7JH9vLz2Du8AZyJFRh0J+OORIxH2g43NfVsmj5hV7Iur6lq+EQdqNYRflNEn/7Dpx3Cmg==}
+    engines: {node: 16.x || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/plugin-proposal-do-expressions': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-proposal-export-default-from': 7.22.17(@babel/core@7.23.0)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-transform-destructuring': 7.22.15(@babel/core@7.23.0)
+      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.23.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.23.0)
+      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.23.0)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.23.0)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.23.0)
+      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.0)
+      '@babel/preset-env': 7.22.15(@babel/core@7.23.0)
+      '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
+      '@babel/preset-typescript': 7.22.15(@babel/core@7.23.0)
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/babel-preset-css-prop': 11.11.0(@babel/core@7.23.0)
+      babel-plugin-dev-expression: 0.2.3(@babel/core@7.23.0)
+      babel-plugin-lodash: 3.3.4
+      babel-plugin-macros: 3.1.0
+      babel-plugin-preval: 5.1.0
+      babel-plugin-transform-react-remove-prop-types: 0.4.24
+      core-js: 3.32.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@commercetools-frontend/constants@22.11.0:
+    resolution: {integrity: sha512-fRCBddiJf5xtE/TIgIDPQbu+I2wdLJfey0PVdsCnyD1HQbXO/lkUnOH1zG6RQjK9aaE+22qBZ8+J/jIORtKVaA==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+    dev: true
+
   /@commercetools-test-data/channel@4.11.1:
     resolution: {integrity: sha512-AQBjcYrkjOYegTq6aFfCX5rKHIf0gFpgUNfHYutEcpjMXPEZpnQ2vATUWe6nmYKbAuHfrplMxDA6kR+3Dflz/Q==}
     dependencies:
@@ -6856,6 +6937,21 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /@commercetools-test-data/commons@6.4.1:
+    resolution: {integrity: sha512-77+dDMcLKOUPyrFOoM9SrpptdV6D+fiqKUT4k0gZZ5lwFlOYcvZnbu6P7p1WyT7C0JxuEdq3d5PWy5wSfgIdRg==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+      '@commercetools-test-data/core': 6.4.1
+      '@commercetools-test-data/utils': 6.4.1
+      '@commercetools/platform-sdk': 6.0.0
+      '@faker-js/faker': 8.2.0
+      '@types/lodash': 4.14.198
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /@commercetools-test-data/core@4.11.1:
     resolution: {integrity: sha512-9K/sTN53T65oJ5LkuNpxZN51ZY0a9ivzLeDhPA2f/p9Iay48Sm5eVVX6t1i+kCO5LD3TN7LRQqIA1kHELmcdHA==}
     dependencies:
@@ -6865,6 +6961,38 @@ packages:
       '@types/lodash': 4.14.198
       lodash: 4.17.21
 
+  /@commercetools-test-data/core@6.4.1:
+    resolution: {integrity: sha512-rQO3SYMOiVSzFxFQP/BZCG/d/VnnaDikCzqT3RCZJ7VSAGVykiiJgUUbVxDzdsNYWNl/RQGeSxs2MDRwPTK4kg==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+      '@faker-js/faker': 8.2.0
+      '@types/lodash': 4.14.198
+      lodash: 4.17.21
+    dev: true
+
+  /@commercetools-test-data/custom-view@6.4.1:
+    resolution: {integrity: sha512-x/UGusfH6L2NbhL9a7xlYtTtrysrLHniBfb1nrSyrruPVr3Cs7HCN3AECRh3dFQtOXZXtgkfQGp0/AG+o8nlpA==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+      '@commercetools-frontend/application-config': 22.11.0
+      '@commercetools-frontend/constants': 22.11.0
+      '@commercetools-test-data/commons': 6.4.1
+      '@commercetools-test-data/core': 6.4.1
+      '@commercetools-test-data/utils': 6.4.1
+      '@commercetools/platform-sdk': 6.0.0
+      '@faker-js/faker': 8.2.0
+      '@types/lodash': 4.14.198
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@commercetools-test-data/utils@4.11.1:
     resolution: {integrity: sha512-Y8NbbSPWht2GAcX7pQiVhjCJwn4FMZpRq6fyCq5ZjPr+gWXkfoO0f+gZncI/1asShs5fAXavyQx+bw1/2CtZng==}
     dependencies:
@@ -6872,6 +7000,14 @@ packages:
       '@babel/runtime-corejs3': 7.22.15
       '@faker-js/faker': 7.6.0
     dev: false
+
+  /@commercetools-test-data/utils@6.4.1:
+    resolution: {integrity: sha512-fkYsW3YQgA2ciqsuAObgK0yuB4H6SL5hlMqMBT6MmYpxfV+MYAaBi7JQLqXGQ/leXqd4fpAxHdZ6JRfyeolz5g==}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@babel/runtime-corejs3': 7.22.15
+      '@faker-js/faker': 8.2.0
+    dev: true
 
   /@commercetools-uikit/accessible-button@16.7.3(@types/react@17.0.56)(react@17.0.2):
     resolution: {integrity: sha512-po0eteNTgpMp2umK9Y4SgHOjsGrR6jvAhJVr87/S5JLf3u58vB5fyxHoPJBNpJj1b8IwhDObeiaUb54mpF8g9w==}
@@ -6898,7 +7034,7 @@ packages:
     peerDependencies:
       react: 17.x
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.22.15
       '@babel/runtime-corejs3': 7.22.15
       '@commercetools-uikit/design-system': 16.7.3(@types/react@17.0.56)
       '@commercetools-uikit/utils': 16.7.3(react@18.2.0)
@@ -7093,7 +7229,7 @@ packages:
     peerDependencies:
       react: 17.x
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.22.15
       '@babel/runtime-corejs3': 7.22.15
       '@commercetools-uikit/design-system': 16.7.3(@types/react@17.0.56)
       '@commercetools-uikit/utils': 16.7.3(react@18.2.0)
@@ -7525,7 +7661,7 @@ packages:
     peerDependencies:
       react: 17.x
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.22.15
       '@babel/runtime-corejs3': 7.22.15
       '@commercetools-uikit/accessible-button': 16.7.3(@types/react@17.0.56)(react@18.2.0)
       '@commercetools-uikit/design-system': 16.7.3(@types/react@17.0.56)
@@ -7722,7 +7858,7 @@ packages:
       react-intl: 6.x
       react-router-dom: 5.x
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.22.15
       '@babel/runtime-corejs3': 7.22.15
       '@commercetools-uikit/design-system': 16.7.3(@types/react@17.0.56)
       '@commercetools-uikit/icons': 16.7.3(@types/react@17.0.56)(react@18.2.0)
@@ -9004,6 +9140,18 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /@commercetools/platform-sdk@6.0.0:
+    resolution: {integrity: sha512-ADpyUUiDJ6ltTc1l5H4I/Rn0MyqSAD2ZP5QHiq++SAtM2CNEjfqgePty07sUhG8IxdN145i7/XNHopMxwap8Ow==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@commercetools/sdk-client-v2': 2.3.0
+      '@commercetools/sdk-middleware-auth': 7.0.1
+      '@commercetools/sdk-middleware-http': 7.0.2
+      '@commercetools/sdk-middleware-logger': 3.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /@commercetools/sdk-client-v2@2.1.5:
     resolution: {integrity: sha512-coE3c4qpG8u+QR9GmaXIIWfhQgH+n8DA3PSGUJWnDh+tDFxcjqFp1MV8RKRj/nV1/h4KkEkqWuVFzT7pBTDNdQ==}
     engines: {node: '>=14'}
@@ -9013,6 +9161,16 @@ packages:
       querystring: 0.2.1
     transitivePeerDependencies:
       - encoding
+
+  /@commercetools/sdk-client-v2@2.3.0:
+    resolution: {integrity: sha512-+vS6qRoKBbkunZCpdozung+7te97nFxaidLPqOTlz/9TmJaRfMMcYC/KUZCTS8S5a/4BFfY6DYujddolaU7e6Q==}
+    engines: {node: '>=14'}
+    dependencies:
+      buffer: 6.0.3
+      node-fetch: 2.6.11
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
   /@commercetools/sdk-client@3.0.0:
     resolution: {integrity: sha512-N8Eem8aHyxs3xAfscuemERbhH4po/1fMQs0SBfWgLda77qaIGyyfMqwgJNsPBweBsyt5RC9p5tpMDZ0lSPugDA==}
@@ -9336,7 +9494,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
-    dev: false
 
   /@emotion/babel-plugin@11.11.0:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
@@ -9375,7 +9532,6 @@ packages:
       '@babel/runtime': 7.22.15
       '@emotion/babel-plugin': 11.11.0
       '@emotion/babel-plugin-jsx-pragmatic': 0.2.1(@babel/core@7.23.0)
-    dev: false
 
   /@emotion/cache@11.11.0:
     resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
@@ -9791,6 +9947,11 @@ packages:
   /@faker-js/faker@7.6.0:
     resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+
+  /@faker-js/faker@8.2.0:
+    resolution: {integrity: sha512-VacmzZqVxdWdf9y64lDOMZNDMM/FQdtM9IsaOPKOm2suYwEatb8VkdHqOzXcDnZbk7YDE2BmsJmy/2Hmkn563g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+    dev: true
 
   /@floating-ui/core@1.2.6:
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
@@ -13607,7 +13768,6 @@ packages:
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
-    dev: false
 
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -13752,7 +13912,6 @@ packages:
     resolution: {integrity: sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==}
     dependencies:
       '@types/trusted-types': 2.0.3
-    dev: false
 
   /@types/dotenv-flow@3.3.1:
     resolution: {integrity: sha512-z4W5zC6mx9j1OGV+cUDoyLqYkh09BCUq64+TPwnmWpqXQs39DpegWtFQBzvNDdjeXhzW9Xvuy+z1Fn2RSkfTfA==}
@@ -14258,7 +14417,6 @@ packages:
 
   /@types/trusted-types@2.0.3:
     resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
-    dev: false
 
   /@types/ungap__structured-clone@0.3.0:
     resolution: {integrity: sha512-eBWREUhVUGPze+bUW22AgUr05k8u+vETzuYdLYSvWqGTUe0KOf+zVnOB1qER5wMcw8V6D9Ar4DfJmVvD1yu0kQ==}
@@ -14911,7 +15069,6 @@ packages:
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    dev: false
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -14939,7 +15096,6 @@ packages:
     dependencies:
       acorn: 8.8.2
       acorn-walk: 8.2.0
-    dev: false
 
   /acorn-import-assertions@1.8.0(acorn@8.10.0):
     resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
@@ -15625,6 +15781,14 @@ packages:
       '@babel/core': 7.22.17
     dev: false
 
+  /babel-plugin-dev-expression@0.2.3(@babel/core@7.23.0):
+    resolution: {integrity: sha512-rP5LK9QQTzCW61nVVzw88En1oK8t8gTsIeC6E61oelxNsU842yMjF0G1MxhvUpCkxCEIj7sE8/e5ieTheT//uw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.23.0
+    dev: true
+
   /babel-plugin-dynamic-import-node@2.3.3:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
     dependencies:
@@ -15708,7 +15872,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.22.17):
     resolution: {integrity: sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==}
@@ -15731,7 +15894,6 @@ packages:
       core-js-compat: 3.32.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.22.17):
     resolution: {integrity: sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==}
@@ -15752,7 +15914,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /babel-plugin-preval@5.1.0:
     resolution: {integrity: sha512-G5R+xmo5LS41A4UyZjOjV0mp9AvkuCyUOAJ6TOv/jTZS+VKh7L7HUDRcCSOb0YCM/u0fFarh7Diz0wjY8rFNFg==}
@@ -15762,7 +15923,6 @@ packages:
       '@types/babel__core': 7.20.1
       babel-plugin-macros: 3.1.0
       require-from-string: 2.0.2
-    dev: false
 
   /babel-plugin-remove-graphql-queries@5.12.0(@babel/core@7.22.17)(gatsby@5.12.4):
     resolution: {integrity: sha512-9lLU6pYKtS0tSfqzehAHp1ODgTzOtoZPIkVfmjCTxATtEmgCO+Z8tptdW+pcp2cKEs9BIJ6SuOkE47SEXxVeiw==}
@@ -17581,7 +17741,6 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       rrweb-cssom: 0.6.0
-    dev: false
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -17710,7 +17869,6 @@ packages:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-    dev: false
 
   /dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -17809,7 +17967,6 @@ packages:
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
-    dev: false
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -18157,7 +18314,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       webidl-conversions: 7.0.0
-    dev: false
 
   /domhandler@2.4.2:
     resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
@@ -18179,7 +18335,6 @@ packages:
 
   /dompurify@2.4.7:
     resolution: {integrity: sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==}
-    dev: false
 
   /domutils@1.5.1:
     resolution: {integrity: sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==}
@@ -20015,7 +20170,6 @@ packages:
       commondir: 1.0.1
       make-dir: 2.1.0
       pkg-dir: 3.0.0
-    dev: false
 
   /find-cache-dir@3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
@@ -22172,7 +22326,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       whatwg-encoding: 2.0.0
-    dev: false
 
   /html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
@@ -22299,7 +22452,6 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /http-proxy-middleware@2.0.6(@types/express@4.17.17):
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
@@ -22398,7 +22550,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: false
 
   /icss-replace-symbols@1.1.0:
     resolution: {integrity: sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==}
@@ -22936,7 +23087,6 @@ packages:
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-    dev: false
 
   /is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
@@ -24057,7 +24207,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -24902,7 +25051,6 @@ packages:
     dependencies:
       pify: 4.0.1
       semver: 5.7.2
-    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -26437,7 +26585,6 @@ packages:
 
   /nwsapi@2.2.4:
     resolution: {integrity: sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==}
-    dev: false
 
   /oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
@@ -26536,7 +26683,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.15
       '@babel/runtime-corejs3': 7.22.15
-    dev: false
 
   /on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -27110,7 +27256,6 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
-    dev: false
 
   /pirates@4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
@@ -27121,7 +27266,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       find-up: 3.0.0
-    dev: false
 
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -27994,7 +28138,6 @@ packages:
 
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -29355,7 +29498,6 @@ packages:
 
   /rrweb-cssom@0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
-    dev: false
 
   /rss@1.2.2:
     resolution: {integrity: sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==}
@@ -29430,7 +29572,6 @@ packages:
     engines: {node: '>=v12.22.7'}
     dependencies:
       xmlchars: 2.2.0
-    dev: false
 
   /scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -30695,7 +30836,6 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: false
 
   /sync-fetch@0.3.0:
     resolution: {integrity: sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==}
@@ -31030,7 +31170,6 @@ packages:
       punycode: 2.3.0
       universalify: 0.2.0
       url-parse: 1.5.10
-    dev: false
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -31047,7 +31186,6 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       punycode: 2.3.0
-    dev: false
 
   /traverse@0.3.9:
     resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
@@ -31853,7 +31991,6 @@ packages:
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
-    dev: false
 
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -31955,7 +32092,6 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-    dev: false
 
   /url@0.11.0:
     resolution: {integrity: sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==}
@@ -32319,7 +32455,6 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       xml-name-validator: 4.0.0
-    dev: false
 
   /wait-for-expect@3.0.2:
     resolution: {integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==}
@@ -32411,7 +32546,6 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
-    dev: false
 
   /webpack-bundle-analyzer@4.8.0:
     resolution: {integrity: sha512-ZzoSBePshOKhr+hd8u6oCkZVwpVaXgpw23ScGLFpR6SjYI7+7iIWYarjN6OEYOfRt8o7ZyZZQk0DuMizJ+LEIg==}
@@ -32648,12 +32782,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
-    dev: false
 
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
-    dev: false
 
   /whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
@@ -32669,7 +32801,6 @@ packages:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
-    dev: false
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -32909,7 +33040,6 @@ packages:
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
-    dev: false
 
   /xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
@@ -32917,7 +33047,6 @@ packages:
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: false
 
   /xmlhttprequest-ssl@2.0.0:
     resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -6695,6 +6695,35 @@
             "deprecationReason": null
           },
           {
+            "name": "activateOrderDetailView",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrderDetailView",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "activateOrdersListView",
             "description": null,
             "args": [
@@ -7376,6 +7405,39 @@
             "deprecationReason": null
           },
           {
+            "name": "createOrderDetailView",
+            "description": null,
+            "args": [
+              {
+                "name": "data",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "OrderDetailViewInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "OrderDetailView",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createOrdersListView",
             "description": null,
             "args": [
@@ -7744,6 +7806,35 @@
             "deprecationReason": null
           },
           {
+            "name": "deactivateOrderDetailView",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrderDetailView",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "deactivateOrdersListView",
             "description": null,
             "args": [
@@ -7933,6 +8024,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "DashboardView",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteAllOrderDetailViews",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "OrderDetailView",
                     "ofType": null
                   }
                 }
@@ -8273,6 +8388,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "DiscountsCustomView",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteOrderDetailView",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrderDetailView",
               "ofType": null
             },
             "isDeprecated": false,
@@ -9486,6 +9630,51 @@
             "type": {
               "kind": "OBJECT",
               "name": "DiscountsCustomView",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateOrderDetailView",
+            "description": null,
+            "args": [
+              {
+                "name": "data",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "OrderDetailViewInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrderDetailView",
               "ofType": null
             },
             "isDeprecated": false,
@@ -10900,6 +11089,223 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "OrderDetailView",
+        "description": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nameAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedField",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "table",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Table",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "OrderDetailViewInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "nameAllLocales",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LocalizedFieldCreateInput",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "table",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrderDetailViewTableInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "OrderDetailViewTableInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "visibleColumns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "OrderStatesVisibility",
         "description": null,
@@ -11651,6 +12057,73 @@
                 "name": "RestrictedCustomApplicationForOrganization",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "OrganizationExtensionForCustomView",
+        "description": null,
+        "fields": [
+          {
+            "name": "customView",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RestrictedCustomViewForOrganization",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13227,6 +13700,18 @@
             "deprecationReason": null
           },
           {
+            "name": "activeOrderDetailView",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrderDetailView",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "activeOrdersListView",
             "description": null,
             "args": [],
@@ -14069,6 +14554,55 @@
             "deprecationReason": null
           },
           {
+            "name": "orderDetailView",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrderDetailView",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderDetailViews",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderDetailView",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ordersListView",
             "description": null,
             "args": [
@@ -14170,6 +14704,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "OrganizationExtensionForCustomApplication",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationExtensionForCustomView",
+            "description": null,
+            "args": [
+              {
+                "name": "customViewId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrganizationExtensionForCustomView",
               "ofType": null
             },
             "isDeprecated": false,
@@ -16742,6 +17305,12 @@
         "enumValues": [
           {
             "name": "FASHION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GOODSTORE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<img width="647" alt="Screenshot 2023-11-06 at 09 55 48" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/9975c604-38ad-4a3a-bf97-9708b214fc64">
