### PR TITLE
Reverting `header-polyfill` dependency resolution (fix starter templates tests)

### DIFF
--- a/application-templates/starter-typescript/package.json
+++ b/application-templates/starter-typescript/package.json
@@ -100,6 +100,6 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.3.0"
+    "headers-polyfill": "3.2.5"
   }
 }

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -98,6 +98,6 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.3.0"
+    "headers-polyfill": "3.2.5"
   }
 }

--- a/custom-views-templates/starter-typescript/package.json
+++ b/custom-views-templates/starter-typescript/package.json
@@ -100,6 +100,6 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.3.0"
+    "headers-polyfill": "3.2.5"
   }
 }

--- a/custom-views-templates/starter/package.json
+++ b/custom-views-templates/starter/package.json
@@ -98,6 +98,6 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.3.0"
+    "headers-polyfill": "3.2.5"
   }
 }


### PR DESCRIPTION
#### Summary

Reverting ` header-polyfill` dependency resolution (fix starter templates tests)

closes #3498

#### Description

We have the starter templates tests failing again.

The original problem was a dependency update which was incompatible with our version of `msw` as we explained and fixed in [this PR](https://github.com/commercetools/merchant-center-application-kit/pull/3451).

We have the issue again because we unintentionally updated the dependency resolution we had set.
That dependency resolution can't be updated until we move to `msw` version 2, which requires some effort.
