### PR TITLE
fix: svgo plugin to use collision resistant IDs

### DIFF
--- a/.changeset/angry-apes-marry.md
+++ b/.changeset/angry-apes-marry.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/mc-scripts": patch
+---
+
+Avoid collisions of SVG IDs in webpack's SVGR loader and Vite SVGR plugin.
+
+More information about the approach can be found [here](https://github.com/svg/svgo/issues/1746#issuecomment-1803600573).

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
@@ -16,6 +16,8 @@ import momentLocalesToKeep from /* preval */ './moment-locales';
 import paths from './paths';
 import vendorsToTranspile from './vendors-to-transpile';
 
+let svgoPrefixIdsCount = 0;
+
 const defaultToggleFlags: TWebpackConfigToggleFlagsForDevelopment = {
   generateIndexHtml: true,
   disableCoreJs: false,
@@ -248,6 +250,21 @@ function createWebpackConfigForDevelopment(
                         overrides: {
                           removeViewBox: false,
                         },
+                      },
+                    },
+                    // Avoid collisions with ids in other SVGs,
+                    // which was causing incorrect gradient directions
+                    // https://github.com/svg/svgo/issues/1746#issuecomment-1803600573
+                    //
+                    // Previously, this was a problem where unique ids
+                    // could not be generated since svgo@3
+                    // https://github.com/svg/svgo/issues/674
+                    // https://github.com/svg/svgo/issues/1746
+                    {
+                      name: 'prefixIds',
+                      params: {
+                        delim: '',
+                        prefix: () => svgoPrefixIdsCount++,
                       },
                     },
                   ],

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
@@ -21,6 +21,8 @@ import momentLocalesToKeep from /* preval */ './moment-locales';
 import paths from './paths';
 import vendorsToTranspile from './vendors-to-transpile';
 
+let svgoPrefixIdsCount = 0;
+
 const defaultToggleFlags: TWebpackConfigToggleFlagsForProduction = {
   // Allow to disable CSS extraction in case it's not necessary (e.g. for Storybook)
   enableExtractCss: true,
@@ -268,6 +270,21 @@ function createWebpackConfigForProduction(
                         overrides: {
                           removeViewBox: false,
                         },
+                      },
+                    },
+                    // Avoid collisions with ids in other SVGs,
+                    // which was causing incorrect gradient directions
+                    // https://github.com/svg/svgo/issues/1746#issuecomment-1803600573
+                    //
+                    // Previously, this was a problem where unique ids
+                    // could not be generated since svgo@3
+                    // https://github.com/svg/svgo/issues/674
+                    // https://github.com/svg/svgo/issues/1746
+                    {
+                      name: 'prefixIds',
+                      params: {
+                        delim: '',
+                        prefix: () => svgoPrefixIdsCount++,
                       },
                     },
                   ],

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-svgr.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-svgr.ts
@@ -5,6 +5,8 @@ import fs from 'fs';
 import { createFilter } from '@rollup/pluginutils';
 import { transformWithEsbuild, type Plugin } from 'vite';
 
+let svgoPrefixIdsCount = 0;
+
 function vitePluginSvgr(): Plugin {
   const filter = createFilter('**/*.react.svg');
   return {
@@ -27,6 +29,21 @@ function vitePluginSvgr(): Plugin {
                     overrides: {
                       removeViewBox: false,
                     },
+                  },
+                },
+                // Avoid collisions with ids in other SVGs,
+                // which was causing incorrect gradient directions
+                // https://github.com/svg/svgo/issues/1746#issuecomment-1803600573
+                //
+                // Previously, this was a problem where unique ids
+                // could not be generated since svgo@3
+                // https://github.com/svg/svgo/issues/674
+                // https://github.com/svg/svgo/issues/1746
+                {
+                  name: 'prefixIds',
+                  params: {
+                    delim: '',
+                    prefix: () => svgoPrefixIdsCount++ as unknown as string,
                   },
                 },
               ],


### PR DESCRIPTION
> [!NOTE]
> Original PR #3332 but somehow some CI jobs were failing there 🤷‍♂️

Fixes issue where `svgo`'s `cleanupIds` default preset would cause id collisions between different svg files.

For more context see the [svgo docs for cleanupIds](https://svgo.dev/docs/plugins/cleanup-ids/), [this svgo issue](https://github.com/svg/svgo/issues/1746), and [this mc-frontend PR](https://github.com/commercetools/merchant-center-frontend/pull/15854).