### PR TITLE
fix: local login side effects when running in strict mode

### DIFF
--- a/.changeset/happy-trainers-reflect.md
+++ b/.changeset/happy-trainers-reflect.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-applications/merchant-center-custom-view-template-starter-typescript': minor
+'@commercetools-applications/merchant-center-template-starter-typescript': minor
+'@commercetools-applications/merchant-center-custom-view-template-starter': minor
+'@commercetools-applications/merchant-center-template-starter': minor
+---
+
+Enable React strict mode by default

--- a/.changeset/large-rats-begin.md
+++ b/.changeset/large-rats-begin.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix login flow for local development to safely run the side effects when using React strict mode

--- a/application-templates/starter-typescript/src/components/entry-point/entry-point.tsx
+++ b/application-templates/starter-typescript/src/components/entry-point/entry-point.tsx
@@ -20,7 +20,11 @@ const AsyncApplicationRoutes = lazy(
 setupGlobalErrorListener();
 
 const EntryPoint = () => (
-  <ApplicationShell environment={window.app} applicationMessages={loadMessages}>
+  <ApplicationShell
+    enableReactStrictMode
+    environment={window.app}
+    applicationMessages={loadMessages}
+  >
     <AsyncApplicationRoutes />
   </ApplicationShell>
 );

--- a/application-templates/starter/src/components/entry-point/entry-point.jsx
+++ b/application-templates/starter/src/components/entry-point/entry-point.jsx
@@ -17,7 +17,11 @@ const AsyncApplicationRoutes = lazy(() =>
 setupGlobalErrorListener();
 
 const EntryPoint = () => (
-  <ApplicationShell environment={window.app} applicationMessages={loadMessages}>
+  <ApplicationShell
+    enableReactStrictMode
+    environment={window.app}
+    applicationMessages={loadMessages}
+  >
     <AsyncApplicationRoutes />
   </ApplicationShell>
 );

--- a/custom-views-templates/starter-typescript/src/components/entry-point/entry-point.tsx
+++ b/custom-views-templates/starter-typescript/src/components/entry-point/entry-point.tsx
@@ -17,7 +17,7 @@ const AsyncApplicationRoutes = lazy(
 setupGlobalErrorListener();
 
 const EntryPoint = () => (
-  <CustomViewShell applicationMessages={loadMessages}>
+  <CustomViewShell enableReactStrictMode applicationMessages={loadMessages}>
     <AsyncApplicationRoutes />
   </CustomViewShell>
 );

--- a/custom-views-templates/starter/src/components/entry-point/entry-point.jsx
+++ b/custom-views-templates/starter/src/components/entry-point/entry-point.jsx
@@ -17,7 +17,7 @@ const AsyncApplicationRoutes = lazy(() =>
 setupGlobalErrorListener();
 
 const EntryPoint = () => (
-  <CustomViewShell applicationMessages={loadMessages}>
+  <CustomViewShell enableReactStrictMode applicationMessages={loadMessages}>
     <AsyncApplicationRoutes />
   </CustomViewShell>
 );

--- a/packages/application-shell-connectors/src/utils/oidc-storage.ts
+++ b/packages/application-shell-connectors/src/utils/oidc-storage.ts
@@ -45,13 +45,8 @@ const getSessionState = <State extends {}>(stateId?: string): State | null => {
   if (unparsedSessionState) {
     try {
       const parsedSessionState = JSON.parse(unparsedSessionState) as State;
-
-      window.sessionStorage.removeItem(sessionStateKey);
-
       return parsedSessionState;
     } catch (error) {
-      window.sessionStorage.removeItem(sessionStateKey);
-
       if (process.env.NODE_ENV !== 'production') {
         // eslint-disable-next-line no-console
         console.warn(
@@ -71,12 +66,18 @@ const setSessionState = <State extends {}>(
   window.sessionStorage.setItem(sessionStateKey, JSON.stringify(state));
 };
 
+const removeSessionState = (stateId?: string): void => {
+  const sessionStateKey = `${STORAGE_KEYS.NONCE}_${stateId}`;
+  window.sessionStorage.removeItem(sessionStateKey);
+};
+
 export {
   getSessionToken,
   setActiveSession,
   clearSession,
   getSessionState,
   setSessionState,
+  removeSessionState,
   getActiveProjectKey,
   setActiveProjectKey,
   removeActiveProjectKey,

--- a/packages/application-shell/src/components/authenticated/oidc-callback-error-page.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback-error-page.tsx
@@ -58,6 +58,7 @@ const AuthCallbackErrorPage = (props: TProps) => {
                   <Spacings.Stack scale="l">
                     <Spacings.Inline justifyContent="center">
                       <img
+                        width="100%"
                         src={FailedAuthenticationSVG}
                         alt="Failed authentication"
                       />

--- a/packages/application-shell/src/components/authenticated/oidc-callback.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback.tsx
@@ -1,10 +1,11 @@
+import { useEffect, useState } from 'react';
 import jwtDecode from 'jwt-decode';
 import { decode } from 'qss';
 import { useLocation } from 'react-router-dom';
 import { oidcStorage } from '@commercetools-frontend/application-shell-connectors';
 import type { ApplicationWindow } from '@commercetools-frontend/constants';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
-import Redirector from '../redirector';
+import { useRedirector } from '../redirector';
 import OidcCallbackErrorPage from './oidc-callback-error-page';
 import type { AuthorizeSessionState } from './types';
 
@@ -20,65 +21,85 @@ type SessionToken = { nonce: string };
 
 const OidcCallback = (props: TOidcCallbackProps) => {
   const location = useLocation();
-  let errorMessage: string | undefined;
-
+  const redirector = useRedirector();
+  const [message, setMessage] = useState<string>();
   const fragments = decode<AuthorizeCallbackFragments>(
     location.hash.substring(1)
   );
-
-  // Validate the nonce (coming as a `state` parameter)
-  // By trying to load the related session state, we can implicitly check if the nonce is correct or not.
-  const sessionState = oidcStorage.getSessionState<AuthorizeSessionState>(
-    fragments.state
-  );
-
   const sessionToken = fragments.sessionToken;
-  let decodedSessionToken: SessionToken | undefined;
-  try {
-    if (sessionToken) {
-      decodedSessionToken = jwtDecode<SessionToken>(sessionToken);
-    } else {
-      errorMessage = 'Invalid client session (missing sessionToken)';
-    }
-  } catch (err) {
-    if (err instanceof Error) {
-      errorMessage = err.message;
-    } else {
-      errorMessage = 'Unknown error';
-    }
-  }
 
-  if (!errorMessage) {
-    const hasValidSessionId = decodedSessionToken?.nonce === fragments.state;
-    const hasValidApplicationId =
-      window.app.applicationId === sessionState?.applicationId;
-    if (!sessionState || !hasValidSessionId || !hasValidApplicationId) {
-      errorMessage = 'Invalid client session';
-    }
-  }
+  useEffect(() => {
+    // Validate the nonce (coming as a `state` parameter)
+    // By trying to load the related session state, we can implicitly check if the nonce is correct or not.
+    const sessionState = oidcStorage.getSessionState<AuthorizeSessionState>(
+      fragments.state
+    );
 
-  if (errorMessage) {
+    let errorMessage: string | undefined;
+    let decodedSessionToken: SessionToken | undefined;
+    try {
+      if (sessionToken) {
+        decodedSessionToken = jwtDecode<SessionToken>(sessionToken);
+      } else {
+        errorMessage = 'Invalid client session (missing sessionToken)';
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        errorMessage = err.message;
+      } else {
+        errorMessage = 'Unknown error';
+      }
+    }
+
+    if (!errorMessage) {
+      const hasValidSessionId = decodedSessionToken?.nonce === fragments.state;
+      const hasValidApplicationId =
+        window.app.applicationId === sessionState?.applicationId;
+      if (!sessionState || !hasValidSessionId || !hasValidApplicationId) {
+        errorMessage = 'Invalid client session';
+      }
+    }
+
+    if (errorMessage) {
+      setMessage(errorMessage);
+    } else {
+      oidcStorage.setActiveSession(sessionToken);
+      oidcStorage.removeSessionState(fragments.state);
+
+      if (sessionState?.query.redirectTo) {
+        try {
+          const redirectToUrl = new URL(sessionState.query.redirectTo);
+          redirector({ to: redirectToUrl.pathname });
+          return;
+        } catch (error) {
+          console.warn(
+            `Invalid "redirectTo" URL`,
+            sessionState.query.redirectTo
+          );
+          // ignore
+        }
+      }
+      redirector({
+        to: location.pathname.replace('/oidc/callback', ''),
+      });
+      return;
+    }
+
+    // Only execute once!
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (message) {
     return (
       <OidcCallbackErrorPage
-        message={errorMessage}
+        message={message}
         locale={props.locale}
         applicationMessages={props.applicationMessages}
       />
     );
   }
 
-  oidcStorage.setActiveSession(sessionToken);
-
-  if (sessionState?.query.redirectTo) {
-    try {
-      const redirectToUrl = new URL(sessionState.query.redirectTo);
-      return <Redirector to={redirectToUrl.pathname} />;
-    } catch (error) {
-      console.warn(`Invalid "redirectTo" URL`, sessionState.query.redirectTo);
-      // ignore
-    }
-  }
-  return <Redirector to={location.pathname.replace('/oidc/callback', '')} />;
+  return null;
 };
 OidcCallback.displayName = 'OidcCallback';
 

--- a/packages/application-shell/src/components/redirect-to-login/redirect-to-login.tsx
+++ b/packages/application-shell/src/components/redirect-to-login/redirect-to-login.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { oidcStorage } from '@commercetools-frontend/application-shell-connectors';
@@ -12,7 +13,7 @@ import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import getMcOrigin from '../../utils/get-mc-origin';
 import { buildOidcScope } from '../../utils/oidc';
 import type { AuthorizeSessionState } from '../authenticated/types';
-import Redirector from '../redirector';
+import { useRedirector } from '../redirector';
 
 declare let window: ApplicationWindow;
 
@@ -31,49 +32,54 @@ const generateAndCacheNonceWithState = (state: AuthorizeSessionState) => {
 const RedirectToLogin = () => {
   const location = useLocation();
   const servedByProxy = useIsServedByProxy();
+  const redirector = useRedirector();
 
-  if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
-    // We pick the project key from local storage. This assumes that the value
-    // as been previously set when the application starts up.
-    // This is necessary to allow switching projects and triggering a new login.
-    const nextProjectKey = oidcStorage.getActiveProjectKey();
+  useEffect(() => {
+    if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
+      // Remove the `sessionToken` from storage, so that the AppShell can initiate
+      // a new authorization flow.
+      oidcStorage.clearSession();
 
-    // According to the OIDC spec, the `state` parameter is recommended to be sent
-    // to the authorization server to help mitigating Cross-Site Request Forgery.
-    // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
-    // Using `state` or `nonce` is very similar but with subtle differences.
-    // Here we follow the approach described by Auth0 on how to use both, where
-    // we generate a `nonce`, store it in session storage together with some state,
-    // and send it to the authorization server as the `state` parameter.
-    // https://auth0.com/docs/protocols/oauth2/redirect-users
-    // Additionally, we still send the `nonce` parameter as well.
-    const sessionId = generateAndCacheNonceWithState({
-      applicationId: window.app.applicationId,
-      // Store query parameters to be used after the callback redirect
-      query: {
-        redirectTo: nextProjectKey ? `/${nextProjectKey}` : '/',
-      },
-    });
-    const requestedScope = buildOidcScope({
-      projectKey: nextProjectKey ?? undefined,
-      oAuthScopes: window.app.__DEVELOPMENT__?.oidc?.oAuthScopes,
-      additionalOAuthScopes:
-        window.app.__DEVELOPMENT__?.oidc?.additionalOAuthScopes,
-      teamId: window.app.__DEVELOPMENT__?.oidc?.teamId,
-      applicationId: window.app.__DEVELOPMENT__?.oidc?.applicationId,
-    });
+      // We pick the project key from local storage. This assumes that the value
+      // as been previously set when the application starts up.
+      // This is necessary to allow switching projects and triggering a new login.
+      const nextProjectKey = oidcStorage.getActiveProjectKey();
 
-    // Store session scopes, to be able to detect if requested scopes changed
-    // in the application config and invalidate the session.
-    // This is only valid for local development.
-    oidcStorage.setSessionScope(requestedScope);
+      // According to the OIDC spec, the `state` parameter is recommended to be sent
+      // to the authorization server to help mitigating Cross-Site Request Forgery.
+      // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+      // Using `state` or `nonce` is very similar but with subtle differences.
+      // Here we follow the approach described by Auth0 on how to use both, where
+      // we generate a `nonce`, store it in session storage together with some state,
+      // and send it to the authorization server as the `state` parameter.
+      // https://auth0.com/docs/protocols/oauth2/redirect-users
+      // Additionally, we still send the `nonce` parameter as well.
+      const sessionId = generateAndCacheNonceWithState({
+        applicationId: window.app.applicationId,
+        // Store query parameters to be used after the callback redirect
+        query: {
+          redirectTo: nextProjectKey ? `/${nextProjectKey}` : '/',
+        },
+      });
+      const requestedScope = buildOidcScope({
+        projectKey: nextProjectKey ?? undefined,
+        oAuthScopes: window.app.__DEVELOPMENT__?.oidc?.oAuthScopes,
+        additionalOAuthScopes:
+          window.app.__DEVELOPMENT__?.oidc?.additionalOAuthScopes,
+        teamId: window.app.__DEVELOPMENT__?.oidc?.teamId,
+        applicationId: window.app.__DEVELOPMENT__?.oidc?.applicationId,
+      });
 
-    return (
-      <Redirector
-        to=""
-        origin={window.app.__DEVELOPMENT__?.oidc?.authorizeUrl}
-        location={location}
-        queryParams={{
+      // Store session scopes, to be able to detect if requested scopes changed
+      // in the application config and invalidate the session.
+      // This is only valid for local development.
+      oidcStorage.setSessionScope(requestedScope);
+
+      redirector({
+        to: '',
+        origin: window.app.__DEVELOPMENT__?.oidc?.authorizeUrl,
+        location: location,
+        queryParams: {
           reason: LOGOUT_REASONS.UNAUTHORIZED,
           // Query parameters for OIDC-lik workflow.
           client_id: window.app.applicationId,
@@ -81,26 +87,32 @@ const RedirectToLogin = () => {
           scope: requestedScope,
           state: sessionId,
           nonce: sessionId,
-        }}
-      />
-    );
-  }
+        },
+      });
+      return;
+    }
 
-  const mcOrigin = servedByProxy ? getMcOrigin(window.app.mcApiUrl) : undefined;
+    const mcOrigin = servedByProxy
+      ? getMcOrigin(window.app.mcApiUrl)
+      : undefined;
 
-  return (
-    <Redirector
-      to="login"
-      origin={mcOrigin}
-      location={location}
-      queryParams={{
+    redirector({
+      to: 'login',
+      origin: mcOrigin,
+      location: location,
+      queryParams: {
         reason: LOGOUT_REASONS.UNAUTHORIZED,
         redirectTo: trimLeadingAndTrailingSlashes(
           joinPaths(window.location.origin, location.pathname)
         ),
-      }}
-    />
-  );
+      },
+    });
+
+    // Only execute once!
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
 };
 RedirectToLogin.displayName = 'RedirectToLogin';
 

--- a/packages/application-shell/src/components/redirect-to-logout/redirect-to-logout.tsx
+++ b/packages/application-shell/src/components/redirect-to-logout/redirect-to-logout.tsx
@@ -1,5 +1,4 @@
 import { useLocation } from 'react-router-dom';
-import { oidcStorage } from '@commercetools-frontend/application-shell-connectors';
 import {
   LOGOUT_REASONS,
   type ApplicationWindow,
@@ -7,7 +6,7 @@ import {
 import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
 import getMcOrigin from '../../utils/get-mc-origin';
 import RedirectToLogin from '../redirect-to-login';
-import Redirector from '../redirector';
+import { Redirector } from '../redirector';
 
 declare let window: ApplicationWindow;
 
@@ -22,10 +21,6 @@ const RedirectToLogout = (props: Props) => {
   const servedByProxy = useIsServedByProxy();
 
   if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
-    // Remove the `sessionToken` from storage, so that the AppShell can initiate
-    // a new authorization flow.
-    oidcStorage.clearSession();
-
     return <RedirectToLogin />;
   }
 

--- a/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.tsx
+++ b/packages/application-shell/src/components/redirect-to-project-create/redirect-to-project-create.tsx
@@ -1,56 +1,62 @@
-import { css } from '@emotion/react';
-import Card from '@commercetools-uikit/card';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { useEffect } from 'react';
+import { PageContentNarrow } from '@commercetools-frontend/application-components';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
 import { ContentNotification } from '@commercetools-uikit/notifications';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 import useIsServedByProxy from '../../hooks/use-is-served-by-proxy';
+import getMcOrigin from '../../utils/get-mc-origin';
 import { location } from '../../utils/location';
+
+declare let window: ApplicationWindow;
 
 export const RedirectToProjectCreate = () => {
   const servedByProxy = useIsServedByProxy();
-  /**
-   * NOTE:
-   *   This looks a bit unusual: redirecting in render.
-   *   However, when doing it in `cDM` we loose time
-   *   we we actually do never want to render anything or
-   *   interact with anything rendered. Instead we should should
-   *   redirect away. Using a constructor would result in the same.
-   *   In turn this intends wo make explicit that we never want to
-   *   render and instead just navigate away.
-   */
-  if (servedByProxy === true) {
-    location.replace('/account/projects/new');
 
+  useEffect(() => {
+    if (servedByProxy === true) {
+      location.replace('/account/projects/new');
+      return;
+    }
+  }, [servedByProxy]);
+
+  if (servedByProxy) {
     return null;
   }
 
+  const mcUrl = getMcOrigin(window.app.mcApiUrl);
   return (
-    <div
-      css={css`
-        align-self: center;
-        margin-top: ${customProperties.spacingXl};
-        max-width: ${customProperties.constraint10};
-      `}
-    >
-      <Card type="flat" theme="dark">
-        <Spacings.Stack>
-          <Text.Headline as="h1">Please create a project!</Text.Headline>
-          <ContentNotification type="info">
-            You are running in development mode
-          </ContentNotification>
-          <Text.Body>
-            The Custom Application is not running behind the Merchant Center
-            Proxy. Therefore, you are not being redirected to the account
-            section to create a new project.
-          </Text.Body>
-          <Text.Body>
-            If you do need to create a project, we recommend to go to the
-            Merchant Center production URL and create a project there. After
-            that, you can access your new project from your local environment.
-          </Text.Body>
-        </Spacings.Stack>
-      </Card>
+    <div>
+      <Spacings.Inset scale="xl">
+        <PageContentNarrow>
+          <Spacings.Stack>
+            <Text.Headline as="h1">Please create a project!</Text.Headline>
+            <ContentNotification type="warning">
+              You are running in development mode
+            </ContentNotification>
+            <Text.Body>
+              The application is not running behind the{' '}
+              <a
+                href="https://docs.commercetools.com/custom-applications/concepts/merchant-center-proxy-router"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Merchant Center Proxy
+              </a>{' '}
+              in production and thus cannot be redirected to the account section
+              to create a new project.
+            </Text.Body>
+            <Text.Body>
+              Instead, we recommend to go to the{' '}
+              <a href={mcUrl} target="_blank" rel="noopener noreferrer">
+                Merchant Center production URL
+              </a>{' '}
+              and create a project there. After that, you can access your new
+              project from your local environment.
+            </Text.Body>
+          </Spacings.Stack>
+        </PageContentNarrow>
+      </Spacings.Inset>
     </div>
   );
 };

--- a/packages/application-shell/src/components/redirector/index.ts
+++ b/packages/application-shell/src/components/redirector/index.ts
@@ -1,1 +1,1 @@
-export { default } from './redirector';
+export { useRedirector, Redirector } from './redirector';


### PR DESCRIPTION
Fixes #3361

The actual fix is to move the logic with side effects (e.g. redirects, interacting with storage) within a React `useEffect` (_who would have thought of that_ 🤪). This solves the issue with the component re-rendering due to strict mode as the effect is run once.

Additionally, I found some minor things to adjust to some dev-related pages.

> [!NOTE]
> Also a useful note from the legacy docs:
> Once we upgrade to React 18, we can expect multiple (duplicate) logs in the devtools due to strict mode re-rendering.

<img width="942" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/1110551/a817e97a-29a9-41be-851e-12988a2dad7c">