### PR TITLE
refactor(application.html): add meta tag to prevent search engine indexing

### DIFF
--- a/.changeset/nasty-zoos-shop.md
+++ b/.changeset/nasty-zoos-shop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+added meta-tag to the mc-html-template file, preventing search engines from listing merchant center apps in search result pages

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -2,6 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- do not index this page, do not follow links on this page -->
+    <meta name="robots" content="noindex,nofollow" />
+
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"


### PR DESCRIPTION
## Problem
When a user Googles "Merchant Center commercetools", we don't want the various MC's to appear in the search result pages.

## Solution
We add a meta-tag to the `application.html` file to prevent search engines from indexing the apps and potentially following  links.

Breakdown of the meta-tag directive:
- `noindex`: Prevents search engines from indexing the page, so it won’t appear in search results.
- `nofollow`: Tells search engines not to follow the links on the page

