### PR TITLE
Fix starter templates tests

### DIFF
--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -59,6 +59,10 @@ runs:
       shell: bash
       run: pnpm ${{ inputs.typecheck-command }}
 
+    - name: Running integration tests
+      shell: bash
+      run: pnpm test ${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/**/*.spec.js
+
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L23-L30
     # https://github.com/marketplace/actions/cypress-io#custom-install
     - name: Restoring Cypress cache

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Running integration tests
       shell: bash
-      run: pnpm test ${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/**/*.spec.js
+      run: pnpm test -- --testRegex="${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/.*\\.spec\\.(js\ts)"
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L23-L30
     # https://github.com/marketplace/actions/cypress-io#custom-install

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Running integration tests
       shell: bash
-      run: pnpm test -- --testRegex="${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/.*\\.spec\\.(js\ts)"
+      run: pnpm test -- --testRegex="${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/.*\\.spec\\.(js|ts)"
 
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L23-L30
     # https://github.com/marketplace/actions/cypress-io#custom-install

--- a/application-templates/starter-typescript/package.json
+++ b/application-templates/starter-typescript/package.json
@@ -99,6 +99,7 @@
     "@types/react": "<18",
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
-    "@types/react-router-dom": "<6"
+    "@types/react-router-dom": "<6",
+    "headers-polyfill": "3.2.5"
   }
 }

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -97,6 +97,7 @@
     "@types/react": "<18",
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
-    "@types/react-router-dom": "<6"
+    "@types/react-router-dom": "<6",
+    "headers-polyfill": "3.2.5"
   }
 }

--- a/custom-views-templates/starter-typescript/package.json
+++ b/custom-views-templates/starter-typescript/package.json
@@ -99,6 +99,7 @@
     "@types/react": "<18",
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
-    "@types/react-router-dom": "<6"
+    "@types/react-router-dom": "<6",
+    "headers-polyfill": "3.2.5"
   }
 }

--- a/custom-views-templates/starter/package.json
+++ b/custom-views-templates/starter/package.json
@@ -97,6 +97,7 @@
     "@types/react": "<18",
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
-    "@types/react-router-dom": "<6"
+    "@types/react-router-dom": "<6",
+    "headers-polyfill": "3.2.5"
   }
 }


### PR DESCRIPTION
#### Summary

Fix starter templates tests

fixes #3443

#### Description

**TL;DR** -> there'a s problem with a transitive dependency

Running starter templates tests fail due to GraphQL requests mocks not working. When inspecting the GraphQL error, we just see a generic message:
```
ApolloError: Error message not found.
```

After a lot of debugging, I found an inconsistency in dependencies declaration in the http mocking library we use (`msw`).
This library has a dependency on the `headers-polyfill` package set with this version range: `^3.1.0`, which means that any new minor or patch versions of that package can and will be used.

The main problem is that ` headers-polyfill` package removed some public APIs in a minor version ([v3.3.0](https://github.com/mswjs/headers-polyfill/releases/tag/v3.3.0)) and `msw` relies on one of those ([reference](https://github.com/mswjs/msw/blob/v0.49.3/src/node/SetupServerApi.ts#L77)).

When starting a new Custom Application or Custom View project, we download the template and install all the (latest) dependencies, which makes the `headers-polyfill` `v3.3.0` get installed in the `node_modules` with the missing helper methods the version of `msw` we use (`0.49.3`) relies on.

The problem does not happen when running the starter templates tests in this repository as we have an older version on the `headers-polyfill` package declared in the dependencies lock file ([reference](https://github.com/commercetools/merchant-center-application-kit/blob/main/pnpm-lock.yaml#L1939)).


Perhaps we can use this issue to start thinking about upgrading `msw` to its latest version (we are far behind).