### PR TITLE
refactor(e2e): use package name for caching custom views configs

### DIFF
--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Running End-to-End tests for Starter template (template-${{ inputs.application-type }}-${{ inputs.template-name }})
       shell: bash
-      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'pnpm ${{ inputs.e2e-tests-command }} --env TEMPLATE_NAME=${{ inputs.template-name }}'
+      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'pnpm ${{ inputs.e2e-tests-command }} --env PACKAGE_NAME=${{ inputs.package-name }}'
       env:
         NODE_ENV: test
         CYPRESS_CI: "true"

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -76,13 +76,14 @@ runs:
 
     - name: Running End-to-End tests for Starter template (template-${{ inputs.application-type }}-${{ inputs.template-name }})
       shell: bash
-      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'pnpm ${{ inputs.e2e-tests-command }} --env PACKAGE_NAME=${{ inputs.package-name }}'
+      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'pnpm ${{ inputs.e2e-tests-command }}'
       env:
         NODE_ENV: test
         CYPRESS_CI: "true"
         CYPRESS_LOGIN_USER: ${{ inputs.cypress-login-user }}
         CYPRESS_LOGIN_PASSWORD: ${{ inputs.cypress-login-password }}
         CYPRESS_PROJECT_KEY: ${{ inputs.cypress-project-key }}
+        CYPRESS_PACKAGE_NAME: ${{ inputs.cypress-package-name }}
         HOST_GCP_STAGING: ${{ inputs.host-gcp-staging }}
         APP_ID: ${{ inputs.playground-application-id }}
         MC_API_URL: ${{ inputs.mc-api-url }}

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Running End-to-End tests for Starter template (template-${{ inputs.application-type }}-${{ inputs.template-name }})
       shell: bash
-      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'pnpm ${{ inputs.e2e-tests-command }}'
+      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'pnpm ${{ inputs.e2e-tests-command }} --env TEMPLATE_NAME=${{ inputs.template-name }}'
       env:
         NODE_ENV: test
         CYPRESS_CI: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,6 @@ jobs:
         with:
           application-type: custom-view
           template-name: starter
-          package-name: "@commercetools-applications/merchant-center-custom-view-template-starter"
           e2e-tests-command: test:e2e:template-custom-view-starter
           host-gcp-staging: ${{ secrets.HOST_GCP_STAGING }}
           playground-application-id: ${{ secrets.APP_ID_PLAYGROUND }}
@@ -200,6 +199,7 @@ jobs:
           cypress-login-user: ${{ secrets.CYPRESS_LOGIN_USER }}
           cypress-login-password: ${{ secrets.CYPRESS_LOGIN_PASSWORD }}
           cypress-project-key: ${{ secrets.CYPRESS_PROJECT_KEY }}
+          cypress-package-name: "@commercetools-applications/merchant-center-custom-view-template-starter"
 
   test_custom_view_starter_js_template_installation:
     runs-on: ubuntu-latest
@@ -243,7 +243,6 @@ jobs:
         with:
           application-type: custom-view
           template-name: starter-typescript
-          package-name: "@commercetools-applications/merchant-center-custom-view-template-starter-typescript"
           e2e-tests-command: test:e2e:template-custom-view-starter
           typecheck-command: typecheck:starter:custom-views
           host-gcp-staging: ${{ secrets.HOST_GCP_STAGING }}
@@ -252,6 +251,7 @@ jobs:
           cypress-login-user: ${{ secrets.CYPRESS_LOGIN_USER }}
           cypress-login-password: ${{ secrets.CYPRESS_LOGIN_PASSWORD }}
           cypress-project-key: ${{ secrets.CYPRESS_PROJECT_KEY }}
+          cypress-package-name: "@commercetools-applications/merchant-center-custom-view-template-starter-typescript"
 
   test_custom_view_starter_ts_template_installation:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,6 +192,7 @@ jobs:
         with:
           application-type: custom-view
           template-name: starter
