### PR TITLE
ci: include provenance info when publishing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
+            provenance=true
             email=npmjs@commercetools.com
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF


### PR DESCRIPTION
I supposed we somehow missed that announcement: https://github.blog/2023-04-19-introducing-npm-package-provenance/

NPM allows to include a [provenance statement](https://docs.npmjs.com/generating-provenance-statements) to increase security:

> [!NOTE]
> You can generate provenance statements for the packages you publish. This allows you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages.

See example with Vercel
<img width="1193" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/1110551/5f12d43d-5017-4dd7-b62b-04d0ac644164">
