### PR TITLE
chore: forward application context project's isProductionProject

### DIFF
--- a/.changeset/dry-eagles-sin.md
+++ b/.changeset/dry-eagles-sin.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/application-shell-connectors": patch
+---
+
+patch: forward application context project's isProductionProject
+
+This is to be able to exclude non-production projects from Fullstory.

--- a/.changeset/dry-eagles-sin.md
+++ b/.changeset/dry-eagles-sin.md
@@ -2,6 +2,4 @@
 "@commercetools-frontend/application-shell-connectors": patch
 ---
 
-patch: forward application context project's isProductionProject
-
-This is to be able to exclude non-production projects from Fullstory.
+Expose field `isProductionProject` to `ApplicationContext`.

--- a/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.spec.tsx
@@ -281,6 +281,7 @@ describe('mapProjectToApplicationContextProject', () => {
       ownerName: expect.any(String),
       sampleDataImportDataset: expect.any(String),
       isUserAdminOfCurrentProject: expect.any(Boolean),
+      isProductionProject: expect.any(Boolean),
     });
   });
 });

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -148,6 +148,7 @@ export const mapProjectToApplicationContextProject = (
     ownerName: project.owner.name,
     sampleDataImportDataset: project.sampleDataImportDataset,
     isUserAdminOfCurrentProject: project.isUserAdminOfCurrentProject,
+    isProductionProject: project.isProductionProject,
   };
 };
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

Forward application context project's `isProductionProject`.

#### Description

<!-- provide some context -->

This is to be able to exclude non-production projects from Fullstory.

References
- https://commercetools.atlassian.net/browse/PCM-3731
- https://commercetools.slack.com/archives/CCL83RA06/p1721392732288309.