### PR TITLE
fix(TabularModalPage): styles in custom views

### DIFF
--- a/.changeset/lazy-vans-bow.md
+++ b/.changeset/lazy-vans-bow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Styling adjustments for TabularModalPage to ensure proper rendering in Custom Views

--- a/packages/application-components/src/components/internals/tabular-page.tsx
+++ b/packages/application-components/src/components/internals/tabular-page.tsx
@@ -1,8 +1,11 @@
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
 import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import { designTokens as appKitDesignTokens } from '../../theming';
+
+declare let window: ApplicationWindow;
 
 const TabControls = styled.div`
   margin-top: ${uiKitDesignTokens.spacingS};
@@ -59,9 +62,28 @@ const CustomViewsSelectorWrapper = styled.div`
   margin: ${appKitDesignTokens.marginForCustomViewsSelectorAsTabular};
 `;
 
+const CustomViewsTabularPageContainer = (props: { children: ReactNode }) => {
+  const isRenderedInCustomView = Boolean(window.app.customViewId);
+  // wrapper which only appears when rendered in a Custom View
+  const Wrapper = isRenderedInCustomView ? 'div' : Fragment;
+  return (
+    <Wrapper
+      css={css`
+        > div {
+          padding: ${uiKitDesignTokens.spacing50} ${uiKitDesignTokens.spacing55}
+            0 !important;
+        }
+      `}
+    >
+      {props.children}
+    </Wrapper>
+  );
+};
+
 export {
   ControlsContainter,
   TabularPageContainer,
   FormControlsContainer,
   CustomViewsSelectorWrapper,
+  CustomViewsTabularPageContainer,
 };

--- a/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
@@ -18,6 +18,7 @@ import {
   TabularPageContainer,
   FormControlsContainer,
   CustomViewsSelectorWrapper,
+  CustomViewsTabularPageContainer,
 } from '../../internals/tabular-page';
 import ModalPage from '../internals/modal-page';
 
@@ -87,28 +88,30 @@ const TabularModalPage = (props: Props) => {
       shouldDelayOnClose={props.shouldDelayOnClose}
       afterOpenStyles={props.afterOpenStyles}
     >
-      <TabularPageContainer color="neutral">
-        {props.customTitleRow || (
-          <PageHeaderTitle
-            title={props.title}
-            titleSize="big"
-            subtitle={props.subtitle}
-            truncate
+      <CustomViewsTabularPageContainer>
+        <TabularPageContainer color="neutral">
+          {props.customTitleRow || (
+            <PageHeaderTitle
+              title={props.title}
+              titleSize="big"
+              subtitle={props.subtitle}
+              truncate
+            />
+          )}
+          <ControlsContainter
+            tabControls={props.tabControls}
+            formControls={
+              <FormControlsContainer>
+                {!props.hideControls && props.formControls && (
+                  <Spacings.Inline alignItems="flex-end">
+                    {props.formControls}
+                  </Spacings.Inline>
+                )}
+              </FormControlsContainer>
+            }
           />
-        )}
-        <ControlsContainter
-          tabControls={props.tabControls}
-          formControls={
-            <FormControlsContainer>
-              {!props.hideControls && props.formControls && (
-                <Spacings.Inline alignItems="flex-end">
-                  {props.formControls}
-                </Spacings.Inline>
-              )}
-            </FormControlsContainer>
-          }
-        />
-      </TabularPageContainer>
+        </TabularPageContainer>
+      </CustomViewsTabularPageContainer>
       <CustomViewsSelectorWrapper>
         <CustomViewsSelector
           margin={`${uiKitDesignTokens.spacing30} 0 0 0`}


### PR DESCRIPTION
#### Summary

This PR fixes the styles of `TabularModalPage` rendered in a Custom View.
Unfortunately, I couldn't find way to apply styling through [Custom View specific css token overrides added to the theme provider](https://github.com/commercetools/merchant-center-application-kit/blob/c2bba1d065b6fd7882e6feb9162d91538962d85d/packages/application-shell/src/components/custom-view-shell/custom-view-shell.styles.ts#L11-L26), since `paddingForTabularPageHeader` used here is valid for `TabularDetailPage` and `TabularMainPage`. Therefore, the solution I thought was to introduce a wrapper that only shows up in the `TabularModalPage` and only when rendered in a Custom View and overwrites the styles of the `TabularPageContainer`.

Current state:
![image](https://github.com/commercetools/merchant-center-application-kit/assets/49066275/13b455c8-2265-4ec6-a3cb-55ac656274d9)

It does not change the current styling of `TabularModalPage` rendered in a Custom Application, and also does not change the way `TabularDetailPage` and `TabularMainPage` are rendered in Custom Views.

After changes:
|  TabularModalPage in Custom Application | TabularDetailPage in Custom View  |  TabularModalPage in Custom View |
|---|---|---|
| <img width="621" alt="Screenshot 2024-04-11 at 15 01 24" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/9d189375-df36-4569-81bd-3abf89fef3a6">  |  <img width="609" alt="Screenshot 2024-04-11 at 15 01 37" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/8877b30d-514e-4f4e-b971-328d368cef8d"> | <img width="611" alt="Screenshot 2024-04-11 at 15 01 46" src="https://github.com/commercetools/merchant-center-application-kit/assets/49066275/71505e9c-fe20-4189-b023-e73e09372f6d"> |

The PoC for the reviewers to play around was pushed to `SHIELD-1153-fix-tabularmodalpage-in-custom-views-poc` (to test out this PR locally in the playground application)