### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @commercetools/shield-team-fe


### PR DESCRIPTION
#### Summary

Been flipping a 🪙 about the @commercetools/shield-team-ext-and-infra  and @commercetools/shield-team-fe for this.

I think the team should decide. I can share my argument for picking the @commercetools/shield-team-fe. Teams are the "entity of communication" towards the outside world. Pods are an inside construct which "the outside" of a team doesn't care about.