### PR TITLE
fix(i18n): `parseChunkImport` helper function performance issue

### DIFF
--- a/.changeset/khaki-dragons-stare.md
+++ b/.changeset/khaki-dragons-stare.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/i18n': patch
+---
+
+Fix performance issue on parseChunkImport helper function

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -24,11 +24,9 @@ export const parseChunkImport = (
       const messageAsString = isStructuredJson(messageValue)
         ? messageValue.string
         : messageValue;
+      messages[messageKey] = messageAsString;
 
-      return {
-        ...messages,
-        [messageKey]: messageAsString,
-      };
+      return messages;
     },
     {} as TMessageTranslations
   );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

When bootstrapping the MC Discount web app I noticed that 400ms from the TBT metric are coming from the load of the i18n messages. 
The i18n object loaded seems to be quite big and spreading the object on the loop (which is not needed) makes the load of the i18n messages 200x slower (I've tested it on my local env) for the Discounts app

#### Description
This is a trace from the load of the MC Discounts app.
<img width="1718" alt="Screenshot 2024-09-19 at 15 49 07" src="https://github.com/user-attachments/assets/43ca4787-6241-4fec-9089-b5a17170c643">

<!-- provide some context -->
