### PR TITLE
Fix issue with login flow in local development

### DIFF
--- a/.changeset/fair-trains-brake.md
+++ b/.changeset/fair-trains-brake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+We've fixed a bug with the login flow when working on a Custom Application locally when a user updated the [initialProjectKey](https://docs.commercetools.com/custom-applications/api-reference/application-config#envdevelopmentinitialprojectkey) configuration value but the application was still using the old.

--- a/packages/application-shell/src/components/authenticated/has-cached-authentication-state.ts
+++ b/packages/application-shell/src/components/authenticated/has-cached-authentication-state.ts
@@ -17,7 +17,7 @@ const withoutProjectKeyClaim = (scope: string) =>
 const hasCachedAuthenticationState = (): boolean => {
   if (window.app.__DEVELOPMENT__?.oidc?.authorizeUrl) {
     try {
-      const activeProjectKey = oidcStorage.getActiveProjectKey();
+      let activeProjectKey = oidcStorage.getActiveProjectKey();
       if (activeProjectKey) {
         // GIVEN The application is not requesting a project key,
         // THEN we assume that the application does not need a project context.
@@ -26,6 +26,19 @@ const hasCachedAuthenticationState = (): boolean => {
         // This is the case of an application like `account`.
         if (!window.app.__DEVELOPMENT__?.oidc?.initialProjectKey) {
           oidcStorage.removeActiveProjectKey();
+        }
+
+        // If the prohect key we had in the storage does not match the one
+        // we have in the development config, then we need to discard it and
+        // use the one from the development config.
+        if (
+          window.app.__DEVELOPMENT__?.oidc?.initialProjectKey &&
+          window.app.__DEVELOPMENT__?.oidc?.initialProjectKey !==
+            activeProjectKey
+        ) {
+          activeProjectKey =
+            window.app.__DEVELOPMENT__?.oidc?.initialProjectKey;
+          oidcStorage.setActiveProjectKey(activeProjectKey);
         }
       } else {
         if (window.app.__DEVELOPMENT__?.oidc?.initialProjectKey) {

--- a/packages/application-shell/src/components/authenticated/has-cached-authentication-state.ts
+++ b/packages/application-shell/src/components/authenticated/has-cached-authentication-state.ts
@@ -28,7 +28,7 @@ const hasCachedAuthenticationState = (): boolean => {
           oidcStorage.removeActiveProjectKey();
         }
 
-        // If the prohect key we had in the storage does not match the one
+        // If the project key we had in the storage does not match the one
         // we have in the development config, then we need to discard it and
         // use the one from the development config.
         if (


### PR DESCRIPTION
#### Summary

Fix issue with login flow in local development

#### Description

When working locally in a Custom Application, there's a use case when a developer can be blocked in the login page due to cached configuration.

Here is how the issue can be reproduced:
1. Let's say a developer starts working on a Custom Application and, accidentally, the[ project key used to configure the application](https://docs.commercetools.com/custom-applications/api-reference/application-config#envdevelopmentinitialprojectkey) is wrong
2. When starting the Custom Application locally, the login flow will try to log in into that project which does not exist
3. The developer notice it and updates the configuration to use the right project key
4. The developer starts the Custom Application locally again, but the login flow still tries to login in the wrong project

This happens because we're currently caching the project key the first time and we don't update it in this situation.

A user can fix this by clearing the browser storage for the `http://localhost:3001` host, but that's not straightforward as the Custom Application will automatically redirect to production Merchant Center host during the login flow.

In this PR we propose to check whether the stored project key matches the one from the Custom Application configuration and discard the cached one if they don't match.
