### PR TITLE
feat(sentry): send extra info for reported ErrorEvent

### DIFF
--- a/.changeset/late-ears-shout.md
+++ b/.changeset/late-ears-shout.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/sentry': patch
+---
+
+Add extra info when an ErrorEvent is captured

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -142,6 +142,13 @@ export const reportErrorToSentry = (
       } else {
         Sentry.setExtra('extra', extraInfo.extra);
       }
+    } else if (error instanceof ErrorEvent) {
+      Sentry.setExtras({
+        filename: error.filename,
+        lineno: error.lineno,
+        colno: error.colno,
+        error: error.error,
+      });
     }
     // Generate a unique ID referring to the last generated Sentry error
     const errorId = sendErrorToSentry(error);


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
The goal of this PR is to add more info of any ErrorEvent reported to Sentry. 

The captured error message (see https://commercetools.sentry.io/issues/5880399228 as an example) is not enough to have a picture of the issue happening on production.

As an example: introducing the filename to the extra data, we will be able to understand if issues are caused by browser extensions. 

#### Description

<!-- provide some context -->
