### PR TITLE
[FEC-138] Improve js components migration

### DIFF
--- a/packages/codemod/src/transforms/react-default-props-migration.ts
+++ b/packages/codemod/src/transforms/react-default-props-migration.ts
@@ -309,7 +309,10 @@ function extractDefaultPropsFromNode(
   defaultPropsNode: ObjectExpression
 ): TDefaultPropsMap {
   return defaultPropsNode.properties.reduce((acc, prop) => {
-    if (prop.type === 'ObjectProperty' && prop.key.type === 'Identifier') {
+    if (
+      (prop.type === 'ObjectProperty' || prop.type === 'Property') &&
+      prop.key.type === 'Identifier'
+    ) {
       return {
         ...acc,
         [prop.key.name as string]:


### PR DESCRIPTION
#### Summary

Improve js components migration

#### Description

I discovered another use case we were not covering: when we have a React component in a Javascript file and it does not have already destructured properties in the function declaration.

```jsx
import * as PropTypes from 'prop-types';

function MyComponent(props) {
  return <div>{props.foo}</div>;
}
MyComponent.defaultProps = {
  foo: 'bar',
};
MyComponent.propTypes = {
  foo: PropTypes.string,
};

```