### PR TITLE
[FEC-157] Update prerelease workflow

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Set latest commit status as pending
-        uses: myrotvorets/set-commit-status-action@v2
+        uses: myrotvorets/set-commit-status-action@v2.0.1
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ steps.generate_github_token.outputs.token }}
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set latest commit status as ${{ job.status }}
-        uses: myrotvorets/set-commit-status-action@v2
+        uses: myrotvorets/set-commit-status-action@v2.0.1
         if: always()
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -38,14 +38,6 @@ jobs:
             exit 1
           fi
 
-      - name: Set latest commit status as pending
-        uses: myrotvorets/set-commit-status-action@v2.0.1
-        with:
-          sha: ${{ steps.comment-branch.outputs.head_sha }}
-          token: ${{ steps.generate_github_token.outputs.token }}
-          status: pending
-          allowForks: false
-
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
@@ -81,12 +73,3 @@ jobs:
             --body "Release workflow ${{ job.status == 'success' && 'succeeded ✅' || 'failed ❌' }}\nSee details: [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set latest commit status as ${{ job.status }}
-        uses: myrotvorets/set-commit-status-action@v2.0.1
-        if: always()
-        with:
-          sha: ${{ steps.comment-branch.outputs.head_sha }}
-          token: ${{ steps.generate_github_token.outputs.token }}
-          status: ${{ job.status }}
-          allowForks: false


### PR DESCRIPTION
#### Summary

Update prerelease workflow

#### Description

The initial goal of this PR was to fix an error we currently have in the prerelease workflow regarding an invalid version number we're using for the `myrotvorets/set-commit-status-action@v2` action:
![image](https://github.com/user-attachments/assets/f9161b81-6702-4960-8e22-c70c51a8a583)

That action [has not published](https://github.com/myrotvorets/set-commit-status-action/tags) any `v2` tag so we need to use a specific version. I was suggesting to use the latest available (`2.0.1`).
You can take a look at this PR's first commit.

Afterwards, I thought about the purpose of using that action in the workflow: it seems we want to set a visual mark on the last commit before the preview release comment was written.
Since that mark is very subtle (visually) and we are also adding a comment when the release process in finished so we know whether it went well or not, my second commit in this PR is my proposal to remove those steps from the workflow as I believe the code we add to the workflow does not outweigh the benefits we get from it.

Of course, open for discussion.