### PR TITLE
Update GitHub `pnpm` install action

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -7,7 +7,7 @@ runs:
 
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v2.4.0
+      uses: pnpm/action-setup@v4.0.0
       with:
         run_install: false
 

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -32,6 +32,9 @@ inputs:
   cypress-project-key:
     description: 'Cypress project key'
     required: true
+  cypress-package-name:
+    description: 'Cypress package name'
+    required: false
 
 runs:
   using: 'composite'


### PR DESCRIPTION
#### Summary

Update GitHub `pnpm` install action

#### Description

I've noticed some warnings in GitHub jobs about the `pnpm/action-setup` using an old `nodejs` version so I'm updating that dependency in this PR.

![image](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/a80afc38-927b-4cb2-a183-e5aad0cefe6f)

According to the [release notes](https://github.com/pnpm/action-setup/releases), it's safe for us to update to its latest major version.


#### UPDATE

I've also noticed this warning:

![image](https://github.com/commercetools/merchant-center-application-kit/assets/97907068/69511020-facf-4c01-a352-f9c01481781b)

So I'm introducing the missing input declaration in the `test-template-action`.