### PR TITLE
Adjust documentation links used in cli

### DIFF
--- a/.changeset/olive-bananas-dress.md
+++ b/.changeset/olive-bananas-dress.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Fix documentation links used in the cli when creating a new custom aplication or custom view.

--- a/packages/create-mc-app/src/cli.ts
+++ b/packages/create-mc-app/src/cli.ts
@@ -23,12 +23,9 @@ process.on('unhandledRejection', (err) => {
 
 const messagesByApplicationType = {
   [applicationTypes['custom-application']]: {
-    docsLink: 'https://docs.commercetools.com/custom-applications',
     featureName: 'Custom Application',
   },
   [applicationTypes['custom-view']]: {
-    docsLink:
-      'https://docs-beta-custom-views.commercetools.vercel.app/custom-views',
     featureName: 'Custom View',
   },
 } as const;
@@ -91,7 +88,7 @@ const run = () => {
       const messages = messagesByApplicationType[taskOptions.applicationType];
 
       console.log('');
-      console.log(`Documentation available at ${messages.docsLink}`);
+      console.log('Documentation available at https://docs.commercetools.com/merchant-center-customizations/');
       console.log('');
 
       const shouldInstallDependencies =
@@ -125,7 +122,7 @@ const run = () => {
       console.log(`$ ${packageManager} start`);
       console.log('');
       console.log(
-        `Visit ${messages.docsLink} for more info about developing ${messages.featureName}. Enjoy 🚀`
+        `Visit https://docs.commercetools.com/merchant-center-customizations/ for more info about developing ${messages.featureName}. Enjoy 🚀`
       );
     });
 

--- a/packages/create-mc-app/src/cli.ts
+++ b/packages/create-mc-app/src/cli.ts
@@ -88,7 +88,9 @@ const run = () => {
       const messages = messagesByApplicationType[taskOptions.applicationType];
 
       console.log('');
-      console.log('Documentation available at https://docs.commercetools.com/merchant-center-customizations/');
+      console.log(
+        'Documentation available at https://docs.commercetools.com/merchant-center-customizations/'
+      );
       console.log('');
 
       const shouldInstallDependencies =


### PR DESCRIPTION
#### Summary

Adjust documentation links used in cli.

#### Description

In this PR we update the links to the docs we show in the terminal when a user bootstraps a new Custom Application or Custom View.

We've unified the link for both of them so we now link [here](https://docs.commercetools.com/merchant-center-customizations/).
