### PR TITLE
feat(omlet): basic omlet.dev integration

### DIFF
--- a/.omletrc
+++ b/.omletrc
@@ -1,0 +1,38 @@
+{
+  "ignore": [
+       "**/dist/**",
+       "**/visual-testing-app/**"
+  ],
+  "workspaces": {
+    "@commercetools-frontend/application-components": {
+      "exports": {
+        ".": "./src/index.ts"
+      }
+    },
+    "@commercetools-frontend/application-shell": {
+      "exports": {
+        ".": "./src/index.ts"
+      }
+    },
+    "@commercetools-frontend/application-shell-connectors": {
+      "exports": {
+        ".": "./src/index.ts"
+      }
+    },
+    "@commercetools-frontend/i18n": {
+      "exports": {
+        ".": "./src/index.ts"
+      }
+    },
+    "@commercetools-frontend/react-notifications": {
+      "exports": {
+        ".": "./src/index.ts"
+      }
+    },
+    "@commercetools-frontend/sentry": {
+      "exports": {
+        ".": "./src/index.ts"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "generate-types:core": "graphql-codegen -r dotenv/config --config codegen.core.yml",
     "generate-types:settings": "graphql-codegen -r dotenv/config --config codegen.settings.yml",
     "generate-types:proxy": "graphql-codegen -r dotenv/config --config codegen.proxy.yml",
-    "generate-types": "pnpm generate-types:mc && pnpm generate-types:ctp && pnpm generate-types:core && pnpm generate-types:settings && pnpm generate-types:proxy"
+    "generate-types": "pnpm generate-types:mc && pnpm generate-types:ctp && pnpm generate-types:core && pnpm generate-types:settings && pnpm generate-types:proxy",
+    "omlet:scan": "pnpm omlet analyze --hook-script ./scripts/omlet-hook-script.js"
   },
   "preconstruct": {
     "packages": [
@@ -108,6 +109,7 @@
     "@manypkg/cli": "0.21.4",
     "@manypkg/find-root": "2.2.1",
     "@manypkg/get-packages": "1.1.3",
+    "@omlet/cli": "^1.12.0",
     "@percy/cli": "1.30.2",
     "@percy/core": "1.30.2",
     "@percy/cypress": "3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@manypkg/get-packages':
         specifier: 1.1.3
         version: 1.1.3
+      '@omlet/cli':
+        specifier: ^1.12.0
+        version: 1.12.0(eslint@8.57.0)
       '@percy/cli':
         specifier: 1.30.2
         version: 1.30.2
@@ -14985,7 +14988,7 @@ packages:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.6.2
       tar: 6.1.13
     transitivePeerDependencies:
       - encoding
@@ -15212,6 +15215,126 @@ packages:
     resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
     dependencies:
       '@octokit/openapi-types': 12.11.0
+    dev: false
+
+  /@omlet/cli-darwin-arm64@1.12.0:
+    resolution: {integrity: sha512-/Ioa1nP07YQ6AjVa58JET4JS030GlLry7yOFTueTvf10alVCMxZWRLwUUyJ6xqjGd14mfy0iAs7peUk5bI/l3Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli-darwin-x64@1.12.0:
+    resolution: {integrity: sha512-1juYTJL15sad+l/qc8/Va30NV0F676ER83ejouoS76XbEEwWiAPi6SN/pt5nR+cW/3o1v+uTdIYkGuaIIFz71Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli-linux-arm64-gnu@1.12.0:
+    resolution: {integrity: sha512-DEL0zieaiVJC0AMg81Ohrp7tywoaandHlwcs/ckrnoCs19psrabLqKE2vpnmHZBc5HXJMQpPC/jp1taqHU3CEw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli-linux-arm64-musl@1.12.0:
+    resolution: {integrity: sha512-23MWGkMbyL2bAJaIWaYAdViPLaMbCy5si9T1tmuz91VsRFOOkmUGRedX+YlU08C7bzp/M6Dt3+ES650Me1G6pQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli-linux-x64-gnu@1.12.0:
+    resolution: {integrity: sha512-NBowrE6LKyhrpbIfXwZj6LIDIjPhvly7a+/PgnnzgPMEfTw4H5tMAmAraRtteZB/r3pp6nReZBr3dhw9ULnjJw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli-linux-x64-musl@1.12.0:
+    resolution: {integrity: sha512-esItyft0jz/RAd/EZotLRSzVqM3Xfj6MWj2K9dsld9mJLEizUOrhKF98SEo9/QDqzFb4d3Y4P/s3WTN+WgcZiw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli-win32-x64-msvc@1.12.0:
+    resolution: {integrity: sha512-6yYfBYxJF0eQ0UZ/LQXh2U9LvCN8gOuTdvKd2sgb4Y/pagqZqkzUbhVGs2K7OPofweosqYv6HmbaZK6P2gz6tw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@omlet/cli@1.12.0(eslint@8.57.0):
+    resolution: {integrity: sha512-Fbs40VYVcJjcMO2j5blPCSmD7gjeEV1cvpR0uZtd+gdNAhNipc6YmAWE0/QWGL98RPT/Ia9uVJbNMfvpP0Dr3Q==}
+    engines: {node: '>= 14'}
+    hasBin: true
+    dependencies:
+      '@sentry/node': 7.120.1
+      ajv: 8.16.0
+      ci-info: 4.1.0
+      colorette: 2.0.19
+      commander: 9.5.0
+      core-js: 3.32.2
+      cosmiconfig: 8.2.0
+      current-git-branch: 1.1.0
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.57.0)
+      fast-glob: 3.3.1
+      find-git-root: 1.0.4
+      find-root: 1.1.0
+      get-tsconfig: 4.7.1
+      git-repo-info: 2.1.1
+      hosted-git-info: 5.2.1
+      http-status-codes: 2.3.0
+      https-proxy-agent: 5.0.1
+      inquirer: 8.2.5
+      is-docker: 2.2.1
+      js-yaml: 4.1.0
+      json-stream-stringify: 3.1.6
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      memfs: 4.8.2
+      micromatch: 4.0.8
+      node-fetch: 2.7.0
+      node-machine-id: 1.1.12
+      open: 8.4.2
+      ora: 5.4.1
+      parse-git-config: 3.0.0
+      server-destroy: 1.0.1
+      upath: 2.0.1
+      update-notifier: 5.1.0
+      uuid: 9.0.1
+      winston: 3.13.0
+    optionalDependencies:
+      '@omlet/cli-darwin-arm64': 1.12.0
+      '@omlet/cli-darwin-x64': 1.12.0
+      '@omlet/cli-linux-arm64-gnu': 1.12.0
+      '@omlet/cli-linux-arm64-musl': 1.12.0
+      '@omlet/cli-linux-x64-gnu': 1.12.0
+      '@omlet/cli-linux-x64-musl': 1.12.0
+      '@omlet/cli-win32-x64-msvc': 1.12.0
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - encoding
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: false
 
   /@open-draft/until@1.0.3:
@@ -15884,6 +16007,15 @@ packages:
       '@sentry/utils': 7.119.1
     dev: false
 
+  /@sentry-internal/tracing@7.120.1:
+    resolution: {integrity: sha512-MwZlhQY27oM4V05m2Q46WB2F7jqFu8fewg14yRcjCuK3tdxvQoLsXOEPMZxLxpoXPTqPCm3Ig7mA4GwdlCL41w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.120.1
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
+    dev: false
+
   /@sentry/browser@7.117.0:
     resolution: {integrity: sha512-29X9HlvDEKIaWp6XKlNPPSNND0U6P/ede5WA2nVHfs1zJLWdZ7/ijuMc0sH/CueEkqHe/7gt94hBcI7HOU/wSw==}
     engines: {node: '>=8'}
@@ -15928,6 +16060,14 @@ packages:
       '@sentry/utils': 7.119.1
     dev: false
 
+  /@sentry/core@7.120.1:
+    resolution: {integrity: sha512-tXpJlf/8ngsSCpcRD+4DDvh4TqUbY0MlvE9Mpc/jO5GgYl/goAH2H1COw6W/UNfkr/l80P2jejS0HLPk0moi0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
+    dev: false
+
   /@sentry/integrations@7.117.0:
     resolution: {integrity: sha512-U3suSZysmU9EiQqg0ga5CxveAyNbi9IVdsapMDq5EQGNcVDvheXtULs+BOc11WYP3Kw2yWB38VDqLepfc/Fg2g==}
     engines: {node: '>=8'}
@@ -15946,6 +16086,27 @@ packages:
       '@sentry/types': 7.119.1
       '@sentry/utils': 7.119.1
       localforage: 1.10.0
+    dev: false
+
+  /@sentry/integrations@7.120.1:
+    resolution: {integrity: sha512-dshhLZUN+pYpyZiS5QRYKaYSqvWYtmsbwmBlH4SCGOnN9sbY4nZn0h8njr+xKT8UFnPxoTlbZmkcrVY3qPVMfg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.120.1
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
+      localforage: 1.10.0
+    dev: false
+
+  /@sentry/node@7.120.1:
+    resolution: {integrity: sha512-YF/TDUCtUOQeUMwL4vcUWGNv/8Qz9624xBnaL8nXW888xNBoSRr2vH/zMrmTup5zfmWAh9lVbp98BZFF6F0WJg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/tracing': 7.120.1
+      '@sentry/core': 7.120.1
+      '@sentry/integrations': 7.120.1
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
     dev: false
 
   /@sentry/react@7.117.0(react@17.0.2):
@@ -15992,6 +16153,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /@sentry/types@7.120.1:
+    resolution: {integrity: sha512-f/WT7YUH8SA2Jhez/hYz/dA351AJqr1Eht/URUdYsqMFecXr/blAcNKRVFccSsvQeTqWVV9HVQ9BXUSjPJOvFA==}
+    engines: {node: '>=8'}
+    dev: false
+
   /@sentry/utils@7.117.0:
     resolution: {integrity: sha512-KkcLY8643SGBiDyPvMQOubBkwVX5IPknMHInc7jYC8pDVncGp7C65Wi506bCNPpKCWspUd/0VDNWOOen51/qKA==}
     engines: {node: '>=8'}
@@ -16004,6 +16170,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@sentry/types': 7.119.1
+    dev: false
+
+  /@sentry/utils@7.120.1:
+    resolution: {integrity: sha512-4boeo5Y3zw3gFrWZmPHsYOIlTh//eBaGBgWL25FqLbLObO23gFE86G6O6knP1Gamm1DGX2IWH7w4MChYuBm6tA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.120.1
     dev: false
 
   /@sheerun/mutationobserver-shim@0.3.3:
@@ -17615,7 +17788,7 @@ packages:
       estree-walker: 2.0.2
       glob: 7.2.3
       graceful-fs: 4.2.11
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       node-gyp-build: 4.6.0
       node-pre-gyp: 0.13.0
       resolve-from: 5.0.0
@@ -18545,6 +18718,10 @@ packages:
       webpack: 5.94.0
     dev: false
 
+  /babel-plugin-add-module-exports@0.2.1:
+    resolution: {integrity: sha512-3AN/9V/rKuv90NG65m4tTHsI04XrCKsWbztIcW7a8H5iIN7WlvWucRtVV0V/rT4QvtA11n5Vmp20fLwfMWqp6g==}
+    dev: false
+
   /babel-plugin-dev-expression@0.2.3(@babel/core@7.22.17):
     resolution: {integrity: sha512-rP5LK9QQTzCW61nVVzw88En1oK8t8gTsIeC6E61oelxNsU842yMjF0G1MxhvUpCkxCEIj7sE8/e5ieTheT//uw==}
     peerDependencies:
@@ -19421,6 +19598,11 @@ packages:
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  /ci-info@4.1.0:
+    resolution: {integrity: sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==}
+    engines: {node: '>=8'}
+    dev: false
 
   /cjs-module-lexer@1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
@@ -20311,6 +20493,14 @@ packages:
       csv-parse: 4.16.3
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
+    dev: false
+
+  /current-git-branch@1.1.0:
+    resolution: {integrity: sha512-n5mwGZllLsFzxDPtTmadqGe4IIBPfqPbiIRX4xgFR9VK/Bx47U+94KiVkxSKAKN6/s43TlkztS2GZpgMKzwQ8A==}
+    dependencies:
+      babel-plugin-add-module-exports: 0.2.1
+      execa: 0.6.3
+      is-git-repository: 1.1.1
     dev: false
 
   /currently-unhandled@0.4.1:
@@ -22045,6 +22235,19 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  /execa@0.6.3:
+    resolution: {integrity: sha512-/teX3MDLFBdYUhRk8WCBYboIMUmqeizu0m9Z3YF3JWrbEh/SlZg00vLJSaAGWw3wrZ9tE0buNw79eaAPYhUuvg==}
+    engines: {node: '>=4'}
+    dependencies:
+      cross-spawn: 5.1.0
+      get-stream: 3.0.0
+      is-stream: 1.1.0
+      npm-run-path: 2.0.2
+      p-finally: 1.0.0
+      signal-exit: 3.0.7
+      strip-eof: 1.0.0
+    dev: false
+
   /execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
@@ -22475,6 +22678,10 @@ packages:
       resolve-dir: 0.1.1
     dev: false
 
+  /find-git-root@1.0.4:
+    resolution: {integrity: sha512-468fmirKKgcrqfZfPn0xIpwZUUsZQcYXfx0RC2/jX39GPz83TwutQNZZhDrI6HqjO8cRejxQVaUY8GQdXopFfA==}
+    dev: false
+
   /find-node-modules@2.1.3:
     resolution: {integrity: sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==}
     dependencies:
@@ -22846,6 +23053,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /get-stream@3.0.0:
+    resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
+    engines: {node: '>=4'}
+    dev: false
+
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
@@ -22873,6 +23085,12 @@ packages:
 
   /get-tsconfig@4.5.0:
     resolution: {integrity: sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==}
+    dev: false
+
+  /get-tsconfig@4.7.1:
+    resolution: {integrity: sha512-sLtd6Bcwbi9IrAow/raCOTE9pmhvo5ksQo5v2lApUGJMzja64MUYhBp0G6X1S+f7IrBPn1HP+XkS2w2meoGcjg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: false
 
   /get-tsconfig@4.7.3:
@@ -22903,6 +23121,11 @@ packages:
     dependencies:
       assert-plus: 1.0.0
 
+  /git-config-path@2.0.0:
+    resolution: {integrity: sha512-qc8h1KIQbJpp+241id3GuAtkdyJ+IK+LIVtkiFTRKRrmddDzs3SI9CvP1QYmWBFvm1I/PWRwj//of8bgAc0ltA==}
+    engines: {node: '>=4'}
+    dev: false
+
   /git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
@@ -22913,6 +23136,11 @@ packages:
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
+    dev: false
+
+  /git-repo-info@2.1.1:
+    resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
+    engines: {node: '>= 4.0'}
     dev: false
 
   /glob-base@0.3.0:
@@ -23533,6 +23761,13 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /hosted-git-info@5.2.1:
+    resolution: {integrity: sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      lru-cache: 7.18.3
+    dev: false
+
   /hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
     dependencies:
@@ -23688,6 +23923,10 @@ packages:
       assert-plus: 1.0.0
       jsprim: 2.0.2
       sshpk: 1.18.0
+
+  /http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+    dev: false
 
   /http2-wrapper@2.2.0:
     resolution: {integrity: sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==}
@@ -24099,6 +24338,13 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
+
+  /is-git-repository@1.1.1:
+    resolution: {integrity: sha512-hxLpJytJnIZ5Og5QsxSkzmb8Qx8rGau9bio1JN/QtXcGEFuSsQYau0IiqlsCwftsfVYjF1mOq6uLdmwNSspgpA==}
+    dependencies:
+      execa: 0.6.3
+      path-is-absolute: 1.0.1
+    dev: false
 
   /is-glob@2.0.1:
     resolution: {integrity: sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==}
@@ -25475,6 +25721,11 @@ packages:
       object-keys: 1.1.1
     dev: false
 
+  /json-stream-stringify@3.1.6:
+    resolution: {integrity: sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==}
+    engines: {node: '>=7.10.1'}
+    dev: false
+
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -25497,6 +25748,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  /jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+    dev: false
 
   /jsondiffpatch@0.4.1:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
@@ -26267,7 +26522,6 @@ packages:
     engines: {node: '>= 4.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -27051,6 +27305,10 @@ packages:
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
+  /node-machine-id@1.1.12:
+    resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
+    dev: false
+
   /node-pre-gyp@0.13.0:
     resolution: {integrity: sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==}
     deprecated: 'Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future'
@@ -27589,6 +27847,14 @@ packages:
       is-absolute: 1.0.0
       map-cache: 0.2.2
       path-root: 0.1.1
+    dev: false
+
+  /parse-git-config@3.0.0:
+    resolution: {integrity: sha512-wXoQGL1D+2COYWCD35/xbiKma1Z15xvZL8cI25wvxzled58V51SJM04Urt/uznS900iQor7QO04SgdfT/XlbuA==}
+    engines: {node: '>=8'}
+    dependencies:
+      git-config-path: 2.0.0
+      ini: 1.3.8
     dev: false
 
   /parse-github-url@1.0.2:
@@ -29849,6 +30115,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /server-destroy@1.0.1:
+    resolution: {integrity: sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==}
+    dev: false
+
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: false
@@ -31695,6 +31965,11 @@ packages:
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
+
+  /upath@2.0.1:
+    resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
+    engines: {node: '>=4'}
+    dev: false
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}

--- a/scripts/omlet-hook-script.js
+++ b/scripts/omlet-hook-script.js
@@ -1,0 +1,16 @@
+/**
+ * This hook script is executed by the "pnpm run omlet:scan" after the scan phase.
+ * It is used to add metadata to the scanned components.
+ * @see https://docs.omlet.dev/discover-omlet/learn-omlet-cli/custom-component-properties#scanning-with-a-hook-script
+ * @type {import('@omlet/cli').CliHookModule}
+ */
+module.exports = {
+  async afterScan(components) {
+    for (const component of components) {
+      if (!component.filePath) {
+        /** = component from external component library */
+        component.setMetadata('package_name', component.component.package_name);
+      }
+    }
+  },
+};


### PR DESCRIPTION
#### Summary

This PR integrates the possibility to scan the repository with [omlet.dev](https:/omlet.dev/) via their cli. A scan will collect information about component usage and dependencies.

#### Description
I added the omlet config file (`.omletrc`) to the root, configured it to the best of my knowledge and added an `omlet:scan` script-shortcut to the root `package.json`.

I also prepared a hook-file according to the omlet docs, so that we can easily add more meta-data to the component-scan results in the future (e.g. add the owning team to a component).
