### PR TITLE
Setting up the `min-width` for Project selector

### DIFF
--- a/.changeset/real-rabbits-scream.md
+++ b/.changeset/real-rabbits-scream.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Setting up the `min-width` in the Project selector

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -5,6 +5,7 @@ import type {
   OptionProps,
   ValueContainerProps,
   MenuListProps,
+  ControlProps,
 } from 'react-select';
 import { components } from 'react-select';
 import {
@@ -146,6 +147,17 @@ const CustomMenuList = (props: MenuListProps) => {
   );
 };
 
+const Control = (props: ControlProps) => (
+  <components.Control
+    {...props}
+    css={css`
+      min-width: ${designTokens.constraint3};
+    `}
+  >
+    {props.children}
+  </components.Control>
+);
+
 const redirectTo = (targetUrl: string) => location.replace(targetUrl);
 
 const ProjectSwitcher = (props: Props) => {
@@ -197,6 +209,7 @@ const ProjectSwitcher = (props: Props) => {
           Option: ProjectSwitcherOption,
           ValueContainer,
           MenuList: CustomMenuList,
+          Control,
         }}
         isClearable={false}
         backspaceRemovesValue={false}


### PR DESCRIPTION
This PR improves the Project selector's interface that's too narrow, by setting up the `min-width`. Specifically when users start typing to search in the `SelectInput`.

**Before**:

<img width="332" alt="Screenshot 2023-12-19 at 14 46 43" src="https://github.com/commercetools/merchant-center-application-kit/assets/52276952/7153cf45-ec73-47df-b7c8-bfdada031c59">



**After**:

<img width="323" alt="Screenshot 2023-12-19 at 14 44 48" src="https://github.com/commercetools/merchant-center-application-kit/assets/52276952/e4b28c05-a6e4-434a-a617-d906cea75bee">
