### PR TITLE
Project and locale switcher changes

### DIFF
--- a/.changeset/six-needles-kiss.md
+++ b/.changeset/six-needles-kiss.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Removing the counters from locale and project swritchers. And adjusting their widths.

--- a/.changeset/six-needles-kiss.md
+++ b/.changeset/six-needles-kiss.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-shell': patch
 ---
 
-Removing the counters from locale and project swritchers. And adjusting their widths.
+Removing the counters from locale and project switcher in the app bar.

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
@@ -58,11 +58,7 @@ const LocaleSwitcher = (props: Props) => {
     [setProjectDataLocale]
   );
   return (
-    <div
-      css={css`
-        position: relative;
-      `}
-    >
+    <div>
       <AccessibleHidden>
         <span id={LOCALE_SWITCHER_LABEL_ID}>
           <FormattedMessage {...messages.localesLabel} />

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
@@ -1,7 +1,11 @@
 import { useCallback } from 'react';
 import { css } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
-import type { SingleValueProps, ValueContainerProps } from 'react-select';
+import type {
+  SingleValueProps,
+  ValueContainerProps,
+  MenuListProps,
+} from 'react-select';
 import { components } from 'react-select';
 import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 import { designTokens } from '@commercetools-uikit/design-system';
@@ -49,6 +53,19 @@ const PatchedValueContainer = (props: ValueContainerProps) => (
 );
 PatchedValueContainer.displayName = 'PatchedValueContainer';
 
+const CustomMenuList = (props: MenuListProps) => {
+  return (
+    <div
+      css={css`
+        width: max-content;
+        max-width: ${designTokens.constraint6};
+      `}
+    >
+      <components.MenuList {...props}>{props.children}</components.MenuList>
+    </div>
+  );
+};
+
 const LocaleSwitcher = (props: Props) => {
   const { setProjectDataLocale } = props;
   const handleSelection = useCallback(
@@ -78,18 +95,7 @@ const LocaleSwitcher = (props: Props) => {
             <SingleValue {...valueProps} />
           ),
           ValueContainer: PatchedValueContainer,
-          MenuList: (props) => (
-            <div
-              css={css`
-                width: max-content;
-                max-width: ${designTokens.constraint6};
-              `}
-            >
-              <components.MenuList {...props}>
-                {props.children}
-              </components.MenuList>
-            </div>
-          ),
+          MenuList: CustomMenuList,
         }}
         isClearable={false}
         backspaceRemovesValue={false}

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
@@ -91,9 +91,7 @@ const LocaleSwitcher = (props: Props) => {
           value: locale,
         }))}
         components={{
-          SingleValue: (valueProps: SingleValueProps) => (
-            <SingleValue {...valueProps} />
-          ),
+          SingleValue,
           ValueContainer: PatchedValueContainer,
           MenuList: CustomMenuList,
         }}

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { css } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
 import type { SingleValueProps, ValueContainerProps } from 'react-select';
+import { components } from 'react-select';
 import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 import { designTokens } from '@commercetools-uikit/design-system';
 import { WorldIcon } from '@commercetools-uikit/icons';
@@ -60,7 +61,6 @@ const LocaleSwitcher = (props: Props) => {
     <div
       css={css`
         position: relative;
-        width: ${designTokens.constraint4};
       `}
     >
       <AccessibleHidden>
@@ -82,10 +82,23 @@ const LocaleSwitcher = (props: Props) => {
             <SingleValue {...valueProps} />
           ),
           ValueContainer: PatchedValueContainer,
+          MenuList: (props) => (
+            <div
+              css={css`
+                width: max-content;
+                max-width: ${designTokens.constraint6};
+              `}
+            >
+              <components.MenuList {...props}>
+                {props.children}
+              </components.MenuList>
+            </div>
+          ),
         }}
         isClearable={false}
         backspaceRemovesValue={false}
         isSearchable={false}
+        horizontalConstraint={'auto'}
       />
     </div>
   );

