### PR TITLE
refactor: change http-adapter to eager mode

### DIFF
--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -4,7 +4,12 @@ import combineAdapters from '@flopflip/combine-adapters';
 import httpAdapter from '@flopflip/http-adapter';
 import ldAdapter from '@flopflip/launchdarkly-adapter';
 import { ConfigureFlopFlip } from '@flopflip/react-broadcast';
-import { cacheIdentifiers, cacheModes } from '@flopflip/types';
+import {
+  type TAdapterIdentifiers,
+  cacheIdentifiers,
+  cacheModes,
+  adapterIdentifiers,
+} from '@flopflip/types';
 import type { TFlags } from '@flopflip/types';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import {
@@ -93,13 +98,17 @@ const parseFlags = (fetchedFlags: TFetchedFlags): TParsedHttpAdapterFlags =>
     ])
   );
 
-const getCacheMode = () => {
+const getCacheMode = (adapterIdentifier: TAdapterIdentifiers) => {
   // @ts-ignore
-  if (typeof window.Cypress !== 'undefined') {
+  if (
+    typeof window.Cypress !== 'undefined' ||
+    adapterIdentifier === adapterIdentifiers.http
+  ) {
     // Temporary workaround: when running in Cypress, do not use lazy mode
     // as the flag is not being updated in time during the test run.
     return cacheModes.eager;
   }
+
   return cacheModes.lazy;
 };
 
@@ -146,7 +155,7 @@ export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
       },
       launchdarkly: {
         cacheIdentifier: cacheIdentifiers.local,
-        cacheMode: getCacheMode(),
+        cacheMode: getCacheMode(adapterIdentifiers.launchdarkly),
         sdk: {
           // Allow to overwrite the client ID, passed via the `additionalEnv` properties
           // of the application config.
@@ -166,7 +175,7 @@ export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
         // polling interval set to 15 minutes
         pollingIntervalMs: 1000 * 60 * 15,
         cacheIdentifier: cacheIdentifiers.local,
-        cacheMode: getCacheMode(),
+        cacheMode: getCacheMode(adapterIdentifiers.http),
         user: {
           key: props.user?.id,
         },


### PR DESCRIPTION
#### Summary

We've been to lazy and should be more eager.

#### Description

After a lot of communication and alignment we realized that being eager on the http-adapter helps drive user expectations.

The background is that we toggle functionality through the http-adapter which is generally available to users. Having a "delayed" appearing through a reload for these functionalities is not ideal. It's acceptable for anything which sits behind LaunchDarkly and there has also the benefit to avoid the flicker.

#### Followings

1. @CarlosCortizasCT will evaluate the delay waiting for flags would actually cost and if we can globally wait
2. @tdeekens will investigate if we can integrate our http-adapter query into a more global GraphQL query and hydrate the memory-adapter with it to avoid flash flickering

The general storyline is also to get flopflip ready for React Suspense finally when time permits. 