### PR TITLE
refactor(main nav): use emotion for styling - follow up

### DIFF
--- a/.changeset/spotty-worms-check.md
+++ b/.changeset/spotty-worms-check.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Refactored Navbar CSS-in-JS styles by transitioning from global styles based on classnames to encapsulated component styles

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -1,6 +1,7 @@
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-import { designTokens } from '@commercetools-uikit/design-system';
+import { designTokens as appKitDesignTokens } from '@commercetools-frontend/application-components';
+import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import { NAVBAR } from '../../constants';
 import { MenuListItem, LeftNavigation } from './menu-items.styles';
 import { ItemIconText, Title } from './shared.styles';
@@ -26,7 +27,7 @@ const FixedMenu = styled.div`
 `;
 
 const ItemContent = styled.div`
-  color: var(--color-for-navbar-link);
+  color: ${appKitDesignTokens.colorForNavbarLink};
   width: ${NAVBAR.itemSize};
   position: relative;
   display: block;
@@ -36,12 +37,13 @@ const ScrollableMenu = styled.div`
   flex: 1 1 0;
   overflow-x: hidden;
   overflow-y: hidden;
-  padding: var(--spacing-30) var(--spacing-30) ${NAVBAR.itemSize};
+  padding: ${uiKitDesignTokens.spacing30} ${uiKitDesignTokens.spacing30}
+    ${NAVBAR.itemSize};
   width: ${NAVBAR.widthLeftNavigation};
   box-sizing: border-box;
   /* For Firefox */
   scrollbar-width: thin;
