### PR TITLE
chore(flopflip): increase pooling interval from 1 to 15 minutes

### DIFF
--- a/.changeset/nine-goats-return.md
+++ b/.changeset/nine-goats-return.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+chore(flopflip): increase pooling interval from 1 to 15 minutes

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -153,6 +153,8 @@ export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
         ),
       },
       http: {
+        // polling interval set to 15 minutes
+        pollingIntervalMs: 1000 * 60 * 15,
         cacheIdentifier: cacheIdentifiers.local,
         cacheMode: cacheModes.lazy,
         user: {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR increase `flop-flip` polling interval from 1 minute to 15 minutes.


#### Background
I was working locally (and same thing happens on prod) when saw that we have requests for `AllFeatures` going every minute which seemed a bit wasteful since we don't update those values and when we do, we don't expect an instant change since it requires a PR and a CI run
