### PR TITLE
Add `isProductionProject` to project query

### DIFF
--- a/.changeset/little-sloths-talk.md
+++ b/.changeset/little-sloths-talk.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/permissions': patch
+---
+
+Add `isProductionProject` to project query.

--- a/@types-extensions/graphql-mc/index.d.ts
+++ b/@types-extensions/graphql-mc/index.d.ts
@@ -1,6 +1,14 @@
 /* THIS IS A GENERATED FILE */
 /* eslint-disable import/no-duplicates */
 
+declare module '*/select-user-id.mc.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+  export const FetchUserId: DocumentNode;
+
+  export default defaultDocument;
+}
+
 declare module '*/authenticated.mc.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
@@ -37,14 +45,6 @@ declare module '*/fetch-all-features.mc.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;
   export const AllFeatures: DocumentNode;
-
-  export default defaultDocument;
-}
-
-declare module '*/select-user-id.mc.graphql' {
-  import { DocumentNode } from 'graphql';
-  const defaultDocument: DocumentNode;
-  export const FetchUserId: DocumentNode;
 
   export default defaultDocument;
 }

--- a/graphql-test-utils/graphql-models/project.ts
+++ b/graphql-test-utils/graphql-models/project.ts
@@ -35,6 +35,7 @@ const Project = new Factory()
     id: faker.string.uuid(),
     name: faker.company.name(),
   }))
-  .attr('sampleDataImportDataset', 'FASHION');
+  .attr('sampleDataImportDataset', 'FASHION')
+  .attr('isProductionProject', true);
 
 export default Project;

--- a/graphql-test-utils/graphql-models/project.ts
+++ b/graphql-test-utils/graphql-models/project.ts
@@ -21,6 +21,7 @@ const Project = new Factory()
     isActive: false,
     reason: null,
   })
+  .attr('isProductionProject', false)
   .attr('allAppliedPermissions', [])
   .attr('allAppliedActionRights', [])
   .attr('allAppliedDataFences', [])
@@ -35,7 +36,6 @@ const Project = new Factory()
     id: faker.string.uuid(),
     name: faker.company.name(),
   }))
-  .attr('sampleDataImportDataset', 'FASHION')
-  .attr('isProductionProject', true);
+  .attr('sampleDataImportDataset', 'FASHION');
 
 export default Project;

--- a/packages/application-components/src/types/generated/settings.ts
+++ b/packages/application-components/src/types/generated/settings.ts
@@ -94,6 +94,7 @@ export type TBusinessUnitsListMyViewTableInput = {
 
 export enum TCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType'
 }
@@ -376,6 +377,21 @@ export type TCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']>;
 };
 
+export type TCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Scalars['String']>;
+  where?: InputMaybe<TCustomViewQueryWhereInput>;
+};
+
+export type TCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']>;
+  locators?: InputMaybe<Array<Scalars['String']>>;
+  organizationId?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<TCustomViewType>;
+};
+
 export enum TCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL'
@@ -397,6 +413,15 @@ export type TCustomViewTypeSettings = {
 
 export type TCustomViewTypeSettingsInput = {
   size?: InputMaybe<TCustomViewSize>;
+};
+
+export type TCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TCustomView>;
+  total: Scalars['Int'];
 };
 
 export type TCustomersListView = {
@@ -1295,6 +1320,32 @@ export type TMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TCustomApplicationStatus>;
 };
 
+export type TMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime'];
+  defaultLabel: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  labelAllLocales: Array<TLocalizedField>;
+  locators: Array<Scalars['String']>;
+  organizationId: Scalars['String'];
+  organizationName: Scalars['String'];
+  permissions: Array<TCustomViewPermission>;
+  status: TCustomViewStatus;
+  type: TCustomViewType;
+  typeSettings?: Maybe<TCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime'];
+  url: Scalars['String'];
+};
+
+export type TMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMyCustomViewsQueryWhereInput>;
+};
+
+export type TMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TCustomViewStatus>;
+};
+
 export type TNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime'];
@@ -1481,6 +1532,7 @@ export type TOrganizationExtensionForCustomView = {
 export type TPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime'];
+  expandedRows: Array<Scalars['String']>;
   filters?: Maybe<Array<TFilterValues>>;
   id: Scalars['ID'];
   isActive?: Maybe<Scalars['Boolean']>;
@@ -1494,6 +1546,7 @@ export type TPimSearchListView = {
 };
 
 export type TPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']>>;
   filters: Array<TFilterValuesCreateInput>;
   nameAllLocales: Array<TLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']>;
@@ -1629,6 +1682,8 @@ export type TQuery = {
   allAppliedCustomViewPermissions: Array<TCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TCustomViewLocatorGroup>;
   allFeatures: Array<TFeature>;
@@ -1655,6 +1710,7 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  myCustomViews: Array<TMyCustomView>;
   orderDetailView?: Maybe<TOrderDetailView>;
   orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
@@ -1696,6 +1752,11 @@ export type TQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TCustomApplicationQueryInput>;
+};
+
+
+export type TQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TCustomViewQueryInput>;
 };
 
 
@@ -1766,6 +1827,11 @@ export type TQuery_GlobalOrganizationExtensionArgs = {
 
 export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
+};
+
+
+export type TQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMyCustomViewsQueryInput>;
 };
 
 

--- a/packages/application-config/src/generated/settings.ts
+++ b/packages/application-config/src/generated/settings.ts
@@ -100,6 +100,7 @@ export type TBusinessUnitsListMyViewTableInput = {
 
 export enum TCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType',
 }
@@ -382,6 +383,21 @@ export type TCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']>;
 };
 
+export type TCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Scalars['String']>;
+  where?: InputMaybe<TCustomViewQueryWhereInput>;
+};
+
+export type TCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']>;
+  locators?: InputMaybe<Array<Scalars['String']>>;
+  organizationId?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<TCustomViewType>;
+};
+
 export enum TCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL',
@@ -403,6 +419,15 @@ export type TCustomViewTypeSettings = {
 
 export type TCustomViewTypeSettingsInput = {
   size?: InputMaybe<TCustomViewSize>;
+};
+
+export type TCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TCustomView>;
+  total: Scalars['Int'];
 };
 
 export type TCustomersListView = {
@@ -1210,6 +1235,32 @@ export type TMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TCustomApplicationStatus>;
 };
 
+export type TMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime'];
+  defaultLabel: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  labelAllLocales: Array<TLocalizedField>;
+  locators: Array<Scalars['String']>;
+  organizationId: Scalars['String'];
+  organizationName: Scalars['String'];
+  permissions: Array<TCustomViewPermission>;
+  status: TCustomViewStatus;
+  type: TCustomViewType;
+  typeSettings?: Maybe<TCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime'];
+  url: Scalars['String'];
+};
+
+export type TMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMyCustomViewsQueryWhereInput>;
+};
+
+export type TMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TCustomViewStatus>;
+};
+
 export type TNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime'];
@@ -1396,6 +1447,7 @@ export type TOrganizationExtensionForCustomView = {
 export type TPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime'];
+  expandedRows: Array<Scalars['String']>;
   filters?: Maybe<Array<TFilterValues>>;
   id: Scalars['ID'];
   isActive?: Maybe<Scalars['Boolean']>;
@@ -1409,6 +1461,7 @@ export type TPimSearchListView = {
 };
 
 export type TPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']>>;
   filters: Array<TFilterValuesCreateInput>;
   nameAllLocales: Array<TLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']>;
@@ -1541,6 +1594,8 @@ export type TQuery = {
   allAppliedCustomViewPermissions: Array<TCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TCustomViewLocatorGroup>;
   allFeatures: Array<TFeature>;
@@ -1567,6 +1622,7 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  myCustomViews: Array<TMyCustomView>;
   orderDetailView?: Maybe<TOrderDetailView>;
   orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
@@ -1606,6 +1662,10 @@ export type TQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TCustomApplicationQueryInput>;
+};
+
+export type TQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TCustomViewQueryInput>;
 };
 
 export type TQuery_AllCustomViewsInstallationsByLocatorArgs = {
@@ -1662,6 +1722,10 @@ export type TQuery_GlobalOrganizationExtensionArgs = {
 
 export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
+};
+
+export type TQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMyCustomViewsQueryInput>;
 };
 
 export type TQuery_OrderDetailViewArgs = {

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -280,7 +280,6 @@ describe('mapProjectToApplicationContextProject', () => {
       ownerId: expect.any(String),
       ownerName: expect.any(String),
       sampleDataImportDataset: expect.any(String),
-      isProductionProject: expect.any(Boolean),
     });
   });
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -280,6 +280,7 @@ describe('mapProjectToApplicationContextProject', () => {
       ownerId: expect.any(String),
       ownerName: expect.any(String),
       sampleDataImportDataset: expect.any(String),
+      isProductionProject: expect.any(Boolean),
     });
   });
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -147,6 +147,7 @@ export const mapProjectToApplicationContextProject = (
     ownerId: project.owner.id,
     ownerName: project.owner.name,
     sampleDataImportDataset: project.sampleDataImportDataset,
+    isProductionProject: project.isProductionProject,
   };
 };
 

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -147,7 +147,6 @@ export const mapProjectToApplicationContextProject = (
     ownerId: project.owner.id,
     ownerName: project.owner.name,
     sampleDataImportDataset: project.sampleDataImportDataset,
-    isProductionProject: project.isProductionProject,
   };
 };
 

--- a/packages/application-shell-connectors/src/configure-apollo.ts
+++ b/packages/application-shell-connectors/src/configure-apollo.ts
@@ -84,6 +84,16 @@ const createApolloClient = (
         // CTP types with `key` as identifier
         Project: {
           keyFields: ['key'],
+          fields: {
+            expiry: {
+              merge: (existing, incoming, { mergeObjects }) =>
+                mergeObjects(existing, incoming),
+            },
+            suspension: {
+              merge: (existing, incoming, { mergeObjects }) =>
+                mergeObjects(existing, incoming),
+            },
+          },
         },
         Store: {
           keyFields: ['key'],

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -663,7 +663,7 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/application-shell-connectors/src/types/generated/mc.ts
+++ b/packages/application-shell-connectors/src/types/generated/mc.ts
@@ -638,6 +638,11 @@ export enum TVerificationStatus {
   Verified = 'Verified'
 }
 
+export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };
+
 export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -648,7 +653,7 @@ export type TFetchProjectQueryVariables = Exact<{
 }>;
 
 
-export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
+export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, isProductionProject: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
 
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -658,14 +663,9 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type TAllFeaturesQuery = { __typename?: 'Query', allFeatures: Array<{ __typename?: 'Feature', name: string, value: boolean, reason?: string | null }> };
-
-export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };

--- a/packages/application-shell-connectors/src/types/generated/settings.ts
+++ b/packages/application-shell-connectors/src/types/generated/settings.ts
@@ -94,6 +94,7 @@ export type TBusinessUnitsListMyViewTableInput = {
 
 export enum TCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType'
 }
