### PR TITLE
refactor(application-shell): to remove fetchPolicy again

### DIFF
--- a/.changeset/tame-hats-glow.md
+++ b/.changeset/tame-hats-glow.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+refactor(application-shell): to remove fetchPolicy again

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -157,7 +157,6 @@ export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
           const response = await apolloClient.query<TAllFeaturesQuery>({
             query: AllFeaturesQuery,
             errorPolicy: 'ignore',
-            fetchPolicy: 'network-only',
             context: {
               target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
               projectKey: adapterArgs.user?.project,


### PR DESCRIPTION
#### Summary

The context now changes as the projectKey is passed. Apollo will automatically refetch once the context changes to my understanding - due to the projectKey changes.