### PR TITLE
fix: components playground rewrite rules for spa support

### DIFF
--- a/website-components-playground/vercel.json
+++ b/website-components-playground/vercel.json
@@ -4,5 +4,11 @@
     "enabled": true
   },
   "buildCommand": "pnpm run -w build && pnpm build",
-  "framework": "vite"
+  "framework": "vite",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
Leftover of #3400 

I thought Vite framework preset in Vercel was already configured to support SPAs but it's not because Vite can also be used for SSR.

https://vercel.com/docs/frameworks/vite#using-vite-to-make-spas