### PR TITLE
proposed Fix: issue with submenu vertical position when text wraps

### DIFF
--- a/.changeset/calm-students-mix.md
+++ b/.changeset/calm-students-mix.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+When the submenu has a text link that wraps to the next line, the vertical position of the submenu is adjusted, causing the submenu submenu position to be recalculated and as a result, hidden.
+This change fixes the issue by adding a 12-pixel buffer to the height calculation when determining if the submenu fits within the viewport below the menu item, this value accounts for the padding introduced on link hover.

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -186,12 +186,18 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
 
       const [entry] = entries;
 
-      /** Adding a 12 pixel (spacing-25) buffer to the height calculation when determining if the submenu fits within the viewport below the menu item,
-       * this value accounts for the padding introduced on link hover. We need this to account for the additional card height when a hovered submenu text link wraps to the next line*/
+      /**
+       * Adding a 12 pixel buffer to the height calculation when determining if the submenu fits within the viewport below the menu item.
+       * This buffer accounts for the padding added during link hover, accommodating one additional line height.
+       * We need this to account for the additional card height when a hovered submenu text link wraps to the next line,
+       * as otherwise the submenu would extend beyond the viewport's bottom edge and flip above the menu item.
+       */
+      const SINGLE_LINE_HEIGHT_BUFFER = 12;
+
       const doesSubmenuFitWithinViewportBelowMenuItem =
         entry.boundingClientRect.height +
           (props.isMenuOpen ? menuItemTop : menuItemBottom) +
-          12 >
+          SINGLE_LINE_HEIGHT_BUFFER >
         window.innerHeight;
       // if the submenu does not fit at the bottom of the viewport (below the menu item)
       if (doesSubmenuFitWithinViewportBelowMenuItem) {

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -186,6 +186,8 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
 
       const [entry] = entries;
 
+      /** Adding a 12 pixel (spacing-25) buffer to the height calculation when determining if the submenu fits within the viewport below the menu item,
+       * this value accounts for the padding introduced on link hover. We need this to account for the additional card height when a hovered submenu text link wraps to the next line*/
       const doesSubmenuFitWithinViewportBelowMenuItem =
         entry.boundingClientRect.height +
           (props.isMenuOpen ? menuItemTop : menuItemBottom) +

--- a/packages/application-shell/src/components/navbar/navbar.tsx
+++ b/packages/application-shell/src/components/navbar/navbar.tsx
@@ -188,7 +188,8 @@ export const ApplicationMenu = (props: ApplicationMenuProps) => {
 
       const doesSubmenuFitWithinViewportBelowMenuItem =
         entry.boundingClientRect.height +
-          (props.isMenuOpen ? menuItemTop : menuItemBottom) >
+          (props.isMenuOpen ? menuItemTop : menuItemBottom) +
+          12 >
         window.innerHeight;
       // if the submenu does not fit at the bottom of the viewport (below the menu item)
       if (doesSubmenuFitWithinViewportBelowMenuItem) {


### PR DESCRIPTION
#### Summary

Fix issue with submenu vertical position when text wraps

#### Description
When the submenu has a text link that wraps to the next line, the vertical position of the submenu is adjusted, causing the submenu submenu position to be recalculated but already out of visibility. This makes the submenu card to be hidden. This change fixes the issue by adding a 12-pixel buffer to the height calculation when determining if the submenu fits within the viewport below the menu item, this value accounts for the padding introduced on link hover. This ensures that the submenu is displayed correctly even when the text wraps to the next line.

Before: 

![2024-09-04 11 50 18](https://github.com/user-attachments/assets/43d65fc0-73a8-49aa-997d-93e6ddf3612a)

After: 

![2024-09-04 11 51 01](https://github.com/user-attachments/assets/e7404e72-910a-4e40-a703-3f14dcedab73)

Shorter submenu items still fit when the buffer is added and it has enough vertical space:
![2024-09-04 11 42 42](https://github.com/user-attachments/assets/fc2cae4e-2389-4096-9104-17edd4667ba1)








