### PR TITLE
fix: migration leftovers for `eslint-plugin-n`

### DIFF
--- a/.changeset/real-steaks-brush.md
+++ b/.changeset/real-steaks-brush.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-backend/eslint-config-node': patch
+---
+
+Leftovers for migrating from `eslint-plugin-node` to `eslint-plugin-n`

--- a/packages-backend/eslint-config-node/index.js
+++ b/packages-backend/eslint-config-node/index.js
@@ -62,8 +62,8 @@ module.exports = {
 
   rules: {
     // Nodejs
-    'node/no-missing-import': statusCode.off,
-    'node/no-unsupported-features/es-syntax': statusCode.off,
+    'n/no-missing-import': statusCode.off,
+    'n/no-unsupported-features/es-syntax': statusCode.off,
 
     // NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
     'no-unused-expressions': statusCode.off,
@@ -106,7 +106,7 @@ module.exports = {
         'jest/globals': true,
       },
       rules: {
-        'node/no-extraneous-require': [
+        'n/no-extraneous-require': [
           statusCode.error,
           {
             allowModules: ['jest-each', 'msw'],


### PR DESCRIPTION
Leftovers of #3467 