### PR TITLE
docs: Add deployment with commercetools Connect

### DIFF
--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -19,91 +19,98 @@ Before you get started, you need to have:
 
 # Configuration
 
-## Create a connector using starter template
+1. Create a connector using the [starter template](https://docs.commercetools.com/connect/development#install-a-starter-template).
+2. [Install the Custom Applications starter template](/getting-started#installing-a-starter-template) with the name `sample-custom-application` inside the connector folder.
+3. Add the environment variables to the `custom-application-config.mjs`. These variables will be injected into the application from the Connect configration (`connect.yml`).
 
-Download custom applications template inside an application folder of connector (Note: connector can have multiple applications)
-Update custom-application-config.mjs to use environment variables that can differ for each connect deployment
+    ```js title="custom-application-config.mjs" highlightLines="5-13"
+    const config = {
+      name: 'Example Custom Application',
+      entryPointUriPath,
+      cloudIdentifier: '${env:CLOUD_IDENTIFIER}',
+      env: {
+        development: {
+          initialProjectKey: '${env:CTP_PROJECT_KEY}',
+        },
+        production: {
+          applicationId: '${env:CUSTOM_APPLICATION_ID}',
+          url: '${env:APPLICATION_URL}',
+        },
+      },
+      oAuthScopes: {
+        view: ['view_products'],
+        manage: ['manage_products'],
+      },
+      icon: '${path:@commercetools-frontend/assets/application-icons/rocket.svg}',
+      mainMenuLink: {
+        defaultLabel: 'Template starter',
+        labelAllLocales: [],
+        permissions: [PERMISSIONS.View],
+      },
+      submenuLinks: [
+        {
+          uriPath: 'channels',
+          defaultLabel: 'Channels',
+          labelAllLocales: [],
+          permissions: [PERMISSIONS.View],
+        },
+      ],
+    };
 
-```ts
-const config = {
-  name: 'custom applications',
-  entryPointUriPath,
-  cloudIdentifier: '${env:CLOUD_IDENTIFIER}',
-  env: {
-    development: {
-      initialProjectKey: '${env:CTP_PROJECT_KEY}',
-    },
-    production: {
-      applicationId: '${env:APPLICATION_ID}',
-      url: '${env:APPLICATION_URL}',
-    },
-  },
-  oAuthScopes: {
-    view: ['view_products'],
-    manage: ['manage_products'],
-  },
-  icon: '${path:@commercetools-frontend/assets/application-icons/rocket.svg}',
-  mainMenuLink: {
-    defaultLabel: 'Template starter',
-    labelAllLocales: [],
-    permissions: [PERMISSIONS.View],
-  },
-  submenuLinks: [
-    {
-      uriPath: 'channels',
-      defaultLabel: 'Channels',
-      labelAllLocales: [],
-      permissions: [PERMISSIONS.View],
-    },
-  ],
-};
+    export default config;
+    ```
 
-export default config;
-```
+4. Configure the Custom Application in the `connect.yaml` with name as the folder name of the custom application and needed standard, secured configurations as defined in `custom-application-config.mjs`
 
-Configure custom application in connect.yaml with name as the folder name of the custom application and needed standard , secured configurations as defined in custom-application-config.mjs (Note: APPLICATION_URL will be automatically provided by connect and doesn't need to be defined as configuration for connect)
+      ```yml
+      deployAs:
+        - name: example-custom-application
+          applicationType: mc-app
+          endpoint: /
+          configuration:
+            standardConfiguration:
+              - key: CTP_PROJECT_KEY
+                description: project key from the Composable Commerce Project
+                default: "your-project"
+              - key: CTP_REGION
+                description: region of the Composable Commerce Project
+                required: true
+              - key: CUSTOM_APPLICATION_ID
+                description: the Custom Application ID
+                required: true
+              - key: CLOUD_IDENTIFIER
+                description: the cloud identifier
+                default: "gcp-eu"
+            securedConfiguration:
+              - key: CTP_CLIENT_ID
+                description: client id from the Composable Commerce Project
+                required: true
+              - key: CTP_CLIENT_SECRET
+                description: client secret from the Composable Commerce Project
+      ```
 
-```yml
-deployAs:
-  - name: sample-custom-application
-    applicationType: mc-app
-    endpoint: /
-    configuration:
-      standardConfiguration:
-        - key: CTP_PROJECT_KEY
-          description: project key from commercetools composable commerce project
-          default: "your-project"
-        - key: CTP_REGION
-          description: region of commercetools composable commerce project
-          required: true
-        - key: APPLICATION_ID
-          description: the custom application id
-          required: true
-        - key: CLOUD_IDENTIFIER
-          description: the cloud identifier
-          default: "gcp-eu"
-      securedConfiguration:
-        - key: CTP_CLIENT_ID
-          description: client id from commercetools composable commerce project
-          required: true
-        - key: CTP_CLIENT_SECRET
-          description: client secret from commercetools composable commerce project
-```
+<Info>
 
+The `APPLICATION_URL` environment variable is automatically provided by Connect and you don't need to define it in the Connect configuration.
 
-# Deployment to connect
+</Info>
 
-## Create the connector
+# Deploy to Connect
 
-Use preview or publish flow for preparing connector for deployment
+1. [Create the connector](https://docs.commercetools.com/connect/getting-started#create-a-connector).
+2. Use the [preview](https://docs.commercetools.com/connect/getting-started#request-previewable-status-for-connectorstaged) or [publish](https://docs.commercetools.com/connect/getting-started#publish-for-private-use) flow for preparing connector for deployment.
+3. In the Merchant Center, [add a Custom Application](https://docs.commercetools.com/merchant-center/managing-custom-applications#adding-a-custom-application).
+    <Info>
 
-Create a custom application in your organization to fetch Application ID (Note- dummy http://test.com can be configured as Application URL since its not generated yet)
-Deploy connector providing all configuration values along with application id in last step
-Fetch Application Url from deployment using Deployment API . Its part deployment.applications[x].url
-Update Application Url in in merchant center custom application setup
+      For the **Application URL**, enter a placeholder URL for now because you'll change it to the actual URL in the following steps.
 
+    </Info>
+4. [Configure the Application ID](https://docs.commercetools.com/merchant-center/managing-custom-applications#assigning-the-application-id) in your code.
+4. [Deploy the connector](https://docs.commercetools.com/connect/getting-started#deploy-a-connector) with the correct configuration values.
+5. Get the Application URL for your deployment using the [Deployment API](https://docs.commercetools.com/connect/deployments#get-deployment) `deployment.applications["sample-custom-application"].url`.
+6. In the Merchant Center, update **Application URL** for your Custom Application.
 
 # Test your deployment
 
-In the Merchant Center you can now follow the steps to install the Custom Application and access it in your Projects.
+[Install the Custom Application](https://docs.commercetools.com/merchant-center/managing-custom-applications#installing-a-custom-application) in the Merchant Center and access it in your Projects.
 

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -1,0 +1,99 @@
+---
+title: Deploying to commercetools Connect
+---
+
+# Prerequisite
+
+Before you get started, you need to have:
+
+- A commercetools account and a Project.
+- A Custom Application configured in the Merchant Center.
+- Access to connect APIs can be accessed using Client credentials Authorization flow with commercetools Project
+
+# Configuration
+
+Create a connector using starter template
+Download custom applications template inside an application folder of connector (Note: connector can have multiple applications)
+Update custom-application-config.mjs to use environment variables that can differ for each connect deployment
+
+```ts
+const config = {
+  name: 'custom applications',
+  entryPointUriPath,
+  cloudIdentifier: '${env:CLOUD_IDENTIFIER}',
+  env: {
+    development: {
+      initialProjectKey: '${env:CTP_PROJECT_KEY}',
+    },
+    production: {
+      applicationId: '${env:APPLICATION_ID}',
+      url: '${env:APPLICATION_URL}',
+    },
+  },
+  oAuthScopes: {
+    view: ['view_products'],
+    manage: ['manage_products'],
+  },
+  icon: '${path:@commercetools-frontend/assets/application-icons/rocket.svg}',
+  mainMenuLink: {
+    defaultLabel: 'Template starter',
+    labelAllLocales: [],
+    permissions: [PERMISSIONS.View],
+  },
+  submenuLinks: [
+    {
+      uriPath: 'channels',
+      defaultLabel: 'Channels',
+      labelAllLocales: [],
+      permissions: [PERMISSIONS.View],
+    },
+  ],
+};
+
+export default config;
+```
+
+Configure custom application in connect.yaml with name as the folder name of the custom application and needed standard , secured configurations as defined in custom-application-config.mjs (Note: APPLICATION_URL will be automatically provided by connect and doesn't need to be defined as configuration for connect)
+
+```yml
+deployAs:
+  - name: sample-custom-application
+    applicationType: mc-app
+    endpoint: /
+    configuration:
+      standardConfiguration:
+        - key: CTP_PROJECT_KEY
+          description: project key from commercetools composable commerce project
+          default: "your-project"
+        - key: CTP_REGION
+          description: region of commercetools composable commerce project
+          required: true
+        - key: APPLICATION_ID
+          description: the custom application id
+          required: true
+        - key: CLOUD_IDENTIFIER
+          description: the cloud identifier
+          default: "gcp-eu"
+      securedConfiguration:
+        - key: CTP_CLIENT_ID
+          description: client id from commercetools composable commerce project
+          required: true
+        - key: CTP_CLIENT_SECRET
+          description: client secret from commercetools composable commerce project
+```
+
+
+# Deployment to connect
+
+## Create the connector
+Use preview or publish flow for preparing connector for deployment
+Create a custom application in your organization to fetch Application ID (Note- dummy http://test.com can be configured as Application URL since its not generated yet)
+Deploy connector providing all configuration values along with application id in last step
+Fetch Application Url from deployment using Deployment API . Its part deployment.applications[x].url
+Update Application Url in in merchant center custom application setup
+
+
+# Test your deployment
+
+In the Merchant Center you can now follow the steps to install the Custom Application and access it in your Projects.
+

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -107,8 +107,8 @@ The `APPLICATION_URL` environment variable is automatically provided by Connect 
     </Info>
 4. [Configure the Application ID](https://docs.commercetools.com/merchant-center/managing-custom-applications#assigning-the-application-id) in your code.
 4. [Deploy the connector](https://docs.commercetools.com/connect/getting-started#deploy-a-connector) with the correct configuration values.
-5. Get the Application URL for your deployment using the [Deployment API](https://docs.commercetools.com/connect/deployments#get-deployment) `deployment.applications["sample-custom-application"].url`.
-6. In the Merchant Center, update **Application URL** for your Custom Application.
+5. Get the deployment URL for your deployment using the [Deployment API](https://docs.commercetools.com/connect/deployments#get-deployment). You can access it from `deployment.applications["example-custom-application"].url` path from the JSON response.
+6. In the Merchant Center, update the **Application URL** for your Custom Application with the deployment URL collected in the previous step.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -6,10 +6,16 @@ title: Deploying to commercetools Connect
 
 Before you get started, you need to have:
 
-Before you get started, you need to have:
-
 - A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
 - A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
+- Access to [commercetools Connect](https://docs.commercetools.com/connect/overview).
+
+  <Info>
+
+    You can access the [Connect APIs](https://docs.commercetools.com/connect/deployments) using the [Client credentials Authorization flow](https://docs.commercetools.com/connect/hosts-and-authorization).
+
+  </Info>
+
 
 # Configuration
 

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -2,26 +2,18 @@
 title: Deploying to commercetools Connect
 ---
 
-# Prerequisite
+# Prerequisites
 
 Before you get started, you need to have:
 
-- A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
+- A commercetools Composable Commerce Project Project ([get started](https://docs.commercetools.com/getting-started)).
 - A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
-- Access to [commercetools Connect](https://docs.commercetools.com/connect/overview).
 
-  <Info>
+# Create your application
 
-    You can access the [Connect APIs](https://docs.commercetools.com/connect/deployments) using the [Client credentials Authorization flow](https://docs.commercetools.com/connect/hosts-and-authorization).
-
-  </Info>
-
-
-# Configuration
-
-1. Create a connector using the [starter template](https://docs.commercetools.com/connect/development#install-a-starter-template).
-2. [Install the Custom Applications starter template](/getting-started#installing-a-starter-template) with the name `sample-custom-application` inside the connector folder.
-3. Add the environment variables to the `custom-application-config.mjs`. These variables will be injected into the application from the Connect configration (`connect.yml`).
+1. Install a Connect [starter template](https://docs.commercetools.com/connect/development#install-a-starter-template).
+2. Open the `mc-app` folder in the Connect starter template and [install the Custom Applications starter template](/getting-started#installing-a-starter-template) with the name `sample-custom-application` inside this folder.
+3. Add your environment variables to `custom-application-config.mjs`.
 
     ```js title="custom-application-config.mjs" highlightLines="5-13"
     const config = {
@@ -60,7 +52,7 @@ Before you get started, you need to have:
     export default config;
     ```
 
-4. Configure the Custom Application in the `connect.yaml` with name as the folder name of the custom application and needed standard, secured configurations as defined in `custom-application-config.mjs`
+4. Open `connect.yaml` in the root of the Connect starter template and replace it with the following. The environment variables you included in `custom-application-config.mjs` should be defined here. Sensitive variables, such as API client information, should be defined within `securedConfiguration`.
 
       ```yml
       deployAs:
@@ -71,7 +63,7 @@ Before you get started, you need to have:
             standardConfiguration:
               - key: CTP_PROJECT_KEY
                 description: project key from the Composable Commerce Project
-                default: "your-project"
+                default: "your-project-key"
               - key: CTP_REGION
                 description: region of the Composable Commerce Project
                 required: true
@@ -91,24 +83,35 @@ Before you get started, you need to have:
 
 <Info>
 
-The `APPLICATION_URL` environment variable is automatically provided by Connect and you don't need to define it in the Connect configuration.
+`APPLICATION_URL` is automatically provided by commercetools Connect and you do not need to define it in `connect.yaml`.
 
 </Info>
 
-# Deploy to Connect
+5. Push your code to a GitHub repository and make a new release. Your release must have a Git tag.
 
-1. [Create the connector](https://docs.commercetools.com/connect/getting-started#create-a-connector).
-2. Use the [preview](https://docs.commercetools.com/connect/getting-started#request-previewable-status-for-connectorstaged) or [publish](https://docs.commercetools.com/connect/getting-started#publish-for-private-use) flow for preparing connector for deployment.
-3. In the Merchant Center, [add a Custom Application](https://docs.commercetools.com/merchant-center/managing-custom-applications#adding-a-custom-application).
-    <Info>
+<Info>
 
-      For the **Application URL**, enter a placeholder URL for now because you'll change it to the actual URL in the following steps.
+Your GitHub repository can be public or private. If you are using a private repository, you must provide access to the GitHub machine user [connect-mu](https://github.com/connect-mu).
 
-    </Info>
-4. [Configure the Application ID](https://docs.commercetools.com/merchant-center/managing-custom-applications#assigning-the-application-id) in your code.
-4. [Deploy the connector](https://docs.commercetools.com/connect/getting-started#deploy-a-connector) with the correct configuration values.
-5. Get the deployment URL for your deployment using the [Deployment API](https://docs.commercetools.com/connect/deployments#get-deployment). You can access it from `deployment.applications["example-custom-application"].url` path from the JSON response.
-6. In the Merchant Center, update the **Application URL** for your Custom Application with the deployment URL collected in the previous step.
+</Info>
+
+# Publish and deploy your application
+
+## Using the Connect API
+
+1. [Create a Connector](https://docs.commercetools.com/connect/getting-started#create-a-connector) which references the GitHub repository and release tag of your application.
+2. Publish your Connector using the [preview](https://docs.commercetools.com/connect/getting-started#request-previewable-status-for-connectorstaged) or [publish](https://docs.commercetools.com/connect/getting-started#publish-for-private-use) flow.
+3. [Deploy the Connector](https://docs.commercetools.com/connect/getting-started#deploy-a-connector) with the correct configuration values. `CUSTOM_APPLICATION_ID` should be the `applicationId` of your configured Custom Application.
+4. Once your Connector is deployed, [get the Deployment](https://docs.commercetools.com/connect/deployments#get-deployment) and copy the value of `applications[*].url`. This is the URL where your Custom Application is deployed.
+6. In the Merchant Center, update the **Application URL** of your Custom Application with the URL where your Custom Application is deployed.
+
+## Using the Merchant Center
+
+1. [Create an Organization Connector](https://docs.commercetools.com/merchant-center/connect#create-an-organization-connector) which references the GitHub repository and release tag of your application.
+2. Publish your Connector using **Request Preview** or **Publish for private use**.
+3. [Install the Organization Connector](https://docs.commercetools.com/merchant-center/connect#install-an-organization-connector) with the correct configuration values. `CUSTOM_APPLICATION_ID` should be the `applicationId` of your configured Custom Application.
+4. Open **Manage connectors** and click the **Installations**. When the **Status** of the Connector is `Installed`, click the Connector and select your application from the list. Copy the value of the `URL` field. This is the URL where your Custom Application is deployed.
+6. Update the **Application URL** of your Custom Application with the URL where your Custom Application is deployed.
 
 # Test your deployment
 

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -110,7 +110,7 @@ Your GitHub repository can be public or private. If you are using a private repo
 1. [Create an Organization Connector](https://docs.commercetools.com/merchant-center/connect#create-an-organization-connector) which references the GitHub repository and release tag of your application.
 2. Publish your Connector using **Request Preview** or **Publish for private use**.
 3. [Install the Organization Connector](https://docs.commercetools.com/merchant-center/connect#install-an-organization-connector) with the correct configuration values. `CUSTOM_APPLICATION_ID` should be the `applicationId` of your configured Custom Application.
-4. Open **Manage connectors** and click the **Installations**. When the **Status** of the Connector is `Installed`, click the Connector and select your application from the list. Copy the value of the `URL` field. This is the URL where your Custom Application is deployed.
+4. Open **Manage connectors** and click **Installations**. When the **Status** of the Connector is `Installed`, click the Connector and select your application from the list. Copy the value of the `URL` field. This is the URL where your Custom Application is deployed.
 6. Update the **Application URL** of your Custom Application with the URL where your Custom Application is deployed.
 
 # Test your deployment

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -15,7 +15,7 @@ Before you get started, you need to have:
 2. Open the `mc-app` folder in the Connect starter template and [install the Custom Applications starter template](/getting-started#installing-a-starter-template) inside this folder.
 3. Add your environment variables to `custom-application-config.mjs`.
 
-    ```js title="custom-application-config.mjs" highlightLines="5-13"
+    ```js title="custom-application-config.mjs" highlightLines="4-13"
     const config = {
       name: 'Example Custom Application',
       entryPointUriPath,
@@ -54,7 +54,7 @@ Before you get started, you need to have:
 
 4. Open `connect.yaml` in the root of the Connect starter template and replace it with the following. Enter a `name` for the application, and define the environment variables you included in `custom-application-config.mjs`.
 
-      ```yml
+      ```yml title="connect.yaml"
       deployAs:
         - name: name-of-custom-application
           applicationType: mc-app

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -6,7 +6,7 @@ title: Deploying to commercetools Connect
 
 Before you get started, you need to have:
 
-- A commercetools Composable Commerce Project Project ([get started](https://docs.commercetools.com/getting-started)).
+- A commercetools Composable Commerce Project ([get started](https://docs.commercetools.com/getting-started)).
 - A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
 
 # Create your application

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -12,7 +12,7 @@ Before you get started, you need to have:
 # Create your application
 
 1. Install a Connect [starter template](https://docs.commercetools.com/connect/development#install-a-starter-template).
-2. Open the `mc-app` folder in the Connect starter template and [install the Custom Applications starter template](/getting-started#installing-a-starter-template) with the name `sample-custom-application` inside this folder.
+2. Open the `mc-app` folder in the Connect starter template and [install the Custom Applications starter template](/getting-started#installing-a-starter-template) inside this folder.
 3. Add your environment variables to `custom-application-config.mjs`.
 
     ```js title="custom-application-config.mjs" highlightLines="5-13"
@@ -52,11 +52,11 @@ Before you get started, you need to have:
     export default config;
     ```
 
-4. Open `connect.yaml` in the root of the Connect starter template and replace it with the following. The environment variables you included in `custom-application-config.mjs` should be defined here. Sensitive variables, such as API client information, should be defined within `securedConfiguration`.
+4. Open `connect.yaml` in the root of the Connect starter template and replace it with the following. Enter a `name` for the application, and define the environment variables you included in `custom-application-config.mjs`.
 
       ```yml
       deployAs:
-        - name: example-custom-application
+        - name: name-of-custom-application
           applicationType: mc-app
           endpoint: /
           configuration:
@@ -64,21 +64,12 @@ Before you get started, you need to have:
               - key: CTP_PROJECT_KEY
                 description: project key from the Composable Commerce Project
                 default: "your-project-key"
-              - key: CTP_REGION
-                description: region of the Composable Commerce Project
-                required: true
               - key: CUSTOM_APPLICATION_ID
                 description: the Custom Application ID
                 required: true
               - key: CLOUD_IDENTIFIER
                 description: the cloud identifier
                 default: "gcp-eu"
-            securedConfiguration:
-              - key: CTP_CLIENT_ID
-                description: client id from the Composable Commerce Project
-                required: true
-              - key: CTP_CLIENT_SECRET
-                description: client secret from the Composable Commerce Project
       ```
 
 <Info>
@@ -96,6 +87,8 @@ Your GitHub repository can be public or private. If you are using a private repo
 </Info>
 
 # Publish and deploy your application
+
+You can publish and deploy your application using either the [Connect API](#using-the-connect-api) or the [Merchant Center](#using-the-merchant-center).
 
 ## Using the Connect API
 

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -6,13 +6,15 @@ title: Deploying to commercetools Connect
 
 Before you get started, you need to have:
 
-- A commercetools account and a Project.
-- A Custom Application configured in the Merchant Center.
-- Access to connect APIs can be accessed using Client credentials Authorization flow with commercetools Project
+Before you get started, you need to have:
+
+- A [commercetools](https://docs.commercetools.com/getting-started) account and a Project.
+- A Custom Application [configured in the Merchant Center](https://docs.commercetools.com/merchant-center/managing-custom-applications).
 
 # Configuration
 
-Create a connector using starter template
+## Create a connector using starter template
+
 Download custom applications template inside an application folder of connector (Note: connector can have multiple applications)
 Update custom-application-config.mjs to use environment variables that can differ for each connect deployment
 
@@ -86,7 +88,9 @@ deployAs:
 # Deployment to connect
 
 ## Create the connector
+
 Use preview or publish flow for preparing connector for deployment
+
 Create a custom application in your organization to fetch Application ID (Note- dummy http://test.com can be configured as Application URL since its not generated yet)
 Deploy connector providing all configuration values along with application id in last step
 Fetch Application Url from deployment using Deployment API . Its part deployment.applications[x].url

--- a/website/src/content/deployment-examples/commercetools-connect.mdx
+++ b/website/src/content/deployment-examples/commercetools-connect.mdx
@@ -97,7 +97,7 @@ Your GitHub repository can be public or private. If you are using a private repo
 
 # Publish and deploy your application
 
-## Using the Connect API
+## Using the Connect API
 
 1. [Create a Connector](https://docs.commercetools.com/connect/getting-started#create-a-connector) which references the GitHub repository and release tag of your application.
 2. Publish your Connector using the [preview](https://docs.commercetools.com/connect/getting-started#request-previewable-status-for-connectorstaged) or [publish](https://docs.commercetools.com/connect/getting-started#publish-for-private-use) flow.
@@ -105,7 +105,7 @@ Your GitHub repository can be public or private. If you are using a private repo
 4. Once your Connector is deployed, [get the Deployment](https://docs.commercetools.com/connect/deployments#get-deployment) and copy the value of `applications[*].url`. This is the URL where your Custom Application is deployed.
 6. In the Merchant Center, update the **Application URL** of your Custom Application with the URL where your Custom Application is deployed.
 
-## Using the Merchant Center
+## Using the Merchant Center
 
 1. [Create an Organization Connector](https://docs.commercetools.com/merchant-center/connect#create-an-organization-connector) which references the GitHub repository and release tag of your application.
 2. Publish your Connector using **Request Preview** or **Publish for private use**.

--- a/website/src/content/deployment-examples/index.mdx
+++ b/website/src/content/deployment-examples/index.mdx
@@ -6,6 +6,12 @@ This page outlines some of the common platforms and services Custom Applications
 
 <Cards smallTitle clickable>
   <Card
+    title="commercetools Connect"
+    href="/deployment-examples/commercetools-connect"
+  >
+    Learn more about deploying using commercetools Connect.
+  </Card>
+  <Card
     title="Vercel"
     href="/deployment-examples/vercel"
   >

--- a/website/src/data/navigation.yaml
+++ b/website/src/data/navigation.yaml
@@ -50,6 +50,8 @@
   pages:
     - title: Overview
       path: /deployment-examples
+    - title: Deploying to commercetools Connect
+      path: /deployment-examples/commercetools-connect
     - title: Deploying to Vercel
       path: /deployment-examples/vercel
     - title: Deploying to Netlify
@@ -68,8 +70,6 @@
       path: /deployment-examples/cloudflare
     - title: Deploying to Google Cloud with Static Web Apps
       path: /deployment-examples/google-cloud-static-web-apps
-    - title: Deploying to commercetools Connect
-      path: /deployment-examples/commercetools-connect
 - chapter-title: API Reference
   pages:
     - title: CLI

--- a/website/src/data/navigation.yaml
+++ b/website/src/data/navigation.yaml
@@ -68,6 +68,8 @@
       path: /deployment-examples/cloudflare
     - title: Deploying to Google Cloud with Static Web Apps
       path: /deployment-examples/google-cloud-static-web-apps
+    - title: Deploying to commercetools Connect
+      path: /deployment-examples/commercetools-connect
 - chapter-title: API Reference
   pages:
     - title: CLI


### PR DESCRIPTION
Add documentation for deploying a Custom Application to commercetools Connect.

Preview: https://appkit-pr-3307.commercetools.vercel.app/custom-applications/deployment-examples/commercetools-connect

Original draft: https://docs.google.com/document/d/1-BokqprvJhq-K6w2TbD-0RLQi3mPzD23vl-0rLX-sYA/