### PR TITLE
refactor: append graphql operation name as query param

### DIFF
--- a/.changeset/bright-olives-yell.md
+++ b/.changeset/bright-olives-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+---
+
+Append the GraphQL operation name as a query parameter to the `/graphql` endpoint. This is useful for debugging purposes, for example when inspecting the network tab.


### PR DESCRIPTION
To help debugging the GraphQL requests in the network tab:

<img width="616" alt="image" src="https://github.com/user-attachments/assets/d5a14b1c-91f6-4bfb-8932-95c9bafe44ec" />
