### PR TITLE
refactor(constants): expose regex

### DIFF
--- a/.changeset/purple-otters-behave.md
+++ b/.changeset/purple-otters-behave.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Re-export regex for backwards compatibility

--- a/.changeset/seven-falcons-turn.md
+++ b/.changeset/seven-falcons-turn.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/constants': patch
+---
+
+Expose some regex `PROJECT_KEY_REGEX`, `ENTRY_POINT_URI_PATH_REGEX`, `PERMISSION_GROUP_NAME_REGEX`.

--- a/packages/application-config/src/constants.ts
+++ b/packages/application-config/src/constants.ts
@@ -1,16 +1,3 @@
-/**
- * The entryPointUriPath may be between 2 and 64 characters and only contain alphabetic lowercase characters,
- * non-consecutive underscores and hyphens. Leading and trailing underscore and hyphens are also not allowed.
- */
-export const ENTRY_POINT_URI_PATH_REGEX =
-  /^[^-_#]([0-9a-z]|[-_](?![-_])){0,62}[^-_#]$/g;
-
-/**
- * The permission group name may be between 2 and 64 characters and only contain alphanumeric lowercase characters and non-consecutive hyphens. Leading and trailing hyphens are also not allowed.
- */
-export const PERMISSION_GROUP_NAME_REGEX =
-  /^[^-#]([a-z]|[-](?![-])){0,62}[^-#]$/g;
-
 export const CLOUD_IDENTIFIERS = {
   GCP_AU: 'gcp-au',
   GCP_EU: 'gcp-eu',

--- a/packages/application-config/src/index.ts
+++ b/packages/application-config/src/index.ts
@@ -4,3 +4,9 @@ export { default as sanitizeSvg } from './sanitize-svg';
 export * from './constants';
 export * from './errors';
 export * from './types';
+
+// Backwards compatiblity
+export {
+  ENTRY_POINT_URI_PATH_REGEX,
+  PERMISSION_GROUP_NAME_REGEX,
+} from '@commercetools-frontend/constants';

--- a/packages/application-config/src/validations.ts
+++ b/packages/application-config/src/validations.ts
@@ -1,11 +1,11 @@
 import Ajv, { ValidateFunction, type ErrorObject } from 'ajv';
-import customApplicationSchemaJson from '../custom-application.schema.json';
-import customViewSchemaJson from '../custom-view.schema.json';
 import {
   ENTRY_POINT_URI_PATH_REGEX,
-  LOADED_CONFIG_TYPES,
   PERMISSION_GROUP_NAME_REGEX,
-} from './constants';
+} from '@commercetools-frontend/constants';
+import customApplicationSchemaJson from '../custom-application.schema.json';
+import customViewSchemaJson from '../custom-view.schema.json';
+import { LOADED_CONFIG_TYPES } from './constants';
 import type { JSONSchemaForCustomApplicationConfigurationFiles } from './schemas/generated/custom-application.schema';
 import type { JSONSchemaForCustomViewConfigurationFiles } from './schemas/generated/custom-view.schema';
 import type { LoadedConfigType } from './types';

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -1,5 +1,24 @@
 import type { TCustomView } from './types/generated/settings';
 
+/**
+ * The entryPointUriPath may be between 2 and 36 characters and only contain alphabetic lowercase characters,
+ * non-consecutive underscores and hyphens. Leading and trailing underscore and hyphens are also not allowed.
+ */
+export const PROJECT_KEY_REGEX = /^[^-_#]([0-9a-z]|[-_](?![-_])){0,34}[^-_#]$/g;
+
+/**
+ * The entryPointUriPath may be between 2 and 64 characters and only contain alphabetic lowercase characters,
+ * non-consecutive underscores and hyphens. Leading and trailing underscore and hyphens are also not allowed.
+ */
+export const ENTRY_POINT_URI_PATH_REGEX =
+  /^[^-_#]([0-9a-z]|[-_](?![-_])){0,62}[^-_#]$/g;
+
+/**
+ * The permission group name may be between 2 and 64 characters and only contain alphanumeric lowercase characters and non-consecutive hyphens. Leading and trailing hyphens are also not allowed.
+ */
+export const PERMISSION_GROUP_NAME_REGEX =
+  /^[^-#]([a-z]|[-](?![-])){0,62}[^-#]$/g;
+
 // DOM elements
 export const PORTALS_CONTAINER_ID = 'portals-container';
 export const PORTALS_CONTAINER_INDENTATION_SIZE = '48px';


### PR DESCRIPTION
To have a single source of truth for validation regex that we use in the MC apps.