### PR TITLE
Fix starter templates failing tests

### DIFF
--- a/application-templates/starter-typescript/package.json
+++ b/application-templates/starter-typescript/package.json
@@ -100,6 +100,7 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.2.5"
+    "headers-polyfill": "3.2.5",
+    "nwsapi": "2.2.7"
   }
 }

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -98,6 +98,7 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.2.5"
+    "headers-polyfill": "3.2.5",
+    "nwsapi": "2.2.7"
   }
 }

--- a/custom-views-templates/starter-typescript/package.json
+++ b/custom-views-templates/starter-typescript/package.json
@@ -100,6 +100,7 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.2.5"
+    "headers-polyfill": "3.2.5",
+    "nwsapi": "2.2.7"
   }
 }

--- a/custom-views-templates/starter/package.json
+++ b/custom-views-templates/starter/package.json
@@ -98,6 +98,7 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "headers-polyfill": "3.2.5"
+    "headers-polyfill": "3.2.5",
+    "nwsapi": "2.2.7"
   }
 }


### PR DESCRIPTION
#### Summary

Fix starter templates failing tests.

#### Description

When a Custom Application / Custom View is installed, running the default test suites yield some errors.

The problem seem to be with the latests versions of a transitive dependency ([nwsapi](https://github.com/dperini/nwsapi/)) which is used as part of the tests setup (`jest`, `jsdom`, `react-testing-library`).

[Here](https://github.com/jsdom/jsdom/issues/3055) is a related issue I found in `jsdom` repository and [here](https://github.com/dperini/nwsapi/issues/47) is another one in the `nwsapi` one.

I wasn't able to track down the exact change in `nswapi` which causes our problem, but I found it was introduced in the `2.8.0` version. That's why I'm adding a custom resolution rule in the templates `package.json` file to use the latest functioning version (`2.7.0` ).

#### Follow up

As a follow up, we need to look into our CI jobs to see how we can make this kind of errors fail over there.
Currently this is not happening because the resolutions in the templates `packages.json` files are ignored.