### PR TITLE
Fix Playground Custom Application deployment previews

### DIFF
--- a/playground/.env
+++ b/playground/.env
@@ -1,5 +1,5 @@
 CLOUD_IDENTIFIER="gcp-eu"
-APP_URL="https://mc-app-kit-playgound.vercel.app"
+APP_URL="https://${VERCEL_URL}"
 ECHO_SERVER_URL="https://mc-app-kit-playgound.vercel.app/api/echo"
 PLAYGROUND_API_AUDIENCE="https://mc-app-kit-playgound.vercel.app"
 HOST_GCP_STAGING=""

--- a/playground/.env
+++ b/playground/.env
@@ -1,5 +1,5 @@
 CLOUD_IDENTIFIER="gcp-eu"
-APP_URL="https://${VERCEL_URL}"
+APP_URL="https://mc-app-kit-playgound.vercel.app"
 ECHO_SERVER_URL="https://mc-app-kit-playgound.vercel.app/api/echo"
 PLAYGROUND_API_AUDIENCE="https://mc-app-kit-playgound.vercel.app"
 HOST_GCP_STAGING=""

--- a/playground/custom-application-config.mjs
+++ b/playground/custom-application-config.mjs
@@ -1,7 +1,9 @@
 import { PERMISSIONS, entryPointUriPath } from './src/constants';
 const name = 'AppKit Playground Application';
 
-const productionUrl = Boolean(process.env.VERCEL_URL) ? `https://${process.env.VERCEL_URL}` : process.env.APP_URL;
+const productionUrl = process.env.VERCEL_ENV !== 'production' && Boolean(process.env.VERCEL_URL) ?
+  `https://${process.env.VERCEL_URL}` :
+  process.env.APP_URL;
 
 /**
  * @type {import('@commercetools-frontend/application-config').ConfigOptionsForCustomApplication}

--- a/playground/custom-application-config.mjs
+++ b/playground/custom-application-config.mjs
@@ -1,6 +1,8 @@
 import { PERMISSIONS, entryPointUriPath } from './src/constants';
 const name = 'AppKit Playground Application';
 
+const productionUrl = Boolean(process.env.VERCEL_URL) ? `https://${process.env.VERCEL_URL}` : process.env.APP_URL;
+
 /**
  * @type {import('@commercetools-frontend/application-config').ConfigOptionsForCustomApplication}
  */
@@ -19,7 +21,7 @@ const config = {
     },
     production: {
       applicationId: '${env:APP_ID}',
-      url: '${env:APP_URL}',
+      url: productionUrl,
     },
   },
   additionalEnv: {


### PR DESCRIPTION
#### Summary

Fix Playground Custom Application deployment previews

#### Description

We can't use a fixed value for the Custom Application configured URL but the one provided by Vercel for each deployment (`VERCEL_URL` env variable; [reference](https://vercel.com/docs/projects/environment-variables/system-environment-variables)).
