### PR TITLE
fix(cypress): onBeforeLoad being called during login

### DIFF
--- a/.changeset/large-bats-travel.md
+++ b/.changeset/large-bats-travel.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/cypress": patch
+---
+
+fix(cypress): onBeforeLoad being called during login

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -125,7 +125,7 @@ function loginByForm(commandOptions: CommandLoginOptions) {
     // const mcFrontendHostname = mcUrl.hostname.replace('mc-api', 'mc');
 
     function authCallback() {
-      cy.visit(url);
+      cy.visit(url, { onBeforeLoad: commandOptions.onBeforeLoad });
 
       // NOTE: using `cy.origin` is currently disabled as it does not seem to properly work.
       // Interestingly, starting an application locally using Vite works, however not when using Webpack.


### PR DESCRIPTION
#### Summary

The `onBeforeLoad` never seems to be called which this intends to fix.

#### Description

In the `loginByOidc` we call the `onBeforeLoad` like:

```js
if (commandOptions.onBeforeLoad) {
  commandOptions.onBeforeLoad(win);
}
```

I noticed that we do not do this when logging in via the form. This causes issues internally when we use the general `loginToMerchantCenter` command which we often pass an `onBeforeLoad` to e.g. set local storage values to hide collapse the menu or hide certain models (like for rebranding). 

We could either invoke the `onBeforeLoad` in the `authCallback` or when navigating to the `initialRoute`. The latter seems unexpected as you then only invoke the callback when another parameter is passed.

