### PR TITLE
Shield 1129 support link tooltip

### DIFF
--- a/.changeset/silver-buses-collect.md
+++ b/.changeset/silver-buses-collect.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+When the navbar is collapsed, onhover, the support menu item should display a tooltip.

--- a/.changeset/silver-buses-collect.md
+++ b/.changeset/silver-buses-collect.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-shell': minor
 ---
 
-When the navbar is collapsed, onhover, the support menu item should display a tooltip.
+Updated the "Support" navigation menu item so it also has a tooltip when the menu is collapsed (same as the rest of the menu root items).

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -869,6 +869,8 @@ describe('when clicking on navbar menu toggle', () => {
     expect(
       navbarRendered.getByRole('tooltip', { hidden: true })
     ).toBeInTheDocument();
+    // Verify that only "SUpport" text from tooltip is available when the menu is collapsed
+    expect(navbarRendered.getAllByText('Support')).toHaveLength(1);
   });
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -865,8 +865,10 @@ describe('when clicking on navbar menu toggle', () => {
       );
     });
 
-    // Verify that the "Support" link is not rendered when the menu is collapsed
-    expect(navbarRendered.queryByText('Support')).not.toBeVisible();
+    // Verify that the tooltip is available when the menu is collapsed
+    expect(
+      navbarRendered.getByRole('tooltip', { hidden: true })
+    ).toBeInTheDocument();
   });
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -846,7 +846,9 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Check that the "Support" link is rendered when the menu is expanded
-    expect(navbarRendered.getByText('Support')).toBeInTheDocument();
+    expect(navbarRendered.queryByTestId('support-label').textContent).toBe(
+      'Support'
+    );
 
     // Collapse the menu and verify local storage changes
     fireEvent.click(button);
@@ -866,7 +868,7 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Verify that the "Support" link is not rendered when the menu is collapsed
-    expect(navbarRendered.queryByText('Support')).toBeNull();
+    expect(navbarRendered.queryByTestId('support-label')).toBeNull();
   });
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -846,7 +846,9 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Check that the "Support" link is rendered when the menu is expanded
-    expect(navbarRendered.getAllByText('Support')).toHaveLength(1);
+    // Make sure the element we find is not the tooltip rendered when the menu is collapsed
+    const supportMenuItemLabel = navbarRendered.getByText('Support');
+    expect(supportMenuItemLabel.getAttribute('role')).not.toEqual('tooltip');
 
     // Collapse the menu and verify local storage changes
     fireEvent.click(button);
@@ -866,11 +868,9 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Verify that the tooltip is available when the menu is collapsed
-    expect(
-      navbarRendered.getByRole('tooltip', { hidden: true })
-    ).toBeInTheDocument();
-    // Verify that only "SUpport" text from tooltip is available when the menu is collapsed
-    expect(navbarRendered.getAllByText('Support')).toHaveLength(1);
+    const supportMenuItemTooltip = navbarRendered.getByText('Support');
+    expect(supportMenuItemTooltip.getAttribute('role')).toEqual('tooltip');
+    expect(supportMenuItemTooltip).not.toBeVisible();
   });
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -846,9 +846,7 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Check that the "Support" link is rendered when the menu is expanded
-    expect(navbarRendered.queryByTestId('support-label').textContent).toBe(
-      'Support'
-    );
+    expect(navbarRendered.getAllByText('Support')).toHaveLength(1);
 
     // Collapse the menu and verify local storage changes
     fireEvent.click(button);
@@ -868,7 +866,7 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Verify that the "Support" link is not rendered when the menu is collapsed
-    expect(navbarRendered.queryByTestId('support-label')).toBeNull();
+    expect(navbarRendered.getAllByText('Support')).toHaveLength(1);
   });
 });
 

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -866,7 +866,7 @@ describe('when clicking on navbar menu toggle', () => {
     });
 
     // Verify that the "Support" link is not rendered when the menu is collapsed
-    expect(navbarRendered.getAllByText('Support')).toHaveLength(1);
+    expect(navbarRendered.queryByText('Support')).not.toBeVisible();
   });
 });
 

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -177,12 +177,10 @@ const TextLink = styled.a`
 const SupportMenuTooltipContainer = styled.div`
   position: fixed;
   left: ${NAVBAR.sublistIndentationWhenCollapsed};
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: flex-start;
   height: ${NAVBAR.itemSize};
