### PR TITLE
perf: defer application main JS chunks

### DIFF
--- a/.changeset/serious-trainers-cough.md
+++ b/.changeset/serious-trainers-cough.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-frontend/mc-html-template": patch
+"@commercetools-frontend/mc-scripts": patch
+---
+
+Use `defer` when loading main application JavaScript chunks.

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -55,6 +55,9 @@
       href="__CDN_URL__favicon_144x144px.png"
     />
 
+    <!-- Main application chunks -->
+    __APPLICATION_SCRIPT_IMPORTS__
+
     <!-- Fonts -->
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
@@ -167,8 +170,5 @@
 
     <!-- Application globals -->
     __APPLICATION_ENVIRONMENT__
-
-    <!-- Main application chunks -->
-    __APPLICATION_SCRIPT_IMPORTS__
   </body>
 </html>

--- a/packages/mc-html-template/src/webpack-html-template.ts
+++ b/packages/mc-html-template/src/webpack-html-template.ts
@@ -30,7 +30,7 @@ function webpackHtmlTemplate(templateParams: TemplateParameter) {
       `<link href="__CDN_URL__${chunkPath}" rel='stylesheet' type='text/css'>`
   );
   const scriptImports = scriptChunks.map(
-    (chunkPath) => `<script src="__CDN_URL__${chunkPath}"></script>`
+    (chunkPath) => `<script src="__CDN_URL__${chunkPath}" defer></script>`
   );
 
   return generateTemplate({ cssImports, scriptImports });

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -21,7 +21,9 @@ async function run() {
   const html = generateTemplate({
     // Define the module entry point (path relative from the `/public` folder).
     // NOTE: that this is different from the development configuration.
-    scriptImports: [`<script type="module" src="/${appEntryPoint}"></script>`],
+    scriptImports: [
+      `<script type="module" src="/${appEntryPoint}" defer></script>`,
+    ],
   });
   // Write `index.html` (template) into the `/public` folder.
   fs.writeFileSync(paths.appIndexHtml, html, { encoding: 'utf8' });

--- a/packages/mc-scripts/src/commands/start-vite.ts
+++ b/packages/mc-scripts/src/commands/start-vite.ts
@@ -25,7 +25,7 @@ async function run() {
     // Define the module entry point (path relative to the `/public` folder).
     // NOTE: that this is different from the production configuration.
     scriptImports: [
-      `<script type="module" src="/../${appEntryPoint}"></script>`,
+      `<script type="module" src="/../${appEntryPoint}" defer></script>`,
     ],
   });
   // Write `index.html` (template) into the `/public` folder.


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Description

The goal of this PR is to avoid network falls when downloading MC apps initial JS chunks (runtime and app bundles.See screenshots below).
By moving initial JS chunks to the HTML head and deferring them, we allow the browser to concurrently download the initial JS chunks and the initial CSS files.
We save ~60ms when cold loading a MC app.

You can use https://github.com/commercetools/merchant-center-frontend/pull/17738 to test the Webpack changes (I've patched `@commercetools-frontend/mc-html-template` in that branch of the monorepo).

#### Current Discount app
https://mc.europe-west1.gcp.escemo.com/sunrise-data-alex/discounts

<img width="801" alt="Screenshot 2024-10-03 at 15 17 56" src="https://github.com/user-attachments/assets/a0da28ac-41e0-4676-8c78-c7f90b6fdd27">

#### DIscount app with this PR changes 
https://mc-17738.mc-preview.europe-west1.gcp.escemo.com/sunrise-data-alex/discounts

<img width="640" alt="Screenshot 2024-10-04 at 11 40 52" src="https://github.com/user-attachments/assets/09597c04-b99a-4bc7-b34a-cad23770c8e8">

