### PR TITLE
[FEC-96] Migrate react-router redirects

### DIFF
--- a/.changeset/early-ducks-itch.md
+++ b/.changeset/early-ducks-itch.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/application-shell': patch
+---
+
+Update usages of `Redirect` component in order to set the path for the upcoming migration to `react-router` v6.

--- a/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.spec.tsx
+++ b/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.spec.tsx
@@ -19,9 +19,7 @@ jest.mock('@commercetools-uikit/utils', () => ({
 const Content = () => (
   <Spacings.Stack scale="m">
     <Switch>
-      <Route exact={true} path="/">
-        <Redirect to="/tab-one" />
-      </Route>
+      <Route exact={true} path="/" render={() => <Redirect to="/tab-one" />} />
       <Route path="/tab-one">
         <Text.Body>
           {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}

--- a/packages/application-components/src/components/main-pages/tabular-main-page/tabular-main-page.spec.tsx
+++ b/packages/application-components/src/components/main-pages/tabular-main-page/tabular-main-page.spec.tsx
@@ -19,9 +19,7 @@ jest.mock('@commercetools-uikit/utils', () => ({
 const Content = () => (
   <Spacings.Stack scale="m">
     <Switch>
-      <Route exact={true} path="/">
-        <Redirect to="/tab-one" />
-      </Route>
+      <Route exact={true} path="/" render={() => <Redirect to="/tab-one" />} />
       <Route path="/tab-one">
         <Text.Body>
           {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}

--- a/packages/application-shell/src/components/application-entry-point/application-entry-point.tsx
+++ b/packages/application-shell/src/components/application-entry-point/application-entry-point.tsx
@@ -51,10 +51,12 @@ const ApplicationEntryPoint = (props: TApplicationEntryPointProps) => {
           // For development, it's useful to redirect to the actual
           // application routes when you open the browser at http://localhost:3001
           process.env.NODE_ENV === 'production' ? null : (
-            <Redirect
+            <Route
               exact={true}
-              from="/:projectKey"
-              to={`/:projectKey/${entryPointUriPath}`}
+              path="/:projectKey"
+              render={() => (
+                <Redirect to={`/:projectKey/${entryPointUriPath}`} />
+              )}
             />
           )
         }

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -387,10 +387,13 @@ export const ApplicationShellAuthenticated = (
                                 }
                               />
                               <Switch>
-                                <Redirect
-                                  from="/profile"
-                                  to="/account/profile"
+                                <Route
+                                  path="/profile"
+                                  render={() => (
+                                    <Redirect to="/account/profile" />
+                                  )}
                                 />
+
                                 <Route path="/account">
                                   {
                                     /**

--- a/visual-testing-app/src/components/tabular-detail-page/tabular-detail-page.visualroute.tsx
+++ b/visual-testing-app/src/components/tabular-detail-page/tabular-detail-page.visualroute.tsx
@@ -47,9 +47,11 @@ TabularDetailPageContainer.displayName = 'TabularDetailPageContainer';
 const Content = () => (
   <Spacings.Stack scale="m">
     <Switch>
-      <Route exact={true} path="/tabular-detail-page">
-        <Redirect to="/tabular-detail-page/tab-one" />
-      </Route>
+      <Route
+        exact={true}
+        path="/tabular-detail-page"
+        render={() => <Redirect to="/tabular-detail-page/tab-one" />}
+      />
       <Route path="/tabular-detail-page/tab-one">
         <Text.Body>
           {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}

--- a/visual-testing-app/src/components/tabular-main-page/tabular-main-page.visualroute.tsx
+++ b/visual-testing-app/src/components/tabular-main-page/tabular-main-page.visualroute.tsx
@@ -46,9 +46,11 @@ TabularMainPageContainer.displayName = 'TabularMainPageContainer';
 const Content = () => (
   <Spacings.Stack scale="m">
     <Switch>
-      <Route exact={true} path="/tabular-main-page">
-        <Redirect to="/tabular-main-page/tab-one" />
-      </Route>
+      <Route
+        exact={true}
+        path="/tabular-main-page"
+        render={() => <Redirect to="/tabular-main-page/tab-one" />}
+      />
       <Route path="/tabular-main-page/tab-one">
         <Text.Body>
           {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}

--- a/visual-testing-app/src/components/tabular-modal-page/tabular-modal-page.visualroute.tsx
+++ b/visual-testing-app/src/components/tabular-modal-page/tabular-modal-page.visualroute.tsx
@@ -59,9 +59,11 @@ const Content = () => {
   return (
     <Spacings.Stack scale="m">
       <Switch>
-        <Route exact={true} path={`${match.path}`}>
-          <Redirect to={`${match.url}/tab-one`} />
-        </Route>
+        <Route
+          exact={true}
+          path={`${match.path}`}
+          render={() => <Redirect to={`${match.url}/tab-one`} />}
+        />
         <Route path={`${match.path}/tab-one`}>
           <Text.Body>
             {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec turpis in risus elementum fringilla. Vestibulum nec vulputate metus, fringilla luctus nisl. Vestibulum mattis ultricies augue sagittis vestibulum. Nulla facilisi. Quisque tempor pulvinar efficitur. Praesent interdum ultrices leo. Vivamus non ex maximus justo egestas suscipit eget sed purus. Aliquam ut venenatis nulla. Fusce ac ligula viverra, blandit augue eget, congue turpis. Curabitur a sagittis leo. Nunc sed quam dictum, placerat nunc quis, luctus erat.`}

--- a/website-components-playground/src/pages/tabular-detail-page.tsx
+++ b/website-components-playground/src/pages/tabular-detail-page.tsx
@@ -156,7 +156,11 @@ const TabularDetailPageExample = () => {
               <Route path={`${match.path}/tabular-detail-page/tab-two`}>
                 <Text.Body>{values['tab-two-content']}</Text.Body>
               </Route>
-              <Redirect to={`${match.url}/tabular-detail-page/tab-one`} />
+              <Route
+                render={() => (
+                  <Redirect to={`${match.url}/tabular-detail-page/tab-one`} />
+                )}
+              />
             </Switch>
           </TabularDetailPage>
         )}

--- a/website-components-playground/src/pages/tabular-main-page.tsx
+++ b/website-components-playground/src/pages/tabular-main-page.tsx
@@ -155,7 +155,11 @@ const TabularMainPageExample = () => {
               <Route path={`${match.path}/tabular-main-page/tab-two`}>
                 <Text.Body>{values['tab-two-content']}</Text.Body>
               </Route>
-              <Redirect to={`${match.url}/tabular-main-page/tab-one`} />
+              <Route
+                render={() => (
+                  <Redirect to={`${match.url}/tabular-main-page/tab-one`} />
+                )}
+              />
             </Switch>
           </TabularMainPage>
         )}

--- a/website-components-playground/src/pages/tabular-modal-page.tsx
+++ b/website-components-playground/src/pages/tabular-modal-page.tsx
@@ -135,7 +135,13 @@ const TabularModalPageExample = () => {
                   <Route path={`${match.path}/tabular-modal-page/tab-two`}>
                     <Text.Body>{values['tab-two-content']}</Text.Body>
                   </Route>
-                  <Redirect to={`${match.url}/tabular-modal-page/tab-one`} />
+                  <Route
+                    render={() => (
+                      <Redirect
+                        to={`${match.url}/tabular-modal-page/tab-one`}
+                      />
+                    )}
+                  />
                 </Switch>
               </TabularModalPage>
             )}


### PR DESCRIPTION
#### Summary

Migrate react-router redirects

#### Description

As part of the preparations for the upcoming `react-router` v6 migration, there are some changes related to how client-side redirects are managed ([reference](https://reactrouter.com/en/main/upgrading/v5#remove-redirects-inside-switch)) that we can already apply to our codebase (supported in v5).
