### PR TITLE
fix(l10n): explicitly include export file for supported locales

### DIFF
--- a/.changeset/swift-squids-clean.md
+++ b/.changeset/swift-squids-clean.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/l10n': patch
+---
+
+Explicitly include `supported-locales` export and type declarations from bundle.

--- a/packages/l10n/package.json
+++ b/packages/l10n/package.json
@@ -16,7 +16,15 @@
   },
   "main": "dist/commercetools-frontend-l10n.cjs.js",
   "module": "dist/commercetools-frontend-l10n.esm.js",
-  "files": ["data", "dist", "package.json", "LICENSE", "README.md"],
+  "files": [
+    "data",
+    "dist",
+    "package.json",
+    "LICENSE",
+    "README.md",
+    "supported-locales.d.ts",
+    "supported-locales.js"
+  ],
   "scripts": {
     "generate-data": "node ./scripts/generate-l10n-data.js"
   },


### PR DESCRIPTION
Otherwise TS gets confused and the types cannot be properly recognized.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/dfcc7b3b-a901-4d10-bb59-ff2c9734db34">
