### PR TITLE
`CustomViewShell` component not using provided custom Apollo client

### DIFF
--- a/.changeset/hungry-rules-shop.md
+++ b/.changeset/hungry-rules-shop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+The `apolloClient` property in the `CustomViewShell` component was not being used internally, making it impossible for consumers to user a custom Apollo client.

--- a/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
+++ b/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
@@ -295,7 +295,10 @@ const CustomViewShellWrapper = (props: TCustomViewShellProps) => {
       <StrictModeEnablement enableReactStrictMode={props.enableReactStrictMode}>
         <Suspense fallback={<ApplicationLoader />}>
           <CustomViewDevHost applicationMessages={props.applicationMessages}>
-            <CustomViewShell applicationMessages={props.applicationMessages}>
+            <CustomViewShell
+              apolloClient={props.apolloClient}
+              applicationMessages={props.applicationMessages}
+            >
               {props.children}
             </CustomViewShell>
           </CustomViewDevHost>
@@ -305,7 +308,10 @@ const CustomViewShellWrapper = (props: TCustomViewShellProps) => {
   }
   return (
     <StrictModeEnablement enableReactStrictMode={props.enableReactStrictMode}>
-      <CustomViewShell applicationMessages={props.applicationMessages}>
+      <CustomViewShell
+        apolloClient={props.apolloClient}
+        applicationMessages={props.applicationMessages}
+      >
         {props.children}
       </CustomViewShell>
     </StrictModeEnablement>


### PR DESCRIPTION
#### Summary

`CustomViewShell` component not using provided custom Apollo client

#### Description

The `apolloClient` property in the `CustomViewShell` component was not being used internally, making it impossible for consumers to user a custom Apollo client.