-  transition: ${NAVBAR.leftNavigationTransition};
-  visibility: hidden;
   z-index: 20001;
 `;
 
@@ -190,8 +188,11 @@ const SupportMenu = styled.div`
   padding: ${uiKitDesignTokens.spacing10} ${uiKitDesignTokens.spacing30}
     ${uiKitDesignTokens.spacing20} ${uiKitDesignTokens.spacing30};
   height: calc(${NAVBAR.itemSize} + ${uiKitDesignTokens.spacing20});
-  :hover .support {
-    visibility: visible;
+  :hover
+    ${SupportMenuTooltipContainer},
+    :focus-within
+    ${SupportMenuTooltipContainer} {
+    display: flex;
   }
 `;
 

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -34,8 +34,6 @@ const SupportMenuTooltipContainer = styled.div`
   justify-content: flex-start;
   height: ${NAVBAR.itemSize};
   z-index: 20001;
-
-  ${MenuListItem} ${ItemIconText}
 `;
 
 const ItemContent = styled.div`

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -174,10 +174,25 @@ const TextLink = styled.a`
   justify-content: center;
 `;
 
+const SupportMenuTooltipContainer = styled.div`
+  position: fixed;
+  left: ${NAVBAR.sublistIndentationWhenCollapsed};
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: ${NAVBAR.itemSize};
+  transition: ${NAVBAR.leftNavigationTransition};
+  visibility: hidden;
+  z-index: 1;
+`;
+
 const SupportMenu = styled.div`
   padding: ${uiKitDesignTokens.spacing10} ${uiKitDesignTokens.spacing30}
     ${uiKitDesignTokens.spacing20} ${uiKitDesignTokens.spacing30};
   height: calc(${NAVBAR.itemSize} + ${uiKitDesignTokens.spacing20});
+  :hover .support {
+    visibility: visible;
+  }
 `;
 
 const Text = styled.div`
@@ -228,4 +243,5 @@ export {
   Title,
   Tooltip,
   TooltipContainer,
+  SupportMenuTooltipContainer,
 };

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -26,11 +26,29 @@ const FixedMenu = styled.div`
   }
 `;
 
+const SupportMenuTooltipContainer = styled.div`
+  position: fixed;
+  left: ${NAVBAR.sublistIndentationWhenCollapsed};
+  display: none;
+  align-items: center;
+  justify-content: flex-start;
+  height: ${NAVBAR.itemSize};
+  z-index: 20001;
+
+  ${MenuListItem} ${ItemIconText}
+`;
+
 const ItemContent = styled.div`
   color: ${uiKitDesignTokens.colorNeutral};
   width: ${NAVBAR.itemSize};
   position: relative;
   display: block;
+  :hover
+    ${SupportMenuTooltipContainer},
+    :focus-within
+    ${SupportMenuTooltipContainer} {
+    display: flex;
+  }
 `;
 
 const ScrollableMenu = styled.div`
@@ -174,26 +192,10 @@ const TextLink = styled.a`
   justify-content: center;
 `;
 
-const SupportMenuTooltipContainer = styled.div`
-  position: fixed;
-  left: ${NAVBAR.sublistIndentationWhenCollapsed};
-  display: none;
-  align-items: center;
-  justify-content: flex-start;
-  height: ${NAVBAR.itemSize};
-  z-index: 20001;
-`;
-
 const SupportMenu = styled.div`
   padding: ${uiKitDesignTokens.spacing10} ${uiKitDesignTokens.spacing30}
     ${uiKitDesignTokens.spacing20} ${uiKitDesignTokens.spacing30};
   height: calc(${NAVBAR.itemSize} + ${uiKitDesignTokens.spacing20});
-  :hover
-    ${SupportMenuTooltipContainer},
-    :focus-within
-    ${SupportMenuTooltipContainer} {
-    display: flex;
-  }
 `;
 
 const Text = styled.div`

--- a/packages/application-shell/src/components/navbar/main-navbar.styles.ts
+++ b/packages/application-shell/src/components/navbar/main-navbar.styles.ts
@@ -183,7 +183,7 @@ const SupportMenuTooltipContainer = styled.div`
   height: ${NAVBAR.itemSize};
   transition: ${NAVBAR.leftNavigationTransition};
   visibility: hidden;
