### PR TITLE
feat(application-page-title): remove case transformations in browser tab title

### DIFF
--- a/.changeset/tricky-islands-wash.md
+++ b/.changeset/tricky-islands-wash.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Remove case transformations in browser tab titles for Merchant Center

--- a/cypress/e2e/custom-application-template-starter/channels.cy.ts
+++ b/cypress/e2e/custom-application-template-starter/channels.cy.ts
@@ -23,7 +23,7 @@ describe('Channels', () => {
     });
     cy.title().should(
       'eq',
-      `Store Munich - Template-starter - ${Cypress.env(
+      `Store Munich - template-starter - ${Cypress.env(
         'PROJECT_KEY'
       )} - Merchant Center`
     );

--- a/packages/application-shell/src/components/application-page-title/application-page-title.spec.tsx
+++ b/packages/application-shell/src/components/application-page-title/application-page-title.spec.tsx
@@ -9,32 +9,32 @@ const memoryHistory = (route: string) =>
 
 describe.each`
   route                                                                              | title
-  ${`/my-project-key/dashboard`}                                                     | ${`Dashboard - my-project-key - Merchant Center`}
-  ${`/my-project-key/products`}                                                      | ${`Products - my-project-key - Merchant Center`}
-  ${`/my-project-key/products/new`}                                                  | ${`Products - my-project-key - Merchant Center`}
-  ${`/my-project-key/products/<id>`}                                                 | ${`Products - my-project-key - Merchant Center`}
-  ${`/my-project-key/products/<id>/variants`}                                        | ${`Products - my-project-key - Merchant Center`}
-  ${`/my-project-key/products/<id>/variants/<id>`}                                   | ${`Products - my-project-key - Merchant Center`}
-  ${`/my-project-key/products/<id>/variants/<id>/prices`}                            | ${`Products - my-project-key - Merchant Center`}
-  ${`/my-project-key/orders/<id>`}                                                   | ${`Orders - my-project-key - Merchant Center`}
-  ${`/my-project-key/settings/project/international`}                                | ${`Settings - my-project-key - Merchant Center`}
-  ${`/my-project-key/settings/project/stores`}                                       | ${`Settings - my-project-key - Merchant Center`}
-  ${`/my-project-key/settings/project/stores/<id>`}                                  | ${`Settings - my-project-key - Merchant Center`}
-  ${`/my-project-key/settings/product-types`}                                        | ${`Settings - my-project-key - Merchant Center`}
-  ${`/my-project-key/settings/product-types/<id>`}                                   | ${`Settings - my-project-key - Merchant Center`}
-  ${`/my-project-key/settings/product-types/<id>/attribute-definitions/detail/<id>`} | ${`Settings - my-project-key - Merchant Center`}
-  ${`/account/projects`}                                                             | ${`Account - Merchant Center`}
-  ${`/account/organizations`}                                                        | ${`Account - Merchant Center`}
-  ${`/account/organizations/<id>/teams`}                                             | ${`Account - Merchant Center`}
-  ${`/account/organizations/<id>/teams/<id>/permissions/<id>`}                       | ${`Account - Merchant Center`}
-  ${`/account/organizations/<id>/custom-applications`}                               | ${`Account - Merchant Center`}
-  ${`/account/organizations/<id>/custom-applications/owned/<id>`}                    | ${`Account - Merchant Center`}
-  ${`/account/organizations/<id>/custom-applications/installations/<id>`}            | ${`Account - Merchant Center`}
-  ${`/login`}                                                                        | ${`Login - Merchant Center`}
-  ${`/login/new`}                                                                    | ${`Login - Merchant Center`}
-  ${`/login/sso`}                                                                    | ${`Login - Merchant Center`}
-  ${`/login/forgot`}                                                                 | ${`Login - Merchant Center`}
-  ${`/login/choose`}                                                                 | ${`Login - Merchant Center`}
+  ${`/my-project-key/dashboard`}                                                     | ${`dashboard - my-project-key - Merchant Center`}
+  ${`/my-project-key/products`}                                                      | ${`products - my-project-key - Merchant Center`}
+  ${`/my-project-key/products/new`}                                                  | ${`products - my-project-key - Merchant Center`}
+  ${`/my-project-key/products/<id>`}                                                 | ${`products - my-project-key - Merchant Center`}
+  ${`/my-project-key/products/<id>/variants`}                                        | ${`products - my-project-key - Merchant Center`}
+  ${`/my-project-key/products/<id>/variants/<id>`}                                   | ${`products - my-project-key - Merchant Center`}
+  ${`/my-project-key/products/<id>/variants/<id>/prices`}                            | ${`products - my-project-key - Merchant Center`}
+  ${`/my-project-key/orders/<id>`}                                                   | ${`orders - my-project-key - Merchant Center`}
+  ${`/my-project-key/settings/project/international`}                                | ${`settings - my-project-key - Merchant Center`}
+  ${`/my-project-key/settings/project/stores`}                                       | ${`settings - my-project-key - Merchant Center`}
+  ${`/my-project-key/settings/project/stores/<id>`}                                  | ${`settings - my-project-key - Merchant Center`}
+  ${`/my-project-key/settings/product-types`}                                        | ${`settings - my-project-key - Merchant Center`}
+  ${`/my-project-key/settings/product-types/<id>`}                                   | ${`settings - my-project-key - Merchant Center`}
+  ${`/my-project-key/settings/product-types/<id>/attribute-definitions/detail/<id>`} | ${`settings - my-project-key - Merchant Center`}
+  ${`/account/projects`}                                                             | ${`account - Merchant Center`}
+  ${`/account/organizations`}                                                        | ${`account - Merchant Center`}
+  ${`/account/organizations/<id>/teams`}                                             | ${`account - Merchant Center`}
+  ${`/account/organizations/<id>/teams/<id>/permissions/<id>`}                       | ${`account - Merchant Center`}
+  ${`/account/organizations/<id>/custom-applications`}                               | ${`account - Merchant Center`}
+  ${`/account/organizations/<id>/custom-applications/owned/<id>`}                    | ${`account - Merchant Center`}
+  ${`/account/organizations/<id>/custom-applications/installations/<id>`}            | ${`account - Merchant Center`}
+  ${`/login`}                                                                        | ${`login - Merchant Center`}
+  ${`/login/new`}                                                                    | ${`login - Merchant Center`}
+  ${`/login/sso`}                                                                    | ${`login - Merchant Center`}
+  ${`/login/forgot`}                                                                 | ${`login - Merchant Center`}
+  ${`/login/choose`}                                                                 | ${`login - Merchant Center`}
 `(`when location is "$route"`, ({ route, title }) => {
   it('should render default page title', async () => {
     render(
@@ -50,10 +50,10 @@ describe.each`
 
 describe.each`
   content                                                                                                      | title
-  ${[`Short title`]}                                                                                           | ${`Short title - Products - my-project-key - Merchant Center`}
-  ${[`Long title, a very long product name`]}                                                                  | ${`Long title, ...product name - Products - my-project-key - Merchant Center`}
-  ${['Short title1', 'Short title2']}                                                                          | ${`Short title1 - Short title2 - Products - my-project-key - Merchant Center`}
-  ${['First title of product, a very long product name', 'Second title of product, a very long product name']} | ${`First title ...product name - Second title...product name - Products - my-project-key - Merchant Center`}
+  ${[`Short title`]}                                                                                           | ${`Short title - products - my-project-key - Merchant Center`}
+  ${[`Long title, a very long product name`]}                                                                  | ${`Long title, ...product name - products - my-project-key - Merchant Center`}
+  ${['Short title1', 'Short title2']}                                                                          | ${`Short title1 - Short title2 - products - my-project-key - Merchant Center`}
+  ${['First title of product, a very long product name', 'Second title of product, a very long product name']} | ${`First title ...product name - Second title...product name - products - my-project-key - Merchant Center`}
 `(`'when the custom "content" is "$content"`, ({ content, title }) => {
   it('should render the custom value', async () => {
     render(
@@ -104,7 +104,7 @@ describe('when page title component content is nested in another component', () 
     );
     await waitFor(() => {
       expect(document.title).toBe(
-        'Level 3 with...product name - Products - my-project-key - Merchant Center'
+        'Level 3 with...product name - products - my-project-key - Merchant Center'
       );
     });
   });

--- a/packages/application-shell/src/components/application-page-title/application-page-title.tsx
+++ b/packages/application-shell/src/components/application-page-title/application-page-title.tsx
@@ -1,5 +1,4 @@
 import { useLayoutEffect } from 'react';
-import upperFirst from 'lodash/upperFirst';
 import { useLocation } from 'react-router-dom';
 
 type TApplicationPageTitleProps = {

--- a/packages/application-shell/src/components/application-page-title/application-page-title.tsx
+++ b/packages/application-shell/src/components/application-page-title/application-page-title.tsx
@@ -45,14 +45,14 @@ const getPageTitle = (pathname: string, additionalParts: string[]) => {
   if (staticPaths.includes(projectKeyOrStaticPath)) {
     return [
       ...(customTitleParts || []),
-      upperFirst(projectKeyOrStaticPath),
+      projectKeyOrStaticPath,
       'Merchant Center',
     ].join(' - ');
   }
 
   return [
     ...(customTitleParts || []),
-    upperFirst(entryPointUriPath),
+    entryPointUriPath,
     projectKeyOrStaticPath,
     'Merchant Center',
   ].join(' - ');


### PR DESCRIPTION
#### Summary

The case transformations in the browser tab title component were removed. This affects all the custom and native applications. 

#### Description

The custom application "commercetools Checkout" was displaying "Commercetools-checkout" in the browser tab title, with the first letter of "commercetools" incorrectly capitalized. This issue stemmed from intentional case transformations in the `ApplicationPageTitle` component. 

To address this, the case transformations in the getPageTitle function were removed to ensure that all the custom and native applications remains in lowercase as required. 

Corresponding ticket: [SHIELD-1092](https://commercetools.atlassian.net/browse/SHIELD-1092)

[SHIELD-1092]: https://commercetools.atlassian.net/browse/SHIELD-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