### PR TITLE
Fix Custom Views docs links and naming references

### DIFF
--- a/website-custom-views/src/content/api-reference/cli.mdx
+++ b/website-custom-views/src/content/api-reference/cli.mdx
@@ -76,7 +76,7 @@ By default, compiling the `index.html` is implicitly done in the `build` command
 
   ```ts
   type TransformerFunctionOptions = {
-    // The runtime environment specified within the application config.
+    // The runtime environment specified within the Custom View config.
     env: Json;
     // The compiled HTTP headers, including the Content-Security-Policy headers.
     headers: Json;
@@ -132,7 +132,7 @@ Developers can use the `config:sync` command to automatically manage the configu
 
 If a new Custom View needs to be created, an interactive prompt will ask the user to select the Organization where the Custom View should be configured to.
 
-Additionally, after creating a new Custom View using the `config:sync` command, you must add the generated [Custom View ID](/api-reference/custom-view-config#envproductioncustomviewid) to the application config file, following the instructions in the terminal.
+Additionally, after creating a new Custom View using the `config:sync` command, you must add the generated [Custom View ID](/api-reference/custom-view-config#envproductioncustomviewid) to the Custom View config file, following the instructions in the terminal.
 
 Note that this command requires a valid API token. You can get one by using the `mc-scripts login` command.
 

--- a/website-custom-views/src/content/concepts/merchant-center-api.mdx
+++ b/website-custom-views/src/content/concepts/merchant-center-api.mdx
@@ -189,7 +189,7 @@ For more information on what to do next, we recommend the following sections:
     Learn more about fetching data via Merchant Center API.
   </Card>
   <Card
-    title="Application Config"
+    title="Custom View Config"
     href="/api-reference/custom-view-config"
   >
     Learn more about the Custom View configuration file.

--- a/website-custom-views/src/content/concepts/oauth-scopes-and-user-permissions.mdx
+++ b/website-custom-views/src/content/concepts/oauth-scopes-and-user-permissions.mdx
@@ -97,7 +97,7 @@ For more information on what to do next, we recommend the following sections:
 
 <Cards smallTitle clickable>
   <Card
-    title="Application Config"
+    title="Custom View Config"
     href="/api-reference/custom-view-config"
   >
     Learn more about the Custom View configuration file.

--- a/website-custom-views/src/content/help-needed.mdx
+++ b/website-custom-views/src/content/help-needed.mdx
@@ -73,10 +73,10 @@ OAuth Scopes cannot be changed when a Custom View is in the **Ready** state as i
 
 To change the OAuth Scopes:
 
-1. [Move the Custom View to the **Draft** state](https://docs-beta-custom-views.commercetools.vercel.app/merchant-center/managing-custom-views#moving-the-custom-applications-to-the-draft-state).
+1. [Move the Custom View to the **Draft** state](https://docs-beta-custom-views.commercetools.vercel.app/merchant-center/managing-custom-views#moving-a-custom-view-to-the-draft-state).
 2. Update the list of OAuth Scopes.
 3. Change the state to **Ready**.
-4. [Install the Custom View](https://docs-beta-custom-views.commercetools.vercel.app/merchant-center/managing-custom-views#installing-a-custom-application) again.
+4. [Install the Custom View](https://docs-beta-custom-views.commercetools.vercel.app/merchant-center/managing-custom-views#installing-a-custom-view) again.
 
 <Info>
 

--- a/website-custom-views/src/content/help-needed.mdx
+++ b/website-custom-views/src/content/help-needed.mdx
@@ -69,7 +69,7 @@ Custom Views have the following limitations:
 
 ## OAuth Scopes cannot be changed in the Ready state
 
-OAuth Scopes cannot be changed when a Custom View is in the **Ready** state as it can be installed and used while in this state. You can change the list of OAuth Scopes assigned to the Custom View permissions only in the **Draft** state when [configuring the Custom View in the Merchant Center](https://docs-beta-custom-views.commercetools.vercel.app/merchant-center/managing-custom-views#configuring-custom-applications).
+OAuth Scopes cannot be changed when a Custom View is in the **Ready** state as it can be installed and used while in this state. You can change the list of OAuth Scopes assigned to the Custom View permissions only in the **Draft** state when [configuring the Custom View in the Merchant Center](https://docs-beta-custom-views.commercetools.vercel.app/merchant-center/managing-custom-views#configuring-custom-views).
 
 To change the OAuth Scopes:
 


### PR DESCRIPTION
#### Summary

Fix Custom Views docs links and naming references

#### Description

Some issues have been spotted in the Custom Views documentation:
* Links to the MC docs need to be verified and updated if necessary.  There are some underlying links under the [Limitations](https://docs-beta-custom-views.commercetools.vercel.app/custom-views/help-needed#limitations) section no longer go to specific sections (because the section name was changed in MC docs) and they default to the top of the page instead. There will likely be other links to the MC docs elsewhere (you know best where they might be) and need to be verified.
* The cards in use in the [Concepts](https://docs-beta-custom-views.commercetools.vercel.app/custom-views/concepts/oauth-scopes-and-user-permissions) section (multiple pages) show "Application Config" and needs to be updated to "Custom View Config".
