### PR TITLE
New codemod to help migrating React components "defaultProps" usage

### DIFF
--- a/.changeset/purple-panthers-attack.md
+++ b/.changeset/purple-panthers-attack.md
@@ -1,0 +1,40 @@
+---
+'@commercetools-frontend/codemod': minor
+---
+
+There's a new codemod which helps migrating the way React Components `defaultProps` are used.
+
+This is how the change looks like:
+
+```ts
+// BEFORE
+type TMyComponentProps = {
+  message: string;
+  size: string;
+}
+
+function MyComponent(props: TMyComponentProps) {
+ ...
+}
+
+MyComponent.defaultProps = {
+  size: 'big'
+}
+
+
+// AFTER
+type TMyComponentProps = {
+  message: string;
+  size?: string; // <--- Note this property is now defined as optional
+}
+
+function MyComponent({ size = 'big', ...props }: TMyComponentProps) {
+ ...
+}
+```
+
+And here is how the new codemod can be run:
+
+```
+$ npx @commercetools-frontend/codemod@latest react-default-props-migration 'src/**/*.{jsx,tsx}'
+```

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -49,3 +49,41 @@ Remove code related to the old design when using the `useTheme` hook, for exampl
 ```
 $ npx @commercetools-frontend/codemod@latest redesign-cleanup 'src/**/*.{jsx,tsx}'
 ```
+
+### `react-default-props-migration`
+
+Migrates the way React Components `defaultProps` are used to comply with the new pattern.
+Example:
+
+```jsx
+// BEFORE
+function MyComponent(props) {
+  return (
+    <ul>
+    <li>Prop 1: {props.prop1}</li>
+    <li>Prop 2: {props.prop2}</li>
+    <li>Prop 3: {props.prop3}</li>
+  </ul>
+  );
+}
+MyComponent.defaultProps = {
+  prop1: 'My default value',
+};
+
+// AFTER
+function MyComponent({ prop1: 'My default value', ...props }) {
+  return (
+    <ul>
+    <li>Prop 1: {prop1}</li>
+    <li>Prop 2: {props.prop2}</li>
+    <li>Prop 3: {props.prop3}</li>
+  </ul>
+  );
+}
+```
+
+You can run this codemod by using the following command:
+
+```
+$ npx @commercetools-frontend/codemod@latest react-default-props-migration 'src/**/*.{jsx,tsx}'
+```

--- a/packages/codemod/src/cli.ts
+++ b/packages/codemod/src/cli.ts
@@ -31,6 +31,11 @@ const transforms: { name: TCliTransformName; description: string }[] = [
     description:
       'Remove code related to the old design when using the "useTheme" hook, for example the usage of "themedValue".',
   },
