### PR TITLE
chore(tsconfig): include DOM and DOM.Iterable for improved type checking

### DIFF
--- a/packages/cypress/tsconfig.json
+++ b/packages/cypress/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable"]
+  },
   "include": ["./src"]
 }


### PR DESCRIPTION
#### Summary

TypeScript errors when running `pnpm build` in merchant-center-application-kit

#### Description

The issue occurs occasionally when running the pnpm build command in the root of the app-kit directory. The build process encounters TypeScript errors related to missing basic DOM types. Specifically, TypeScript is unable to recognize the names Window, HTMLElement, and ScrollLogicalPosition, which are essential for browser-based environments.

#### Solution

The issue was related to the cypress directory within the merchant-center-application-kit repository. The missing types (Window, HTMLElement, ScrollLogicalPosition) are typically available in a browser environment but are not found during the TypeScript build process. Including "DOM" and "DOM.Iterable" helps TypeScript provide better type safety and error checking for the code that interacts with DOM elements and iterable objects.

Corresponding Jira Ticket: [SHIELD-1349](https://commercetools.atlassian.net/browse/SHIELD-1349)


[SHIELD-1349]: https://commercetools.atlassian.net/browse/SHIELD-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