### PR TITLE
Fix Custom Views panel width behaviour

### DIFF
--- a/.changeset/four-kids-flow.md
+++ b/.changeset/four-kids-flow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Fixed Custom Views panels size behaviour in narrow viewports.

--- a/.changeset/hot-parents-study.md
+++ b/.changeset/hot-parents-study.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/constants': patch
+---
+
+New shared constant about modals UI.

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
@@ -1,4 +1,5 @@
 import { css, type SerializedStyles } from '@emotion/react';
+import { PORTALS_CONTAINER_INDENTATION_SIZE } from '@commercetools-frontend/constants';
 import { customProperties } from '@commercetools-uikit/design-system';
 import type { TModalPageSize } from './modal-page';
 
@@ -32,7 +33,11 @@ export const getContainerStyles = (props: StyleProps): SerializedStyles => css`
   right: 0;
   height: 100%;
   width: ${props.size !== 'scale'
-    ? `${stylesBySize[props.size].width} !important`
+    ? // In case we're using a specific size, we want it to be used until there's no space left.
+      // In such scenario, we want the modal to be as wide as possible, but using the shared indentation width size.
+      `min(${
+        stylesBySize[props.size].width
+      }, calc(100% - ${PORTALS_CONTAINER_INDENTATION_SIZE})) !important`
     : stylesBySize.scale.width};
   display: flex;
   flex-direction: column;

--- a/packages/application-components/src/components/portals-container/portals-container.tsx
+++ b/packages/application-components/src/components/portals-container/portals-container.tsx
@@ -7,7 +7,10 @@ import {
 } from 'react';
 import { css, Global } from '@emotion/react';
 import useResizeObserver from '@react-hook/resize-observer';
-import { PORTALS_CONTAINER_ID } from '@commercetools-frontend/constants';
+import {
+  PORTALS_CONTAINER_ID,
+  PORTALS_CONTAINER_INDENTATION_SIZE,
+} from '@commercetools-frontend/constants';
 import { useMutationObserver } from '@commercetools-uikit/hooks';
 
 type TLayoutRefs = {
@@ -78,9 +81,6 @@ type TPortalsContainerProps = {
    */
   baseModalZIndex?: number;
 };
-
-// The width of each indentation level.
-const indentationSize = '48px';
 
 const useObserverElementDimensions = (
   element: RefObject<HTMLDivElement> | null
@@ -218,7 +218,10 @@ const PortalsContainer = forwardRef<TLayoutRefs, TPortalsContainerProps>(
                   [role='dialog'] {
                   width: calc(
                     100% -
-                      (${indentationSize} * ${stackingLayer.indentationLevel})
+                      (
+                        ${PORTALS_CONTAINER_INDENTATION_SIZE} *
+                          ${stackingLayer.indentationLevel}
+                      )
                   );
                 }
               `

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -2,6 +2,7 @@ import type { TCustomView } from './types/generated/settings';
 
 // DOM elements
 export const PORTALS_CONTAINER_ID = 'portals-container';
+export const PORTALS_CONTAINER_INDENTATION_SIZE = '48px';
 
 // Links
 export const SUPPORT_PORTAL_URL = 'https://support.commercetools.com';


### PR DESCRIPTION
#### Summary

Custom Views panels are overlapping navigation bar in narrow viewports.

#### Description

Custom Views panels can have a `small` or `large` size which are defined as a fixed width for them.

The issue we were having is that, by using only fixed values, we get to situations where viewport width is not enough so we run out of space and overlap things:

[Customers - test-project-with-sample-data - Merchant Center.webm](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/6f189232-c3b7-4c54-a556-a69112457199)

The expected behaviour is for the Custom Views panels to have that fixed width as long as there's enough viewport space. Whenever it's not, it should behave like the other modal components and get to a max width. If the viewport is narrower, the panel itself must shrink.

[App-kit-playground - almond-40 - Merchant Center (7).webm](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/4334dd7c-523c-4e85-b4d8-829b43f54e9c)

