### PR TITLE
fix(i18n): parallel loading of translations

### DIFF
--- a/.changeset/wicked-actors-smile.md
+++ b/.changeset/wicked-actors-smile.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/i18n': patch
+---
+
+Parallel loading in `loadI18n` helper function

--- a/packages/i18n/src/load-i18n.ts
+++ b/packages/i18n/src/load-i18n.ts
@@ -99,17 +99,17 @@ const getCommunityKitChunkImport = async (
 export default async function loadI18n(
   locale: string
 ): Promise<TMessageTranslations> {
-  // Load moment localizations
-  await loadMomentLocales(locale);
-
-  // Load ui-kit translations
-  const uiKitChunkImport = await getUiKitChunkImport(locale);
-
-  // Load app-kit translations
-  const appKitChunkImport = await getAppKitChunkImport(locale);
-
-  // Load community-kit translations
-  const communityKitChunkImport = await getCommunityKitChunkImport(locale);
+  const [, uiKitChunkImport, appKitChunkImport, communityKitChunkImport] =
+    await Promise.all([
+      // Load moment localizations
+      loadMomentLocales(locale),
+      // Load ui-kit translations
+      getUiKitChunkImport(locale),
+      // Load app-kit translations
+      getAppKitChunkImport(locale),
+      // Load community-kit translations
+      getCommunityKitChunkImport(locale),
+    ]);
 
   // Prefer loading `default` (for ESM bundles) and
   // fall back to normal import (for CJS bundles).


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

While debugging https://github.com/commercetools/merchant-center-application-kit/pull/3607 I realized we have an opportunity to improve the `loadI18n` helper function by loading the translations in parallel.

It's a small improvement, but it could save ~50ms on each cold load.

#### Description
This is the network waterfall (Discounts app) that this PR avoids.
[
![Screenshot 2024-09-23 at 10 59 50](https://github.com/user-attachments/assets/e9aa130d-df0b-48e2-98d1-ac1301e19e38)
](url)

<!-- provide some context -->