-  z-index: 1;
+  z-index: 20001;
 `;
 
 const SupportMenu = styled.div`

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -407,7 +407,7 @@ const NavBar = (props: TNavbarProps) => {
           <Faded />
           <SupportMenu>
             {!isMenuOpen && (
-              <SupportMenuTooltipContainer className="support">
+              <SupportMenuTooltipContainer>
                 <Tooltip>
                   <FormattedMessage {...messages['NavBar.MCSupport.title']} />
                 </Tooltip>
@@ -437,7 +437,7 @@ const NavBar = (props: TNavbarProps) => {
                     </Icon>
                   </IconWrapper>
                   {isMenuOpen ? (
-                    <Title data-testid="support-label">
+                    <Title>
                       <FormattedMessage
                         {...messages['NavBar.MCSupport.title']}
                       />

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -242,7 +242,7 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
         >
           {!props.isMenuOpen && (
             <TooltipContainer alignsAgainstBottom={isSubmenuAboveMenuItem}>
-              <Tooltip aria-owns={`group-${props.menu.key}`}>
+              <Tooltip aria-owns={`group-${props.menu.key}`} role="tooltip">
                 <MenuLabel
                   labelAllLocales={props.menu.labelAllLocales}
                   defaultLabel={props.menu.defaultLabel}
@@ -408,7 +408,7 @@ const NavBar = (props: TNavbarProps) => {
           <SupportMenu>
             {!isMenuOpen && (
               <SupportMenuTooltipContainer>
-                <Tooltip>
+                <Tooltip role="tooltip">
                   <FormattedMessage {...messages['NavBar.MCSupport.title']} />
                 </Tooltip>
               </SupportMenuTooltipContainer>

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -40,6 +40,7 @@ import {
   Text,
   Tooltip,
   TooltipContainer,
+  SupportMenuTooltipContainer,
 } from './main-navbar.styles';
 import {
   type MenuItemLinkProps,
@@ -405,6 +406,13 @@ const NavBar = (props: TNavbarProps) => {
           {/* TODO: remove <Faded /> completely as part of the recolouring rollout cleanup process */}
           <Faded />
           <SupportMenu>
+            {!isMenuOpen && (
+              <SupportMenuTooltipContainer className="support">
+                <Tooltip>
+                  <FormattedMessage {...messages['NavBar.MCSupport.title']} />
+                </Tooltip>
+              </SupportMenuTooltipContainer>
+            )}
             <MenuItem
               hasSubmenu={false}
               isActive={false}

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -437,7 +437,7 @@ const NavBar = (props: TNavbarProps) => {
                     </Icon>
                   </IconWrapper>
                   {isMenuOpen ? (
-                    <Title>
+                    <Title data-testid="support-label">
                       <FormattedMessage
                         {...messages['NavBar.MCSupport.title']}
                       />

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -406,13 +406,6 @@ const NavBar = (props: TNavbarProps) => {
           {/* TODO: remove <Faded /> completely as part of the recolouring rollout cleanup process */}
           <Faded />
           <SupportMenu>
-            {!isMenuOpen && (
-              <SupportMenuTooltipContainer>
-                <Tooltip role="tooltip">
-                  <FormattedMessage {...messages['NavBar.MCSupport.title']} />
-                </Tooltip>
-              </SupportMenuTooltipContainer>
-            )}
             <MenuItem
               hasSubmenu={false}
               isActive={false}
@@ -425,6 +418,13 @@ const NavBar = (props: TNavbarProps) => {
               }
               onMouseLeave={isMenuOpen ? undefined : shouldCloseMenuFly}
             >
+              {!isMenuOpen && (
+                <SupportMenuTooltipContainer>
+                  <Tooltip role="tooltip">
+                    <FormattedMessage {...messages['NavBar.MCSupport.title']} />
+                  </Tooltip>
+                </SupportMenuTooltipContainer>
+              )}
               <TextLink
                 href={SUPPORT_PORTAL_URL}
                 rel="noopener noreferrer"


### PR DESCRIPTION

#### Summary

Show tooltip on support link when hovered
#### Description

When the navbar is collapsed, onhover, the support menu item should display a tooltip.

Screenshot:
<img width="387" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/19975842/bfbcf06d-9b9f-40d9-b727-115c67e717e4">
