### PR TITLE
fix(navbar): prevent menu-items from growing when hovered

### DIFF
--- a/packages/application-shell/src/components/navbar/menu-items.styles.ts
+++ b/packages/application-shell/src/components/navbar/menu-items.styles.ts
@@ -98,6 +98,16 @@ const TextLinkSublistWrapper = styled.div`
 const NavlinkClickableContent = styled.div`
   height: 100%;
   width: 100%;
+  display: block;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: all 150ms ease-out;
+
+  position: relative;
+  left: calc(-1 * ${uiKitDesignTokens.spacing20});
 `;
 
 const listStyles = css`
@@ -179,11 +189,11 @@ const SublistItem = styled.li<{ isActive: boolean }>`
   display: flex;
   align-items: center;
   align-self: stretch;
+  border-radius: ${uiKitDesignTokens.borderRadius4};
 
   ${(props) => [
     props.isActive &&
       css`
-        border-radius: ${uiKitDesignTokens.borderRadius4};
         background: ${uiKitDesignTokens.colorPrimary40};
       `,
     !props.isActive &&
@@ -196,12 +206,9 @@ const SublistItem = styled.li<{ isActive: boolean }>`
           background: ${uiKitDesignTokens.colorPrimary95};
 
           [data-link-level='text-link-sublist'] {
-            /* additional left padding on hover and focus */
-            padding: ${uiKitDesignTokens.spacing25}
-              ${uiKitDesignTokens.spacing25} ${uiKitDesignTokens.spacing25}
-              calc(
-                ${uiKitDesignTokens.spacing30} + ${uiKitDesignTokens.spacing20}
-              );
+            > ${NavlinkClickableContent} {
+              left: 0;
+            }
           }
         }
       `,

--- a/packages/application-shell/src/constants.ts
+++ b/packages/application-shell/src/constants.ts
@@ -12,7 +12,7 @@ export const NAVBAR = {
   sublistIndentationWhenCollapsed: '72px',
   sublistIndentationWhenExpanded: '248px',
   sublistItemMinHeight: '50px',
-  sublistWidth: '253px',
+  sublistWidth: '272px',
   leftNavigationTransition: 'all 150ms cubic-bezier(1, 0, 0.58, 1)',
   widthLeftNavigation: '80px',
   widthLeftNavigationWhenExpanded: '256px',


### PR DESCRIPTION
#### Summary
When hovering an element in a navbar-submenu with a long wording, the wording may wrap into the next line when the item is hovered and cause sub-menus to close, essentially making some menu-items unnavigable.

#### Description
The problem is caused by the hovering element changing its size during the hover, triggering a layout shift of neighbouring elements.

After syncing on what is possible @FilPob and I agreed on keeping a fixed, but slightly increased width for submenus.
To preserve the animation of the text-indentation, the moving of the text is now done with relative positioning. This way, padding-values stay untouched and the DOM element won't change dimensions and can't cause layout shifts.

Additionally, the mechanism to truncate/clamp text after 2 consequent lines of text was fixed (currently it clamps, but also shows a third line of text).

