### PR TITLE
feat: add `iconLeft` prop to `CustomFormDetailPage.FormPrimaryButton`

### DIFF
--- a/.changeset/metal-hotels-judge.md
+++ b/.changeset/metal-hotels-judge.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+Add `iconLeft` prop to `CustomFormDetailPage.FormPrimaryButton`

--- a/packages/application-components/src/components/internals/default-form-buttons.tsx
+++ b/packages/application-components/src/components/internals/default-form-buttons.tsx
@@ -39,7 +39,11 @@ const useFormattedLabel = (label: Label) => {
   return typeof label === 'string' ? label : intl.formatMessage(label);
 };
 
-const FormPrimaryButton = (props: Props) => {
+type PrimaryButtonProps = {
+  iconLeft?: ReactElement;
+} & Props;
+
+const FormPrimaryButton = (props: PrimaryButtonProps) => {
   const label = useFormattedLabel(props.label);
 
   return (
@@ -47,6 +51,7 @@ const FormPrimaryButton = (props: Props) => {
       label={label}
       onClick={props.onClick}
       isDisabled={props.isDisabled}
+      iconLeft={props.iconLeft}
       {...filterDataAttributes(props.dataAttributes)}
     />
   );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<img width="539" alt="Screenshot 2024-07-08 at 18 19 44" src="https://github.com/commercetools/merchant-center-application-kit/assets/13467563/d43d8ebe-fe11-43fd-8ec0-74cdfa497aca">


#### Description

In @commercetools/priceless-team-fe, we have a design where `CustomFormDetailPage.FormPrimaryButton` and `CustomFormDetailPage.FormSecondaryButton` have an icon (see screenshots https://commercetools.atlassian.net/browse/PRC-3533).
Currently `CustomFormDetailPage.FormPrimaryButton` does not accept an `iconLeft` prop (`CustomFormDetailPage.FormSecondaryButton` does)

<!-- provide some context -->
