### PR TITLE
fix(customizations templates): include babel-preset package as a dependency

### DIFF
--- a/.changeset/sharp-cups-think.md
+++ b/.changeset/sharp-cups-think.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-applications/merchant-center-custom-view-template-starter-typescript': patch
+'@commercetools-applications/merchant-center-template-starter-typescript': patch
+'@commercetools-applications/merchant-center-custom-view-template-starter': patch
+'@commercetools-applications/merchant-center-template-starter': patch
+---
+
+Ensure compatibility with yarn v3 by explicitly adding `@commercetools-frontend/babel-preset-mc-app` dependency for customization templates

--- a/application-templates/starter-typescript/package.json
+++ b/application-templates/starter-typescript/package.json
@@ -28,6 +28,7 @@
     "@commercetools-frontend/application-shell": "workspace:*",
     "@commercetools-frontend/application-shell-connectors": "workspace:*",
     "@commercetools-frontend/assets": "workspace:*",
+    "@commercetools-frontend/babel-preset-mc-app": "workspace:*",
     "@commercetools-frontend/constants": "workspace:*",
     "@commercetools-frontend/eslint-config-mc-app": "workspace:*",
     "@commercetools-frontend/i18n": "workspace:*",

--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -26,6 +26,7 @@
     "@commercetools-frontend/application-shell": "workspace:*",
     "@commercetools-frontend/application-shell-connectors": "workspace:*",
     "@commercetools-frontend/assets": "workspace:*",
+    "@commercetools-frontend/babel-preset-mc-app": "workspace:*",
     "@commercetools-frontend/constants": "workspace:*",
     "@commercetools-frontend/eslint-config-mc-app": "workspace:*",
     "@commercetools-frontend/i18n": "workspace:*",

--- a/custom-views-templates/starter-typescript/package.json
+++ b/custom-views-templates/starter-typescript/package.json
@@ -28,6 +28,7 @@
     "@commercetools-frontend/application-shell": "workspace:*",
     "@commercetools-frontend/application-shell-connectors": "workspace:*",
     "@commercetools-frontend/assets": "workspace:*",
+    "@commercetools-frontend/babel-preset-mc-app": "workspace:*",
     "@commercetools-frontend/constants": "workspace:*",
     "@commercetools-frontend/eslint-config-mc-app": "workspace:*",
     "@commercetools-frontend/i18n": "workspace:*",

--- a/custom-views-templates/starter/package.json
+++ b/custom-views-templates/starter/package.json
@@ -26,6 +26,7 @@
     "@commercetools-frontend/application-shell": "workspace:*",
     "@commercetools-frontend/application-shell-connectors": "workspace:*",
     "@commercetools-frontend/assets": "workspace:*",
+    "@commercetools-frontend/babel-preset-mc-app": "workspace:*",
     "@commercetools-frontend/constants": "workspace:*",
     "@commercetools-frontend/eslint-config-mc-app": "workspace:*",
     "@commercetools-frontend/i18n": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@commercetools-frontend/assets':
         specifier: workspace:*
         version: link:../../packages/assets
+      '@commercetools-frontend/babel-preset-mc-app':
+        specifier: workspace:*
+        version: link:../../packages/babel-preset-mc-app
       '@commercetools-frontend/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -537,6 +540,9 @@ importers:
       '@commercetools-frontend/assets':
         specifier: workspace:*
         version: link:../../packages/assets
+      '@commercetools-frontend/babel-preset-mc-app':
+        specifier: workspace:*
+        version: link:../../packages/babel-preset-mc-app
       '@commercetools-frontend/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -753,6 +759,9 @@ importers:
       '@commercetools-frontend/assets':
         specifier: workspace:*
         version: link:../../packages/assets
+      '@commercetools-frontend/babel-preset-mc-app':
+        specifier: workspace:*
+        version: link:../../packages/babel-preset-mc-app
       '@commercetools-frontend/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -972,6 +981,9 @@ importers:
       '@commercetools-frontend/assets':
         specifier: workspace:*
         version: link:../../packages/assets
+      '@commercetools-frontend/babel-preset-mc-app':
+        specifier: workspace:*
+        version: link:../../packages/babel-preset-mc-app
       '@commercetools-frontend/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -6356,10 +6368,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.23.5
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.23.0
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.0)
     dev: false
@@ -6370,10 +6382,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.23.5
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.24.5)
     dev: true


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Creating and starting a new customization using yarn v3 is currently failing:
```
Error: Your application tried to access @commercetools-frontend/babel-preset-mc-app, but it isn't declared in your dependencies; this makes the require call ambiguous and unsound.

Make sure that all the Babel plugins and presets you are using
are defined as dependencies or devDependencies in your package.json
file. It's possible that the missing plugin is loaded by a preset
you are using that forgot to add the plugin to its dependencies: you
can workaround this problem by explicitly adding the missing package
to your top-level package.json.
```

Adding the babel preset dependency appears to solve the issue.

The alternative would be to only allow yarn classic.
