### PR TITLE
Validate branch name in preview release workflow

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -34,15 +34,7 @@ jobs:
         run: |
           BRANCH_NAME=${{ steps.comment-branch.outputs.head_ref }}
           if [[ ! "$BRANCH_NAME" =~ ^preview/[a-zA-Z0-9_-]+$ ]]; then
-            echo "Invalid branch name. Exiting workflow."
-            exit 1
-          fi
-
-      - name: Ensure branch name matches 'preview/**'
-        run: |
-          BRANCH_NAME=${{ steps.comment-branch.outputs.head_ref }}
-          if [[ ! "$BRANCH_NAME" =~ ^preview/ ]]; then
-            echo "Branch name does not match 'preview/**'. Exiting workflow."
+            echo "Ignoring PR because of the branch name. Exiting workflow."
             exit 1
           fi
 

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -30,6 +30,14 @@ jobs:
         uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
 
+      - name: Validate branch name
+        run: |
+          BRANCH_NAME=${{ steps.comment-branch.outputs.head_ref }}
+          if [[ ! "$BRANCH_NAME" =~ ^preview/[a-zA-Z0-9_-]+$ ]]; then
+            echo "Invalid branch name. Exiting workflow."
+            exit 1
+          fi
+
       - name: Ensure branch name matches 'preview/**'
         run: |
           BRANCH_NAME=${{ steps.comment-branch.outputs.head_ref }}


### PR DESCRIPTION
#### Summary

Validate branch name in preview release workflow

#### Description

We detected some attempts to exploit the new workflow for preview releases so we want to include a quick and simple validation for the branch names we use in order to protect the flow.

We now only allow numbers, letters, underscores, and hyphens in the branch name.
