### PR TITLE
fix(app-shell): feature flags for menu to not use launchdarkly

### DIFF
--- a/.changeset/lemon-cameras-yawn.md
+++ b/.changeset/lemon-cameras-yawn.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+Fix to not pass feature flags for menu to not be used via LaunchDarkly.

--- a/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
+++ b/packages/application-shell/src/components/setup-flop-flip-provider/setup-flop-flip-provider.tsx
@@ -126,10 +126,9 @@ export const SetupFlopFlipProvider = (props: TSetupFlopFlipProviderProps) => {
   const flags = useMemo(
     () => ({
       ...featureFlags.FLAGS,
-      ...allMenuFeatureToggles.allFeatureToggles,
       ...props.flags,
     }),
-    [allMenuFeatureToggles.allFeatureToggles, props.flags]
+    [props.flags]
   );
   useMemo(() => {
     if (enableLongLivedFeatureFlags) {


### PR DESCRIPTION
#### Summary

We have two adapters in flopflip: one for LaunchDarkly and one for our GraphQL endpoint. The first acts lazy and the latter eager. 

When we pass the menu flags to LaunchDarkly's adapter, they will be used to build a subscriptions to LaunchDarkly and then be persisted as a in the cache of the adapter. The value then cached is `false` (as the default). This means the menu item will not show unless the page is reloaded until the cache updates. This is cause the default value from the cache is used as LaunchDarkly has precedence over the MC API flags.

In short: we should not use LaunchDarkly to toggle menu visibility. In fact no team right now does. Instead we should use the MC API. For this to work eagerly (menu items show without reloading) we need to have the MC API adapter have precedence not the LaunchDarkly adapter.