### PR TITLE
refactor(Navbar): keyboard navigation

### DIFF
--- a/.changeset/big-beans-grin.md
+++ b/.changeset/big-beans-grin.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Improve Navbar keyboard accessibility

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -359,17 +359,15 @@ const NavLinkClickableContentWrapper = (props: MenuItemLinkProps) => {
 const MenuItemLink = (props: MenuItemLinkProps) => {
   const redirectTo = (targetUrl: string) => location.replace(targetUrl);
   if (props.linkTo) {
+    const linkLevel = props.isSubmenuLink ? 'text-link-sublist' : 'text-link';
     return (
       <NavLinkWrapper {...props}>
         <NavLink
           to={props.linkTo}
           exact={props.exactMatch}
           activeClassName={styles.highlighted}
-          className={
-            props.isSubmenuLink
-              ? styles['text-link-sublist']
-              : styles['text-link']
-          }
+          className={styles[linkLevel]}
+          data-link-level={linkLevel}
           onClick={(event) => {
             if (props.linkTo && props.useFullRedirectsForLinks) {
               event.preventDefault();

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -4,6 +4,7 @@ import {
   type MouseEventHandler,
   type FocusEventHandler,
   type MouseEvent,
+  type KeyboardEvent,
   type ReactNode,
   type SyntheticEvent,
 } from 'react';
@@ -121,7 +122,9 @@ IconSwitcher.displayName = 'IconSwitcher';
 
 type MenuExpanderProps = {
   isVisible: boolean;
-  onClick: MouseEventHandler<HTMLDivElement>;
+  onClick: (
+    e: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>
+  ) => void;
   isMenuOpen: boolean;
 };
 
@@ -142,7 +145,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
         onClick={props.onClick}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            props.onClick(e as unknown as MouseEvent<HTMLDivElement>);
+            props.onClick(e);
           }
         }}
         tabIndex={0}

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -6,7 +6,6 @@ import {
   type MouseEvent,
   type ReactNode,
   type SyntheticEvent,
-  useCallback,
 } from 'react';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -356,24 +355,10 @@ const NavLinkClickableContentWrapper = (props: MenuItemLinkProps) => {
 
 const MenuItemLink = (props: MenuItemLinkProps) => {
   const redirectTo = (targetUrl: string) => location.replace(targetUrl);
-  const handler = useCallback(
-    (event) => {
-      if (props.linkTo && props.useFullRedirectsForLinks) {
-        event.preventDefault();
-        redirectTo(props.linkTo);
-      } else if (props.onClick) {
-        event.persist();
-        props.onClick(event);
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [props.onClick, props.linkTo, props.useFullRedirectsForLinks]
-  );
   if (props.linkTo) {
     return (
       <NavLinkWrapper {...props}>
         <NavLink
-          tabIndex={0}
           to={props.linkTo}
           exact={props.exactMatch}
           activeClassName={styles.highlighted}
@@ -382,7 +367,15 @@ const MenuItemLink = (props: MenuItemLinkProps) => {
               ? styles['text-link-sublist']
               : styles['text-link']
           }
-          onClick={handler}
+          onClick={(event) => {
+            if (props.linkTo && props.useFullRedirectsForLinks) {
+              event.preventDefault();
+              redirectTo(props.linkTo);
+            } else if (props.onClick) {
+              event.persist();
+              props.onClick(event);
+            }
+          }}
         >
           <NavLinkClickableContentWrapper {...props}>
             {props.children}

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -293,7 +293,9 @@ type MenuItemProps = {
   onMouseEnter?:
     | MouseEventHandler<HTMLElement>
     | FocusEventHandler<HTMLElement>;
-  onMouseLeave?: MouseEventHandler<HTMLElement>;
+  onMouseLeave?:
+    | MouseEventHandler<HTMLElement>
+    | FocusEventHandler<HTMLElement>;
   children: ReactNode;
   identifier?: string;
 };
@@ -308,8 +310,9 @@ const MenuItem = (props: MenuItemProps) => {
       })}
       onClick={props.onClick}
       onMouseEnter={props.onMouseEnter as MouseEventHandler<HTMLElement>}
-      onMouseLeave={props.onMouseLeave}
+      onMouseLeave={props.onMouseLeave as MouseEventHandler<HTMLElement>}
       onFocus={props.onMouseEnter as FocusEventHandler<HTMLElement>}
+      onBlur={props.onMouseLeave as FocusEventHandler<HTMLElement>}
       data-menuitem={props.identifier}
     >
       <div className={styles['item-link']}>{props.children}</div>
@@ -380,7 +383,6 @@ const MenuItemLink = (props: MenuItemLinkProps) => {
               : styles['text-link']
           }
           onClick={handler}
-          onFocus={handler}
         >
           <NavLinkClickableContentWrapper {...props}>
             {props.children}

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -9,7 +9,6 @@
   --sublist-indentation-when-expanded: 248px;
   --sublist-width: 253px;
   --left-navigation-transition: all 150ms cubic-bezier(1, 0, 0.58, 1);
-  --focus-ring-color: -webkit-focus-ring-color;
 
   /* Left navigation */
   --width-left-navigation: 80px;

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -9,6 +9,7 @@
   --sublist-indentation-when-expanded: 248px;
   --sublist-width: 253px;
   --left-navigation-transition: all 150ms cubic-bezier(1, 0, 0.58, 1);
+  --focus-ring-color: -webkit-focus-ring-color;
 
   /* Left navigation */
   --width-left-navigation: 80px;
@@ -537,10 +538,10 @@
 .list-item:not(.item_menu-collapsed):has(.text-link:focus),  /* An alternative to `.list-item:not(.item_menu-collapsed):focus-within`, with the added advantage that the main menu item doesn't receive focus outline when a submenu item is in focus. */ 
 /* Submenu item */
 .sublist-item:focus-within {
-  outline: auto 1px Highlight;
+  outline: auto 1px var(--focus-ring-color, Highlight);
   outline-offset: 1px;
 }
-/* TODO: Remove once Firefox version is adopted widely beyond v121 */
+/* TODO: Remove once Firefox version is adopted widely beyond v121 and `:has` pseudo-class can be used */
 @-moz-document url-prefix('') {
   .list-item:not(.item_menu-collapsed):focus-within,
   .sublist-item:focus-within {

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -187,12 +187,6 @@
   border-radius: var(--border-radius-8);
 }
 
-.list-item:not(.item_menu__active):focus,
-.list-item:not(.item_menu-collapsed):focus-within {
-  outline: auto 1px Highlight;
-  outline-offset: 1px;
-}
-
 .item_menu-open {
   height: auto !important;
 }
@@ -353,11 +347,6 @@
     var(--spacing-30);
 }
 
-.sublist-item:focus-within {
-  outline: auto 1px Highlight;
-  outline-offset: 1px;
-}
-
 .navlink-clickable-content {
   height: 100%;
   width: 100%;
@@ -365,16 +354,10 @@
 
 /* Item active */
 .item__active,
-.item_menu__active {
-  background: var(--color-accent-30);
-  border-radius: var(--border-radius-8);
-}
-
+.item_menu__active,
 .item_menu__active:focus-within .list-item {
   background: var(--color-accent-30);
   border-radius: var(--border-radius-8);
-  outline: auto 1px Highlight;
-  outline-offset: 1px;
 }
 
 .list-item.item__active .item-icon-text {
@@ -547,4 +530,21 @@
 
 :global(.body__menu-open) .fixed-menu {
   width: var(--width-left-navigation-when-expanded);
+}
+
+/* Focus outline */
+/* Expanded main menu item */
+.list-item:not(.item_menu-collapsed):has(.text-link:focus),  /* An alternative to `.list-item:not(.item_menu-collapsed):focus-within`, with the added advantage that the main menu item doesn't receive focus outline when a submenu item is in focus. */ 
+/* Submenu item */
+.sublist-item:focus-within {
+  outline: auto 1px Highlight;
+  outline-offset: 1px;
+}
+/* TODO: Remove once Firefox version is adopted widely beyond v121 */
+@-moz-document url-prefix('') {
+  .list-item:not(.item_menu-collapsed):focus-within,
+  .sublist-item:focus-within {
+    outline: auto 1px Highlight;
+    outline-offset: 1px;
+  }
 }

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -205,7 +205,6 @@
 :global(.body__menu-open) .list-item {
   height: auto;
   min-height: var(--item-size);
-  overflow: hidden;
   width: 100%;
 }
 
@@ -281,7 +280,6 @@
   display: flex;
   align-items: center;
   align-self: stretch;
-  transition: padding-left 150ms ease-out;
 }
 
 .sublist-item__active {
@@ -297,7 +295,6 @@
   font-weight: var(--font-weight-for-navbar-link-when-hovered);
   border-radius: var(--border-radius-4);
   background: var(--color-primary-95);
-  padding-left: var(--spacing-20);
 }
 
 .text {
@@ -326,7 +323,6 @@
 }
 
 .text-link-sublist-wrapper {
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -338,7 +334,6 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  overflow: hidden;
   color: var(--color-solid);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   font-weight: var(--font-weight-for-navbar-link-when-hovered);
@@ -346,6 +341,14 @@
   flex: 1;
   padding: var(--spacing-25) var(--spacing-25) var(--spacing-25)
     var(--spacing-30);
+  transition: padding 150ms ease-out;
+}
+
+.sublist-item:not(.sublist-item__active):hover .text-link-sublist,
+.sublist-item:not(.sublist-item__active):focus-within .text-link-sublist {
+  /* additional left padding on hover and focus */
+  padding: var(--spacing-25) var(--spacing-25) var(--spacing-25)
+    calc(var(--spacing-30) + var(--spacing-20));
 }
 
 .navlink-clickable-content {
@@ -531,21 +534,4 @@
 
 :global(.body__menu-open) .fixed-menu {
   width: var(--width-left-navigation-when-expanded);
-}
-
-/* Focus outline */
-/* Expanded main menu item */
-.list-item:not(.item_menu-collapsed):has(.text-link:focus),  /* An alternative to `.list-item:not(.item_menu-collapsed):focus-within`, with the added advantage that the main menu item doesn't receive focus outline when a submenu item is in focus. */ 
-/* Submenu item */
-.sublist-item:focus-within {
-  outline: auto 1px var(--focus-ring-color, Highlight);
-  outline-offset: 1px;
-}
-/* TODO: Remove once Firefox version is adopted widely beyond v121 and `:has` pseudo-class can be used */
-@-moz-document url-prefix('') {
-  .list-item:not(.item_menu-collapsed):focus-within,
-  .sublist-item:focus-within {
-    outline: auto 1px Highlight;
-    outline-offset: 1px;
-  }
 }

--- a/packages/application-shell/src/components/navbar/navbar.mod.css
+++ b/packages/application-shell/src/components/navbar/navbar.mod.css
@@ -105,7 +105,8 @@
   transition: var(--left-navigation-transition);
 }
 
-.list-item:hover .icon {
+.list-item:hover .icon,
+.list-item:focus-within .icon {
   /* 1.16 is roughly the ratio of icon-size-hover to --icon-size */
   transform: scale(1.2);
 }
@@ -143,7 +144,8 @@
   padding: var(--spacing-30) var(--spacing-25);
 }
 
-.expander:hover {
+.expander:hover,
+.expander:focus {
   background-color: var(--color-primary-40);
 }
 
@@ -168,7 +170,8 @@
   align-items: center;
 }
 
-.expand-icon:hover {
+.expand-icon:hover,
+.expand-icon:focus {
   background: rgba(255, 255, 255, 0.3);
   cursor: pointer;
 }
@@ -178,9 +181,16 @@
   bottom: var(--expander-height);
 }
 
-.list-item:not(.item_menu__active):hover {
+.list-item:not(.item_menu__active):hover,
+.list-item:not(.item_menu__active):focus-within {
   background-color: var(--color-primary-40);
   border-radius: var(--border-radius-8);
+}
+
+.list-item:not(.item_menu__active):focus,
+.list-item:not(.item_menu-collapsed):focus-within {
+  outline: auto 1px Highlight;
+  outline-offset: 1px;
 }
 
 .item_menu-open {
@@ -217,16 +227,19 @@
   animation: visible 150ms cubic-bezier(1, 0, 0.58, 1);
 }
 
-.list-item:hover .title {
+.list-item:hover .title,
+.list-item:focus-within .title {
   margin-left: calc(var(--spacing-25) + 2px);
 }
 
-.list-item:not(.item__active):hover .icon > svg *:not([fill='none']) {
+.list-item:not(.item__active):hover .icon > svg *:not([fill='none']),
+.list-item:not(.item__active):focus-within .icon > svg *:not([fill='none']) {
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   fill: var(--color-for-navbar-icon-when-active);
 }
 
-.list-item:not(.item__active):hover .title {
+.list-item:not(.item__active):hover .title,
+.list-item:not(.item__active):focus-within .title {
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   color: var(--color-for-navbar-link-when-hovered);
 }
@@ -281,7 +294,8 @@
   background: var(--color-accent-30);
 }
 
-.sublist-item:not(.sublist-item__active):hover {
+.sublist-item:not(.sublist-item__active):hover,
+.sublist-item:not(.sublist-item__active):focus-within {
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   color: var(--color-for-navbar-link-when-hovered);
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
@@ -339,6 +353,11 @@
     var(--spacing-30);
 }
 
+.sublist-item:focus-within {
+  outline: auto 1px Highlight;
+  outline-offset: 1px;
+}
+
 .navlink-clickable-content {
   height: 100%;
   width: 100%;
@@ -349,6 +368,13 @@
 .item_menu__active {
   background: var(--color-accent-30);
   border-radius: var(--border-radius-8);
+}
+
+.item_menu__active:focus-within .list-item {
+  background: var(--color-accent-30);
+  border-radius: var(--border-radius-8);
+  outline: auto 1px Highlight;
+  outline-offset: 1px;
 }
 
 .list-item.item__active .item-icon-text {
@@ -369,7 +395,8 @@
 }
 
 .support-menu {
-  padding: 0 var(--spacing-30) var(--spacing-20) var(--spacing-30);
+  padding: var(--spacing-10) var(--spacing-30) var(--spacing-20)
+    var(--spacing-30);
   height: calc(var(--item-size) + var(--spacing-20));
 }
 
@@ -424,7 +451,10 @@
 
 .item-link:hover .sublist-collapsed__active,
 .item-link:hover .sublist-collapsed__active__above,
-.item-link:hover .sublist-expanded__active {
+.item-link:hover .sublist-expanded__active,
+.item-link:focus-within .sublist-collapsed__active,
+.item-link:focus-within .sublist-collapsed__active__above,
+.item-link:focus-within .sublist-expanded__active {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -440,11 +470,15 @@
 }
 
 .item-link:hover .sublist-collapsed__active.sublist-collapsed__empty,
-.item-link:hover .sublist-collapsed__active__above.sublist-collapsed__empty {
+.item-link:hover .sublist-collapsed__active__above.sublist-collapsed__empty,
+.item-link:focus-within .sublist-collapsed__active.sublist-collapsed__empty,
+.item-link:focus-within
+  .sublist-collapsed__active__above.sublist-collapsed__empty {
   visibility: hidden;
 }
 
-.item-link:hover .sublist-expanded__active {
+.item-link:hover .sublist-expanded__active,
+.item-link:focus-within .sublist-expanded__active {
   left: var(--sublist-indentation-when-expanded);
 }
 

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -74,6 +74,14 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
+const isFocusOutEventCalledBySubmenu = (event: FocusEvent) =>
+  // a case when a submenu item loses focus
+  event.type === 'focusout' &&
+  // element receiving focus
+  (event.relatedTarget as Element)?.matches('a[class*="__text-link__"]') &&
+  // element losing focus
+  (event.target as Element)?.matches('a[class*="__text-link-sublist__"]');
+
 const useNavbarStateManager = (props: HookProps) => {
   const navBarNode = useRef<HTMLElement>(null);
   const applicationsNavBarMenuGroups = useApplicationsMenu<'navBarGroups'>(
@@ -196,18 +204,19 @@ const useNavbarStateManager = (props: HookProps) => {
   );
 
   const shouldCloseMenuFly = useCallback<
-    (e: React.MouseEvent<HTMLElement> | MouseEvent) => void
+    (e: React.MouseEvent<HTMLElement> | MouseEvent | FocusEvent) => void
   >(
     (event) => {
       if (
-        navBarNode &&
-        navBarNode.current &&
-        !navBarNode.current.contains(event.target as Node) &&
+        !navBarNode?.current?.contains(event.target as Node) &&
         !state.isMenuOpen
-      )
+      ) {
         dispatch({ type: 'unsetActiveItemIndex' });
-      else if (event.type === 'mouseleave')
+      } else if (event.type === 'mouseleave') {
         dispatch({ type: 'unsetActiveItemIndex' });
+      } else if (isFocusOutEventCalledBySubmenu(event as FocusEvent)) {
+        dispatch({ type: 'unsetActiveItemIndex' });
+      }
     },
     [state.isMenuOpen]
   );
@@ -215,10 +224,12 @@ const useNavbarStateManager = (props: HookProps) => {
   useEffect(() => {
     window.addEventListener('resize', checkSize);
     window.addEventListener('click', shouldCloseMenuFly, true);
+    window.addEventListener('focusout', shouldCloseMenuFly, true);
 
     return () => {
       window.removeEventListener('resize', checkSize);
       window.removeEventListener('click', shouldCloseMenuFly, true);
+      window.addEventListener('focusout', shouldCloseMenuFly, true);
     };
   }, [checkSize, shouldCloseMenuFly]);
 

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -78,9 +78,9 @@ const isFocusOutEventCalledBySubmenuItem = (event: FocusEvent) =>
   // a case when a submenu item loses focus
   event.type === 'focusout' &&
   // element receiving focus
-  (event.relatedTarget as Element)?.matches('a[class*="__text-link__"]') &&
+  (event.relatedTarget as Element)?.matches('a[data-link-level="text-link"]') &&
   // element losing focus
-  (event.target as Element)?.matches('a[class*="__text-link-sublist__"]');
+  (event.target as Element)?.matches('a[data-link-level="text-link-sublist"]');
 
 const useNavbarStateManager = (props: HookProps) => {
   const navBarNode = useRef<HTMLElement>(null);

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -74,7 +74,7 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
-const isFocusOutEventCalledBySubmenu = (event: FocusEvent) =>
+const isFocusOutEventCalledBySubmenuItem = (event: FocusEvent) =>
   // a case when a submenu item loses focus
   event.type === 'focusout' &&
   // element receiving focus
@@ -214,7 +214,7 @@ const useNavbarStateManager = (props: HookProps) => {
         dispatch({ type: 'unsetActiveItemIndex' });
       } else if (event.type === 'mouseleave') {
         dispatch({ type: 'unsetActiveItemIndex' });
-      } else if (isFocusOutEventCalledBySubmenu(event as FocusEvent)) {
+      } else if (isFocusOutEventCalledBySubmenuItem(event as FocusEvent)) {
         dispatch({ type: 'unsetActiveItemIndex' });
       }
     },
@@ -229,7 +229,7 @@ const useNavbarStateManager = (props: HookProps) => {
     return () => {
       window.removeEventListener('resize', checkSize);
       window.removeEventListener('click', shouldCloseMenuFly, true);
-      window.addEventListener('focusout', shouldCloseMenuFly, true);
+      window.removeEventListener('focusout', shouldCloseMenuFly, true);
     };
   }, [checkSize, shouldCloseMenuFly]);
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

[Deployment link in the MC](https://mc-15795.mc-preview.europe-west1.gcp.escemo.com/adnan-nodejs-test-project/welcome)

To test out, navigate within the Navbar using `Tab` / `Shift` + `Tab`.

This PR introduces keyboard navigation to the Navbar component, adhering to the default browser focus ring color, as discussed with Filip.

~~Known limitation:
Primary limitation is in Firefox, details provided below 👇~~