### PR TITLE
Fix preview releases workflow

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -1,10 +1,10 @@
 name: Preview Release on Comment
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
   issues: write
-  statuses: write
 
 on:
   issue_comment:


### PR DESCRIPTION
#### Summary

The preview release workflow was not working because one permission was missing.