+          package-name: "@commercetools-applications/merchant-center-custom-view-template-starter"
           e2e-tests-command: test:e2e:template-custom-view-starter
           host-gcp-staging: ${{ secrets.HOST_GCP_STAGING }}
           playground-application-id: ${{ secrets.APP_ID_PLAYGROUND }}
@@ -242,6 +243,7 @@ jobs:
         with:
           application-type: custom-view
           template-name: starter-typescript
+          package-name: "@commercetools-applications/merchant-center-custom-view-template-starter-typescript"
           e2e-tests-command: test:e2e:template-custom-view-starter
           typecheck-command: typecheck:starter:custom-views
           host-gcp-staging: ${{ secrets.HOST_GCP_STAGING }}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
           LOGIN_USER: process.env.CYPRESS_LOGIN_USER,
           LOGIN_PASSWORD: process.env.CYPRESS_LOGIN_PASSWORD,
           PROJECT_KEY: process.env.CYPRESS_PROJECT_KEY,
+          PACKAGE_NAME: process.env.PACKAGE_NAME,
         }),
       });
     },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
           LOGIN_USER: process.env.CYPRESS_LOGIN_USER,
           LOGIN_PASSWORD: process.env.CYPRESS_LOGIN_PASSWORD,
           PROJECT_KEY: process.env.CYPRESS_PROJECT_KEY,
-          PACKAGE_NAME: process.env.PACKAGE_NAME,
+          PACKAGE_NAME: process.env.CYPRESS_PACKAGE_NAME,
         }),
       });
     },

--- a/packages/cypress/add-commands/index.d.ts
+++ b/packages/cypress/add-commands/index.d.ts
@@ -21,10 +21,7 @@ declare namespace Cypress {
      */
     loginToMerchantCenterForCustomView(
       // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#import-types
-      options?: Omit<
-        import('./dist/commercetools-frontend-cypress-add-commands.cjs').CommandLoginOptions,
-        'entryPointUriPath' | 'initialRoute'
-      >
+      options?: import('./dist/commercetools-frontend-cypress-add-commands.cjs').LoginToMerchantCenterForCustomViewCommandLoginOptions
     ): Chainable<Subject>;
     /**
      * Log into the Custom Application using the OIDC workflow.

--- a/packages/cypress/src/add-commands/index.ts
+++ b/packages/cypress/src/add-commands/index.ts
@@ -10,6 +10,8 @@ import {
 import { realHover } from './real-hover';
 
 export type CommandLoginOptions = TCommandLoginOptions;
+export type LoginToMerchantCenterForCustomViewCommandLoginOptions =
+  TLoginToMerchantCenterForCustomViewCommandLoginOptions;
 export type Matcher = TMatcher;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/cypress/src/add-commands/index.ts
+++ b/packages/cypress/src/add-commands/index.ts
@@ -5,6 +5,7 @@ import {
   loginByOidc,
   isLocalhost,
   type CommandLoginOptions as TCommandLoginOptions,
+  type LoginToMerchantCenterForCustomViewCommandLoginOptions as TLoginToMerchantCenterForCustomViewCommandLoginOptions,
 } from './login';
 import { realHover } from './real-hover';
 
@@ -31,12 +32,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'loginToMerchantCenterForCustomView',
-  (
-    commandOptions: Omit<
-      CommandLoginOptions,
-      'entryPointUriPath' | 'initialRoute'
-    >
-  ) => {
+  (commandOptions: TLoginToMerchantCenterForCustomViewCommandLoginOptions) => {
     Cypress.log({ name: 'loginToMerchantCenterForCustomView' });
 
     const projectKey = Cypress.env('PROJECT_KEY');

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -61,6 +61,10 @@ export type CommandLoginOptions = {
    * This is only relevant for Cypress version >= `10.9.0`.
    */
   disableCacheAcrossSpecs?: boolean;
+  /**
+   * The package name as listed in the tested Custom View's package.json
+   */
+  packageName?: string;
 };
 // Alias for backwards compatibility
 export type CommandLoginByOidcOptions = CommandLoginOptions;
