### PR TITLE
Fix navigation sidebar menu icons alignment

### DIFF
--- a/.changeset/stupid-mugs-end.md
+++ b/.changeset/stupid-mugs-end.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix applications icons alignment in main navigation sidebar

--- a/packages/application-shell/src/components/navbar/menu-items.styles.ts
+++ b/packages/application-shell/src/components/navbar/menu-items.styles.ts
@@ -236,7 +236,6 @@ const MenuListItem = styled.li<{
     width: auto;
     display: flex;
     justify-content: center;
-    align-self: flex-start;
   }
 
   ${(props) => [


### PR DESCRIPTION
#### Summary

Fix navigation sidebar menu icons alignment.

#### Description

We noticed a vertical misalignment in the main navigation sidebar between the icons and their corresponding label text:
![image](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/752c34ff-2e0c-456b-ae81-379818fb02a2)

This is how it looks after applying the fix:
![image](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/f3319c99-456b-4120-a582-3aa8edadb624)