+  {
+    name: 'react-default-props-migration',
+    description:
+      'Migrate React components using defaultProps as a component property to a destructured object param.',
+  },
 ];
 
 const executeCodemod = async (
@@ -49,6 +54,7 @@ const executeCodemod = async (
   };
   switch (transform) {
     case 'redesign-cleanup':
+    case 'react-default-props-migration':
     case 'remove-deprecated-modal-level-props':
     case 'rename-js-to-jsx':
     case 'rename-mod-css-to-module-css': {

--- a/packages/codemod/src/cli.ts
+++ b/packages/codemod/src/cli.ts
@@ -43,7 +43,18 @@ const executeCodemod = async (
   globPattern: string,
   globalOptions: TCliGlobalOptions
 ) => {
-  const files = glob.sync(globPattern);
+  const absoluteGlobPattern = path.resolve(globPattern);
+  const files = glob.sync(
+    path.join(absoluteGlobPattern, '**/*.{ts,tsx,js,jsx}'),
+    {
+      ignore: [
+        '**/node_modules/**',
+        '**/public/**',
+        '**/dist/**',
+        '**/build/**',
+      ],
+    }
+  );
 
   const runJscodeshift = async (
     transformPath: string,
@@ -62,12 +73,6 @@ const executeCodemod = async (
 
       await runJscodeshift(transformPath, files, {
         extensions: 'tsx,ts,jsx,js',
-        ignorePattern: [
-          '**/node_modules/**',
-          '**/public/**',
-          '**/dist/**',
-          '**/build/**',
-        ],
         parser: 'tsx',
         verbose: 0,
         dry: globalOptions.dryRun,

--- a/packages/codemod/src/transforms/react-default-props-migration.ts
+++ b/packages/codemod/src/transforms/react-default-props-migration.ts
@@ -1,0 +1,276 @@
+import {
+  API,
+  AssignmentExpression,
+  ASTPath,
+  CallExpression,
+  FileInfo,
+  JSCodeshift,
+  MemberExpression,
+  ObjectExpression,
+  TSTypeAliasDeclaration,
+} from 'jscodeshift';
+import prettier from 'prettier';
+import { TRunnerOptions } from '../types';
+
+/*
+  This helper takes care of replacing the defaultProps usage in the component body
+  Previously the component code was relying on the props object to access the default values
+  but now the default props are destructured in the function signature
+  Example:
+  ```
+  // BEFORE
+  const MyComponent = (props) => {
+    return <div>{props.prop1}</div>;
+  }
+  // AFTER
+  const MyComponent = ({ prop1 }) => {
+    return <div>{prop1}</div>;
+  }
+  ```
+*/
+function replacePropsUsage({
+  j,
+  defaultPropsKeys,
+  scope,
+}: {
+  j: JSCodeshift;
+  defaultPropsKeys: string[];
+  scope: JSCodeshift;
+}) {
+  /*
+    Next code block replaces destructured props usage in the component body.
+    ```
+      // BEFORE
+        const MyComponent = (props) => {
+          return <div>{props.prop1}</div>;
+        }
+      }
+
+      // AFTER
+      const MyComponent = ({ prop1, ...props }) => {
+        return <div>{prop1}</div>;
+      }
+    ```
+  */
+  scope
+    .find(j.MemberExpression, {
+      object: { type: 'Identifier', name: 'props' },
+    })
+    .forEach((memberPath: ASTPath<MemberExpression>) => {
+      const property = memberPath.node.property;
+      // Add type guard for Identifier
+      if (
+        property.type === 'Identifier' &&
+        defaultPropsKeys.includes(property.name)
+      ) {
+        j(memberPath).replaceWith(j.identifier(property.name));
+      }
+    });
+
+  /*
+    Next code block replaces props usage in the component body where
+    props is passed as an argument to a function.
+    ```
+      // BEFORE
+      const MyComponent = (props) => {
+        return <div>{getStyles(props)}</div>;
+      }
+
+      // AFTER
+      const MyComponent = ({ prop1, ...props }) => {
+        return <div>{getStyles({ prop1, ...props })}</div>;
+      }
+    ```
+  */
+  scope
+    .find(j.CallExpression, {
+      arguments: [{ type: 'Identifier', name: 'props' }],
+    })
+    .forEach((callPath: ASTPath<CallExpression>) => {
+      // Create a destructured object
+      const properties = [
+        ...defaultPropsKeys.map((key) => {
+          const id = j.identifier(key);
+          const newProp = j.property('init', id, id);
+          newProp.shorthand = true;
+          return newProp;
+        }),
+        j.spreadElement(j.identifier('props')),
+      ];
+
+      const objectExpression = j.objectExpression(properties);
+
+      // Replace the 'props' argument with the destructured object
+      callPath.node.arguments[0] = objectExpression;
+    });
+}
+
+/*
+  We need to make sure the component type definition is updated to reflect the
+  props that are now optional.
+  Example:
+  ```
+  // BEFORE
+  type MyComponentProps = {
+    prop1: string;
+    prop2: string;
+    prop3: string;
+  }
+  function MyComponent(props: MyComponentProps) { ... }
+  MyComponent.defaultProps = {
+    prop1: 'default value',
+  }
+
+  // AFTER
+  type MyComponentProps = {
+    prop1?: string;
+    prop2: string;
+    prop3: string;
+  }
+  function MyComponent({ prop1, ...props }: MyComponentProps) { ... }
+  ```
+*/
+function updateComponentTypes({
+  j,
+  root,
+  typeName,
+  destructuredKeys,
+}: {
+  j: JSCodeshift;
+  root: JSCodeshift;
+  typeName: string;
+  destructuredKeys: string[];
+}) {
+  // Find the type definition of the component props
+  root
+    .find(j.TSTypeAliasDeclaration)
+    .forEach((typePath: ASTPath<TSTypeAliasDeclaration>) => {
+      if (typePath.node.id.name === typeName) {
+        const typeAnnotation = typePath.node.typeAnnotation;
+
+        if (typeAnnotation.type === 'TSTypeLiteral') {
+          typeAnnotation.members.forEach((member) => {
+            if (
+              member.type === 'TSPropertySignature' &&
+              member.key.type === 'Identifier' &&
+              destructuredKeys.includes(member.key.name)
+            ) {
+              member.optional = true;
+            }
+          });
+        }
+      }
+    });
+}
+
+function extractDefaultPropsFromNode(
+  defaultPropsNode: ObjectExpression
+): Record<string, unknown> {
+  return defaultPropsNode.properties.reduce((acc, prop) => {
+    if (
+      prop.type === 'ObjectProperty' &&
+      'name' in prop.key &&
+      'value' in prop.value
+    ) {
+      return {
+        ...acc,
+        [prop.key.name as string]: prop.value.value,
+      };
+    }
+    return acc;
+  }, {} as Record<string, unknown>);
+}
+
+async function reactDefaultPropsMigration(
+  file: FileInfo,
+  api: API,
+  options: TRunnerOptions
+) {
+  const j = api.jscodeshift;
+  const root = j(file.source, { comment: false });
+  const originalSource = root.toSource();
+
+  console.log('Processing file:', file.path);
+
+  // 1. Search for "defaultProps" definitions
+  root
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        property: { name: 'defaultProps' },
+      },
+    })
+    .forEach((path: ASTPath<AssignmentExpression>) => {
+      // Types validation to please Typescript
+      if (
+        path.node.left.type === 'MemberExpression' &&
+        path.node.left.object.type === 'Identifier'
+      ) {
+        // The node path looks like this:
+        //  defaultProps: MyComponent.defaultProps = defaultProps;
+        const componentName = path.node.left.object.name;
+        const defaultPropsNode = path.node.right;
+        let defaultPropsMap: Record<string, unknown> = {};
+
+        // Default props can be defined inline or as a reference to another object
+        //  INLINE -- MyComponent.defaultProps: { prop1: 'value1', prop2: 'value2' }
+        //  REFERENCE -- MyComponent.defaultProps: defaultProps
+        if (defaultPropsNode.type === 'Identifier') {
+          //  REFERENCE -- MyComponent.defaultProps: defaultProps
+          // 1. Look for the identifier declaration
+          const defaultPropsDeclaration = root
+            .find(j.VariableDeclarator, {
+              id: { type: 'Identifier', name: defaultPropsNode.name },
+            })
+            .nodes()[0];
+
+          if (defaultPropsDeclaration) {
+            // 2. Extract default props keys/values
+            defaultPropsMap = extractDefaultPropsFromNode(
+              defaultPropsDeclaration.init as ObjectExpression
+            );
+            // 3. Remove the identifier declaration
+            // defaultPropsDeclaration.remove();
+            j(defaultPropsDeclaration).remove();
+          } else {
+            console.warn(
+              `[WARNING]: Could not find defaultProps declaration for "${componentName}"`
+            );
+          }
+        } else if (defaultPropsNode.type === 'ObjectExpression') {
+          // INLINE -- MyComponent.defaultProps: { prop1: 'value1', prop2: 'value2' }
+          // Extract default props keys/values
+          defaultPropsMap = extractDefaultPropsFromNode(defaultPropsNode);
+        } else {
+          console.warn(
+            `[WARNING]: Do not know how to process default props for component "${componentName}": ${j(
+              path
+            ).toSource()}`
+          );
+        }
+
+        // Remove the defaultProps assignment
+        j(path).remove();
+
+        console.log('   //---> defaultProps:', defaultPropsMap);
+      }
+      // const foo = j(path);
+      // console.log('   //---> defaultProps:', foo.toSource());
+    });
+
+  // Do not return anything if no changes were applied
+  // so we don't rewrite the file
+  if (originalSource === root.toSource()) {
+    return null;
+  }
+
+  if (!options.dry) {
+    // Format output code with prettier
+    const prettierConfig = await prettier.resolveConfig(file.path);
+    return prettier.format(root.toSource(), prettierConfig!);
+  } else {
+    return null;
+  }
+}
+
+export default reactDefaultPropsMigration;

--- a/packages/codemod/src/types.ts
+++ b/packages/codemod/src/types.ts
@@ -16,4 +16,5 @@ export type TCliTransformName =
   | 'remove-deprecated-modal-level-props'
   | 'rename-js-to-jsx'
   | 'rename-mod-css-to-module-css'
-  | 'redesign-cleanup';
+  | 'redesign-cleanup'
+  | 'react-default-props-migration';


### PR DESCRIPTION
## Summary

The way we are using React components `defaultProps` in our codebase is no longer supported in the new React 19 version ([reference](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops)).

This is the main concept:
```tsx
// BEFORE
type TMyComponentProps = {
  prop1: string;
  prop2: string;
  prop3: string;
};

function MyComponent(props: TMyComponentProps) {
  return (
    <ul>
    <li>Prop 1: {props.prop1}</li>
    <li>Prop 2: {props.prop2}</li>
    <li>Prop 3: {props.prop3}</li>
  </ul>
  );
}
MyComponent.defaultProps = {
  prop1: 'My default value',
};


// AFTER
type TMyComponentProps = {
  prop1?: string; // <--- Make sure this is marked as optional
  prop2: string;
  prop3: string;
};

function MyComponent({ prop1: 'My default value', ...props }: TMyComponentProps) {
  return (
    <ul>
    <li>Prop 1: {prop1}</li> {* <--- Direct access to destructured property *}
    <li>Prop 2: {props.prop2}</li>
    <li>Prop 3: {props.prop3}</li>
  </ul>
  );
}
// <--- No "defaultProps" component property
```

## Description

There are multiple adjustments that are needed and this codemod does not address 100% of them but it helps with most of the common use cases. However, a double check review is recommended after running it; at least checking the Typescript types and building the codebase.

These are the main steps the codemod goes through:
1. Search for React components that have a `defaultProps` property
```tsx
MyComponent.defaultProps = {
  prop1: 'My default value',
};
```
2. Extract the keys and values for the default props
3. Update the component function signature
```tsx
// BEFORE
function MyComponent(props: TMyComponentProps) { ... }

// AFTER
function MyComponent({ prop1, ...props }: TMyComponentProps) { ... }
```
4. Refactor the usages of the default props in the body of the component
```tsx
// BEFORE
function MyComponent(props: TMyComponentProps) {
  return (
    <ul>
      <li>Prop 1: {props.prop1}</li>
      <li>Prop 2: {props.prop2}</li>
      <li>Prop 3: {props.prop3}</li>
    </ul>
  );
}

// AFTER
// BEFORE
function MyComponent({ prop1, ...props }: TMyComponentProps) {
  return (
    <ul>
      <li>Prop 1: {prop1}</li>
      <li>Prop 2: {props.prop2}</li>
      <li>Prop 3: {props.prop3}</li>
    </ul>
  );
}

```
5. Update the component TS type definition so we make sure the default props are optional
```tsx
// BEFORE 
type TMyComponentProps = {
  prop1: string;
  prop2: string;
  prop3: string;
};

// AFTER
type TMyComponentProps = {
  prop1?: string;
  prop2: string;
  prop3: string;
};
```
6. Remove the `defaultProps` assignment from the component
```tsx
// Delete this code block
MyComponent.defaultProps = {
  prop1: 'My default value',
};
```

### NOTE
I tried to be very verbose with the inline comments of the codemod explaining what every block is for.