### PR TITLE
feat(react-notifications): add `DuplicateStandalonePriceScope` error code

### DIFF
--- a/.changeset/new-walls-rest.md
+++ b/.changeset/new-walls-rest.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/react-notifications': minor
+---
+
+Add message for `DuplicateStandalonePriceScope` error code

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -27,6 +27,10 @@
     "developer_comment": "User tries to create a resource with an already existing slug",
     "string": "\"{slugValue}\" is already in use. Please enter a new slug value for this product."
   },
+  "ApiError.DuplicateStandalonePriceScope": {
+    "developer_comment": "User tries to create a standalone price with the exact same values as for an already existing standalone price",
+    "string": "A price with the same scope already exists for this product variant. The combination of currency, country, customer group, channel and validity date must be unique for each price per SKU."
+  },
   "ApiError.DuplicateVariantValues": {
     "developer_comment": "User tries to generate a variant with the same SKU or attribute values",
     "string": "The same variant already exists for this product. Please enter different values for the fields."

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/messages.ts
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/messages.ts
@@ -66,6 +66,13 @@ export default defineMessages({
     defaultMessage:
       'A price with the same scope already exists for this product variant. Make sure that the combination of currency, country, customer group, channel and valid dates is unique per price.',
   },
+  DuplicateStandalonePriceScope: {
+    id: 'ApiError.DuplicateStandalonePriceScope',
+    description:
+      'User tries to create a standalone price with the exact same values as for an already existing standalone price',
+    defaultMessage:
+      'A price with the same scope already exists for this product variant. The combination of currency, country, customer group, channel and validity date must be unique for each price per SKU.',
+  },
   DuplicateVariantValues: {
     id: 'ApiError.DuplicateVariantValues',
     description:


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR adds a new error code: `DuplicateStandalonePriceScope`
https://docs.commercetools.com/api/errors#duplicatestandalonepricescope

#### Description

In Standalone Prices web app we are intercepting this error code, although it make more sense to make the error notification available for any app using the API of CT
https://github.com/commercetools/merchant-center-prices/blob/main/packages-frontend/application-standalone-prices/src/hooks/use-show-standalone-price-api-error-notification/messages.ts#L11
