### PR TITLE
Provide new prop to add content to left area of form dialog

### DIFF
--- a/.changeset/nasty-dragons-grin.md
+++ b/.changeset/nasty-dragons-grin.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+Add a new property `leftAlignedFooterContent`to the form dialog. This provides an additional content positioned to the left area of the form dialog footer.

--- a/.changeset/nasty-dragons-grin.md
+++ b/.changeset/nasty-dragons-grin.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-components': minor
 ---
 
-Add a new property `leftAlignedFooterContent`to the form dialog. This provides an additional content positioned to the left area of the form dialog footer.
+Add a new property `footerContent`to the form dialog. This provides an additional content positioned to the left area of the form dialog footer.

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
@@ -58,10 +58,10 @@ describe('rendering', () => {
     validateComponent({
       title: 'Lorem ipsus',
       extraProps: {
-        leftAlignedFooterContent: <div>Additional Content</div>,
+        leftAlignedFooterContent: <a href="/#">Left aligned content</a>,
       },
       extraChecks: () => {
-        screen.getByText('Additional Content');
+        screen.getByText('Left aligned content');
       },
     }));
 });

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
@@ -53,6 +53,17 @@ describe('rendering', () => {
         screen.getByText('button icon');
       },
     }));
+
+  it('should show additional content in footer', () =>
+    validateComponent({
+      title: 'Lorem ipsus',
+      extraProps: {
+        leftAlignedFooterContent: <div>Additional Content</div>,
+      },
+      extraChecks: () => {
+        screen.getByText('Additional Content');
+      },
+    }));
 });
 
 describe('with custom title', () => {

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
@@ -58,7 +58,7 @@ describe('rendering', () => {
     validateComponent({
       title: 'Lorem ipsus',
       extraProps: {
-        leftAlignedFooterContent: <a href="/#">Left aligned content</a>,
+        footerContent: <a href="/#">Left aligned content</a>,
       },
       extraChecks: () => {
         screen.getByText('Left aligned content');

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -31,6 +31,7 @@ export type TFormDialogProps = {
   dataAttributesPrimaryButton?: { [key: string]: string };
   getParentSelector?: () => HTMLElement;
   iconLeftSecondaryButton?: ReactElement;
+  leftAlignedFooterContent: ReactNode;
 };
 const defaultProps: Pick<TFormDialogProps, 'labelSecondary' | 'labelPrimary'> =
   {
@@ -59,6 +60,7 @@ const FormDialog = (props: TFormDialogProps) => (
       dataAttributesSecondaryButton={props.dataAttributesSecondaryButton}
       dataAttributesPrimaryButton={props.dataAttributesPrimaryButton}
       iconLeftSecondaryButton={props.iconLeftSecondaryButton}
+      leftAlignedFooterContent={props.leftAlignedFooterContent}
     />
   </DialogContainer>
 );

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -31,7 +31,7 @@ export type TFormDialogProps = {
   dataAttributesPrimaryButton?: { [key: string]: string };
   getParentSelector?: () => HTMLElement;
   iconLeftSecondaryButton?: ReactElement;
-  leftAlignedFooterContent: ReactNode;
+  leftAlignedFooterContent?: ReactNode;
 };
 const defaultProps: Pick<TFormDialogProps, 'labelSecondary' | 'labelPrimary'> =
   {

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -31,7 +31,7 @@ export type TFormDialogProps = {
   dataAttributesPrimaryButton?: { [key: string]: string };
   getParentSelector?: () => HTMLElement;
   iconLeftSecondaryButton?: ReactElement;
-  leftAlignedFooterContent?: ReactNode;
+  footerContent?: ReactNode;
 };
 const defaultProps: Pick<TFormDialogProps, 'labelSecondary' | 'labelPrimary'> =
   {
@@ -60,7 +60,7 @@ const FormDialog = (props: TFormDialogProps) => (
       dataAttributesSecondaryButton={props.dataAttributesSecondaryButton}
       dataAttributesPrimaryButton={props.dataAttributesPrimaryButton}
       iconLeftSecondaryButton={props.iconLeftSecondaryButton}
-      leftAlignedFooterContent={props.leftAlignedFooterContent}
+      footerContent={props.footerContent}
     />
   </DialogContainer>
 );

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, SyntheticEvent } from 'react';
+import type { ReactElement, SyntheticEvent, ReactNode } from 'react';
 import { css } from '@emotion/react';
 import { useIntl, type IntlShape } from 'react-intl';
 import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
@@ -26,6 +26,7 @@ type Props = {
   dataAttributesSecondaryButton: { [key: string]: string };
   children?: never;
   iconLeftSecondaryButton?: ReactElement;
+  leftAlignedFooterContent?: ReactNode;
 };
 const defaultProps: Pick<
   Props,
@@ -49,19 +50,34 @@ const DialogFooter = (props: Props) => {
         margin-top: ${uiKitDesignTokens.spacing50};
       `}
     >
-      <Spacings.Inline scale="m" alignItems="center" justifyContent="flex-end">
-        <SecondaryButton
-          label={getFormattedLabel(props.labelSecondary, intl)}
-          onClick={props.onCancel}
-          iconLeft={props.iconLeftSecondaryButton}
-          {...filterDataAttributes(props.dataAttributesSecondaryButton)}
-        />
-        <PrimaryButton
-          label={getFormattedLabel(props.labelPrimary, intl)}
-          onClick={props.onConfirm}
-          isDisabled={props.isPrimaryButtonDisabled}
-          {...filterDataAttributes(props.dataAttributesPrimaryButton)}
-        />
+      <Spacings.Inline alignItems="center" justifyContent="space-between">
+        {props.leftAlignedFooterContent && (
+          <Spacings.Inline
+            scale="m"
+            alignItems="center"
+            justifyContent="flex-start"
+          >
+            {props.leftAlignedFooterContent}
+          </Spacings.Inline>
+        )}
+        <Spacings.Inline
+          scale="m"
+          alignItems="center"
+          justifyContent="flex-end"
+        >
+          <SecondaryButton
+            label={getFormattedLabel(props.labelSecondary, intl)}
+            onClick={props.onCancel}
+            iconLeft={props.iconLeftSecondaryButton}
+            {...filterDataAttributes(props.dataAttributesSecondaryButton)}
+          />
+          <PrimaryButton
+            label={getFormattedLabel(props.labelPrimary, intl)}
+            onClick={props.onConfirm}
+            isDisabled={props.isPrimaryButtonDisabled}
+            {...filterDataAttributes(props.dataAttributesPrimaryButton)}
+          />
+        </Spacings.Inline>
       </Spacings.Inline>
     </div>
   );

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -51,13 +51,7 @@ const DialogFooter = (props: Props) => {
       `}
     >
       <Spacings.Inline alignItems="center" justifyContent="space-between">
-        <Spacings.Inline
-          scale="m"
-          alignItems="center"
-          justifyContent="flex-start"
-        >
-          <div>{props.footerContent}</div>
-        </Spacings.Inline>
+        <div>{props.footerContent}</div>
         <Spacings.Inline
           scale="m"
           alignItems="center"

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -60,24 +60,30 @@ const DialogFooter = (props: Props) => {
             {props.leftAlignedFooterContent}
           </Spacings.Inline>
         )}
-        <Spacings.Inline
-          scale="m"
-          alignItems="center"
-          justifyContent="flex-end"
+        <div
+          css={css`
+            margin-left: auto;
+          `}
         >
-          <SecondaryButton
-            label={getFormattedLabel(props.labelSecondary, intl)}
-            onClick={props.onCancel}
-            iconLeft={props.iconLeftSecondaryButton}
-            {...filterDataAttributes(props.dataAttributesSecondaryButton)}
-          />
-          <PrimaryButton
-            label={getFormattedLabel(props.labelPrimary, intl)}
-            onClick={props.onConfirm}
-            isDisabled={props.isPrimaryButtonDisabled}
-            {...filterDataAttributes(props.dataAttributesPrimaryButton)}
-          />
-        </Spacings.Inline>
+          <Spacings.Inline
+            scale="m"
+            alignItems="center"
+            justifyContent="flex-end"
+          >
+            <SecondaryButton
+              label={getFormattedLabel(props.labelSecondary, intl)}
+              onClick={props.onCancel}
+              iconLeft={props.iconLeftSecondaryButton}
+              {...filterDataAttributes(props.dataAttributesSecondaryButton)}
+            />
+            <PrimaryButton
+              label={getFormattedLabel(props.labelPrimary, intl)}
+              onClick={props.onConfirm}
+              isDisabled={props.isPrimaryButtonDisabled}
+              {...filterDataAttributes(props.dataAttributesPrimaryButton)}
+            />
+          </Spacings.Inline>
+        </div>
       </Spacings.Inline>
     </div>
   );

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -26,7 +26,7 @@ type Props = {
   dataAttributesSecondaryButton: { [key: string]: string };
   children?: never;
   iconLeftSecondaryButton?: ReactElement;
-  leftAlignedFooterContent?: ReactNode;
+  footerContent?: ReactNode;
 };
 const defaultProps: Pick<
   Props,
@@ -51,39 +51,31 @@ const DialogFooter = (props: Props) => {
       `}
     >
       <Spacings.Inline alignItems="center" justifyContent="space-between">
-        {props.leftAlignedFooterContent && (
-          <Spacings.Inline
-            scale="m"
-            alignItems="center"
-            justifyContent="flex-start"
-          >
-            {props.leftAlignedFooterContent}
-          </Spacings.Inline>
-        )}
-        <div
-          css={css`
-            margin-left: auto;
-          `}
+        <Spacings.Inline
+          scale="m"
+          alignItems="center"
+          justifyContent="flex-start"
         >
-          <Spacings.Inline
-            scale="m"
-            alignItems="center"
-            justifyContent="flex-end"
-          >
-            <SecondaryButton
-              label={getFormattedLabel(props.labelSecondary, intl)}
-              onClick={props.onCancel}
-              iconLeft={props.iconLeftSecondaryButton}
-              {...filterDataAttributes(props.dataAttributesSecondaryButton)}
-            />
-            <PrimaryButton
-              label={getFormattedLabel(props.labelPrimary, intl)}
-              onClick={props.onConfirm}
-              isDisabled={props.isPrimaryButtonDisabled}
-              {...filterDataAttributes(props.dataAttributesPrimaryButton)}
-            />
-          </Spacings.Inline>
-        </div>
+          <div>{props.footerContent}</div>
+        </Spacings.Inline>
+        <Spacings.Inline
+          scale="m"
+          alignItems="center"
+          justifyContent="flex-end"
+        >
+          <SecondaryButton
+            label={getFormattedLabel(props.labelSecondary, intl)}
+            onClick={props.onCancel}
+            iconLeft={props.iconLeftSecondaryButton}
+            {...filterDataAttributes(props.dataAttributesSecondaryButton)}
+          />
+          <PrimaryButton
+            label={getFormattedLabel(props.labelPrimary, intl)}
+            onClick={props.onConfirm}
+            isDisabled={props.isPrimaryButtonDisabled}
+            {...filterDataAttributes(props.dataAttributesPrimaryButton)}
+          />
+        </Spacings.Inline>
       </Spacings.Inline>
     </div>
   );

--- a/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
@@ -30,7 +30,7 @@ const FormDialogExample = (props: ContainerProps) => (
             document.querySelector(`#${props.portalId}`) as HTMLElement
           }
           zIndex={10001}
-          leftAlignedFooterContent={props.leftAlignedFooterContent}
+          footerContent={props.footerContent}
         >
           <Spacings.Stack scale="m">
             <TextField
@@ -111,14 +111,14 @@ export const Component = () => (
       />
     </Spec>
     <Spec
-      label="FormDialog - leftAlignedFooterContent provided"
+      label="FormDialog - footerContent provided"
       size="l"
       contentAlignment="center"
     >
       <FormDialogExample
         size="l"
         portalId="dialog-left-aligned-footer-content"
-        leftAlignedFooterContent={<a href="/#">lorem ipsum</a>}
+        footerContent={<a href="/#">lorem ipsum</a>}
       />
     </Spec>
   </Suite>

--- a/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
+++ b/visual-testing-app/src/components/form-dialog/form-dialog.visualroute.tsx
@@ -30,6 +30,7 @@ const FormDialogExample = (props: ContainerProps) => (
             document.querySelector(`#${props.portalId}`) as HTMLElement
           }
           zIndex={10001}
+          leftAlignedFooterContent={props.leftAlignedFooterContent}
         >
           <Spacings.Stack scale="m">
             <TextField
@@ -107,6 +108,17 @@ export const Component = () => (
         size="l"
         isPrimaryButtonDisabled={true}
         portalId="dialog-disabled"
+      />
+    </Spec>
+    <Spec
+      label="FormDialog - leftAlignedFooterContent provided"
+      size="l"
+      contentAlignment="center"
+    >
+      <FormDialogExample
+        size="l"
+        portalId="dialog-left-aligned-footer-content"
+        leftAlignedFooterContent={<a href="/#">lorem ipsum</a>}
       />
     </Spec>
   </Suite>

--- a/website-components-playground/src/pages/form-dialog.tsx
+++ b/website-components-playground/src/pages/form-dialog.tsx
@@ -64,6 +64,7 @@ const FormDialogExample = () => (
                       event as FormEvent<HTMLFormElement>
                     )
                   }
+                  leftAlignedFooterContent={<div>Left aligned content</div>}
                 >
                   <Spacings.Stack scale="m">
                     <TextField

--- a/website-components-playground/src/pages/form-dialog.tsx
+++ b/website-components-playground/src/pages/form-dialog.tsx
@@ -64,9 +64,7 @@ const FormDialogExample = () => (
                       event as FormEvent<HTMLFormElement>
                     )
                   }
-                  leftAlignedFooterContent={
-                    <a href="/#">Left aligned content</a>
-                  }
+                  footerContent={<a href="/#">Left aligned content</a>}
                 >
                   <Spacings.Stack scale="m">
                     <TextField

--- a/website-components-playground/src/pages/form-dialog.tsx
+++ b/website-components-playground/src/pages/form-dialog.tsx
@@ -64,7 +64,9 @@ const FormDialogExample = () => (
                       event as FormEvent<HTMLFormElement>
                     )
                   }
-                  leftAlignedFooterContent={<div>Left aligned content</div>}
+                  leftAlignedFooterContent={
+                    <a href="/#">Left aligned content</a>
+                  }
                 >
                   <Spacings.Stack scale="m">
                     <TextField


### PR DESCRIPTION

#### Summary

Add a new property `leftAlignedFooterContent`to the form dialog. This provides an additional content positioned to the left area of the form dialog footer.

#### Screenshots

<img width="737" alt="image" src="https://github.com/user-attachments/assets/99cc3eaf-58bb-4437-aaa1-94b07d8ad5b8">

