### PR TITLE
FCT 615: suppress ResizeObserver error

### DIFF
--- a/.changeset/rich-grapes-cheat.md
+++ b/.changeset/rich-grapes-cheat.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/sentry': patch
+---
+
+Avoid displaying 'unhandled error' banner and passing error to sentry for ResizeObserver loop related errors

--- a/packages/application-shell/src/utils/setup-global-error-listener/setup-global-error-listener.ts
+++ b/packages/application-shell/src/utils/setup-global-error-listener/setup-global-error-listener.ts
@@ -8,7 +8,9 @@ import internalReduxStore from '../../configure-store';
 type ReportableEvent = ErrorEvent | PromiseRejectionEvent;
 type Reportable = Error | ReportableEvent | string;
 
-const errorMessageIgnoreList = [/ResizeObserver loop limit exceeded/i];
+const errorMessageIgnoreList = [
+  /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
+];
 
 // Ensure to initialize Sentry as soon as possible, so that we have the chance
 // of catching possible errors.

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -83,6 +83,11 @@ export const boot = () => {
       // from our code and ignore errors that come from other services
       // https://blog.sentry.io/2017/03/27/tips-for-reducing-javascript-error-noise.html
       allowUrls: [window.app.cdnUrl, window.app.frontendHost],
+      // suppress any resize observer errors, see
+      // https://github.com/vercel/next.js/discussions/51551
+      ignoreErrors: [
+        /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
+      ],
       integrations: [
         new Sentry.Integrations.GlobalHandlers({
           onunhandledrejection: false,


### PR DESCRIPTION

When a page uses ResizeObserver API, it may occasionally throw "ResizeObserver loop completed with undelivered notifications" (Firefox) or "ResizeObserver loop limit exceeded" (Chrome). The error has weird semantics, it never gets printed to browser console, only gets caught by window.onerror listener (used by the error overlay)

This error is a known false alarm: https://github.com/w3c/csswg-drafts/issues/5488

This PR is to ignore the `ResizeObserver` loop error in sentry.  For more context see [this github issue](https://github.com/vercel/next.js/discussions/51551)