@@ -186,9 +190,13 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
     ? 'customViewConfig'
     : 'customApplicationConfig';
 
-  if (isCustomViewConfigCommand && !Cypress.env('PACKAGE_NAME')) {
+  const packageName = commandOptions.packageName ?? Cypress.env('PACKAGE_NAME');
+
+  if (isCustomViewConfigCommand && !packageName) {
     throw new Error(
-      `Cypress environment variable "PACKAGE_NAME" must be provided when testing a Custom View locally. Re-run the command with, for example, "--env PACKAGE_NAME=@commercetools-applications/merchant-center-custom-view-template-starter"`
+      `Specify a package name for Custom View local testing:
+      - Provide it as the "loginToMerchantCenterForCustomView" command option
+      - Alternatively, use the Cypress environment variable: "--env PACKAGE_NAME=@commercetools-applications/merchant-center-custom-view-template-starter"`
     );
   }
 
@@ -197,9 +205,7 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
     {
       entryPointUriPath: commandOptions.entryPointUriPath,
       dotfiles: commandOptions.dotfiles,
-      ...(isCustomViewConfigCommand
-        ? { packageName: Cypress.env('PACKAGE_NAME') }
-        : {}),
+      ...(isCustomViewConfigCommand ? { packageName } : {}),
     },
     // Do not show log, as it may contain sensible information.
     { log: false }

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -61,11 +61,20 @@ export type CommandLoginOptions = {
    * This is only relevant for Cypress version >= `10.9.0`.
    */
   disableCacheAcrossSpecs?: boolean;
+};
+
+export type LoginToMerchantCenterForCustomViewCommandLoginOptions = Omit<
+  CommandLoginOptions,
+  'entryPointUriPath' | 'initialRoute'
+> & {
   /**
-   * The package name as listed in the tested Custom View's package.json
+   * The package name as specified in the `package.json` to uniquely identify the configuration.
+   * This is only required for testing Custom Views.
+   * Defaults to `Cypress.env('PACKAGE_NAME')`
    */
   packageName?: string;
 };
+
 // Alias for backwards compatibility
 export type CommandLoginByOidcOptions = CommandLoginOptions;
 
@@ -170,7 +179,10 @@ function loginByForm(commandOptions: CommandLoginOptions) {
 const isCustomView = (commandOptions: CommandLoginOptions) =>
   commandOptions.entryPointUriPath === CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH;
 
-function loginByOidc(commandOptions: CommandLoginOptions) {
+function loginByOidc(
+  commandOptions: CommandLoginOptions &
+    LoginToMerchantCenterForCustomViewCommandLoginOptions
+) {
   const isCustomViewConfigCommand = isCustomView(commandOptions);
   if (!isLocalhost()) {
     throw new Error(
@@ -194,9 +206,7 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
 
   if (isCustomViewConfigCommand && !packageName) {
     throw new Error(
-      `Specify a package name for Custom View local testing:
-      - Provide it as the "loginToMerchantCenterForCustomView" command option
-      - Alternatively, use the Cypress environment variable: "--env PACKAGE_NAME=@commercetools-applications/merchant-center-custom-view-template-starter"`
+      `Missing required option "packageName" when using the "loginToMerchantCenterForCustomView" command.`
     );
   }
 

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -186,9 +186,9 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
     ? 'customViewConfig'
     : 'customApplicationConfig';
 
-  if (isCustomViewConfigCommand && !Cypress.env('TEMPLATE_NAME')) {
+  if (isCustomViewConfigCommand && !Cypress.env('PACKAGE_NAME')) {
     throw new Error(
-      `Cypress environment variable "TEMPLATE_NAME" must be provided when testing a Custom View locally. Re-run the command with, for example, "--env TEMPLATE_NAME=starter"`
+      `Cypress environment variable "PACKAGE_NAME" must be provided when testing a Custom View locally. Re-run the command with, for example, "--env PACKAGE_NAME=@commercetools-applications/merchant-center-custom-view-template-starter"`
     );
   }
 
@@ -198,7 +198,7 @@ function loginByOidc(commandOptions: CommandLoginOptions) {
       entryPointUriPath: commandOptions.entryPointUriPath,
       dotfiles: commandOptions.dotfiles,
       ...(isCustomViewConfigCommand
-        ? { templateName: Cypress.env('TEMPLATE_NAME') }
+        ? { packageName: Cypress.env('PACKAGE_NAME') }
         : {}),
     },
     // Do not show log, as it may contain sensible information.

--- a/packages/cypress/src/task/index.ts
+++ b/packages/cypress/src/task/index.ts
@@ -11,7 +11,7 @@ import { CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH } from '@commercetools-frontend/c
 type CustomEntityConfigTaskOptions = {
   entryPointUriPath: string;
   dotfiles?: string[];
-  templateName?: string;
+  packageName?: string;
 };
 type AllCustomEntityConfigs = Record<string, ApplicationRuntimeConfig['env']>;
 
@@ -72,9 +72,7 @@ const loadAllCustomEntityConfigs = async (
         );
 
         const customEntityConfigCacheKey = isCustomViewConfig
-          ? `${processedConfig.env.entryPointUriPath}-${path.basename(
-              packageInfo.dir
-            )}`
+          ? `${processedConfig.env.entryPointUriPath}-${packageInfo.packageJson.name}`
           : processedConfig.env.entryPointUriPath;
 
         return {
@@ -127,7 +125,7 @@ const customViewConfig = async (
 
   const customViewConfig =
     allCustomEntityConfigs[
-      `${CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH}-${options.templateName}`
+      `${CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH}-${options.packageName}`
     ];
 
   if (!customViewConfig) {
@@ -135,7 +133,7 @@ const customViewConfig = async (
   }
 
   console.log(
-    `Using Custom View config for the "${options.templateName}" template`
+    `Using Custom View config for the "${options.packageName}" package`
   );
   return customViewConfig;
 };

--- a/packages/cypress/src/task/index.ts
+++ b/packages/cypress/src/task/index.ts
@@ -132,9 +132,7 @@ const customViewConfig = async (
     throw new Error(`Could not find Custom View config`);
   }
 
-  console.log(
-    `Using Custom View config for the "${options.packageName}" package`
-  );
+  console.log(`Using Custom View config for "${options.packageName}"`);
   return customViewConfig;
 };
 

--- a/packages/cypress/src/task/index.ts
+++ b/packages/cypress/src/task/index.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { getPackages } from '@manypkg/get-packages';
-import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
 import {
+  type ApplicationRuntimeConfig,
   processConfig,
   MissingOrInvalidConfigError,
 } from '@commercetools-frontend/application-config';
@@ -11,6 +11,7 @@ import { CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH } from '@commercetools-frontend/c
 type CustomEntityConfigTaskOptions = {
   entryPointUriPath: string;
   dotfiles?: string[];
+  templateName?: string;
 };
 type AllCustomEntityConfigs = Record<string, ApplicationRuntimeConfig['env']>;
 
@@ -69,9 +70,16 @@ const loadAllCustomEntityConfigs = async (
             isCustomViewConfig ? 'View' : 'Application'
           } config for ${packageInfo.packageJson.name}`
         );
+
+        const customEntityConfigCacheKey = isCustomViewConfig
+          ? `${processedConfig.env.entryPointUriPath}-${path.basename(
+              packageInfo.dir
+            )}`
+          : processedConfig.env.entryPointUriPath;
+
         return {
           ...allConfigs,
-          [processedConfig.env.entryPointUriPath]: processedConfig.env,
+          [customEntityConfigCacheKey]: processedConfig.env,
         };
       } catch (error) {
         // Ignore packages that do not have a valid config file, either because
@@ -118,13 +126,17 @@ const customViewConfig = async (
   });
 
   const customViewConfig =
-    allCustomEntityConfigs[CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH];
+    allCustomEntityConfigs[
+      `${CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH}-${options.templateName}`
+    ];
 
   if (!customViewConfig) {
     throw new Error(`Could not find Custom View config`);
   }
 
-  console.log(`Using Custom View config`);
+  console.log(
+    `Using Custom View config for the "${options.templateName}" template`
+  );
   return customViewConfig;
 };
 

--- a/website-custom-views/src/content/api-reference/commercetools-frontend-cypress.mdx
+++ b/website-custom-views/src/content/api-reference/commercetools-frontend-cypress.mdx
@@ -89,9 +89,8 @@ it('should render page 1', () => {
 
 Available options are:
 
-* `entryPointUriPath` (**required**): User the constant for the entry point URI path: `CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH`.
+* `packageName` (optional): The package name as listed in the tested Custom View's package.json. Alternatively, can be provided as `Cypress.env('PACKAGE_NAME')`
 * `dotfiles` (optional): A list of dotenv files to load when the `custom-view-config.mjs` is loaded (in case you're using an environment placeholder). By default the following dotenv files are loaded: `.env` and `.env.local`. You can also define the values using paths relative to the Custom View folder.
-* `initialRoute` (optional): The route to open after login. If not defined, make sure to call `cy.visit` yourself.
 * `projectKey` (optional): The project key to access the user session. The session token is valid for one project key at a time. Defaults to `Cypress.env('PROJECT_KEY')`.
 * `onBeforeLoad` (optional): The function to call before the page has loaded all of its resources. Use this as a chance to interact, for example, with the browser storage.
 * `login` (optional): An object with the user login credentials `email` and `password`. If not provided, the `email` defaults to `Cypress.env('LOGIN_EMAIL') || Cypress.env('LOGIN_USER')` and the `password` defaults to `Cypress.env('LOGIN_PASSWORD')`.
@@ -102,7 +101,7 @@ The `.env` and `.env.local` files are loaded by default from the Custom View fol
 
 <Info>
 
-Ensure that the following environment variables are available if the related options aren't provided explicitly: `PROJECT_KEY`, `LOGIN_USER`, `LOGIN_PASSWORD`.
+Ensure that the following environment variables are available if the related options aren't provided explicitly: `PROJECT_KEY`, `LOGIN_USER`, `LOGIN_PASSWORD`, `PACKAGE_NAME`.
 
 </Info>
 

--- a/website-custom-views/src/content/api-reference/commercetools-frontend-cypress.mdx
+++ b/website-custom-views/src/content/api-reference/commercetools-frontend-cypress.mdx
@@ -89,7 +89,7 @@ it('should render page 1', () => {
 
 Available options are:
 
-* `packageName` (optional): The package name as listed in the tested Custom View's package.json. Alternatively, can be provided as `Cypress.env('PACKAGE_NAME')`
+* `packageName` (optional): The package name as specified in the Custom View's `package.json`. If not provided, it defaults to `Cypress.env('PACKAGE_NAME').`
 * `dotfiles` (optional): A list of dotenv files to load when the `custom-view-config.mjs` is loaded (in case you're using an environment placeholder). By default the following dotenv files are loaded: `.env` and `.env.local`. You can also define the values using paths relative to the Custom View folder.
 * `projectKey` (optional): The project key to access the user session. The session token is valid for one project key at a time. Defaults to `Cypress.env('PROJECT_KEY')`.
 * `onBeforeLoad` (optional): The function to call before the page has loaded all of its resources. Use this as a chance to interact, for example, with the browser storage.


### PR DESCRIPTION
#### Summary
This PR addresses the issue related to [caching processed custom view configs](https://github.com/commercetools/merchant-center-application-kit/pull/3350#discussion_r1429811666).

This approach involves using `entryPointUriPath` for caching Custom App configs (not changing anything here for backwards compatibility) and `entryPointUriPath`-`templateName` combination as the cache key for Custom Views. The template name is expected to be passed as a Cypress environment variable.