@@ -376,6 +377,21 @@ export type TCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']>;
 };
 
+export type TCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Scalars['String']>;
+  where?: InputMaybe<TCustomViewQueryWhereInput>;
+};
+
+export type TCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']>;
+  locators?: InputMaybe<Array<Scalars['String']>>;
+  organizationId?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<TCustomViewType>;
+};
+
 export enum TCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL'
@@ -397,6 +413,15 @@ export type TCustomViewTypeSettings = {
 
 export type TCustomViewTypeSettingsInput = {
   size?: InputMaybe<TCustomViewSize>;
+};
+
+export type TCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TCustomView>;
+  total: Scalars['Int'];
 };
 
 export type TCustomersListView = {
@@ -1295,6 +1320,32 @@ export type TMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TCustomApplicationStatus>;
 };
 
+export type TMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime'];
+  defaultLabel: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  labelAllLocales: Array<TLocalizedField>;
+  locators: Array<Scalars['String']>;
+  organizationId: Scalars['String'];
+  organizationName: Scalars['String'];
+  permissions: Array<TCustomViewPermission>;
+  status: TCustomViewStatus;
+  type: TCustomViewType;
+  typeSettings?: Maybe<TCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime'];
+  url: Scalars['String'];
+};
+
+export type TMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMyCustomViewsQueryWhereInput>;
+};
+
+export type TMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TCustomViewStatus>;
+};
+
 export type TNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime'];
@@ -1481,6 +1532,7 @@ export type TOrganizationExtensionForCustomView = {
 export type TPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime'];
+  expandedRows: Array<Scalars['String']>;
   filters?: Maybe<Array<TFilterValues>>;
   id: Scalars['ID'];
   isActive?: Maybe<Scalars['Boolean']>;
@@ -1494,6 +1546,7 @@ export type TPimSearchListView = {
 };
 
 export type TPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']>>;
   filters: Array<TFilterValuesCreateInput>;
   nameAllLocales: Array<TLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']>;
@@ -1629,6 +1682,8 @@ export type TQuery = {
   allAppliedCustomViewPermissions: Array<TCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TCustomViewLocatorGroup>;
   allFeatures: Array<TFeature>;
@@ -1655,6 +1710,7 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  myCustomViews: Array<TMyCustomView>;
   orderDetailView?: Maybe<TOrderDetailView>;
   orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
@@ -1696,6 +1752,11 @@ export type TQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TCustomApplicationQueryInput>;
+};
+
+
+export type TQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TCustomViewQueryInput>;
 };
 
 
@@ -1766,6 +1827,11 @@ export type TQuery_GlobalOrganizationExtensionArgs = {
 
 export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
+};
+
+
+export type TQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMyCustomViewsQueryInput>;
 };
 
 

--- a/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.mc.graphql
@@ -15,6 +15,7 @@ query FetchProject($projectKey: String) {
       isActive
       reason
     }
+    isProductionProject
     allAppliedPermissions {
       name
       value

--- a/packages/application-shell/src/components/project-switcher/project-switcher-test-utils.ts
+++ b/packages/application-shell/src/components/project-switcher/project-switcher-test-utils.ts
@@ -41,6 +41,7 @@ export const createGraphqlResponseForProjectsQuery = ({
                 __typename: 'ProjectExpiry',
                 isActive: getIsExpired(key),
               },
+              isProductionProject: true,
             };
           }),
         },

--- a/packages/application-shell/src/components/project-switcher/project-switcher-test-utils.ts
+++ b/packages/application-shell/src/components/project-switcher/project-switcher-test-utils.ts
@@ -26,6 +26,7 @@ export const createGraphqlResponseForProjectsQuery = ({
         id: 'user-id',
         projects: {
           __typename: 'ProjectQueryResult',
+          total: numberOfProjects,
           results: Array.from({ length: numberOfProjects }).map((_, index) => {
             const key = `key-${index}`;
             const name = `Name ${index}`;

--- a/packages/application-shell/src/components/project-switcher/project-switcher-test-utils.ts
+++ b/packages/application-shell/src/components/project-switcher/project-switcher-test-utils.ts
@@ -41,7 +41,7 @@ export const createGraphqlResponseForProjectsQuery = ({
                 __typename: 'ProjectExpiry',
                 isActive: getIsExpired(key),
               },
-              isProductionProject: true,
+              isProductionProject: false,
             };
           }),
         },

--- a/packages/application-shell/src/components/project-switcher/project-switcher.mc.graphql
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.mc.graphql
@@ -11,6 +11,7 @@ query FetchUserProjects {
         expiry {
           isActive
         }
+        isProductionProject
       }
     }
   }

