### PR TITLE
fix: wrong default OverlappingPriceValidity and  OverlappingStandalonePriceValidity error codes messages

### DIFF
--- a/.changeset/wise-lizards-switch.md
+++ b/.changeset/wise-lizards-switch.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/react-notifications': patch
+'@commercetools-frontend/i18n': patch
+---
+
+Fix default `OverlappingPriceValidity` and `OverlappingStandalonePriceValidity` error codes messages

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -73,7 +73,7 @@
   },
   "ApiError.OverlappingPriceValidity": {
     "developer_comment": "Returned when a given price validity period conflicts with an existing one",
-    "string": "Two prices have overlapping validity periods."
+    "string": "Another price with overlapping validity dates exists. Each price combination needs to have unique validity dates."
   },
   "ApiError.OverlappingPrices": {
     "developer_comment": "",
@@ -81,7 +81,7 @@
   },
   "ApiError.OverlappingStandalonePriceValidity": {
     "developer_comment": "Returned when a given standalone price validity period conflicts with an existing one",
-    "string": "Two standalone prices have overlapping validity periods."
+    "string": "Another price with overlapping validity dates exists. Each price combination needs to have unique validity dates."
   },
   "ApiError.PendingOperation": {
     "developer_comment": "User tries to start a new process when one is already underway",

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/api-error-message.spec.tsx
@@ -291,7 +291,9 @@ describe('render', () => {
     };
     renderMessage(<ApiErrorMessage error={error} />);
     expect(
-      screen.getByText('Two prices have overlapping validity periods.')
+      screen.getByText(
+        'Another price with overlapping validity dates exists. Each price combination needs to have unique validity dates.'
+      )
     ).toBeInTheDocument();
   });
   it('should show message for OverlappingStandalonePriceValidity', () => {
@@ -302,7 +304,7 @@ describe('render', () => {
     renderMessage(<ApiErrorMessage error={error} />);
     expect(
       screen.getByText(
-        'Two standalone prices have overlapping validity periods.'
+        'Another price with overlapping validity dates exists. Each price combination needs to have unique validity dates.'
       )
     ).toBeInTheDocument();
   });

--- a/packages/react-notifications/src/components/notification-kinds/api-error-message/messages.ts
+++ b/packages/react-notifications/src/components/notification-kinds/api-error-message/messages.ts
@@ -101,13 +101,15 @@ export default defineMessages({
     id: 'ApiError.OverlappingPriceValidity',
     description:
       'Returned when a given price validity period conflicts with an existing one',
-    defaultMessage: 'Two prices have overlapping validity periods.',
+    defaultMessage:
+      'Another price with overlapping validity dates exists. Each price combination needs to have unique validity dates.',
   },
   OverlappingStandalonePriceValidity: {
     id: 'ApiError.OverlappingStandalonePriceValidity',
     description:
       'Returned when a given standalone price validity period conflicts with an existing one',
-    defaultMessage: 'Two standalone prices have overlapping validity periods.',
+    defaultMessage:
+      'Another price with overlapping validity dates exists. Each price combination needs to have unique validity dates.',
   },
   PendingOperation: {
     id: 'ApiError.PendingOperation',


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR fixes wrong notification messages 🤞

#### Description

Amends https://github.com/commercetools/merchant-center-application-kit/pull/3517/files