### PR TITLE
Fix Custom Views issues

### DIFF
--- a/.changeset/olive-pots-raise.md
+++ b/.changeset/olive-pots-raise.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/application-shell': patch
+---
+
+Fixes for Custom Views related to styling issues when using Page Layout components and inner routing.

--- a/packages/application-components/src/components/internals/page.styles.ts
+++ b/packages/application-components/src/components/internals/page.styles.ts
@@ -3,7 +3,7 @@ import { designTokens as appKitDesignTokens } from '../../theming';
 
 export const ContentWrapper = styled.div`
   flex: 1;
-  flex-basis: 0;
+  flex-basis: 0%;
   margin: ${appKitDesignTokens.marginForPageContent};
   overflow: auto;
 `;

--- a/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
+++ b/packages/application-components/src/components/main-pages/internals/main-page.styles.ts
@@ -13,7 +13,7 @@ export const Divider = styled.hr`
 
 export const MainPageContent = styled.div`
   flex: 1;
-  flex-basis: 0;
+  flex-basis: 0%;
   overflow: auto;
   // NOTE: do not change to "padding" as this breaks sticky DataTable styles
   margin: ${appKitDesignTokens.marginForPageContent};

--- a/packages/application-shell/src/components/custom-view-shell-authenticated/custom-view-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/custom-view-shell-authenticated/custom-view-shell-authenticated.tsx
@@ -1,12 +1,15 @@
 import { type ReactNode } from 'react';
-import { PageUnauthorized } from '@commercetools-frontend/application-components';
+import {
+  PageUnauthorized,
+  themesOverrides,
+} from '@commercetools-frontend/application-components';
 import { entryPointUriPathToPermissionKeys } from '@commercetools-frontend/application-config/ssr';
 import { ApplicationContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import {
+  CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH,
   type ApplicationWindow,
   type CustomViewData,
 } from '@commercetools-frontend/constants';
-import { CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH } from '@commercetools-frontend/constants';
 import {
   AsyncLocaleData,
   type TAsyncLocaleDataProps,
@@ -79,7 +82,10 @@ function CustomViewShellAuthenticated(
                     environment={props.environment}
                   >
                     <>
-                      <ThemeProvider theme="default" />
+                      <ThemeProvider
+                        theme="default"
+                        themeOverrides={themesOverrides.default}
+                      />
 
                       <FetchProject projectKey={props.projectKey}>
                         {({ isLoading: isProjectLoading, project }) => {

--- a/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
+++ b/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from 'react';
 import { ApolloClient, type NormalizedCacheObject } from '@apollo/client';
+import { Route } from 'react-router-dom';
 import { PageUnauthorized } from '@commercetools-frontend/application-components';
 import { CustomViewContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import {
@@ -152,7 +153,11 @@ function CustomViewShell(props: TCustomViewShellProps) {
                 projectKey={hostContext.projectKey}
                 customViewConfig={hostContext.customViewConfig}
               >
-                {props.children}
+                <Route
+                  path={`/custom-views/${hostContext.customViewConfig.id}/projects/${hostContext.projectKey}`}
+                >
+                  {props.children}
+                </Route>
               </CustomViewShellAuthenticated>
             </CustomViewContextProvider>
           );

--- a/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
+++ b/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
@@ -9,7 +9,10 @@ import {
 } from 'react';
 import { ApolloClient, type NormalizedCacheObject } from '@apollo/client';
 import { Route } from 'react-router-dom';
-import { PageUnauthorized } from '@commercetools-frontend/application-components';
+import {
+  PageUnauthorized,
+  PortalsContainer,
+} from '@commercetools-frontend/application-components';
 import { CustomViewContextProvider } from '@commercetools-frontend/application-shell-connectors';
 import {
   type ApplicationWindow,
@@ -153,6 +156,7 @@ function CustomViewShell(props: TCustomViewShellProps) {
                 projectKey={hostContext.projectKey}
                 customViewConfig={hostContext.customViewConfig}
               >
+                <PortalsContainer />
                 <Route
                   path={`/custom-views/${hostContext.customViewConfig.id}/projects/${hostContext.projectKey}`}
                 >


### PR DESCRIPTION
#### Summary

In this PR we're tackling some last minute issues found around Custom Views rendering.

#### Description

These are the issues addressed in this PR:
* Unstyled Page Layout components when rendered within a Custom View
* Routing issues when navigating within a Custom View
* Custom View not including `PortalsContainer` component (required for modals, dialogs,...).

Regarding the last point, I included the component so it does not break the Custom View if a `Dialog`, `Modal` is used, but I don't think this is the solution we want.

Here's an example of how it looks like:

![Screenshot 2023-12-12 at 20 51 46](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/8d9c351b-4788-4423-8164-cfb7196a19de)

I think it would be better for Custom Views to have a different mechanism for modals and dialogs that we should discuss.