### PR TITLE
fix: to inject app env script as one liner

### DIFF
--- a/.changeset/lovely-squids-cross.md
+++ b/.changeset/lovely-squids-cross.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Ensure injected application environment script is rendered as one liner (to match the CSP hash)

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -166,9 +166,7 @@
     __LOADING_SCREEN_JS__
 
     <!-- Application globals -->
-    <script>
-      window.app = __APPLICATION_ENVIRONMENT__;
-    </script>
+    __APPLICATION_ENVIRONMENT__
 
     <!-- Main application chunks -->
     __APPLICATION_SCRIPT_IMPORTS__

--- a/packages/mc-html-template/src/replace-html-placeholders.ts
+++ b/packages/mc-html-template/src/replace-html-placeholders.ts
@@ -34,7 +34,7 @@ const replaceHtmlPlaceholders = (
     )
     .replace(
       new RegExp('__APPLICATION_ENVIRONMENT__', 'g'),
-      sanitizeAppEnvironment(options.env)
+      `<script>window.app = ${sanitizeAppEnvironment(options.env)};</script>`
     )
     .replace(
       new RegExp('__LOADING_SCREEN_JS__', 'g'),


### PR DESCRIPTION
No idea why this started "failing" now but in the [graphql-explorer Custom Application](https://github.com/commercetools/merchant-center-graphql-explorer) (built with Vite) the deployment was broken as the CSP policy refused to execute the injected script `window.app = ` due to a mismatch with the SHA hash.

After some debugging and try/error, it appeared that the browser expected the hash to be created from a one-liner of the script.

In other words, instead of

```
<script>
  window.app = 
</script>
```

it should be

```
<script>window.app = </script>
```

Update: it looks like this was introduced due to Prettier in #3379 

<img width="1337" alt="image" src="https://github.com/commercetools/merchant-center-application-kit/assets/1110551/48a8fa25-93da-4748-81d5-6ef2bc061a39">

