### PR TITLE
Allow delaying rendering of ApplicationShell contents until all feature flags are fetched

### DIFF
--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -48,6 +48,7 @@ import VersionTracker from '../version-tracker';
 type TApplicationShellAuthenticationProps = {
   featureFlags?: TFlags;
   defaultFeatureFlags?: TFlags;
+  shouldWaitForRemoteFlags?: boolean;
   applicationMessages: TAsyncLocaleDataProps['applicationMessages'];
   onMenuItemClick?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
   disableRoutePermissionCheck?: boolean;

--- a/packages/application-shell/src/components/application-shell/application-shell.tsx
+++ b/packages/application-shell/src/components/application-shell/application-shell.tsx
@@ -42,6 +42,7 @@ type TApplicationShellProps = {
   environment: TApplicationContext<{}>['environment'];
   featureFlags?: TFlags;
   defaultFeatureFlags?: TFlags;
+  shouldWaitForRemoteFlags?: boolean;
   applicationMessages: TAsyncLocaleDataProps['applicationMessages'];
   onRegisterErrorListeners?: (args: { dispatch: Dispatch }) => void;
   onMenuItemClick?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
@@ -91,6 +92,7 @@ const ApplicationShell = (props: TApplicationShellProps) => {
                   <ApplicationShellAuthenticated
                     defaultFeatureFlags={props.defaultFeatureFlags}
                     featureFlags={props.featureFlags}
+                    shouldWaitForRemoteFlags={props.shouldWaitForRemoteFlags}
                     render={props.render}
                     applicationMessages={props.applicationMessages}
                     onMenuItemClick={props.onMenuItemClick}


### PR DESCRIPTION
#### Summary

Allow delaying rendering of ApplicationShell contents until all feature flags are fetched

#### Description

The idea implemented in this PR is that we want to have the opportunity to delay the applications rendering until the remote feature flags are resolved.
This is to avoid potential UI flickers when the initial rendering of the application is based on a feature flag.

Currently, since we don't wait for the flags, the application is first rendered with the default (hardcoded) values and later, when the remote flags are resolved, the application re-renders. So, if the default value and the remote value are different, users will see this flicker effect.

The new behaviour can be controlled by consumer applications using the new `shouldWaitForRemoteFlags` prop in the `ApplicationShell` component.
Its default value now is `true` so we will be including the behaviour right after the consumer applications update to the upcoming new `app-kit` release.

_(This behaviour is supposed to be temporary, although I think it might help to keep it, but change its default value to not delay the rendering by default.)_
