### PR TITLE
fix(AppShell): project switching

### DIFF
--- a/.changeset/fuzzy-tips-scream.md
+++ b/.changeset/fuzzy-tips-scream.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Resolve incorrect parameter handling during project switch

--- a/packages/application-shell/src/components/application-entry-point/application-entry-point.tsx
+++ b/packages/application-shell/src/components/application-entry-point/application-entry-point.tsx
@@ -54,9 +54,10 @@ const ApplicationEntryPoint = (props: TApplicationEntryPointProps) => {
             <Route
               exact={true}
               path="/:projectKey"
-              render={() => (
-                <Redirect to={`/:projectKey/${entryPointUriPath}`} />
-              )}
+              render={({ match }) => {
+                const projectKey = match.params.projectKey;
+                return <Redirect to={`/${projectKey}/${entryPointUriPath}`} />;
+              }}
             />
           )
         }


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

We recently updated how redirects are handled (see [PR #3630](https://github.com/commercetools/merchant-center-application-kit/pull/3630)). Unfortunately, this introduced a regression in project switching behavior. This fix addresses the issue by properly resolving route parameters during redirects.

![image](https://github.com/user-attachments/assets/9c7796fc-ba21-45bf-8265-47a7d4111d30)

