### PR TITLE
chore: allow drawer to expand height with a scrollbar

### DIFF
--- a/.changeset/twenty-files-tie.md
+++ b/.changeset/twenty-files-tie.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+allow drawer to expand height with a scrollbar

--- a/packages/application-components/src/components/drawer/drawer.tsx
+++ b/packages/application-components/src/components/drawer/drawer.tsx
@@ -66,8 +66,10 @@ const defaultProps: Pick<
 };
 
 const ContentWrapper = styled.div`
-  height: 100%;
-  padding: ${designTokens.spacing50};
+  flex: 1;
+  flex-basis: 0;
+  margin: ${appKitDesignTokens.marginForPageContent};
+  overflow: auto;
 `;
 
 const HeaderWrapper = styled.div`


### PR DESCRIPTION
When I first added the drawer, I added it with a bug sadly. 

When the drawer has long content the scrollbar doesn't appear to allow the user to see the content in the bottom of the drawer. This PR fixes that by adopting the same behavior from the higher level modal components