### PR TITLE
feat: extend the list of cloud identifiers to include Azure EU

### DIFF
--- a/.changeset/silly-emus-end.md
+++ b/.changeset/silly-emus-end.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-config': minor
+'@commercetools-backend/express': minor
+---
+
+Extends the cloudIdentifier configuration property enabling Custom Applications and Custom Views to use the Azure EU environment

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -69,6 +69,8 @@ const mapCloudIdentifierToIssuer = <Request extends TBaseRequest>(
       return MC_API_URLS.AWS_CN;
     case CLOUD_IDENTIFIERS.AZURE_US:
       return MC_API_URLS.AZURE_US;
+    case CLOUD_IDENTIFIERS.AZURE_EU:
+      return MC_API_URLS.AZURE_EU;
     default:
       return undefined;
   }

--- a/packages-backend/express/src/constants.ts
+++ b/packages-backend/express/src/constants.ts
@@ -6,6 +6,7 @@ export const CLOUD_IDENTIFIERS = {
   AWS_OHIO: 'aws-ohio',
   AWS_CN: 'aws-cn',
   AZURE_US: 'azure-us',
+  AZURE_EU: 'azure-eu',
 } as const;
 
 export const MC_API_URLS = {
@@ -16,6 +17,7 @@ export const MC_API_URLS = {
   AWS_OHIO: 'https://mc-api.us-east-2.aws.commercetools.com',
   AWS_CN: 'https://mc-api.cn-northwest-1.aws.commercetools.cn',
   AZURE_US: 'https://mc-api.eastus.azure.commercetools.com',
+  AZURE_EU: 'https://mc-api.germanywestcentral.azure.commercetools.com',
 } as const;
 
 export const MC_API_PROXY_HEADERS = {

--- a/packages/application-config/src/constants.ts
+++ b/packages/application-config/src/constants.ts
@@ -6,6 +6,7 @@ export const CLOUD_IDENTIFIERS = {
   AWS_OHIO: 'aws-ohio',
   AWS_CN: 'aws-cn',
   AZURE_US: 'azure-us',
+  AZURE_EU: 'azure-eu',
 } as const;
 
 export const MC_API_URLS = {
@@ -16,6 +17,7 @@ export const MC_API_URLS = {
   AWS_OHIO: 'https://mc-api.us-east-2.aws.commercetools.com',
   AWS_CN: 'https://mc-api.cn-northwest-1.aws.commercetools.cn',
   AZURE_US: 'https://mc-api.eastus.azure.commercetools.com',
+  AZURE_EU: 'https://mc-api.germanywestcentral.azure.commercetools.com',
 } as const;
 
 export const LOADED_CONFIG_TYPES = {

--- a/packages/application-config/src/utils.ts
+++ b/packages/application-config/src/utils.ts
@@ -20,6 +20,8 @@ const mapCloudIdentifierToApiUrl = (
       return MC_API_URLS.AWS_CN;
     case CLOUD_IDENTIFIERS.AZURE_US:
       return MC_API_URLS.AZURE_US;
+    case CLOUD_IDENTIFIERS.AZURE_EU:
+      return MC_API_URLS.AZURE_EU;
     default:
       // We would probably never get to this point, as the JSON schema validation
       // kicks in before.


### PR DESCRIPTION
#### Summary

Add Azure EU as a new target in the MC configuration.

#### Description

Introduce a new cloudIdentifier configuration option for Custom Applications and Custom Views, allowing them to select Azure EU as the target environment.