--- a/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
+++ b/packages/application-shell/src/components/locale-switcher/locale-switcher.tsx
@@ -8,9 +8,6 @@ import { WorldIcon } from '@commercetools-uikit/icons';
 import SelectInput from '@commercetools-uikit/select-input';
 import messages from './messages';
 
-type CustomSingleValueProps = SingleValueProps & {
-  localeCount: number;
-};
 type Props = {
   projectDataLocale: string;
   setProjectDataLocale: (locale: string) => void;
@@ -19,7 +16,7 @@ type Props = {
 
 const LOCALE_SWITCHER_LABEL_ID = 'locale-switcher-label';
 
-export const SingleValue = (props: CustomSingleValueProps) => {
+export const SingleValue = (props: SingleValueProps) => {
   return (
     <div
       css={css`
@@ -37,21 +34,6 @@ export const SingleValue = (props: CustomSingleValueProps) => {
         `}
       >
         {props.children}
-      </span>
-      <span
-        css={css`
-          width: 26px;
-          height: 26px;
-          border-radius: 100%;
-          background: ${designTokens.colorNeutral};
-          color: ${designTokens.colorSurface};
-          font-size: ${designTokens.fontSize30};
-          display: flex;
-          justify-content: center;
-          align-items: center;
-        `}
-      >
-        {props.localeCount}
       </span>
     </div>
   );
@@ -97,10 +79,7 @@ const LocaleSwitcher = (props: Props) => {
         }))}
         components={{
           SingleValue: (valueProps: SingleValueProps) => (
-            <SingleValue
-              {...valueProps}
-              localeCount={props.availableLocales.length}
-            />
+            <SingleValue {...valueProps} />
           ),
           ValueContainer: PatchedValueContainer,
         }}

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -38,9 +38,7 @@ type OptionType = Pick<TProject, 'key' | 'name' | 'suspension' | 'expiry'> & {
 
 const PROJECT_SWITCHER_LABEL_ID = 'project-switcher-label';
 
-export const ProjectSwitcherValueContainer = ({
-  ...restProps
-}: ValueContainerProps) => {
+export const ValueContainer = ({ ...restProps }: ValueContainerProps) => {
   return (
     <div
       css={css`
@@ -196,9 +194,7 @@ const ProjectSwitcher = (props: Props) => {
         }}
         components={{
           Option: ProjectSwitcherOption,
-          ValueContainer: (valueContainerProps) => (
-            <ProjectSwitcherValueContainer {...valueContainerProps} />
-          ),
+          ValueContainer,
           MenuList: CustomMenuList,
         }}
         isClearable={false}

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -1,7 +1,11 @@
 import { css } from '@emotion/react';
 import memoize from 'memoize-one';
 import { FormattedMessage, useIntl } from 'react-intl';
-import type { OptionProps, ValueContainerProps } from 'react-select';
+import type {
+  OptionProps,
+  ValueContainerProps,
+  MenuListProps,
+} from 'react-select';
 import { components } from 'react-select';
 import {
   useMcQuery,
@@ -130,6 +134,19 @@ const mapProjectsToOptions = memoize((projects) =>
   }))
 );
 
+const CustomMenuList = (props: MenuListProps) => {
+  return (
+    <div
+      css={css`
+        width: max-content;
+        max-width: ${designTokens.constraint6};
+      `}
+    >
+      <components.MenuList {...props}>{props.children}</components.MenuList>
+    </div>
+  );
+};
+
 const redirectTo = (targetUrl: string) => location.replace(targetUrl);
 
 const ProjectSwitcher = (props: Props) => {
@@ -182,18 +199,7 @@ const ProjectSwitcher = (props: Props) => {
           ValueContainer: (valueContainerProps) => (
             <ProjectSwitcherValueContainer {...valueContainerProps} />
           ),
-          MenuList: (props) => (
-            <div
-              css={css`
-                width: max-content;
-                max-width: ${designTokens.constraint6};
-              `}
-            >
-              <components.MenuList {...props}>
-                {props.children}
-              </components.MenuList>
-            </div>
-          ),
+          MenuList: CustomMenuList,
         }}
         isClearable={false}
         backspaceRemovesValue={false}

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import memoize from 'memoize-one';
 import { FormattedMessage, useIntl } from 'react-intl';
 import type { OptionProps, ValueContainerProps } from 'react-select';
+import { components } from 'react-select';
 import {
   useMcQuery,
   oidcStorage,
@@ -180,6 +181,18 @@ const ProjectSwitcher = (props: Props) => {
           Option: ProjectSwitcherOption,
           ValueContainer: (valueContainerProps) => (
             <ProjectSwitcherValueContainer {...valueContainerProps} />
+          ),
+          MenuList: (props) => (
+            <div
+              css={css`
+                width: max-content;
+                max-width: ${designTokens.constraint6};
+              `}
+            >
+              <components.MenuList {...props}>
+                {props.children}
+              </components.MenuList>
+            </div>
           ),
         }}
         isClearable={false}

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -30,16 +30,12 @@ type Props = {
 type OptionType = Pick<TProject, 'key' | 'name' | 'suspension' | 'expiry'> & {
   label: string;
 };
-type CustomValueContainerProps = ValueContainerProps & {
-  projectCount: number;
-};
 
 const PROJECT_SWITCHER_LABEL_ID = 'project-switcher-label';
 
 export const ProjectSwitcherValueContainer = ({
-  projectCount,
   ...restProps
-}: CustomValueContainerProps) => {
+}: ValueContainerProps) => {
   return (
     <div
       css={css`
@@ -57,21 +53,6 @@ export const ProjectSwitcherValueContainer = ({
           {restProps.children}
         </SelectInput.ValueContainer>
       </div>
-      <span
-        css={css`
-          width: 26px;
-          height: 26px;
-          border-radius: 100%;
-          background: ${designTokens.colorNeutral};
-          color: ${designTokens.colorSurface};
-          font-size: ${designTokens.fontSize30};
-          display: flex;
-          justify-content: center;
-          align-items: center;
-        `}
-      >
-        {projectCount}
-      </span>
     </div>
   );
 };
@@ -165,11 +146,7 @@ const ProjectSwitcher = (props: Props) => {
   if (loading) return null;
 
   return (
-    <div
-      css={css`
-        width: ${designTokens.constraint6};
-      `}
-    >
+    <div>
       <AccessibleHidden>
         <span id={PROJECT_SWITCHER_LABEL_ID}>
           <FormattedMessage {...messages.projectsLabel} />
@@ -202,18 +179,14 @@ const ProjectSwitcher = (props: Props) => {
         components={{
           Option: ProjectSwitcherOption,
           ValueContainer: (valueContainerProps) => (
-            <ProjectSwitcherValueContainer
-              {...valueContainerProps}
-              projectCount={
-                (data && data.user && data.user.projects.results.length) || 0
-              }
-            />
+            <ProjectSwitcherValueContainer {...valueContainerProps} />
           ),
         }}
         isClearable={false}
         backspaceRemovesValue={false}
         placeholder={intl.formatMessage(messages.searchPlaceholder)}
         noOptionsMessage={() => intl.formatMessage(messages.noResults)}
+        horizontalConstraint={'auto'}
       />
     </div>
   );


### PR DESCRIPTION
**Changes with this PR:**

- Removing the counters from both project and locale switchers
- Setting the switchers inputs to `horizontalConstraint={'auto'}` and adjusting the dropdown menu's width


**Before the changes:**
![Screenshot 2023-11-08 at 09 50 48](https://github.com/commercetools/merchant-center-application-kit/assets/52276952/72729125-561d-4b29-b7ee-ca6e124c95e6)


**After the changes:**
![Screenshot 2023-11-08 at 09 49 59](https://github.com/commercetools/merchant-center-application-kit/assets/52276952/00ebe761-e259-4129-a768-8ed5e8798542)