--- a/packages/application-shell/src/components/project-switcher/project-switcher.mc.graphql
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.mc.graphql
@@ -2,6 +2,7 @@ query FetchUserProjects {
   user: me {
     id
     projects {
+      total
       results {
         name
         key

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -33,7 +33,10 @@ declare let window: ApplicationWindow;
 type Props = {
   projectKey?: string;
 };
-type OptionType = Pick<TProject, 'key' | 'name' | 'suspension' | 'expiry'> & {
+type OptionType = Pick<
+  TProject,
+  'key' | 'name' | 'suspension' | 'expiry' | 'isProductionProject'
+> & {
   label: string;
 };
 
@@ -131,6 +134,7 @@ const mapProjectsToOptions = memoize((projects) =>
     value: project.key,
     suspension: project.suspension,
     expiry: project.expiry,
+    isProductionProject: project.isProductionProject,
   }))
 );
 

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -64,6 +64,7 @@ const defaultProject = {
     isActive: false,
     reason: undefined,
   },
+  isProductionProject: false,
   allAppliedPermissions: [],
   allAppliedActionRights: [],
   allAppliedDataFences: [],

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -64,7 +64,7 @@ const defaultProject = {
     isActive: false,
     reason: undefined,
   },
-  isProductionProject: false,
+  isProductionProject: true,
   allAppliedPermissions: [],
   allAppliedActionRights: [],
   allAppliedDataFences: [],

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -64,7 +64,7 @@ const defaultProject = {
     isActive: false,
     reason: undefined,
   },
-  isProductionProject: true,
+  isProductionProject: false,
   allAppliedPermissions: [],
   allAppliedActionRights: [],
   allAppliedDataFences: [],

--- a/packages/application-shell/src/types/generated/ctp.ts
+++ b/packages/application-shell/src/types/generated/ctp.ts
@@ -56,7 +56,6 @@ export type TApiClientWithoutSecret = {
 export type TApiClientWithoutSecretQueryResult = {
   __typename?: 'APIClientWithoutSecretQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TApiClientWithoutSecret>;
@@ -157,7 +156,6 @@ export type TAddCartDiscountCode = {
   validateDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TAddCartDiscountStore = {
   store: TResourceIdentifierInput;
 };
@@ -702,7 +700,6 @@ export type TApplyStagedChanges = {
   dummy?: InputMaybe<Scalars['String']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlow = TVersioned & {
   __typename?: 'ApprovalFlow';
   approvals: Array<TApprovalFlowApproval>;
@@ -711,6 +708,7 @@ export type TApprovalFlow = TVersioned & {
   createdAt: Scalars['DateTime'];
   createdBy?: Maybe<TInitiator>;
   currentTierPendingApprovers: Array<TRuleApprover>;
+  custom?: Maybe<TCustomFieldsType>;
   eligibleApprovers: Array<TRuleApprover>;
   id: Scalars['String'];
   lastModifiedAt: Scalars['DateTime'];
@@ -724,14 +722,12 @@ export type TApprovalFlow = TVersioned & {
   version: Scalars['Long'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowApproval = {
   __typename?: 'ApprovalFlowApproval';
   approvedAt: Scalars['DateTime'];
   approver: TAssociate;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowApproved = TMessagePayload & {
   __typename?: 'ApprovalFlowApproved';
   associate?: Maybe<TCustomer>;
@@ -741,7 +737,6 @@ export type TApprovalFlowApproved = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowCompleted = TMessagePayload & {
   __typename?: 'ApprovalFlowCompleted';
   order?: Maybe<TOrder>;
@@ -750,7 +745,6 @@ export type TApprovalFlowCompleted = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowCreated = TMessagePayload & {
   __typename?: 'ApprovalFlowCreated';
   approvalFlow: TApprovalFlow;
@@ -760,14 +754,12 @@ export type TApprovalFlowCreated = TMessagePayload & {
 export type TApprovalFlowQueryResult = {
   __typename?: 'ApprovalFlowQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TApprovalFlow>;
   total: Scalars['Long'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowRejected = TMessagePayload & {
   __typename?: 'ApprovalFlowRejected';
   associate?: Maybe<TCustomer>;
@@ -778,7 +770,6 @@ export type TApprovalFlowRejected = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowRejection = {
   __typename?: 'ApprovalFlowRejection';
   reason?: Maybe<Scalars['String']>;
@@ -786,15 +777,13 @@ export type TApprovalFlowRejection = {
   rejecter: TAssociate;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalFlowUpdateAction = {
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   approve?: InputMaybe<TApproveApprovalFlow>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   reject?: InputMaybe<TRejectApprovalFlow>;
+  setCustomField?: InputMaybe<TSetApprovalFlowCustomField>;
+  setCustomType?: InputMaybe<TSetApprovalFlowCustomType>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRule = TVersioned & {
   __typename?: 'ApprovalRule';
   approvers: TApproverHierarchy;
@@ -814,7 +803,6 @@ export type TApprovalRule = TVersioned & {
   version: Scalars['Long'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleApproversSet = TMessagePayload & {
   __typename?: 'ApprovalRuleApproversSet';
   approvers: TApproverHierarchy;
@@ -822,14 +810,12 @@ export type TApprovalRuleApproversSet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleCreated = TMessagePayload & {
   __typename?: 'ApprovalRuleCreated';
   approvalRule: TApprovalRule;
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleDescriptionSet = TMessagePayload & {
   __typename?: 'ApprovalRuleDescriptionSet';
   description?: Maybe<Scalars['String']>;
@@ -837,7 +823,6 @@ export type TApprovalRuleDescriptionSet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleDraft = {
   approvers: TApproverHierarchyDraft;
   description?: InputMaybe<Scalars['String']>;
@@ -848,7 +833,6 @@ export type TApprovalRuleDraft = {
   status: TApprovalRuleStatus;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleKeySet = TMessagePayload & {
   __typename?: 'ApprovalRuleKeySet';
   key?: Maybe<Scalars['String']>;
@@ -856,7 +840,6 @@ export type TApprovalRuleKeySet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleNameSet = TMessagePayload & {
   __typename?: 'ApprovalRuleNameSet';
   name: Scalars['String'];
@@ -864,7 +847,6 @@ export type TApprovalRuleNameSet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRulePredicateSet = TMessagePayload & {
   __typename?: 'ApprovalRulePredicateSet';
   oldPredicate: Scalars['String'];
@@ -875,14 +857,12 @@ export type TApprovalRulePredicateSet = TMessagePayload & {
 export type TApprovalRuleQueryResult = {
   __typename?: 'ApprovalRuleQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TApprovalRule>;
   total: Scalars['Long'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleRequestersSet = TMessagePayload & {
   __typename?: 'ApprovalRuleRequestersSet';
   oldRequesters: Array<TRuleRequester>;
@@ -890,13 +870,11 @@ export type TApprovalRuleRequestersSet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export enum TApprovalRuleStatus {
   Active = 'Active',
   Inactive = 'Inactive'
 }
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleStatusSet = TMessagePayload & {
   __typename?: 'ApprovalRuleStatusSet';
   oldStatus: TApprovalRuleStatus;
@@ -904,71 +882,52 @@ export type TApprovalRuleStatusSet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApprovalRuleUpdateAction = {
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setApprovers?: InputMaybe<TSetApprovalRuleApprovers>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setDescription?: InputMaybe<TSetApprovalRuleDescription>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setKey?: InputMaybe<TSetApprovalRuleKey>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setName?: InputMaybe<TSetApprovalRuleName>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setPredicate?: InputMaybe<TSetApprovalRulePredicate>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setRequesters?: InputMaybe<TSetApprovalRuleRequesters>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setStatus?: InputMaybe<TSetApprovalRuleStatus>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproveApprovalFlow = {
   dummy?: InputMaybe<Scalars['String']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproverConjunction = {
   __typename?: 'ApproverConjunction';
   and: Array<TApproverDisjunction>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproverConjunctionDraft = {
   and: Array<TApproverDisjunctionDraft>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproverDisjunction = {
   __typename?: 'ApproverDisjunction';
   or: Array<TRuleApprover>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproverDisjunctionDraft = {
   or: Array<TRuleApproverDraft>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproverHierarchy = {
   __typename?: 'ApproverHierarchy';
   tiers: Array<TApproverConjunction>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TApproverHierarchyDraft = {
   tiers: Array<TApproverConjunctionDraft>;
 };
 
 export type TAsAssociate = TCartQueryInterface & TOrderQueryInterface & TQuoteQueryInterface & TQuoteRequestQueryInterface & {
   __typename?: 'AsAssociate';
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   approvalFlow?: Maybe<TApprovalFlow>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   approvalFlows: TApprovalFlowQueryResult;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   approvalRule?: Maybe<TApprovalRule>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   approvalRules: TApprovalRuleQueryResult;
   businessUnit?: Maybe<TBusinessUnit>;
   businessUnits: TBusinessUnitQueryResult;
@@ -1240,7 +1199,6 @@ export type TAssociateRolePermissionsSet = TMessagePayload & {
 export type TAssociateRoleQueryResult = {
   __typename?: 'AssociateRoleQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TAssociateRole>;
@@ -1371,7 +1329,6 @@ export type TAttributeGroupLimitsProjection = {
 export type TAttributeGroupQueryResult = {
   __typename?: 'AttributeGroupQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TAttributeGroup>;
@@ -1429,7 +1386,7 @@ export type TAttributeTypeDraft = {
   time?: InputMaybe<TSimpleAttributeTypeDraft>;
 };
 
-/** AuthenticationMode values. BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
+/** AuthenticationMode values. */
 export enum TAuthenticationMode {
   ExternalAuth = 'ExternalAuth',
   Password = 'Password'
@@ -1765,12 +1722,25 @@ export type TBusinessUnitParentChanged = TMessagePayload & {
 export type TBusinessUnitQueryResult = {
   __typename?: 'BusinessUnitQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TBusinessUnit>;
   total: Scalars['Long'];
 };
+
+/** CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta */
+export type TBusinessUnitSearchConfiguration = {
+  __typename?: 'BusinessUnitSearchConfiguration';
+  lastModifiedAt: Scalars['DateTime'];
+  lastModifiedBy?: Maybe<TInitiator>;
+  status: TBusinessUnitSearchStatus;
+};
+
+/** CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta */
+export enum TBusinessUnitSearchStatus {
+  Activated = 'Activated',
+  Deactivated = 'Deactivated'
+}
 
 export type TBusinessUnitShippingAddressAdded = TMessagePayload & {
   __typename?: 'BusinessUnitShippingAddressAdded';
@@ -1886,7 +1856,6 @@ export type TCart = TReferenceExpandable & TVersioned & {
   deleteDaysAfterLastModification?: Maybe<Scalars['Int']>;
   directDiscounts: Array<TDirectDiscount>;
   discountCodes: Array<TDiscountCodeInfo>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   discountOnTotalPrice?: Maybe<TDiscountOnTotalPrice>;
   id: Scalars['String'];
   inventoryMode: TInventoryMode;
@@ -1969,9 +1938,7 @@ export type TCartDiscount = TReferenceExpandable & TVersioned & {
   requiresDiscountCode: Scalars['Boolean'];
   sortOrder: Scalars['String'];
   stackingMode: TStackingMode;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   stores: Array<TStore>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   storesRef: Array<TKeyReference>;
   target?: Maybe<TCartDiscountTarget>;
   validFrom?: Maybe<Scalars['DateTime']>;
@@ -2006,6 +1973,17 @@ export type TCartDiscount_NameArgs = {
   locale?: InputMaybe<Scalars['Locale']>;
 };
 
+export type TCartDiscountCreated = TMessagePayload & {
+  __typename?: 'CartDiscountCreated';
+  cartDiscount: TCartDiscount;
+  type: Scalars['String'];
+};
+
+export type TCartDiscountDeleted = TMessagePayload & {
+  __typename?: 'CartDiscountDeleted';
+  type: Scalars['String'];
+};
+
 export type TCartDiscountDraft = {
   cartPredicate: Scalars['String'];
   custom?: InputMaybe<TCustomFieldsDraft>;
@@ -2016,7 +1994,6 @@ export type TCartDiscountDraft = {
   requiresDiscountCode?: InputMaybe<Scalars['Boolean']>;
   sortOrder: Scalars['String'];
   stackingMode?: InputMaybe<TStackingMode>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   stores?: InputMaybe<Array<TResourceIdentifierInput>>;
   target?: InputMaybe<TCartDiscountTargetInput>;
   validFrom?: InputMaybe<Scalars['DateTime']>;
@@ -2060,11 +2037,31 @@ export type TCartDiscountQueryInterface_CartDiscountsArgs = {
 export type TCartDiscountQueryResult = {
   __typename?: 'CartDiscountQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCartDiscount>;
   total: Scalars['Long'];
+};
+
+export type TCartDiscountStoreAdded = TMessagePayload & {
+  __typename?: 'CartDiscountStoreAdded';
+  store: TStore;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+export type TCartDiscountStoreRemoved = TMessagePayload & {
+  __typename?: 'CartDiscountStoreRemoved';
+  store: TStore;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+export type TCartDiscountStoresSet = TMessagePayload & {
+  __typename?: 'CartDiscountStoresSet';
+  stores: Array<TStore>;
+  storesRef: Array<TKeyReference>;
+  type: Scalars['String'];
 };
 
 export type TCartDiscountTarget = {
@@ -2090,7 +2087,6 @@ export type TCartDiscountTotalPriceTargetInput = {
 };
 
 export type TCartDiscountUpdateAction = {
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   addStore?: InputMaybe<TAddCartDiscountStore>;
   changeCartPredicate?: InputMaybe<TChangeCartDiscountCartPredicate>;
   changeIsActive?: InputMaybe<TChangeCartDiscountIsActive>;
@@ -2100,13 +2096,11 @@ export type TCartDiscountUpdateAction = {
   changeStackingMode?: InputMaybe<TChangeCartDiscountStackingMode>;
   changeTarget?: InputMaybe<TChangeCartDiscountTarget>;
   changeValue?: InputMaybe<TChangeCartDiscountValue>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   removeStore?: InputMaybe<TRemoveCartDiscountStore>;
   setCustomField?: InputMaybe<TSetCartDiscountCustomField>;
   setCustomType?: InputMaybe<TSetCartDiscountCustomType>;
   setDescription?: InputMaybe<TSetCartDiscountDescription>;
   setKey?: InputMaybe<TSetCartDiscountKey>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setStores?: InputMaybe<TSetCartDiscountStores>;
   setValidFrom?: InputMaybe<TSetCartDiscountValidFrom>;
   setValidFromAndUntil?: InputMaybe<TSetCartDiscountValidFromAndUntil>;
@@ -2209,7 +2203,6 @@ export type TCartQueryInterface_CartsArgs = {
 export type TCartQueryResult = {
   __typename?: 'CartQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCart>;
@@ -2448,7 +2441,6 @@ export type TCategoryOrderHintProductSearch = {
 export type TCategoryQueryResult = {
   __typename?: 'CategoryQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCategory>;
@@ -2866,6 +2858,11 @@ export type TChangeProductSlug = {
   staged?: InputMaybe<Scalars['Boolean']>;
 };
 
+/** CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta */
+export type TChangeProjectSettingsBusinessUnitSearchStatus = {
+  status: TBusinessUnitSearchStatus;
+};
+
 export type TChangeProjectSettingsCartsConfiguration = {
   cartsConfiguration: TCartsConfigurationInput;
 };
@@ -3222,7 +3219,6 @@ export type TChannelDraft = {
 export type TChannelQueryResult = {
   __typename?: 'ChannelQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TChannel>;
@@ -3317,7 +3313,6 @@ export type TCommercetoolsSubscription = TVersioned & {
 export type TCommercetoolsSubscriptionQueryResult = {
   __typename?: 'CommercetoolsSubscriptionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCommercetoolsSubscription>;
@@ -3635,7 +3630,6 @@ export type TCustomObjectLimitsProjection = {
 export type TCustomObjectQueryResult = {
   __typename?: 'CustomObjectQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCustomObject>;
@@ -3936,7 +3930,6 @@ export type TCustomerGroupLimitsProjection = {
 export type TCustomerGroupQueryResult = {
   __typename?: 'CustomerGroupQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCustomerGroup>;
@@ -4034,7 +4027,6 @@ export type TCustomerQueryInterface_CustomersArgs = {
 export type TCustomerQueryResult = {
   __typename?: 'CustomerQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TCustomer>;
@@ -4111,7 +4103,6 @@ export type TCustomerSignUpDraft = {
   /** This field will be deprecated in favour of anonymousCart.id. */
   anonymousCartId?: InputMaybe<Scalars['String']>;
   anonymousId?: InputMaybe<Scalars['String']>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   authenticationMode?: InputMaybe<TAuthenticationMode>;
   /** The indices of the billing addresses in the `addresses` list. The `billingAddressIds` of the customer will be set to the IDs of that addresses. */
   billingAddresses?: InputMaybe<Array<Scalars['Int']>>;
@@ -4405,7 +4396,6 @@ export type TDiscountCodeInfo = {
 export type TDiscountCodeQueryResult = {
   __typename?: 'DiscountCodeQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TDiscountCode>;
@@ -4443,7 +4433,6 @@ export type TDiscountCodeUpdateAction = {
   setValidUntil?: InputMaybe<TSetDiscountCodeValidUntil>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TDiscountOnTotalPrice = {
   __typename?: 'DiscountOnTotalPrice';
   discountedAmount: TBaseMoney;
@@ -4500,7 +4489,6 @@ export type TDiscountedProductSearchPriceValue = {
   value: TBaseMoney;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TDiscountedTotalPricePortion = {
   __typename?: 'DiscountedTotalPricePortion';
   discount?: Maybe<TCartDiscount>;
@@ -4630,7 +4618,6 @@ export type TExtensionLimitsProjection = {
 export type TExtensionQueryResult = {
   __typename?: 'ExtensionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TExtension>;
@@ -5271,7 +5258,6 @@ export type TInventoryEntryQuantitySet = TMessagePayload & {
 export type TInventoryEntryQueryResult = {
   __typename?: 'InventoryEntryQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TInventoryEntry>;
@@ -5914,7 +5900,6 @@ export type TMessagePayload = {
 export type TMessageQueryResult = {
   __typename?: 'MessageQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TMessage>;
@@ -6021,6 +6006,14 @@ export type TMoveProductImageToPosition = {
   variantId?: InputMaybe<Scalars['Int']>;
 };
 
+export type TMoveProductTailoringImageToPosition = {
+  imageUrl: Scalars['String'];
+  position: Scalars['Int'];
+  sku?: InputMaybe<Scalars['String']>;
+  staged?: InputMaybe<Scalars['Boolean']>;
+  variantId?: InputMaybe<Scalars['Int']>;
+};
+
 export type TMultiBuyCustomLineItemsTarget = TCartDiscountTarget & {
   __typename?: 'MultiBuyCustomLineItemsTarget';
   discountedQuantity: Scalars['Long'];
@@ -6060,7 +6053,6 @@ export type TMultiBuyLineItemsTargetInput = {
 export type TMutation = {
   __typename?: 'Mutation';
   createApiClient?: Maybe<TApiClientWithSecret>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   createApprovalRule?: Maybe<TApprovalRule>;
   createAssociateRole?: Maybe<TAssociateRole>;
   createAttributeGroup?: Maybe<TAttributeGroup>;
@@ -6215,9 +6207,7 @@ export type TMutation = {
   replicateMyCart?: Maybe<TCart>;
   /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta Signs up a new customer and associates it with the business unit. */
   signUpInMyBusinessUnit: TCustomerSignInResult;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   updateApprovalFlow?: Maybe<TApprovalFlow>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   updateApprovalRule?: Maybe<TApprovalRule>;
   updateAssociateRole?: Maybe<TAssociateRole>;
   updateAttributeGroup?: Maybe<TAttributeGroup>;
@@ -7388,7 +7378,6 @@ export type TMyPaymentDraft = {
 export type TMyPaymentQueryResult = {
   __typename?: 'MyPaymentQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TMyPayment>;
@@ -7530,7 +7519,6 @@ export type TOrder = TReferenceExpandable & TVersioned & {
   customerId?: Maybe<Scalars['String']>;
   directDiscounts: Array<TDirectDiscount>;
   discountCodes: Array<TDiscountCodeInfo>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   discountOnTotalPrice?: Maybe<TDiscountOnTotalPrice>;
   id: Scalars['String'];
   inventoryMode: TInventoryMode;
@@ -7599,7 +7587,7 @@ export type TOrderCartCommand = {
   paymentState?: InputMaybe<TPaymentState>;
   purchaseOrderNumber?: InputMaybe<Scalars['String']>;
   shipmentState?: InputMaybe<TShipmentState>;
-  state?: InputMaybe<TReferenceInput>;
+  state?: InputMaybe<TResourceIdentifierInput>;
   version: Scalars['Long'];
 };
 
@@ -7781,7 +7769,6 @@ export type TOrderEditLimitsProjection = {
 export type TOrderEditQueryResult = {
   __typename?: 'OrderEditQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TOrderEdit>;
@@ -7915,7 +7902,6 @@ export type TOrderQueryInterface_OrdersArgs = {
 export type TOrderQueryResult = {
   __typename?: 'OrderQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TOrder>;
@@ -7930,7 +7916,7 @@ export type TOrderQuoteCommand = {
   quote?: InputMaybe<TResourceIdentifierInput>;
   quoteStateToAccepted?: InputMaybe<Scalars['Boolean']>;
   shipmentState?: InputMaybe<TShipmentState>;
-  state?: InputMaybe<TReferenceInput>;
+  state?: InputMaybe<TResourceIdentifierInput>;
   version: Scalars['Long'];
 };
 
@@ -8263,7 +8249,6 @@ export type TPaymentMethodInfoInput = {
 export type TPaymentQueryResult = {
   __typename?: 'PaymentQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TPayment>;
@@ -8351,7 +8336,6 @@ export enum TPermission {
   AcceptMyQuotes = 'AcceptMyQuotes',
   AcceptOthersQuotes = 'AcceptOthersQuotes',
   AddChildUnits = 'AddChildUnits',
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   CreateApprovalRules = 'CreateApprovalRules',
   CreateMyCarts = 'CreateMyCarts',
   CreateMyOrdersFromMyCarts = 'CreateMyOrdersFromMyCarts',
@@ -8369,9 +8353,7 @@ export enum TPermission {
   ReassignOthersQuotes = 'ReassignOthersQuotes',
   RenegotiateMyQuotes = 'RenegotiateMyQuotes',
   RenegotiateOthersQuotes = 'RenegotiateOthersQuotes',
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   UpdateApprovalFlows = 'UpdateApprovalFlows',
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   UpdateApprovalRules = 'UpdateApprovalRules',
   UpdateAssociates = 'UpdateAssociates',
   UpdateBusinessUnitDetails = 'UpdateBusinessUnitDetails',
@@ -8512,7 +8494,6 @@ export type TProductAssignment = {
   productRef: TReference;
   productSelection?: Maybe<TProductSelection>;
   productSelectionRef: TReference;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   variantExclusion?: Maybe<TProductVariantExclusion>;
   variantSelection?: Maybe<TProductVariantSelection>;
 };
@@ -8520,7 +8501,6 @@ export type TProductAssignment = {
 export type TProductAssignmentQueryResult = {
   __typename?: 'ProductAssignmentQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProductAssignment>;
@@ -8780,7 +8760,6 @@ export type TProductDiscountLimitsProjection = {
 export type TProductDiscountQueryResult = {
   __typename?: 'ProductDiscountQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProductDiscount>;
@@ -8848,7 +8827,6 @@ export type TProductOfSelection = {
   __typename?: 'ProductOfSelection';
   product?: Maybe<TProduct>;
   productRef: TReference;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   variantExclusion?: Maybe<TProductVariantExclusion>;
   variantSelection?: Maybe<TProductVariantSelection>;
 };
@@ -8856,7 +8834,6 @@ export type TProductOfSelection = {
 export type TProductOfSelectionQueryResult = {
   __typename?: 'ProductOfSelectionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProductOfSelection>;
@@ -9161,7 +9138,6 @@ export type TProductPublished = TMessagePayload & {
 export type TProductQueryResult = {
   __typename?: 'ProductQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProduct>;
@@ -9312,7 +9288,7 @@ export type TProductSelectionDeleted = TMessagePayload & {
 export enum TProductSelectionMode {
   /** Mode of Product Selection used to include a specific list of individual Products */
   Individual = 'Individual',
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta. Mode of Product Selection used to exclude a specific list of individual Products */
+  /** Mode of Product Selection used to exclude a specific list of individual Products */
   IndividualExclusion = 'IndividualExclusion'
 }
 
@@ -9324,7 +9300,6 @@ export type TProductSelectionProductAdded = TMessagePayload & {
   variantSelection?: Maybe<TProductVariantSelection>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TProductSelectionProductExcluded = TMessagePayload & {
   __typename?: 'ProductSelectionProductExcluded';
   product?: Maybe<TProduct>;
@@ -9357,7 +9332,6 @@ export type TProductSelectionQueryInterface_ProductSelectionAssignmentsArgs = {
 export type TProductSelectionQueryResult = {
   __typename?: 'ProductSelectionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProductSelection>;
@@ -9384,18 +9358,15 @@ export type TProductSelectionSettingInActionInput = {
 export type TProductSelectionUpdateAction = {
   addProduct?: InputMaybe<TAddProductSelectionProduct>;
   changeName?: InputMaybe<TChangeProductSelectionName>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   excludeProduct?: InputMaybe<TExcludeProductSelectionProduct>;
   removeProduct?: InputMaybe<TRemoveProductSelectionProduct>;
   setCustomField?: InputMaybe<TSetProductSelectionCustomField>;
   setCustomType?: InputMaybe<TSetProductSelectionCustomType>;
   setKey?: InputMaybe<TSetProductSelectionKey>;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   setVariantExclusion?: InputMaybe<TSetProductSelectionVariantExclusion>;
   setVariantSelection?: InputMaybe<TSetProductSelectionVariantSelection>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TProductSelectionVariantExclusionChanged = TMessagePayload & {
   __typename?: 'ProductSelectionVariantExclusionChanged';
   newVariantExclusion?: Maybe<TProductVariantExclusion>;
@@ -9443,6 +9414,136 @@ export type TProductStateTransition = TMessagePayload & {
   type: Scalars['String'];
 };
 
+export type TProductTailoringCreated = TMessagePayload & {
+  __typename?: 'ProductTailoringCreated';
+  description?: Maybe<Scalars['String']>;
+  descriptionAllLocales?: Maybe<Array<TLocalizedString>>;
+  key?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  nameAllLocales?: Maybe<Array<TLocalizedString>>;
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  publish: Scalars['Boolean'];
+  slug?: Maybe<Scalars['String']>;
+  slugAllLocales?: Maybe<Array<TLocalizedString>>;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+
+export type TProductTailoringCreated_DescriptionArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+
+export type TProductTailoringCreated_NameArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+
+export type TProductTailoringCreated_SlugArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+export type TProductTailoringDeleted = TMessagePayload & {
+  __typename?: 'ProductTailoringDeleted';
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+export type TProductTailoringDescriptionSet = TMessagePayload & {
+  __typename?: 'ProductTailoringDescriptionSet';
+  description?: Maybe<Scalars['String']>;
+  descriptionAllLocales?: Maybe<Array<TLocalizedString>>;
+  oldDescription?: Maybe<Scalars['String']>;
+  oldDescriptionAllLocales?: Maybe<Array<TLocalizedString>>;
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+
+export type TProductTailoringDescriptionSet_DescriptionArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+
+export type TProductTailoringDescriptionSet_OldDescriptionArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+export type TProductTailoringNameSet = TMessagePayload & {
+  __typename?: 'ProductTailoringNameSet';
+  name?: Maybe<Scalars['String']>;
+  nameAllLocales?: Maybe<Array<TLocalizedString>>;
+  oldName?: Maybe<Scalars['String']>;
+  oldNameAllLocales?: Maybe<Array<TLocalizedString>>;
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+
+export type TProductTailoringNameSet_NameArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+
+export type TProductTailoringNameSet_OldNameArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+export type TProductTailoringPublished = TMessagePayload & {
+  __typename?: 'ProductTailoringPublished';
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+export type TProductTailoringSlugSet = TMessagePayload & {
+  __typename?: 'ProductTailoringSlugSet';
+  oldSlug?: Maybe<Scalars['String']>;
+  oldSlugAllLocales?: Maybe<Array<TLocalizedString>>;
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  slug?: Maybe<Scalars['String']>;
+  slugAllLocales?: Maybe<Array<TLocalizedString>>;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
+
+export type TProductTailoringSlugSet_OldSlugArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+
+export type TProductTailoringSlugSet_SlugArgs = {
+  acceptLanguage?: InputMaybe<Array<Scalars['Locale']>>;
+  locale?: InputMaybe<Scalars['Locale']>;
+};
+
+export type TProductTailoringUnpublished = TMessagePayload & {
+  __typename?: 'ProductTailoringUnpublished';
+  productKey?: Maybe<Scalars['String']>;
+  productRef: TReference;
+  storeRef: TKeyReference;
+  type: Scalars['String'];
+};
+
 export type TProductTypeDefinition = TReferenceExpandable & TVersioned & {
   __typename?: 'ProductTypeDefinition';
   attributeDefinitions: TAttributeDefinitionResult;
@@ -9469,7 +9570,6 @@ export type TProductTypeDefinition_AttributeDefinitionsArgs = {
 export type TProductTypeDefinitionQueryResult = {
   __typename?: 'ProductTypeDefinitionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProductTypeDefinition>;
@@ -9659,13 +9759,11 @@ export type TProductVariantDeleted = TMessagePayload & {
   variant?: Maybe<TProductVariant>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TProductVariantExclusion = {
   __typename?: 'ProductVariantExclusion';
   skus: Array<Scalars['String']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TProductVariantExclusionDraft = {
   skus?: InputMaybe<Array<Scalars['String']>>;
 };
@@ -9759,6 +9857,8 @@ export type TProjectProjection = {
 };
 
 export type TProjectSettingsUpdateAction = {
+  /** CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta */
+  changeBusinessUnitSearchStatus?: InputMaybe<TChangeProjectSettingsBusinessUnitSearchStatus>;
   changeCartsConfiguration?: InputMaybe<TChangeProjectSettingsCartsConfiguration>;
   changeCountries?: InputMaybe<TChangeProjectSettingsCountries>;
   changeCountryTaxRateFallbackEnabled?: InputMaybe<TChangeProjectSettingsCountryTaxRateFallbackEnabled>;
@@ -10604,7 +10704,6 @@ export type TQuoteQueryInterface_QuotesArgs = {
 export type TQuoteQueryResult = {
   __typename?: 'QuoteQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TQuote>;
@@ -10720,7 +10819,6 @@ export type TQuoteRequestQueryInterface_QuoteRequestsArgs = {
 export type TQuoteRequestQueryResult = {
   __typename?: 'QuoteRequestQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TQuoteRequest>;
@@ -10963,7 +11061,6 @@ export type TRefreshTokenLimitsProjection = {
   total: TRefreshTokenLimitWithCurrent;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TRejectApprovalFlow = {
   reason?: InputMaybe<Scalars['String']>;
 };
@@ -11018,7 +11115,6 @@ export type TRemoveCartDiscountCode = {
   discountCode: TReferenceInput;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TRemoveCartDiscountStore = {
   store: TResourceIdentifierInput;
 };
@@ -11446,7 +11542,6 @@ export type TReviewDraft = {
 export type TReviewQueryResult = {
   __typename?: 'ReviewQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TReview>;
@@ -11513,26 +11608,22 @@ export enum TRoundingMode {
   HalfUp = 'HalfUp'
 }
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TRuleApprover = {
   __typename?: 'RuleApprover';
   associateRole: TAssociateRole;
   associateRoleRef: TKeyReference;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TRuleApproverDraft = {
   associateRole: TResourceIdentifierInput;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TRuleRequester = {
   __typename?: 'RuleRequester';
   associateRole: TAssociateRole;
   associateRoleRef: TKeyReference;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TRuleRequesterDraft = {
   associateRole: TResourceIdentifierInput;
 };
@@ -11604,7 +11695,6 @@ export type TScoreShippingRateInputDraftOutput = TShippingRateInputDraftOutput &
 };
 
 export type TSearchFacetInput = {
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   model?: InputMaybe<TSearchFacetModelInput>;
   string?: InputMaybe<Scalars['String']>;
 };
@@ -11615,7 +11705,6 @@ export type TSearchFacetModelInput = {
 };
 
 export type TSearchFilterInput = {
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   model?: InputMaybe<TSearchFilterModelInput>;
   string?: InputMaybe<Scalars['String']>;
 };
@@ -11630,6 +11719,8 @@ export type TSearchFilterModelInput = {
 
 export type TSearchIndexingConfiguration = {
   __typename?: 'SearchIndexingConfiguration';
+  /** CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta */
+  businessUnits?: Maybe<TBusinessUnitSearchConfiguration>;
   /** CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta */
   customers?: Maybe<TCustomerSearchConfiguration>;
   orders?: Maybe<TOrderSearchConfiguration>;
@@ -11706,7 +11797,6 @@ export type TSelectionOfProduct = {
   lastModifiedAt: Scalars['DateTime'];
   productSelection?: Maybe<TProductSelection>;
   productSelectionRef: TReference;
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   variantExclusion?: Maybe<TProductVariantExclusion>;
   variantSelection?: Maybe<TProductVariantSelection>;
 };
@@ -11714,44 +11804,48 @@ export type TSelectionOfProduct = {
 export type TSelectionOfProductQueryResult = {
   __typename?: 'SelectionOfProductQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TSelectionOfProduct>;
   total: Scalars['Long'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
+export type TSetApprovalFlowCustomField = {
+  name: Scalars['String'];
+  value?: InputMaybe<Scalars['String']>;
+};
+
+export type TSetApprovalFlowCustomType = {
+  fields?: InputMaybe<Array<TCustomFieldInput>>;
+  type?: InputMaybe<TResourceIdentifierInput>;
+  typeId?: InputMaybe<Scalars['String']>;
+  typeKey?: InputMaybe<Scalars['String']>;
+};
+
 export type TSetApprovalRuleApprovers = {
   approvers: TApproverHierarchyDraft;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetApprovalRuleDescription = {
   description?: InputMaybe<Scalars['String']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetApprovalRuleKey = {
   key?: InputMaybe<Scalars['String']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetApprovalRuleName = {
   name: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetApprovalRulePredicate = {
   predicate: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetApprovalRuleRequesters = {
   requesters: Array<TRuleRequesterDraft>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetApprovalRuleStatus = {
   status: TApprovalRuleStatus;
 };
@@ -11972,7 +12066,6 @@ export type TSetCartDiscountKey = {
   key?: InputMaybe<Scalars['String']>;
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TSetCartDiscountStores = {
   stores?: InputMaybe<Array<TResourceIdentifierInput>>;
 };
@@ -12795,7 +12888,7 @@ export type TSetPaymentCustomType = {
 };
 
 export type TSetPaymentCustomer = {
-  customer?: InputMaybe<TReferenceInput>;
+  customer?: InputMaybe<TResourceIdentifierInput>;
 };
 
 export type TSetPaymentExternalId = {
@@ -14303,7 +14396,6 @@ export type TShippingMethodLimitsProjection = {
 export type TShippingMethodQueryResult = {
   __typename?: 'ShippingMethodQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TShippingMethod>;
@@ -14612,7 +14704,6 @@ export type TShoppingListQueryInterface_ShoppingListsArgs = {
 export type TShoppingListQueryResult = {
   __typename?: 'ShoppingListQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TShoppingList>;
@@ -14829,7 +14920,6 @@ export type TStagedQuoteDraft = {
 export type TStagedQuoteQueryResult = {
   __typename?: 'StagedQuoteQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TStagedQuote>;
@@ -14941,7 +15031,6 @@ export type TStandalonePriceDiscountSet = TMessagePayload & {
   type: Scalars['String'];
 };
 
-/** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
 export type TStandalonePriceExpiresAtSet = TMessagePayload & {
   __typename?: 'StandalonePriceExpiresAtSet';
   expiresAt?: Maybe<Scalars['DateTime']>;
@@ -14964,7 +15053,6 @@ export type TStandalonePriceKeySet = TMessagePayload & {
 export type TStandalonePriceQueryResult = {
   __typename?: 'StandalonePriceQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TStandalonePrice>;
@@ -15099,7 +15187,6 @@ export type TStateDraft = {
 export type TStateQueryResult = {
   __typename?: 'StateQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TState>;
@@ -15260,7 +15347,6 @@ export type TStoreProductSelectionsChanged = TMessagePayload & {
 export type TStoreQueryResult = {
   __typename?: 'StoreQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TStore>;
@@ -15452,7 +15538,6 @@ export type TTaxCategoryLimitsProjection = {
 export type TTaxCategoryQueryResult = {
   __typename?: 'TaxCategoryQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TTaxCategory>;
@@ -15895,7 +15980,6 @@ export type TTypeDefinitionDraft = {
 export type TTypeDefinitionQueryResult = {
   __typename?: 'TypeDefinitionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TTypeDefinition>;
@@ -16052,7 +16136,6 @@ export type TZoneLocation = {
 export type TZoneQueryResult = {
   __typename?: 'ZoneQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TZone>;

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -663,7 +663,7 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/application-shell/src/types/generated/mc.ts
+++ b/packages/application-shell/src/types/generated/mc.ts
@@ -638,6 +638,11 @@ export enum TVerificationStatus {
   Verified = 'Verified'
 }
 
+export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };
+
 export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -648,7 +653,7 @@ export type TFetchProjectQueryVariables = Exact<{
 }>;
 
 
-export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
+export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, isProductionProject: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
 
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -658,14 +663,9 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type TAllFeaturesQuery = { __typename?: 'Query', allFeatures: Array<{ __typename?: 'Feature', name: string, value: boolean, reason?: string | null }> };
-
-export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };

--- a/packages/application-shell/src/types/generated/settings.ts
+++ b/packages/application-shell/src/types/generated/settings.ts
@@ -94,6 +94,7 @@ export type TBusinessUnitsListMyViewTableInput = {
 
 export enum TCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType'
 }
@@ -376,6 +377,21 @@ export type TCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']>;
 };
 
+export type TCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Scalars['String']>;
+  where?: InputMaybe<TCustomViewQueryWhereInput>;
+};
+
+export type TCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']>;
+  locators?: InputMaybe<Array<Scalars['String']>>;
+  organizationId?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<TCustomViewType>;
+};
+
 export enum TCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL'
@@ -397,6 +413,15 @@ export type TCustomViewTypeSettings = {
 
 export type TCustomViewTypeSettingsInput = {
   size?: InputMaybe<TCustomViewSize>;
+};
+
+export type TCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TCustomView>;
+  total: Scalars['Int'];
 };
 
 export type TCustomersListView = {
@@ -1295,6 +1320,32 @@ export type TMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TCustomApplicationStatus>;
 };
 
+export type TMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime'];
+  defaultLabel: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  labelAllLocales: Array<TLocalizedField>;
+  locators: Array<Scalars['String']>;
+  organizationId: Scalars['String'];
+  organizationName: Scalars['String'];
+  permissions: Array<TCustomViewPermission>;
+  status: TCustomViewStatus;
+  type: TCustomViewType;
+  typeSettings?: Maybe<TCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime'];
+  url: Scalars['String'];
+};
+
+export type TMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMyCustomViewsQueryWhereInput>;
+};
+
+export type TMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TCustomViewStatus>;
+};
+
 export type TNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime'];
@@ -1481,6 +1532,7 @@ export type TOrganizationExtensionForCustomView = {
 export type TPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime'];
+  expandedRows: Array<Scalars['String']>;
   filters?: Maybe<Array<TFilterValues>>;
   id: Scalars['ID'];
   isActive?: Maybe<Scalars['Boolean']>;
@@ -1494,6 +1546,7 @@ export type TPimSearchListView = {
 };
 
 export type TPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']>>;
   filters: Array<TFilterValuesCreateInput>;
   nameAllLocales: Array<TLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']>;
@@ -1629,6 +1682,8 @@ export type TQuery = {
   allAppliedCustomViewPermissions: Array<TCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TCustomViewLocatorGroup>;
   allFeatures: Array<TFeature>;
@@ -1655,6 +1710,7 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  myCustomViews: Array<TMyCustomView>;
   orderDetailView?: Maybe<TOrderDetailView>;
   orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
@@ -1696,6 +1752,11 @@ export type TQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TCustomApplicationQueryInput>;
+};
+
+
+export type TQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TCustomViewQueryInput>;
 };
 
 
@@ -1766,6 +1827,11 @@ export type TQuery_GlobalOrganizationExtensionArgs = {
 
 export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
+};
+
+
+export type TQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMyCustomViewsQueryInput>;
 };
 
 

--- a/packages/constants/src/generated/settings.ts
+++ b/packages/constants/src/generated/settings.ts
@@ -100,6 +100,7 @@ export type TBusinessUnitsListMyViewTableInput = {
 
 export enum TCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType',
 }
@@ -382,6 +383,21 @@ export type TCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']>;
 };
 
+export type TCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Scalars['String']>;
+  where?: InputMaybe<TCustomViewQueryWhereInput>;
+};
+
+export type TCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']>;
+  locators?: InputMaybe<Array<Scalars['String']>>;
+  organizationId?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<TCustomViewType>;
+};
+
 export enum TCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL',
@@ -403,6 +419,15 @@ export type TCustomViewTypeSettings = {
 
 export type TCustomViewTypeSettingsInput = {
   size?: InputMaybe<TCustomViewSize>;
+};
+
+export type TCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TCustomView>;
+  total: Scalars['Int'];
 };
 
 export type TCustomersListView = {
@@ -1210,6 +1235,32 @@ export type TMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TCustomApplicationStatus>;
 };
 
+export type TMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime'];
+  defaultLabel: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  labelAllLocales: Array<TLocalizedField>;
+  locators: Array<Scalars['String']>;
+  organizationId: Scalars['String'];
+  organizationName: Scalars['String'];
+  permissions: Array<TCustomViewPermission>;
+  status: TCustomViewStatus;
+  type: TCustomViewType;
+  typeSettings?: Maybe<TCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime'];
+  url: Scalars['String'];
+};
+
+export type TMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMyCustomViewsQueryWhereInput>;
+};
+
+export type TMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TCustomViewStatus>;
+};
+
 export type TNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime'];
@@ -1396,6 +1447,7 @@ export type TOrganizationExtensionForCustomView = {
 export type TPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime'];
+  expandedRows: Array<Scalars['String']>;
   filters?: Maybe<Array<TFilterValues>>;
   id: Scalars['ID'];
   isActive?: Maybe<Scalars['Boolean']>;
@@ -1409,6 +1461,7 @@ export type TPimSearchListView = {
 };
 
 export type TPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']>>;
   filters: Array<TFilterValuesCreateInput>;
   nameAllLocales: Array<TLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']>;
@@ -1541,6 +1594,8 @@ export type TQuery = {
   allAppliedCustomViewPermissions: Array<TCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TCustomViewLocatorGroup>;
   allFeatures: Array<TFeature>;
@@ -1567,6 +1622,7 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  myCustomViews: Array<TMyCustomView>;
   orderDetailView?: Maybe<TOrderDetailView>;
   orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
@@ -1606,6 +1662,10 @@ export type TQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TCustomApplicationQueryInput>;
+};
+
+export type TQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TCustomViewQueryInput>;
 };
 
 export type TQuery_AllCustomViewsInstallationsByLocatorArgs = {
@@ -1662,6 +1722,10 @@ export type TQuery_GlobalOrganizationExtensionArgs = {
 
 export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
+};
+
+export type TQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMyCustomViewsQueryInput>;
 };
 
 export type TQuery_OrderDetailViewArgs = {

--- a/packages/mc-scripts/src/generated/core.ts
+++ b/packages/mc-scripts/src/generated/core.ts
@@ -386,7 +386,6 @@ export type TOrganization = TVersioned & {
 export type TOrganizationQueryResult = {
   __typename?: 'OrganizationQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TOrganization>;
@@ -422,7 +421,6 @@ export type TPermission = TVersioned & {
 export type TPermissionQueryResult = {
   __typename?: 'PermissionQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TPermission>;
@@ -544,7 +542,6 @@ export enum TProjectPlan {
 export type TProjectQueryResult = {
   __typename?: 'ProjectQueryResult';
   count: Scalars['Int'];
-  /** BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta */
   exists: Scalars['Boolean'];
   offset: Scalars['Int'];
   results: Array<TProject>;
@@ -788,6 +785,7 @@ export type TUser = TVersioned & {
   firstName: Scalars['String'];
   id: Scalars['String'];
   language: Scalars['Locale'];
+  lastLoginAt?: Maybe<Scalars['DateTime']>;
   lastModifiedAt: Scalars['DateTime'];
   lastModifiedBy?: Maybe<TInitiator>;
   lastName: Scalars['String'];

--- a/packages/mc-scripts/src/generated/settings.ts
+++ b/packages/mc-scripts/src/generated/settings.ts
@@ -100,6 +100,7 @@ export type TBusinessUnitsListMyViewTableInput = {
 
 export enum TCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType',
 }
@@ -382,6 +383,21 @@ export type TCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']>;
 };
 
+export type TCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sort?: InputMaybe<Scalars['String']>;
+  where?: InputMaybe<TCustomViewQueryWhereInput>;
+};
+
+export type TCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']>;
+  locators?: InputMaybe<Array<Scalars['String']>>;
+  organizationId?: InputMaybe<Scalars['String']>;
+  type?: InputMaybe<TCustomViewType>;
+};
+
 export enum TCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL',
@@ -403,6 +419,15 @@ export type TCustomViewTypeSettings = {
 
 export type TCustomViewTypeSettingsInput = {
   size?: InputMaybe<TCustomViewSize>;
+};
+
+export type TCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+  results: Array<TCustomView>;
+  total: Scalars['Int'];
 };
 
 export type TCustomersListView = {
@@ -1210,6 +1235,32 @@ export type TMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TCustomApplicationStatus>;
 };
 
+export type TMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime'];
+  defaultLabel: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  labelAllLocales: Array<TLocalizedField>;
+  locators: Array<Scalars['String']>;
+  organizationId: Scalars['String'];
+  organizationName: Scalars['String'];
+  permissions: Array<TCustomViewPermission>;
+  status: TCustomViewStatus;
+  type: TCustomViewType;
+  typeSettings?: Maybe<TCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime'];
+  url: Scalars['String'];
+};
+
+export type TMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMyCustomViewsQueryWhereInput>;
+};
+
+export type TMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TCustomViewStatus>;
+};
+
 export type TNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime'];
@@ -1396,6 +1447,7 @@ export type TOrganizationExtensionForCustomView = {
 export type TPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime'];
+  expandedRows: Array<Scalars['String']>;
   filters?: Maybe<Array<TFilterValues>>;
   id: Scalars['ID'];
   isActive?: Maybe<Scalars['Boolean']>;
@@ -1409,6 +1461,7 @@ export type TPimSearchListView = {
 };
 
 export type TPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']>>;
   filters: Array<TFilterValuesCreateInput>;
   nameAllLocales: Array<TLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']>;
@@ -1541,6 +1594,8 @@ export type TQuery = {
   allAppliedCustomViewPermissions: Array<TCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TCustomViewLocatorGroup>;
   allFeatures: Array<TFeature>;
@@ -1567,6 +1622,7 @@ export type TQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TOrganizationExtension>;
   myCustomApplications: Array<TMyCustomApplication>;
+  myCustomViews: Array<TMyCustomView>;
   orderDetailView?: Maybe<TOrderDetailView>;
   orderDetailViews: Array<Maybe<TOrderDetailView>>;
   ordersListView?: Maybe<TOrdersListView>;
@@ -1606,6 +1662,10 @@ export type TQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TCustomApplicationQueryInput>;
+};
+
+export type TQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TCustomViewQueryInput>;
 };
 
 export type TQuery_AllCustomViewsInstallationsByLocatorArgs = {
@@ -1662,6 +1722,10 @@ export type TQuery_GlobalOrganizationExtensionArgs = {
 
 export type TQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMyCustomApplicationQueryInput>;
+};
+
+export type TQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMyCustomViewsQueryInput>;
 };
 
 export type TQuery_OrderDetailViewArgs = {

--- a/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
+++ b/packages/permissions/src/components/branch-on-permissions/branch-on-permissions.spec.tsx
@@ -58,6 +58,7 @@ const renderWithPermissions = (demandedPermissions: string[]) => {
           isActive: true,
           reason: undefined,
         },
+        isProductionProject: false,
         allAppliedPermissions: [{ name: 'canViewProducts', value: true }],
         allAppliedActionRights: [
           {

--- a/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
+++ b/packages/permissions/src/components/restricted-by-permissions/restricted-by-permissions.spec.tsx
@@ -63,6 +63,7 @@ const testRender = ({
           isActive: false,
           reason: undefined,
         },
+        isProductionProject: false,
         allAppliedPermissions,
         allAppliedActionRights,
         allAppliedDataFences,

--- a/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
+++ b/packages/permissions/src/hooks/use-is-authorized/use-is-authorized.spec.tsx
@@ -107,6 +107,7 @@ const render = ({
           isActive: true,
           reason: undefined,
         },
+        isProductionProject: false,
         allAppliedPermissions,
         allAppliedActionRights,
         allAppliedDataFences,

--- a/packages/permissions/src/types/generated/mc.ts
+++ b/packages/permissions/src/types/generated/mc.ts
@@ -663,7 +663,7 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/permissions/src/types/generated/mc.ts
+++ b/packages/permissions/src/types/generated/mc.ts
@@ -638,6 +638,11 @@ export enum TVerificationStatus {
   Verified = 'Verified'
 }
 
+export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };
+
 export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -648,7 +653,7 @@ export type TFetchProjectQueryVariables = Exact<{
 }>;
 
 
-export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
+export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, isProductionProject: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
 
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -658,14 +663,9 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type TAllFeaturesQuery = { __typename?: 'Query', allFeatures: Array<{ __typename?: 'Feature', name: string, value: boolean, reason?: string | null }> };
-
-export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };

--- a/schemas/core.json
+++ b/schemas/core.json
@@ -2781,7 +2781,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3212,7 +3212,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4504,7 +4504,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6368,6 +6368,18 @@
                 "name": "Locale",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastLoginAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/schemas/ctp.json
+++ b/schemas/ctp.json
@@ -285,7 +285,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1196,7 +1196,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "AddCartDiscountStore",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -6220,7 +6220,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlow",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "approvals",
@@ -6326,6 +6326,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custom",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomFieldsType",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6533,7 +6545,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlowApproval",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "approvedAt",
@@ -6576,7 +6588,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlowApproved",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "associate",
@@ -6657,7 +6669,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlowCompleted",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "order",
@@ -6730,7 +6742,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlowCreated",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "approvalFlow",
@@ -6799,7 +6811,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6878,7 +6890,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlowRejected",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "associate",
@@ -6971,7 +6983,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalFlowRejection",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "reason",
@@ -7026,12 +7038,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApprovalFlowUpdateAction",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "approve",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ApproveApprovalFlow",
@@ -7043,10 +7055,34 @@
           },
           {
             "name": "reject",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "RejectApprovalFlow",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "setCustomField",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SetApprovalFlowCustomField",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "setCustomType",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SetApprovalFlowCustomType",
               "ofType": null
             },
             "defaultValue": null,
@@ -7061,7 +7097,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRule",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "approvers",
@@ -7310,7 +7346,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleApproversSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "approvers",
@@ -7375,7 +7411,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleCreated",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "approvalRule",
@@ -7424,7 +7460,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleDescriptionSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "description",
@@ -7481,7 +7517,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApprovalRuleDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -7604,7 +7640,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleKeySet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "key",
@@ -7661,7 +7697,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleNameSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "name",
@@ -7726,7 +7762,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRulePredicateSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "oldPredicate",
@@ -7811,7 +7847,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7890,7 +7926,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleRequestersSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "oldRequesters",
@@ -7971,7 +8007,7 @@
       {
         "kind": "ENUM",
         "name": "ApprovalRuleStatus",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -7994,7 +8030,7 @@
       {
         "kind": "OBJECT",
         "name": "ApprovalRuleStatusSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "oldStatus",
@@ -8059,12 +8095,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApprovalRuleUpdateAction",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "setApprovers",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRuleApprovers",
@@ -8076,7 +8112,7 @@
           },
           {
             "name": "setDescription",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRuleDescription",
@@ -8088,7 +8124,7 @@
           },
           {
             "name": "setKey",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRuleKey",
@@ -8100,7 +8136,7 @@
           },
           {
             "name": "setName",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRuleName",
@@ -8112,7 +8148,7 @@
           },
           {
             "name": "setPredicate",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRulePredicate",
@@ -8124,7 +8160,7 @@
           },
           {
             "name": "setRequesters",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRuleRequesters",
@@ -8136,7 +8172,7 @@
           },
           {
             "name": "setStatus",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetApprovalRuleStatus",
@@ -8154,7 +8190,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApproveApprovalFlow",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -8177,7 +8213,7 @@
       {
         "kind": "OBJECT",
         "name": "ApproverConjunction",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "and",
@@ -8212,7 +8248,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApproverConjunctionDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -8247,7 +8283,7 @@
       {
         "kind": "OBJECT",
         "name": "ApproverDisjunction",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "or",
@@ -8282,7 +8318,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApproverDisjunctionDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -8317,7 +8353,7 @@
       {
         "kind": "OBJECT",
         "name": "ApproverHierarchy",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "tiers",
@@ -8352,7 +8388,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ApproverHierarchyDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -8391,7 +8427,7 @@
         "fields": [
           {
             "name": "approvalFlow",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "id",
@@ -8420,7 +8456,7 @@
           },
           {
             "name": "approvalFlows",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "limit",
@@ -8493,7 +8529,7 @@
           },
           {
             "name": "approvalRule",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "id",
@@ -8530,7 +8566,7 @@
           },
           {
             "name": "approvalRules",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "limit",
@@ -10634,7 +10670,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -11936,7 +11972,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -12477,7 +12513,7 @@
       {
         "kind": "ENUM",
         "name": "AuthenticationMode",
-        "description": "AuthenticationMode values. BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": "AuthenticationMode values.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -15471,7 +15507,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -15545,6 +15581,84 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BusinessUnitSearchConfiguration",
+        "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+        "fields": [
+          {
+            "name": "lastModifiedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastModifiedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Initiator",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BusinessUnitSearchStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BusinessUnitSearchStatus",
+        "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "Activated",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Deactivated",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -16709,7 +16823,7 @@
           },
           {
             "name": "discountOnTotalPrice",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -17719,7 +17833,7 @@
           },
           {
             "name": "stores",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17743,7 +17857,7 @@
           },
           {
             "name": "storesRef",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17844,6 +17958,88 @@
           {
             "kind": "INTERFACE",
             "name": "Versioned",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CartDiscountCreated",
+        "description": null,
+        "fields": [
+          {
+            "name": "cartDiscount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CartDiscount",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CartDiscountDeleted",
+        "description": null,
+        "fields": [
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
             "ofType": null
           }
         ],
@@ -17994,7 +18190,7 @@
           },
           {
             "name": "stores",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -18291,7 +18487,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18364,6 +18560,217 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CartDiscountStoreAdded",
+        "description": null,
+        "fields": [
+          {
+            "name": "store",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CartDiscountStoreRemoved",
+        "description": null,
+        "fields": [
+          {
+            "name": "store",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CartDiscountStoresSet",
+        "description": null,
+        "fields": [
+          {
+            "name": "stores",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Store",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storesRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "KeyReference",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -18572,7 +18979,7 @@
         "inputFields": [
           {
             "name": "addStore",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "AddCartDiscountStore",
@@ -18680,7 +19087,7 @@
           },
           {
             "name": "removeStore",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "RemoveCartDiscountStore",
@@ -18740,7 +19147,7 @@
           },
           {
             "name": "setStores",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetCartDiscountStores",
@@ -19631,7 +20038,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21938,7 +22345,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25484,6 +25891,33 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "ChangeProjectSettingsBusinessUnitSearchStatus",
+        "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BusinessUnitSearchStatus",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "ChangeProjectSettingsCartsConfiguration",
         "description": null,
         "fields": null,
@@ -28402,7 +28836,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -29231,7 +29665,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32118,7 +32552,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34950,7 +35384,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35756,7 +36190,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36458,7 +36892,7 @@
           },
           {
             "name": "authenticationMode",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "AuthenticationMode",
@@ -39342,7 +39776,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -39635,7 +40069,7 @@
       {
         "kind": "OBJECT",
         "name": "DiscountOnTotalPrice",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "discountedAmount",
@@ -40102,7 +40536,7 @@
       {
         "kind": "OBJECT",
         "name": "DiscountedTotalPricePortion",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "discount",
@@ -41267,7 +41701,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -46861,7 +47295,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -52011,6 +52445,31 @@
           },
           {
             "kind": "OBJECT",
+            "name": "CartDiscountCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CartDiscountDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CartDiscountStoreAdded",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CartDiscountStoreRemoved",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CartDiscountStoresSet",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "CategoryCreated",
             "ofType": null
           },
@@ -52571,6 +53030,41 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ProductTailoringCreated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductTailoringDeleted",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductTailoringDescriptionSet",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductTailoringNameSet",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductTailoringPublished",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductTailoringSlugSet",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductTailoringUnpublished",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ProductUnpublished",
             "ofType": null
           },
@@ -52844,7 +53338,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -53726,6 +54220,85 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "MoveProductTailoringImageToPosition",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "imageUrl",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "position",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sku",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staged",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variantId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "MultiBuyCustomLineItemsTarget",
         "description": null,
@@ -54145,7 +54718,7 @@
           },
           {
             "name": "createApprovalRule",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "asAssociate",
@@ -54362,7 +54935,7 @@
               },
               {
                 "name": "storeKey",
-                "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+                "description": "The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "KeyReferenceInput",
@@ -56511,7 +57084,7 @@
               },
               {
                 "name": "storeKey",
-                "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+                "description": "The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "KeyReferenceInput",
@@ -58544,7 +59117,7 @@
           },
           {
             "name": "updateApprovalFlow",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "actions",
@@ -58629,7 +59202,7 @@
           },
           {
             "name": "updateApprovalRule",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [
               {
                 "name": "actions",
@@ -59118,7 +59691,7 @@
               },
               {
                 "name": "storeKey",
-                "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+                "description": "The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "KeyReferenceInput",
@@ -63701,7 +64274,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -65052,7 +65625,7 @@
           },
           {
             "name": "discountOnTotalPrice",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -65861,7 +66434,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "ReferenceInput",
+              "name": "ResourceIdentifierInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -67636,7 +68209,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -69147,7 +69720,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -69318,7 +69891,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "ReferenceInput",
+              "name": "ResourceIdentifierInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -72538,7 +73111,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -73336,7 +73909,7 @@
           },
           {
             "name": "CreateApprovalRules",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -73438,13 +74011,13 @@
           },
           {
             "name": "UpdateApprovalFlows",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UpdateApprovalRules",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -74609,7 +75182,7 @@
           },
           {
             "name": "variantExclusion",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -74660,7 +75233,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -76412,7 +76985,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -77175,7 +77748,7 @@
           },
           {
             "name": "variantExclusion",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -77226,7 +77799,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -80353,7 +80926,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -81656,7 +82229,7 @@
           },
           {
             "name": "IndividualExclusion",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta. Mode of Product Selection used to exclude a specific list of individual Products",
+            "description": "Mode of Product Selection used to exclude a specific list of individual Products",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -81739,7 +82312,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductSelectionProductExcluded",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "product",
@@ -81983,7 +82556,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -82228,7 +82801,7 @@
           },
           {
             "name": "excludeProduct",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ExcludeProductSelectionProduct",
@@ -82288,7 +82861,7 @@
           },
           {
             "name": "setVariantExclusion",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SetProductSelectionVariantExclusion",
@@ -82318,7 +82891,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductSelectionVariantExclusionChanged",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "newVariantExclusion",
@@ -82731,6 +83304,1158 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ProductTailoringCreated",
+        "description": null,
+        "fields": [
+          {
+            "name": "description",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nameAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publish",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductTailoringDeleted",
+        "description": null,
+        "fields": [
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductTailoringDescriptionSet",
+        "description": null,
+        "fields": [
+          {
+            "name": "description",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldDescription",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldDescriptionAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductTailoringNameSet",
+        "description": null,
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nameAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldName",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldNameAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductTailoringPublished",
+        "description": null,
+        "fields": [
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductTailoringSlugSet",
+        "description": null,
+        "fields": [
+          {
+            "name": "oldSlug",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oldSlugAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "args": [
+              {
+                "name": "acceptLanguage",
+                "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": "String is defined for different locales. This argument specifies the desired locale.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Locale",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "LocalizedString",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductTailoringUnpublished",
+        "description": null,
+        "fields": [
+          {
+            "name": "productKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storeRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessagePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ProductTypeDefinition",
         "description": null,
         "fields": [
@@ -83007,7 +84732,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -84836,7 +86561,7 @@
       {
         "kind": "OBJECT",
         "name": "ProductVariantExclusion",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "skus",
@@ -84871,7 +86596,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ProductVariantExclusionDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -85980,6 +87705,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "changeBusinessUnitSearchStatus",
+            "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ChangeProjectSettingsBusinessUnitSearchStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "changeCartsConfiguration",
             "description": null,
@@ -92351,7 +94088,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -93462,7 +95199,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -95758,7 +97495,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RejectApprovalFlow",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -96137,7 +97874,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RemoveCartDiscountStore",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -99622,7 +101359,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -100256,7 +101993,7 @@
       {
         "kind": "OBJECT",
         "name": "RuleApprover",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "associateRole",
@@ -100299,7 +102036,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RuleApproverDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -100326,7 +102063,7 @@
       {
         "kind": "OBJECT",
         "name": "RuleRequester",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "associateRole",
@@ -100369,7 +102106,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RuleRequesterDraft",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -101029,7 +102766,7 @@
         "inputFields": [
           {
             "name": "model",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SearchFacetModelInput",
@@ -101109,7 +102846,7 @@
         "inputFields": [
           {
             "name": "model",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SearchFilterModelInput",
@@ -101212,6 +102949,18 @@
         "name": "SearchIndexingConfiguration",
         "description": null,
         "fields": [
+          {
+            "name": "businessUnits",
+            "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "BusinessUnitSearchConfiguration",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "customers",
             "description": "CLOSED BETA: This feature is subject to change and should not be used in production. https://docs.commercetools.com/api/contract#closed-beta",
@@ -101782,7 +103531,7 @@
           },
           {
             "name": "variantExclusion",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -101833,7 +103582,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -101921,8 +103670,114 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "SetApprovalFlowCustomField",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SetApprovalFlowCustomType",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "fields",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CustomFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ResourceIdentifierInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeKey",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "SetApprovalRuleApprovers",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -101949,7 +103804,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetApprovalRuleDescription",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -101972,7 +103827,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetApprovalRuleKey",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -101995,7 +103850,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetApprovalRuleName",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -102022,7 +103877,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetApprovalRulePredicate",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -102049,7 +103904,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetApprovalRuleRequesters",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -102084,7 +103939,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetApprovalRuleStatus",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -103852,7 +105707,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SetCartDiscountStores",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
@@ -110481,7 +112336,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "ReferenceInput",
+              "name": "ResourceIdentifierInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -123327,7 +125182,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -126042,7 +127897,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -128725,7 +130580,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -129732,7 +131587,7 @@
       {
         "kind": "OBJECT",
         "name": "StandalonePriceExpiresAtSet",
-        "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+        "description": null,
         "fields": [
           {
             "name": "expiresAt",
@@ -129899,7 +131754,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -131221,7 +133076,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -132839,7 +134694,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -134441,7 +136296,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -138324,7 +140179,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -139875,7 +141730,7 @@
           },
           {
             "name": "exists",
-            "description": "BETA: This feature can be subject to change and should be used carefully in production. https://docs.commercetools.com/api/contract#public-beta",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -730,8 +730,8 @@
           {
             "name": "MachineLearning",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "The machine learning APIs are not available anymore."
           },
           {
             "name": "ProductType",
@@ -3704,6 +3704,144 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CustomViewQueryInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "limit",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "offset",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sort",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomViewQueryWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CustomViewQueryWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "defaultLabel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locators",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "CustomViewType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "CustomViewSize",
         "description": null,
@@ -3809,6 +3947,105 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CustomViewsPagedQueryResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "offset",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "results",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CustomView",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -10325,6 +10562,303 @@
       },
       {
         "kind": "OBJECT",
+        "name": "MyCustomView",
+        "description": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "defaultLabel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labelAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LocalizedField",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locators",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CustomViewPermission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomViewStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomViewType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeSettings",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomViewTypeSettings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MyCustomViewsQueryInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "MyCustomViewsQueryWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MyCustomViewsQueryWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "CustomViewStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "NavbarMenu",
         "description": null,
         "fields": [
@@ -12200,6 +12734,30 @@
             "deprecationReason": null
           },
           {
+            "name": "expandedRows",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "filters",
             "description": null,
             "args": [],
@@ -12363,6 +12921,26 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "expandedRows",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "filters",
             "description": null,
@@ -13932,6 +14510,35 @@
             "deprecationReason": "Experimental feature - For internal usage only"
           },
           {
+            "name": "allCustomViews",
+            "description": null,
+            "args": [
+              {
+                "name": "params",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CustomViewQueryInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CustomViewsPagedQueryResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Experimental feature - For internal usage only"
+          },
+          {
             "name": "allCustomViewsInstallationsByLocator",
             "description": null,
             "args": [
@@ -14545,6 +15152,43 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "MyCustomApplication",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "myCustomViews",
+            "description": null,
+            "args": [
+              {
+                "name": "params",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MyCustomViewsQueryInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MyCustomView",
                     "ofType": null
                   }
                 }

--- a/test-data/project/generator.ts
+++ b/test-data/project/generator.ts
@@ -14,6 +14,7 @@ const generator = Generator<TProject>({
     currencies: ['EUR'],
     languages: ['de'],
     initialized: fake(() => true),
+    isProductionProject: fake(() => true),
     sampleDataImportDataset: 'FASHION',
     // The following fields are built in the builder
     owner: null,

--- a/test-data/project/generator.ts
+++ b/test-data/project/generator.ts
@@ -14,7 +14,7 @@ const generator = Generator<TProject>({
     currencies: ['EUR'],
     languages: ['de'],
     initialized: fake(() => true),
-    isProductionProject: fake(() => true),
+    isProductionProject: fake(() => false),
     sampleDataImportDataset: 'FASHION',
     // The following fields are built in the builder
     owner: null,

--- a/test-data/project/types.ts
+++ b/test-data/project/types.ts
@@ -62,4 +62,5 @@ export type TProjectGraphql = TBaseProject & {
     allAppliedDataFences: TAppliedStoreDataFencesGraphql;
     allAppliedMenuVisibilities: TAppliedMenuVisibilitiesGraphql;
   };
+  isProductionProject: boolean;
 };

--- a/test-data/project/types.ts
+++ b/test-data/project/types.ts
@@ -35,6 +35,7 @@ type TBaseProject = {
   currencies: string[];
   languages: string[];
   initialized: boolean;
+  isProductionProject: boolean;
   sampleDataImportDataset?: string;
 };
 

--- a/test-data/types/generated/mc.ts
+++ b/test-data/types/generated/mc.ts
@@ -663,7 +663,7 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', total: number, results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/test-data/types/generated/mc.ts
+++ b/test-data/types/generated/mc.ts
@@ -638,6 +638,11 @@ export enum TVerificationStatus {
   Verified = 'Verified'
 }
 
+export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };
+
 export type TAmILoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -648,7 +653,7 @@ export type TFetchProjectQueryVariables = Exact<{
 }>;
 
 
-export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
+export type TFetchProjectQuery = { __typename?: 'Query', project?: { __typename?: 'Project', key: string, version?: number | null, name: string, countries: Array<string>, currencies: Array<string>, languages: Array<string>, initialized: boolean, isProductionProject: boolean, sampleDataImportDataset?: string | null, expiry: { __typename?: 'ProjectExpiry', isActive: boolean, daysLeft?: number | null }, suspension: { __typename?: 'ProjectSuspension', isActive: boolean, reason?: TProjectSuspensionReason | null }, allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }>, allPermissionsForAllApplications: { __typename?: 'AllPermissionsForAllApplications', allAppliedPermissions: Array<{ __typename?: 'AppliedPermission', name: string, value: boolean }>, allAppliedActionRights: Array<{ __typename?: 'AppliedActionRight', group: string, name: string, value: boolean }>, allAppliedMenuVisibilities: Array<{ __typename?: 'AppliedMenuVisibilities', name: string, value: boolean }>, allAppliedDataFences: Array<{ __typename: 'StoreDataFence', type: string, name: string, value: string, group: string }> }, owner: { __typename?: 'Organization', id: string, name: string } } | null };
 
 export type TFetchLoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -658,14 +663,9 @@ export type TFetchLoggedInUserQuery = { __typename?: 'Query', user?: { __typenam
 export type TFetchUserProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
+export type TFetchUserProjectsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, projects: { __typename?: 'ProjectQueryResult', results: Array<{ __typename?: 'Project', name: string, key: string, isProductionProject: boolean, suspension: { __typename?: 'ProjectSuspension', isActive: boolean }, expiry: { __typename?: 'ProjectExpiry', isActive: boolean } }> } } | null };
 
 export type TAllFeaturesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type TAllFeaturesQuery = { __typename?: 'Query', allFeatures: Array<{ __typename?: 'Feature', name: string, value: boolean, reason?: string | null }> };
-
-export type TFetchUserIdQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type TFetchUserIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };


### PR DESCRIPTION
We needed the new field `isProductionProject` so this PR adds it to the project query and generates new graphql types.