-  scrollbar-color: var(--color-primary-40) transparent;
+  scrollbar-color: ${uiKitDesignTokens.colorPrimary40} transparent;
 
   :hover {
     overflow-y: scroll;
@@ -57,8 +59,8 @@ const ScrollableMenu = styled.div`
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: var(--color-primary-40);
-    border-radius: var(--border-radius-8);
+    background-color: ${uiKitDesignTokens.colorPrimary40};
+    border-radius: ${uiKitDesignTokens.borderRadius8};
   }
 `;
 
@@ -98,8 +100,8 @@ const leftNavigationOpenStyles = css`
 
     ${Title} {
       opacity: 1;
-      margin-left: var(--spacing-25);
-      color: var(--color-surface);
+      margin-left: ${uiKitDesignTokens.spacing25};
+      color: ${uiKitDesignTokens.colorSurface};
       transition: ${NAVBAR.leftNavigationTransition};
       animation: ${visible} 150ms cubic-bezier(1, 0, 0.58, 1);
     }
@@ -111,18 +113,18 @@ const leftNavigationOpenStyles = css`
 `;
 
 const NavigationHeader = styled.div`
-  background-color: ${designTokens.colorAccent10};
-  color: ${designTokens.colorSurface};
+  background-color: ${uiKitDesignTokens.colorAccent10};
+  color: ${uiKitDesignTokens.colorSurface};
   display: flex;
   justify-content: center;
   flex-direction: row;
   align-items: center;
-  padding: ${designTokens.spacing30};
+  padding: ${uiKitDesignTokens.spacing30};
 `;
 
 const HeaderTitle = styled.div`
   font-weight: 600;
-  margin-left: ${designTokens.spacing20};
+  margin-left: ${uiKitDesignTokens.spacing20};
   transition: ${NAVBAR.leftNavigationTransition};
   animation: ${visible} 150ms cubic-bezier(1, 0, 0.58, 1);
 `;
@@ -143,40 +145,41 @@ const TooltipContainer = styled.div<{
 `;
 
 const Tooltip = styled.div`
-  padding: var(--spacing-10) calc(var(--spacing-20) + var(--spacing-10));
+  padding: ${uiKitDesignTokens.spacing10}
+    calc(${uiKitDesignTokens.spacing20} + ${uiKitDesignTokens.spacing10});
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  border-radius: var(--border-radius-4);
-  background: var(--color-accent-10);
+  border-radius: ${uiKitDesignTokens.borderRadius4};
+  background: ${uiKitDesignTokens.colorAccent10};
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.25);
-  font-size: var(--font-size-for-navbar-link);
-  line-height: var(--line-height-for-navbar-link);
-  font-weight: var(--font-weight-for-navbar-link);
-  color: var(--color-surface);
+  font-size: ${appKitDesignTokens.fontSizeForNavbarLink};
+  line-height: ${appKitDesignTokens.lineHeightForNavbarLink};
+  font-weight: ${appKitDesignTokens.fontWeightForNavbarLink};
+  color: ${uiKitDesignTokens.colorSurface};
   max-height: ${NAVBAR.itemSize};
   visibility: inherit;
 `;
 
 const TextLink = styled.a`
-  color: var(--color-for-navbar-link);
+  color: ${appKitDesignTokens.colorForNavbarLink};
   text-decoration: none;
   display: flex;
-  padding: var(--spacing-25);
+  padding: ${uiKitDesignTokens.spacing25};
   align-items: center;
   justify-content: center;
 `;
 
 const SupportMenu = styled.div`
-  padding: var(--spacing-10) var(--spacing-30) var(--spacing-20)
-    var(--spacing-30);
-  height: calc(var(--item-size) + var(--spacing-20));
+  padding: ${uiKitDesignTokens.spacing10} ${uiKitDesignTokens.spacing30}
+    ${uiKitDesignTokens.spacing20} ${uiKitDesignTokens.spacing30};
+  height: calc(${NAVBAR.itemSize} + ${uiKitDesignTokens.spacing20});
 `;
 
 const Text = styled.div`
-  font-weight: var(--font-weight-for-navbar-link);
-  font-size: var(--font-size-for-navbar-link);
-  line-height: var(--line-height-for-navbar-link);
+  font-weight: ${appKitDesignTokens.fontWeightForNavbarLink};
+  font-size: ${appKitDesignTokens.fontSizeForNavbarLink};
+  line-height: ${appKitDesignTokens.lineHeightForNavbarLink};
   width: 100%;
   height: 100%;
 `;
@@ -187,20 +190,20 @@ const getMenuItemLinkStyles = (isSubmenuLink: boolean) => [
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
-      color: var(--color-solid);
-      font-weight: var(--font-weight-for-navbar-link-when-hovered);
+      color: ${uiKitDesignTokens.colorSolid};
+      font-weight: ${appKitDesignTokens.fontWeightForNavbarLinkWhenHovered};
       text-decoration: none;
       flex: 1;
-      padding: var(--spacing-25) var(--spacing-25) var(--spacing-25)
-        var(--spacing-30);
+      padding: ${uiKitDesignTokens.spacing25} ${uiKitDesignTokens.spacing25}
+        ${uiKitDesignTokens.spacing25} ${uiKitDesignTokens.spacing30};
       transition: padding 150ms ease-out;
     `,
   !isSubmenuLink &&
     css`
-      color: var(--color-for-navbar-link);
+      color: ${appKitDesignTokens.colorForNavbarLink};
       text-decoration: none;
       display: flex;
-      padding: var(--spacing-25);
+      padding: ${uiKitDesignTokens.spacing25};
       align-items: center;
       justify-content: center;
     `,

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -2,8 +2,8 @@ import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { designTokens } from '@commercetools-uikit/design-system';
 import { NAVBAR } from '../../constants';
-import type { MenuGroupProps } from './menu-items';
-import { MenuListItem } from './menu-items.styles';
+import { MenuListItem, LeftNavigation } from './menu-items.styles';
+import { ItemIconText, Title } from './shared.styles';
 
 const visible = keyframes`
   from {
@@ -18,7 +18,7 @@ const FixedMenu = styled.div`
   position: relative;
   width: ${NAVBAR.widthLeftNavigation};
 
-  ${MenuListItem} .item-icon-text {
+  ${MenuListItem} ${ItemIconText} {
     justify-content: center;
     display: flex;
     width: 100%;
@@ -32,13 +32,43 @@ const ItemContent = styled.div`
   display: block;
 `;
 
+const ScrollableMenu = styled.div`
+  flex: 1 1 0;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  padding: var(--spacing-30) var(--spacing-30) ${NAVBAR.itemSize};
+  width: ${NAVBAR.widthLeftNavigation};
+  box-sizing: border-box;
+  /* For Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-primary-40) transparent;
+
+  :hover {
+    overflow-y: scroll;
+    padding-right: 8px;
+  }
+
+  ::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--color-primary-40);
+    border-radius: var(--border-radius-8);
+  }
+`;
+
 const leftNavigationOpenStyles = css`
-  .body__menu-open .left-navigation {
+  .body__menu-open ${LeftNavigation} {
     transition: ${NAVBAR.leftNavigationTransition};
     width: ${NAVBAR.widthLeftNavigationWhenExpanded};
   }
 
-  .body__menu-open .scrollable-menu {
+  .body__menu-open ${ScrollableMenu} {
     width: ${NAVBAR.widthLeftNavigationWhenExpanded};
   }
 
@@ -54,28 +84,25 @@ const leftNavigationOpenStyles = css`
     height: auto;
     min-height: ${NAVBAR.itemSize};
     width: 100%;
-  }
 
-  .body__menu-open ${MenuListItem} .title {
-    opacity: 1;
-    margin-left: var(--spacing-25);
-    color: var(--color-surface);
-    transition: ${NAVBAR.leftNavigationTransition};
-    animation: ${visible} 150ms cubic-bezier(1, 0, 0.58, 1);
-  }
+    &.active {
+      max-height: 500px;
+      transition: max-height 0.25s ease-in;
 
-  .body__menu-open .item__active {
-    max-height: 500px;
-    transition: max-height 0.25s ease-in;
-  }
+      ${ItemIconText} {
+        position: relative;
+        width: auto;
+        margin-left: 0;
+      }
+    }
 
-  .body__menu-open .item__active .item-icon-text {
-    position: relative;
-    width: auto;
-  }
-
-  .body__menu-open .item__active .item-icon-text {
-    margin-left: 0;
+    ${Title} {
+      opacity: 1;
+      margin-left: var(--spacing-25);
+      color: var(--color-surface);
+      transition: ${NAVBAR.leftNavigationTransition};
+      animation: ${visible} 150ms cubic-bezier(1, 0, 0.58, 1);
+    }
   }
 
   .body__menu-open ${ItemContent} {
@@ -98,15 +125,6 @@ const HeaderTitle = styled.div`
   margin-left: ${designTokens.spacing20};
   transition: ${NAVBAR.leftNavigationTransition};
   animation: ${visible} 150ms cubic-bezier(1, 0, 0.58, 1);
-`;
-
-const listStyles = css`
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  flex: 1 1 0;
 `;
 
 const TooltipContainer = styled.div<{
@@ -140,80 +158,6 @@ const Tooltip = styled.div`
   visibility: inherit;
 `;
 
-const SublistItem = styled.li<{ isActive: boolean }>`
-  display: flex;
-  align-items: center;
-  align-self: stretch;
-
-  ${(props) => [
-    props.isActive &&
-      css`
-        border-radius: var(--border-radius-4);
-        background: var(--color-accent-30);
-      `,
-    !props.isActive &&
-      css`
-        :hover,
-        :focus-within {
-          color: var(--color-for-navbar-link-when-hovered);
-          font-weight: var(--font-weight-for-navbar-link-when-hovered);
-          border-radius: var(--border-radius-4);
-          background: var(--color-primary-95);
-        }
-
-        :not(.sublist-item__active):hover [data-link-level='text-link-sublist'],
-        :not(.sublist-item__active):focus-within
-          [data-link-level='text-link-sublist'] {
-          /* additional left padding on hover and focus */
-          padding: var(--spacing-25) var(--spacing-25) var(--spacing-25)
-            calc(var(--spacing-30) + var(--spacing-20));
-        }
-      `,
-  ]}
-`;
-
-const sublistStyles = css`
-  padding: var(--spacing-30);
-  font-weight: var(--font-weight-for-navbar-link);
-  font-size: var(--font-size-for-navbar-link);
-  background-color: var(--background-color-for-navbar);
-  left: ${NAVBAR.sublistIndentationWhenCollapsed};
-  z-index: -1;
-  list-style: none;
-  position: fixed;
-  display: none;
-`;
-
-const ScrollableMenu = styled.div`
-  flex: 1 1 0;
-  overflow-x: hidden;
-  overflow-y: hidden;
-  padding: var(--spacing-30) var(--spacing-30) ${NAVBAR.itemSize};
-  width: ${NAVBAR.widthLeftNavigation};
-  box-sizing: border-box;
-  /* For Firefox */
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-primary-40) transparent;
-
-  :hover {
-    overflow-y: scroll;
-    padding-right: 8px;
-  }
-
-  ::-webkit-scrollbar {
-    width: 8px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: var(--color-primary-40);
-    border-radius: var(--border-radius-8);
-  }
-`;
-
 const TextLink = styled.a`
   color: var(--color-for-navbar-link);
   text-decoration: none;
@@ -227,19 +171,6 @@ const SupportMenu = styled.div`
   padding: var(--spacing-10) var(--spacing-30) var(--spacing-20)
     var(--spacing-30);
   height: calc(var(--item-size) + var(--spacing-20));
-`;
-
-const Title = styled.div`
-  flex: 1;
-  font-weight: 600;
-  font-size: var(--font-size-for-navbar-link);
-  line-height: var(--line-height-for-navbar-link);
-  color: var(--color-for-navbar-link);
-  opacity: 0;
-  transition: ${NAVBAR.leftNavigationTransition};
-  text-align: left;
-  text-decoration: none;
-  z-index: 1;
 `;
 
 const Text = styled.div`
@@ -275,101 +206,15 @@ const getMenuItemLinkStyles = (isSubmenuLink: boolean) => [
     `,
 ];
 
-const getSubmenuPositionBasedOnMenuItemPosition = (
-  isSubmenuAboveMenuItem?: boolean,
-  submenuVerticalPosition?: number
-) => css`
-  ${isSubmenuAboveMenuItem ? 'bottom' : 'top'}: ${submenuVerticalPosition}px
-`;
-
-const getContainerPositionBasedOnMenuItemPosition = (
-  isSubmenuAboveMenuItem?: boolean,
-  isSublistActiveWhileIsMenuExpanded?: boolean,
-  isSublistActiveWhileIsMenuCollapsed?: boolean
-) => [
-  isSublistActiveWhileIsMenuCollapsed &&
-    css`
-      ${isSubmenuAboveMenuItem ? 'bottom' : 'top'}: -${NAVBAR.itemSize};
-    `,
-  isSublistActiveWhileIsMenuExpanded &&
-    isSubmenuAboveMenuItem &&
-    css`
-      bottom: 0;
-    `,
-  isSublistActiveWhileIsMenuExpanded &&
-    !isSubmenuAboveMenuItem &&
-    css`
-      top: 0;
-    `,
-];
-
-const MenuList = styled.ul<
-  MenuGroupProps & {
-    isSublistActiveWhileIsMenuExpanded: boolean;
-    isSublistActiveWhileIsMenuCollapsed: boolean;
-    isSublistCollapsedAndActive: boolean;
-    isSublistCollapsedAndActiveAndAbove: boolean;
-  }
->`
-  ${(props) => [
-    props.level === 1 && listStyles,
-    getSubmenuPositionBasedOnMenuItemPosition(
-      props.isSubmenuAboveMenuItem,
-      props.submenuVerticalPosition
-    ),
-    props.level === 2 && sublistStyles,
-    // prevent glitchy behavior during the initial render when the submenu's vertical position is evaluated as 0
-    props.submenuVerticalPosition === 0 &&
-      css`
-        visibility: hidden;
-      `,
-    (props.isSublistActiveWhileIsMenuExpanded ||
-      props.isSublistCollapsedAndActive ||
-      props.isSublistCollapsedAndActiveAndAbove) &&
-      css`
-        opacity: 1;
-        display: none;
-        text-align: left;
-        background-color: var(--background-color-for-navbar-when-active);
-
-        /* This pseudo-element is required to enable smooth coursor movement from the main menu item to submenu items with the gap in between */
-        ::before {
-          content: '';
-          position: absolute;
-          display: block;
-          width: calc(${NAVBAR.sublistWidth} + var(--spacing-20));
-          height: ${NAVBAR.itemSize};
-          left: calc(-1 * var(--spacing-20));
-
-          ${getContainerPositionBasedOnMenuItemPosition(
-            props.isSubmenuAboveMenuItem,
-            props.isSublistActiveWhileIsMenuExpanded,
-            props.isSublistActiveWhileIsMenuCollapsed
-          )}
-        }
-      `,
-  ]}
-
-  .highlighted,
-  .highlighted .title {
-    color: var(--color-for-navbar-link-when-active) !important;
-    font-weight: var(--font-weight-for-navbar-link-when-active);
-  }
-`;
-
 export {
   getMenuItemLinkStyles,
   leftNavigationOpenStyles,
-  listStyles,
-  sublistStyles,
   // styled components
   FixedMenu,
   HeaderTitle,
   ItemContent,
-  MenuList,
   NavigationHeader,
   ScrollableMenu,
-  SublistItem,
   SupportMenu,
   Text,
   TextLink,

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -2,6 +2,8 @@ import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { designTokens } from '@commercetools-uikit/design-system';
 import { NAVBAR } from '../../constants';
+import type { MenuGroupProps } from './menu-items';
+import { MenuListItem } from './menu-items.styles';
 
 const visible = keyframes`
   from {
@@ -10,6 +12,24 @@ const visible = keyframes`
   to {
     opacity: 1;
   }
+`;
+
+const FixedMenu = styled.div`
+  position: relative;
+  width: ${NAVBAR.widthLeftNavigation};
+
+  ${MenuListItem} .item-icon-text {
+    justify-content: center;
+    display: flex;
+    width: 100%;
+  }
+`;
+
+const ItemContent = styled.div`
+  color: var(--color-for-navbar-link);
+  width: ${NAVBAR.itemSize};
+  position: relative;
+  display: block;
 `;
 
 const leftNavigationOpenStyles = css`
@@ -22,7 +42,7 @@ const leftNavigationOpenStyles = css`
     width: ${NAVBAR.widthLeftNavigationWhenExpanded};
   }
 
-  .body__menu-open .fixed-menu {
+  .body__menu-open ${FixedMenu} {
     width: ${NAVBAR.widthLeftNavigationWhenExpanded};
   }
 
@@ -30,13 +50,13 @@ const leftNavigationOpenStyles = css`
     justify-content: start;
   }
 
-  .body__menu-open .list-item {
+  .body__menu-open ${MenuListItem} {
     height: auto;
     min-height: ${NAVBAR.itemSize};
     width: 100%;
   }
 
-  .body__menu-open .list-item .title {
+  .body__menu-open ${MenuListItem} .title {
     opacity: 1;
     margin-left: var(--spacing-25);
     color: var(--color-surface);
@@ -58,170 +78,9 @@ const leftNavigationOpenStyles = css`
     margin-left: 0;
   }
 
-  .body__menu-open .item-link {
+  .body__menu-open ${ItemContent} {
     width: 100%;
   }
-
-  // List item
-  .fixed-menu .list-item .item-icon-text {
-    justify-content: center;
-    display: flex;
-    width: 100%;
-  }
-
-  .list-item {
-    min-height: ${NAVBAR.itemSize};
-    background: var(--color-primary);
-    margin: 0;
-    list-style: none;
-    cursor: pointer;
-  }
-
-  .list-item .icon-wrapper {
-    width: auto;
-    display: flex;
-    justify-content: center;
-    align-self: flex-start;
-  }
-
-  .item_menu-collapsed {
-    text-align: center;
-  }
-
-  .item__active,
-  .item_menu__active,
-  .item_menu__active:focus-within {
-    background: var(--color-accent-30);
-    border-radius: var(--border-radius-8);
-  }
-
-  .item__active .item-icon-text {
-    justify-content: flex-start;
-  }
-
-  .list-item:hover .title,
-  .list-item:focus-within .title {
-    margin-left: calc(var(--spacing-25) + 2px);
-  }
-
-  .list-item:hover .icon,
-  .list-item:focus-within .icon {
-    /* 1.16 is roughly the ratio of NAVBAR.iconSizeHover to NAVBAR.iconSize */
-    transform: scale(1.2);
-  }
-
-  .list-item:not(.item_menu__active):hover,
-  .list-item:not(.item_menu__active):focus-within {
-    background-color: var(--color-primary-40);
-    border-radius: var(--border-radius-8);
-  }
-
-  .list-item:not(.item__active):hover .icon > svg *:not([fill='none']),
-  .list-item:not(.item__active):focus-within .icon > svg *:not([fill='none']) {
-    fill: var(--color-for-navbar-icon-when-active);
-  }
-
-  .list-item:not(.item__active):hover .title,
-  .list-item:not(.item__active):focus-within .title {
-    color: var(--color-for-navbar-link-when-hovered);
-  }
-
-  .list-item:hover .sublist-collapsed__active,
-  .list-item:hover .sublist-collapsed__active__above,
-  .list-item:hover .sublist-expanded__active,
-  .list-item:focus-within .sublist-collapsed__active,
-  .list-item:focus-within .sublist-collapsed__active__above,
-  .list-item:focus-within .sublist-expanded__active {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    background-color: var(--color-surface);
-    /* TODO: add design tokens instead hard-coded values */
-    min-height: 50px;
-    width: ${NAVBAR.sublistWidth};
-    border-radius: var(--border-radius-8);
-    /* z-index value must be higher than AppBar's z-index */
-    z-index: 20001;
-    box-shadow: -2px 4px 25px 0 rgba(89, 89, 89, 0.5);
-  }
-
-  .list-item:hover .sublist-collapsed__active.sublist-collapsed__empty,
-  .list-item:hover .sublist-collapsed__active__above.sublist-collapsed__empty,
-  .list-item:focus-within .sublist-collapsed__active.sublist-collapsed__empty,
-  .list-item:focus-within
-    .sublist-collapsed__active__above.sublist-collapsed__empty {
-    visibility: hidden;
-  }
-
-  .list-item:hover .sublist-expanded__active,
-  .list-item:focus-within .sublist-expanded__active {
-    left: ${NAVBAR.sublistIndentationWhenExpanded};
-  }
-
-  // Sublist item
-
-  .item-link {
-    color: var(--color-for-navbar-link);
-    width: ${NAVBAR.itemSize};
-    position: relative;
-    display: block;
-  }
-
-  /* This pseudo-element is required to enable smooth coursor movement from the main menu item to submenu items with the gap in between */
-  .sublist-expanded__active::before,
-  .sublist-collapsed__active::before,
-  .sublist-collapsed__active__above::before {
-    content: '';
-    position: absolute;
-    display: block;
-    width: calc(${NAVBAR.sublistWidth} + var(--spacing-20));
-    height: ${NAVBAR.itemSize};
-    left: calc(-1 * var(--spacing-20));
-  }
-
-  .sublist__inactive {
-    /* empty block */
-  }
-
-  /* Item active */
-
-  .sublist-expanded__active,
-  .sublist-collapsed__active,
-  .sublist-collapsed__active__above {
-    opacity: 1;
-    display: none;
-    text-align: left;
-    background-color: var(--background-color-for-navbar-when-active);
-  }
-
-  .highlighted,
-  .highlighted .title {
-    color: var(--color-for-navbar-link-when-active) !important;
-    font-weight: var(--font-weight-for-navbar-link-when-active);
-  }
-`;
-
-const IconWrapper = styled.div`
-  width: auto;
-  display: flex;
-  justify-content: center;
-`;
-
-const Icon = styled.div`
-  width: ${NAVBAR.iconSize};
-  height: ${NAVBAR.iconSize};
-  transition: ${NAVBAR.leftNavigationTransition};
-
-  > svg *:not([fill='none']) {
-    fill: var(--color-surface);
-  }
-`;
-
-const ItemIconText = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
 `;
 
 const NavigationHeader = styled.div`
@@ -355,11 +214,6 @@ const ScrollableMenu = styled.div`
   }
 `;
 
-const FixedMenu = styled.div`
-  position: relative;
-  width: ${NAVBAR.widthLeftNavigation};
-`;
-
 const TextLink = styled.a`
   color: var(--color-for-navbar-link);
   text-decoration: none;
@@ -421,6 +275,88 @@ const getMenuItemLinkStyles = (isSubmenuLink: boolean) => [
     `,
 ];
 
+const getSubmenuPositionBasedOnMenuItemPosition = (
+  isSubmenuAboveMenuItem?: boolean,
+  submenuVerticalPosition?: number
+) => css`
+  ${isSubmenuAboveMenuItem ? 'bottom' : 'top'}: ${submenuVerticalPosition}px
+`;
+
+const getContainerPositionBasedOnMenuItemPosition = (
+  isSubmenuAboveMenuItem?: boolean,
+  isSublistActiveWhileIsMenuExpanded?: boolean,
+  isSublistActiveWhileIsMenuCollapsed?: boolean
+) => [
+  isSublistActiveWhileIsMenuCollapsed &&
+    css`
+      ${isSubmenuAboveMenuItem ? 'bottom' : 'top'}: -${NAVBAR.itemSize};
+    `,
+  isSublistActiveWhileIsMenuExpanded &&
+    isSubmenuAboveMenuItem &&
+    css`
+      bottom: 0;
+    `,
+  isSublistActiveWhileIsMenuExpanded &&
+    !isSubmenuAboveMenuItem &&
+    css`
+      top: 0;
+    `,
+];
+
+const MenuList = styled.ul<
+  MenuGroupProps & {
+    isSublistActiveWhileIsMenuExpanded: boolean;
+    isSublistActiveWhileIsMenuCollapsed: boolean;
+    isSublistCollapsedAndActive: boolean;
+    isSublistCollapsedAndActiveAndAbove: boolean;
+  }
+>`
+  ${(props) => [
+    props.level === 1 && listStyles,
+    getSubmenuPositionBasedOnMenuItemPosition(
+      props.isSubmenuAboveMenuItem,
+      props.submenuVerticalPosition
+    ),
+    props.level === 2 && sublistStyles,
+    // prevent glitchy behavior during the initial render when the submenu's vertical position is evaluated as 0
+    props.submenuVerticalPosition === 0 &&
+      css`
+        visibility: hidden;
+      `,
+    (props.isSublistActiveWhileIsMenuExpanded ||
+      props.isSublistCollapsedAndActive ||
+      props.isSublistCollapsedAndActiveAndAbove) &&
+      css`
+        opacity: 1;
+        display: none;
+        text-align: left;
+        background-color: var(--background-color-for-navbar-when-active);
+
+        /* This pseudo-element is required to enable smooth coursor movement from the main menu item to submenu items with the gap in between */
+        ::before {
+          content: '';
+          position: absolute;
+          display: block;
+          width: calc(${NAVBAR.sublistWidth} + var(--spacing-20));
+          height: ${NAVBAR.itemSize};
+          left: calc(-1 * var(--spacing-20));
+
+          ${getContainerPositionBasedOnMenuItemPosition(
+            props.isSubmenuAboveMenuItem,
+            props.isSublistActiveWhileIsMenuExpanded,
+            props.isSublistActiveWhileIsMenuCollapsed
+          )}
+        }
+      `,
+  ]}
+
+  .highlighted,
+  .highlighted .title {
+    color: var(--color-for-navbar-link-when-active) !important;
+    font-weight: var(--font-weight-for-navbar-link-when-active);
+  }
+`;
+
 export {
   getMenuItemLinkStyles,
   leftNavigationOpenStyles,
@@ -429,6 +365,8 @@ export {
   // styled components
   FixedMenu,
   HeaderTitle,
+  ItemContent,
+  MenuList,
   NavigationHeader,
   ScrollableMenu,
   SublistItem,
@@ -438,8 +376,4 @@ export {
   Title,
   Tooltip,
   TooltipContainer,
-  // common
-  Icon,
-  IconWrapper,
-  ItemIconText,
 };

--- a/packages/application-shell/src/components/navbar/menu-items.styles.ts
+++ b/packages/application-shell/src/components/navbar/menu-items.styles.ts
@@ -249,15 +249,6 @@ const MenuListItem = styled.li<{
           border-radius: var(--border-radius-8);
         }
       `,
-    !props.isRouteActive &&
-      !props.isActive &&
-      css`
-        :hover,
-        :focus-within {
-          background-color: var(--color-primary-40);
-          border-radius: var(--border-radius-8);
-        }
-      `,
     props.isActive &&
       css`
         ${ItemIconText} {
@@ -307,8 +298,7 @@ const MenuListItem = styled.li<{
     flex-direction: column;
     align-items: flex-start;
     background-color: var(--color-surface);
-    /* TODO: add design tokens instead hard-coded values */
-    min-height: 50px;
+    min-height: ${NAVBAR.sublistItemMinHeight};
     width: ${NAVBAR.sublistWidth};
     border-radius: var(--border-radius-8);
     /* z-index value must be higher than AppBar's z-index */

--- a/packages/application-shell/src/components/navbar/menu-items.styles.ts
+++ b/packages/application-shell/src/components/navbar/menu-items.styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { designTokens } from '@commercetools-uikit/design-system';
+import { designTokens as appKitDesignTokens } from '@commercetools-frontend/application-components';
+import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import { NAVBAR } from '../../constants';
 import type { MenuGroupProps } from './menu-items';
 import { Icon, IconWrapper, ItemIconText, Title } from './shared.styles';
@@ -48,10 +49,10 @@ const Expander = styled.li<{ isVisible: boolean }>`
   justify-content: center;
   background: linear-gradient(
     180deg,
-    ${designTokens.colorPrimary} 0%,
-    ${designTokens.colorPrimary25} 100%
+    ${uiKitDesignTokens.colorPrimary} 0%,
+    ${uiKitDesignTokens.colorPrimary25} 100%
   );
-  padding: ${designTokens.spacing30} ${designTokens.spacing25};
+  padding: ${uiKitDesignTokens.spacing30} ${uiKitDesignTokens.spacing25};
   ${(props) =>
     !props.isVisible &&
     css`
@@ -65,20 +66,20 @@ const Expander = styled.li<{ isVisible: boolean }>`
     top: ${NAVBAR.itemHeight};
     height: 1px;
     background: rgba(255, 255, 255, 0.5);
-    width: calc(100% - 2 * ${designTokens.spacing30});
+    width: calc(100% - 2 * ${uiKitDesignTokens.spacing30});
   }
 
   :hover,
   :focus {
-    background-color: var(--color-primary-40);
+    background-color: ${uiKitDesignTokens.colorPrimary40};
   }
 `;
 
 const ExpanderIcon = styled.div`
   height: ${NAVBAR.expanderSize};
   width: ${NAVBAR.expanderSize};
-  border-radius: ${designTokens.borderRadius4};
-  padding: ${designTokens.spacing20};
+  border-radius: ${uiKitDesignTokens.borderRadius4};
+  padding: ${uiKitDesignTokens.spacing20};
   background: rgba(255, 255, 255, 0.2);
   display: flex;
   justify-content: center;
@@ -94,7 +95,7 @@ const ExpanderIcon = styled.div`
 const LeftNavigation = styled.nav`
   display: grid;
   width: ${NAVBAR.widthLeftNavigation};
-  background: ${designTokens.colorPrimary};
+  background: ${uiKitDesignTokens.colorPrimary};
   height: 100%;
   grid-template-rows: 56px 1fr;
   transition: ${NAVBAR.leftNavigationTransition};
@@ -122,10 +123,10 @@ const listStyles = css`
 `;
 
 const sublistStyles = css`
-  padding: var(--spacing-30);
-  font-weight: var(--font-weight-for-navbar-link);
-  font-size: var(--font-size-for-navbar-link);
-  background-color: var(--background-color-for-navbar);
+  padding: ${uiKitDesignTokens.spacing30};
+  font-weight: ${appKitDesignTokens.fontWeightForNavbarLink};
+  font-size: ${appKitDesignTokens.fontSizeForNavbarLink};
+  background-color: ${appKitDesignTokens.backgroundColorForNavbar};
   left: ${NAVBAR.sublistIndentationWhenCollapsed};
   z-index: -1;
   list-style: none;
@@ -160,16 +161,16 @@ const MenuList = styled.ul<
         opacity: 1;
         display: none;
         text-align: left;
-        background-color: var(--background-color-for-navbar-when-active);
+        background-color: ${appKitDesignTokens.backgroundColorForNavbarWhenActive};
 
         /* This pseudo-element is required to enable smooth coursor movement from the main menu item to submenu items with the gap in between */
         ::before {
           content: '';
           position: absolute;
           display: block;
-          width: calc(${NAVBAR.sublistWidth} + var(--spacing-20));
+          width: calc(${NAVBAR.sublistWidth} + ${uiKitDesignTokens.spacing20});
           height: ${NAVBAR.itemSize};
-          left: calc(-1 * var(--spacing-20));
+          left: calc(-1 * ${uiKitDesignTokens.spacing20});
 
           ${getContainerPositionBasedOnMenuItemPosition(
             props.isSubmenuAboveMenuItem,
@@ -180,10 +181,10 @@ const MenuList = styled.ul<
       `,
   ]}
 
-  .highlighted,
-  .highlighted ${Title} {
-    color: var(--color-for-navbar-link-when-active) !important;
-    font-weight: var(--font-weight-for-navbar-link-when-active);
+  & .highlighted,
+  & .highlighted ${Title} {
+    color: ${appKitDesignTokens.colorForNavbarLinkWhenActive} !important;
+    font-weight: ${appKitDesignTokens.fontWeightForNavbarLinkWhenActive};
   }
 `;
 
@@ -195,22 +196,25 @@ const SublistItem = styled.li<{ isActive: boolean }>`
   ${(props) => [
     props.isActive &&
       css`
-        border-radius: var(--border-radius-4);
-        background: var(--color-accent-30);
+        border-radius: ${uiKitDesignTokens.borderRadius4};
+        background: ${uiKitDesignTokens.colorAccent30};
       `,
     !props.isActive &&
       css`
         :hover,
         :focus-within {
-          color: var(--color-for-navbar-link-when-hovered);
-          font-weight: var(--font-weight-for-navbar-link-when-hovered);
-          border-radius: var(--border-radius-4);
-          background: var(--color-primary-95);
+          color: ${appKitDesignTokens.colorForNavbarLinkWhenHovered};
+          font-weight: ${appKitDesignTokens.fontWeightForNavbarLinkWhenHovered};
+          border-radius: ${uiKitDesignTokens.borderRadius4};
+          background: ${uiKitDesignTokens.colorPrimary95};
 
           [data-link-level='text-link-sublist'] {
             /* additional left padding on hover and focus */
-            padding: var(--spacing-25) var(--spacing-25) var(--spacing-25)
-              calc(var(--spacing-30) + var(--spacing-20));
+            padding: ${uiKitDesignTokens.spacing25}
+              ${uiKitDesignTokens.spacing25} ${uiKitDesignTokens.spacing25}
+              calc(
+                ${uiKitDesignTokens.spacing30} + ${uiKitDesignTokens.spacing20}
+              );
           }
         }
       `,
@@ -224,7 +228,7 @@ const MenuListItem = styled.li<{
 }>`
   min-height: ${NAVBAR.itemSize};
   margin: 0;
-  background: var(--color-primary);
+  background: ${uiKitDesignTokens.colorPrimary};
   list-style: none;
   cursor: pointer;
 
@@ -238,15 +242,15 @@ const MenuListItem = styled.li<{
   ${(props) => [
     props.isRouteActive &&
       css`
-        background: var(--color-accent-30);
-        border-radius: var(--border-radius-8);
+        background: ${uiKitDesignTokens.colorAccent30};
+        border-radius: ${uiKitDesignTokens.borderRadius8};
       `,
     !props.isRouteActive &&
       css`
         :hover,
         :focus-within {
-          background-color: var(--color-primary-40);
-          border-radius: var(--border-radius-8);
+          background-color: ${uiKitDesignTokens.colorPrimary40};
+          border-radius: ${uiKitDesignTokens.borderRadius8};
         }
       `,
     props.isActive &&
@@ -259,11 +263,11 @@ const MenuListItem = styled.li<{
       css`
         :hover ${Icon} > svg *:not([fill='none']),
         :focus-within ${Icon} > svg *:not([fill='none']) {
-          fill: var(--color-for-navbar-icon-when-active);
+          fill: ${appKitDesignTokens.colorForNavbarIconWhenActive};
         }
 
         :hover .${Title}, :focus-within ${Title} {
-          color: var(--color-for-navbar-link-when-hovered);
+          color: ${appKitDesignTokens.colorForNavbarLinkWhenHovered};
         }
       `,
     props.isCollapsed &&
@@ -274,7 +278,7 @@ const MenuListItem = styled.li<{
 
   :hover ${Title},
   :focus-within ${Title} {
-    margin-left: calc(var(--spacing-25) + 2px);
+    margin-left: calc(${uiKitDesignTokens.spacing25} + 2px);
   }
 
   :hover ${Icon}, :focus-within ${Icon} {
@@ -297,10 +301,10 @@ const MenuListItem = styled.li<{
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    background-color: var(--color-surface);
+    background-color: ${uiKitDesignTokens.colorSurface};
     min-height: ${NAVBAR.sublistItemMinHeight};
     width: ${NAVBAR.sublistWidth};
-    border-radius: var(--border-radius-8);
+    border-radius: ${uiKitDesignTokens.borderRadius8};
     /* z-index value must be higher than AppBar's z-index */
     z-index: 20001;
     box-shadow: -2px 4px 25px 0 rgba(89, 89, 89, 0.5);

--- a/packages/application-shell/src/components/navbar/menu-items.styles.ts
+++ b/packages/application-shell/src/components/navbar/menu-items.styles.ts
@@ -2,34 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { designTokens } from '@commercetools-uikit/design-system';
 import { NAVBAR } from '../../constants';
-
-const getSubmenuPositionBasedOnMenuItemPosition = (
-  isSubmenuAboveMenuItem?: boolean,
-  submenuVerticalPosition?: number
-) => css`
-  ${isSubmenuAboveMenuItem ? 'bottom' : 'top'}: ${submenuVerticalPosition}px
-`;
-
-const getContainerPositionBasedOnMenuItemPosition = (
-  isSubmenuAboveMenuItem?: boolean,
-  isSublistActiveWhileIsMenuExpanded?: boolean,
-  isSublistActiveWhileIsMenuCollapsed?: boolean
-) => [
-  isSublistActiveWhileIsMenuCollapsed &&
-    css`
-      ${isSubmenuAboveMenuItem ? 'bottom' : 'top'}: -${NAVBAR.itemSize};
-    `,
-  isSublistActiveWhileIsMenuExpanded &&
-    isSubmenuAboveMenuItem &&
-    css`
-      bottom: 0;
-    `,
-  isSublistActiveWhileIsMenuExpanded &&
-    !isSubmenuAboveMenuItem &&
-    css`
-      top: 0;
-    `,
-];
+import { IconWrapper } from './shared.styles';
 
 const Faded = styled.div`
   position: absolute;
@@ -110,14 +83,120 @@ const NavlinkClickableContent = styled.div`
   width: 100%;
 `;
 
+const MenuListItem = styled.li<{
+  isActive: boolean;
+  isRouteActive: boolean;
+  isCollapsed: boolean;
+}>`
+  min-height: ${NAVBAR.itemSize};
+  margin: 0;
+  background: var(--color-primary);
+  list-style: none;
+  cursor: pointer;
+
+  ${IconWrapper} {
+    width: auto;
+    display: flex;
+    justify-content: center;
+    align-self: flex-start;
+  }
+
+  ${(props) => [
+    props.isRouteActive &&
+      css`
+        background: var(--color-accent-30);
+        border-radius: var(--border-radius-8);
+      `,
+    !props.isRouteActive &&
+      css`
+        :hover,
+        :focus-within {
+          background-color: var(--color-primary-40);
+          border-radius: var(--border-radius-8);
+        }
+      `,
+    !props.isRouteActive &&
+      !props.isActive &&
+      css`
+        :hover,
+        :focus-within {
+          background-color: var(--color-primary-40);
+          border-radius: var(--border-radius-8);
+        }
+      `,
+    props.isActive &&
+      css`
+        .item-icon-text {
+          justify-content: flex-start;
+        }
+      `,
+    !props.isActive &&
+      css`
+        :hover .icon > svg *:not([fill='none']),
+        :focus-within .icon > svg *:not([fill='none']) {
+          fill: var(--color-for-navbar-icon-when-active);
+        }
+
+        :hover .title,
+        :focus-within .title {
+          color: var(--color-for-navbar-link-when-hovered);
+        }
+      `,
+    props.isCollapsed &&
+      css`
+        text-align: center;
+      `,
+  ]}
+
+  :hover .title,
+  :focus-within .title {
+    margin-left: calc(var(--spacing-25) + 2px);
+  }
+
+  :hover .icon,
+  :focus-within .icon {
+    /* 1.16 is roughly the ratio of NAVBAR.iconSizeHover to NAVBAR.iconSize */
+    transform: scale(1.2);
+  }
+
+  :hover .sublist-collapsed__active,
+  :hover .sublist-collapsed__active__above,
+  :hover .sublist-expanded__active,
+  :focus-within .sublist-collapsed__active,
+  :focus-within .sublist-collapsed__active__above,
+  :focus-within .sublist-expanded__active {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background-color: var(--color-surface);
+    /* TODO: add design tokens instead hard-coded values */
+    min-height: 50px;
+    width: ${NAVBAR.sublistWidth};
+    border-radius: var(--border-radius-8);
+    /* z-index value must be higher than AppBar's z-index */
+    z-index: 20001;
+    box-shadow: -2px 4px 25px 0 rgba(89, 89, 89, 0.5);
+  }
+
+  :hover .sublist-collapsed__active.sublist-collapsed__empty,
+  :hover .sublist-collapsed__active__above.sublist-collapsed__empty,
+  :focus-within .sublist-collapsed__active.sublist-collapsed__empty,
+  :focus-within .sublist-collapsed__active__above.sublist-collapsed__empty {
+    visibility: hidden;
+  }
+
+  :hover .sublist-expanded__active,
+  :focus-within .sublist-expanded__active {
+    left: ${NAVBAR.sublistIndentationWhenExpanded};
+  }
+`;
+
 export {
-  getSubmenuPositionBasedOnMenuItemPosition,
-  getContainerPositionBasedOnMenuItemPosition,
-  // styled components
   Expander,
   ExpanderIcon,
   Faded,
   LeftNavigation,
+  MenuListItem,
   TextLinkSublistWrapper,
   NavlinkClickableContent,
 };

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -39,19 +39,18 @@ import {
   getMenuItemLinkStyles,
   leftNavigationOpenStyles,
   ItemContent,
-  MenuList,
-  Title,
 } from './main-navbar.styles';
 import {
   Expander,
   ExpanderIcon,
   Faded,
   LeftNavigation,
+  MenuList,
   MenuListItem,
   TextLinkSublistWrapper,
   NavlinkClickableContent,
 } from './menu-items.styles';
-import { Icon, IconWrapper, ItemIconText } from './shared.styles';
+import { Icon, IconWrapper, ItemIconText, Title } from './shared.styles';
 
 type TProjectPermissions = {
   permissions: TNormalizedPermissions | null;
@@ -217,9 +216,6 @@ const MenuGroup = forwardRef<HTMLUListElement, MenuGroupProps>((props, ref) => {
         {
           'sublist-collapsed__active__above':
             isSublistActiveWhileIsMenuCollapsed && props.isSubmenuAboveMenuItem,
-        },
-        {
-          sublist__inactive: !isSublistActiveWhileIsMenuCollapsed,
         }
       )}
       isSublistActiveWhileIsMenuExpanded={isSublistActiveWhileIsMenuExpanded}
@@ -265,7 +261,7 @@ const MenuItem = (props: MenuItemProps) => {
       onBlur={props.onMouseLeave as FocusEventHandler<HTMLElement>}
       data-menuitem={props.identifier}
       className={classnames({
-        item__active: props.isActive,
+        active: props.isActive,
       })}
       isActive={props.isActive}
       isRouteActive={Boolean(props.isMainMenuRouteActive)}
@@ -442,11 +438,7 @@ const NavBarLayout = forwardRef<HTMLElement, TNavBarLayoutProps>(
   (props, ref) => (
     <>
       <Global styles={leftNavigationOpenStyles} />
-      <LeftNavigation
-        ref={ref}
-        className="left-navigation"
-        data-testid="left-navigation"
-      >
+      <LeftNavigation ref={ref} data-testid="left-navigation">
         {props.children}
       </LeftNavigation>
     </>
@@ -464,14 +456,14 @@ type ItemContainerProps = {
 
 const ItemContainer = (props: ItemContainerProps) => {
   return (
-    <ItemIconText className="item-icon-text">
+    <ItemIconText>
       <IconWrapper>
         <Icon className="icon">
           <IconSwitcher icon={props.icon} size="scale" />
         </Icon>
       </IconWrapper>
       {props.isMenuOpen ? (
-        <Title className="title">
+        <Title>
           <MenuLabel
             labelAllLocales={props.labelAllLocales}
             defaultLabel={props.defaultLabel}

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
   type SyntheticEvent,
 } from 'react';
-import { Global, css } from '@emotion/react';
+import { Global } from '@emotion/react';
 import { useFlagVariation } from '@flopflip/react-broadcast';
 import type { TFlagVariation } from '@flopflip/types';
 import classnames from 'classnames';
@@ -38,23 +38,20 @@ import { location } from '../../utils/location';
 import {
   getMenuItemLinkStyles,
   leftNavigationOpenStyles,
-  listStyles,
-  sublistStyles,
-  IconWrapper,
-  Icon,
-  ItemIconText,
+  ItemContent,
+  MenuList,
   Title,
 } from './main-navbar.styles';
 import {
-  getSubmenuPositionBasedOnMenuItemPosition,
-  getContainerPositionBasedOnMenuItemPosition,
   Expander,
   ExpanderIcon,
   Faded,
   LeftNavigation,
+  MenuListItem,
   TextLinkSublistWrapper,
   NavlinkClickableContent,
 } from './menu-items.styles';
+import { Icon, IconWrapper, ItemIconText } from './shared.styles';
 
 type TProjectPermissions = {
   permissions: TNormalizedPermissions | null;
@@ -168,7 +165,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
 };
 MenuExpander.displayName = 'MenuExpander';
 
-type MenuGroupProps = {
+export type MenuGroupProps = {
   id: string;
   level: 1 | 2;
   isActive?: boolean;
@@ -187,37 +184,16 @@ const MenuGroup = forwardRef<HTMLUListElement, MenuGroupProps>((props, ref) => {
   ) {
     return null;
   }
-  const isSublistActiveWhileIsMenuExpanded =
-    props.level === 2 && props.isActive && props.isExpanded;
-  const isSublistActiveWhileIsMenuCollapsed =
-    props.level === 2 && props.isActive && !props.isExpanded;
+  const isSublistActiveWhileIsMenuExpanded = Boolean(
+    props.level === 2 && props.isActive && props.isExpanded
+  );
+  const isSublistActiveWhileIsMenuCollapsed = Boolean(
+    props.level === 2 && props.isActive && !props.isExpanded
+  );
   return (
-    <ul
+    <MenuList
       ref={ref && props.level === 2 ? ref : null}
-      css={css`
-        ${props.level === 1 && listStyles}
-        ${getSubmenuPositionBasedOnMenuItemPosition(
-          props.isSubmenuAboveMenuItem,
-          props.submenuVerticalPosition
-        )};
-        ${props.level === 2 && sublistStyles}
-      
-      // prevent glitchy behavior during the initial render when the submenu's vertical position is evaluated as 0
-      ${
-        props.submenuVerticalPosition === 0 &&
-        css`
-          visibility: hidden;
-        `
-      }
-
-        // additional styling of the pseudo-element enabling smooth coursor movement
-        ::before {
-          ${getContainerPositionBasedOnMenuItemPosition(
-            props.isSubmenuAboveMenuItem,
-            isSublistActiveWhileIsMenuExpanded,
-            isSublistActiveWhileIsMenuCollapsed
-          )}
-      `}
+      level={props.level}
       id={`group-${props.id}`}
       data-testid={`group-${props.id}`}
       role="menu"
@@ -246,9 +222,19 @@ const MenuGroup = forwardRef<HTMLUListElement, MenuGroupProps>((props, ref) => {
           sublist__inactive: !isSublistActiveWhileIsMenuCollapsed,
         }
       )}
+      isSublistActiveWhileIsMenuExpanded={isSublistActiveWhileIsMenuExpanded}
+      isSublistActiveWhileIsMenuCollapsed={isSublistActiveWhileIsMenuCollapsed}
+      isSublistCollapsedAndActive={
+        isSublistActiveWhileIsMenuCollapsed && !props.isSubmenuAboveMenuItem
+      }
+      isSublistCollapsedAndActiveAndAbove={Boolean(
+        isSublistActiveWhileIsMenuCollapsed && props.isSubmenuAboveMenuItem
+      )}
+      isSubmenuAboveMenuItem={props.isSubmenuAboveMenuItem}
+      submenuVerticalPosition={props.submenuVerticalPosition}
     >
       {props.children}
-    </ul>
+    </MenuList>
   );
 });
 MenuGroup.displayName = 'MenuGroup';
@@ -270,7 +256,7 @@ type MenuItemProps = {
 };
 const MenuItem = (props: MenuItemProps) => {
   return (
-    <li
+    <MenuListItem
       role="menuitem"
       onClick={props.onClick}
       onMouseEnter={props.onMouseEnter as MouseEventHandler<HTMLElement>}
@@ -278,14 +264,15 @@ const MenuItem = (props: MenuItemProps) => {
       onFocus={props.onMouseEnter as FocusEventHandler<HTMLElement>}
       onBlur={props.onMouseLeave as FocusEventHandler<HTMLElement>}
       data-menuitem={props.identifier}
-      className={classnames('list-item', {
+      className={classnames({
         item__active: props.isActive,
-        item_menu__active: props.isMainMenuRouteActive ?? false,
-        'item_menu-collapsed': !props.isMenuOpen,
       })}
+      isActive={props.isActive}
+      isRouteActive={Boolean(props.isMainMenuRouteActive)}
+      isCollapsed={!props.isMenuOpen}
     >
-      <div className="item-link">{props.children}</div>
-    </li>
+      <ItemContent>{props.children}</ItemContent>
+    </MenuListItem>
   );
 };
 
@@ -478,7 +465,7 @@ type ItemContainerProps = {
 const ItemContainer = (props: ItemContainerProps) => {
   return (
     <ItemIconText className="item-icon-text">
-      <IconWrapper className="icon-wrapper">
+      <IconWrapper>
         <Icon className="icon">
           <IconSwitcher icon={props.icon} size="scale" />
         </Icon>

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -33,9 +33,6 @@ import type { TNavbarMenu, TBaseMenu } from '../../types/generated/proxy';
 import {
   FixedMenu,
   HeaderTitle,
-  Icon,
-  IconWrapper,
-  ItemIconText,
   NavigationHeader,
   ScrollableMenu,
   SublistItem,
@@ -61,6 +58,7 @@ import {
 import messages from './messages';
 import NavBarSkeleton from './navbar-skeleton';
 import nonNullable from './non-nullable';
+import { Icon, IconWrapper, ItemIconText } from './shared.styles';
 import useNavbarStateManager from './use-navbar-state-manager';
 
 type TProjectPermissions = {
@@ -404,7 +402,7 @@ const NavBar = (props: TNavbarProps) => {
             })}
           </Spacings.Stack>
         </ScrollableMenu>
-        <FixedMenu className="fixed-menu">
+        <FixedMenu>
           <Faded />
           <SupportMenu>
             <MenuItem

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -35,11 +35,9 @@ import {
   HeaderTitle,
   NavigationHeader,
   ScrollableMenu,
-  SublistItem,
   SupportMenu,
   TextLink,
   Text,
-  Title,
   Tooltip,
   TooltipContainer,
 } from './main-navbar.styles';
@@ -55,10 +53,11 @@ import {
   MenuExpander,
   NavBarLayout,
 } from './menu-items';
+import { SublistItem } from './menu-items.styles';
 import messages from './messages';
 import NavBarSkeleton from './navbar-skeleton';
 import nonNullable from './non-nullable';
-import { Icon, IconWrapper, ItemIconText } from './shared.styles';
+import { Icon, IconWrapper, ItemIconText, Title } from './shared.styles';
 import useNavbarStateManager from './use-navbar-state-manager';
 
 type TProjectPermissions = {
@@ -371,7 +370,7 @@ const NavBar = (props: TNavbarProps) => {
         {isMenuOpen ? <HeaderTitle>Merchant Center</HeaderTitle> : null}
       </NavigationHeader>
       <MenuGroup id="main" level={1}>
-        <ScrollableMenu className="scrollable-menu">
+        <ScrollableMenu>
           <Spacings.Stack scale="l">
             {allApplicationsNavbarMenuGroups.map((navbarMenuGroup) => {
               return (
@@ -421,16 +420,15 @@ const NavBar = (props: TNavbarProps) => {
                 href={SUPPORT_PORTAL_URL}
                 rel="noopener noreferrer"
                 target="_blank"
-                className="text-link"
               >
-                <ItemIconText className="item-icon-text">
+                <ItemIconText>
                   <IconWrapper>
                     <Icon className="icon">
                       <SupportIcon size="scale" />
                     </Icon>
                   </IconWrapper>
                   {isMenuOpen ? (
-                    <Title className="title">
+                    <Title>
                       <FormattedMessage
                         {...messages['NavBar.MCSupport.title']}
                       />

--- a/packages/application-shell/src/components/navbar/shared.styles.ts
+++ b/packages/application-shell/src/components/navbar/shared.styles.ts
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import { designTokens as appKitDesignTokens } from '@commercetools-frontend/application-components';
+import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import { NAVBAR } from '../../constants';
 
 const IconWrapper = styled.div`
@@ -12,7 +14,7 @@ const Icon = styled.div`
   transition: ${NAVBAR.leftNavigationTransition};
 
   > svg *:not([fill='none']) {
-    fill: var(--color-surface);
+    fill: ${uiKitDesignTokens.colorSurface};
   }
 `;
 
@@ -26,9 +28,9 @@ const ItemIconText = styled.div`
 const Title = styled.div`
   flex: 1;
   font-weight: 600;
-  font-size: var(--font-size-for-navbar-link);
-  line-height: var(--line-height-for-navbar-link);
-  color: var(--color-for-navbar-link);
+  font-size: ${appKitDesignTokens.fontSizeForNavbarLink};
+  line-height: ${appKitDesignTokens.lineHeightForNavbarLink};
+  color: ${appKitDesignTokens.colorForNavbarLink};
   opacity: 0;
   transition: ${NAVBAR.leftNavigationTransition};
   text-align: left;

--- a/packages/application-shell/src/components/navbar/shared.styles.ts
+++ b/packages/application-shell/src/components/navbar/shared.styles.ts
@@ -23,4 +23,17 @@ const ItemIconText = styled.div`
   align-items: center;
 `;
 
-export { Icon, IconWrapper, ItemIconText };
+const Title = styled.div`
+  flex: 1;
+  font-weight: 600;
+  font-size: var(--font-size-for-navbar-link);
+  line-height: var(--line-height-for-navbar-link);
+  color: var(--color-for-navbar-link);
+  opacity: 0;
+  transition: ${NAVBAR.leftNavigationTransition};
+  text-align: left;
+  text-decoration: none;
+  z-index: 1;
+`;
+
+export { Icon, IconWrapper, ItemIconText, Title };

--- a/packages/application-shell/src/components/navbar/shared.styles.ts
+++ b/packages/application-shell/src/components/navbar/shared.styles.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { NAVBAR } from '../../constants';
+
+const IconWrapper = styled.div`
+  width: auto;
+  display: flex;
+  justify-content: center;
+`;
+const Icon = styled.div`
+  width: ${NAVBAR.iconSize};
+  height: ${NAVBAR.iconSize};
+  transition: ${NAVBAR.leftNavigationTransition};
+
+  > svg *:not([fill='none']) {
+    fill: var(--color-surface);
+  }
+`;
+
+const ItemIconText = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+export { Icon, IconWrapper, ItemIconText };

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -11,6 +11,7 @@ export const NAVBAR = {
   itemHeight: '56px',
   sublistIndentationWhenCollapsed: '72px',
   sublistIndentationWhenExpanded: '248px',
+  sublistItemMinHeight: '50px',
   sublistWidth: '253px',
   leftNavigationTransition: 'all 150ms cubic-bezier(1, 0, 0.58, 1)',
   widthLeftNavigation: '80px',


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

[Deployment link](https://mc-15822.mc-preview.europe-west1.gcp.escemo.com/)

This PR resolves tech debt by migrating navbar styles from globally applied classname-based styles within `<Global>` to encapsulated component-level styles. It retains specific styling for '.body__menu-open' class within `<Global>`.


