### PR TITLE
refactor: enable feature flag for Custom Views by default

### DIFF
--- a/.changeset/lemon-points-peel.md
+++ b/.changeset/lemon-points-peel.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/constants': patch
+---
+
+Enable feature flag for Custom Views by default

--- a/packages/application-components/src/components/custom-views/custom-views-selector/use-custom-views-connector.ts
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/use-custom-views-connector.ts
@@ -1,4 +1,4 @@
-import { useFeatureToggle } from '@flopflip/react-broadcast';
+import { useFlagVariation } from '@flopflip/react-broadcast';
 import { useMcQuery } from '@commercetools-frontend/application-shell-connectors';
 import {
   CustomViewData,
@@ -23,8 +23,10 @@ type TUseCustomViewsFetcher = (props: TUseCustomViewsFetcherParams) => {
 export const useCustomViewsConnector: TUseCustomViewsFetcher = ({
   customViewLocatorCode,
 }) => {
+  const enableCustomViews = useFlagVariation(featureFlags.CUSTOM_VIEWS);
   const areCustomViewsEnabled =
-    useFeatureToggle(featureFlags.CUSTOM_VIEWS) &&
+    // @ts-ignore In case it's coming from the MC API, it's an object { value: boolean }.
+    (enableCustomViews?.value ?? enableCustomViews) &&
     process.env.DISABLE_CUSTOM_VIEWS_FEATURE !== 'true';
 
   const { data, error, loading } = useMcQuery<

--- a/packages/application-components/src/test-utils/test-utils.tsx
+++ b/packages/application-components/src/test-utils/test-utils.tsx
@@ -54,7 +54,7 @@ const customRender = (
 ) => {
   const client = apolloClient ?? createApolloClient();
   const flags = {
-    [featureFlags.CUSTOM_VIEWS]: true,
+    [featureFlags.CUSTOM_VIEWS]: { value: true },
   };
 
   return {

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -152,7 +152,7 @@ export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
 
   const defaultFlags = useMemo(
     () => ({
-      ...featureFlags.FLAGS,
+      ...featureFlags.DEFAULT_FLAGS,
       ...allMenuFeatureToggles.allFeatureToggles,
       ...props.defaultFlags,
     }),

--- a/packages/constants/src/feature-toggles.ts
+++ b/packages/constants/src/feature-toggles.ts
@@ -21,6 +21,10 @@ export const CUSTOM_VIEWS = 'enableCustomViews';
 export const RECOLOURING = 'mcRecolouring';
 
 export const FLAGS = {
-  [CUSTOM_VIEWS]: false,
   [RECOLOURING]: false,
+};
+
+// Long-lived feature flags, defined in the MC API.
+export const DEFAULT_FLAGS = {
+  [CUSTOM_VIEWS]: { value: true },
 };

--- a/playground/src/test-utils/index.js
+++ b/playground/src/test-utils/index.js
@@ -18,7 +18,7 @@ const renderApplicationWithRedux = (ui, options = {}) =>
     mergeWithDefaultOptions({
       ...options,
       flags: {
-        [featureFlags.CUSTOM_VIEWS]: true,
+        [featureFlags.CUSTOM_VIEWS]: { value: true },
       },
     })
   );

--- a/visual-testing-app/src/application.tsx
+++ b/visual-testing-app/src/application.tsx
@@ -33,7 +33,7 @@ const allSortedComponents = Object.keys(allUniqueVisualRouteComponents)
   .map<TVisualRouteSpec>((key) => allUniqueVisualRouteComponents[key]);
 
 const appFlags = {
-  [featureFlags.CUSTOM_VIEWS]: true,
+  [featureFlags.CUSTOM_VIEWS]: { value: true },
 };
 
 const App = () => (


### PR DESCRIPTION
We want to keep the flag as a long-lived flag (MC API), so that we can remove the one in LD.

