### PR TITLE
refactor: deprecate STS header

### DIFF
--- a/.changeset/hungry-clouds-peel.md
+++ b/.changeset/hungry-clouds-peel.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/constants': patch
+---
+
+Add `Permissions-Policy` to list of security headers

--- a/.changeset/mean-camels-nail.md
+++ b/.changeset/mean-camels-nail.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Do not process `Strict-Transport-Security` header from config (feature has been deprecated).

--- a/.changeset/short-lies-whisper.md
+++ b/.changeset/short-lies-whisper.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Adjust links to docs in schema files. Mark `headers.strictTransportSecurity` as deprecated.

--- a/packages/application-config/custom-application.schema.json
+++ b/packages/application-config/custom-application.schema.json
@@ -14,31 +14,31 @@
   },
   "properties": {
     "name": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#name",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#name",
       "type": "string"
     },
     "description": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#description",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#description",
       "type": "string"
     },
     "entryPointUriPath": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#entrypointuripath",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#entrypointuripath",
       "type": "string"
     },
     "cloudIdentifier": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#cloudidentifier",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#cloudidentifier",
       "type": "string"
     },
     "mcApiUrl": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mcapiurl",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mcapiurl",
       "type": "string"
     },
     "oAuthScopes": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#oauthscopes",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#oauthscopes",
       "type": "object",
       "properties": {
         "view": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#oauthscopesview",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#oauthscopesview",
           "type": "array",
           "default": [],
           "items": {
@@ -48,7 +48,7 @@
           "uniqueItems": true
         },
         "manage": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#oauthscopesmanage",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#oauthscopesmanage",
           "type": "array",
           "default": [],
           "items": {
@@ -62,7 +62,7 @@
       "required": ["view", "manage"]
     },
     "additionalOAuthScopes": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopes",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopes",
       "type": "array",
       "default": [],
       "uniqueItems": true,
@@ -70,11 +70,11 @@
         "type": "object",
         "properties": {
           "name": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopesname",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopesname",
             "type": "string"
           },
           "view": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopesview",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopesview",
             "type": "array",
             "default": [],
             "items": {
@@ -84,7 +84,7 @@
             "uniqueItems": true
           },
           "manage": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopesmanage",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopesmanage",
             "type": "array",
             "default": [],
             "items": {
@@ -99,14 +99,14 @@
       }
     },
     "env": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#env",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#env",
       "type": "object",
       "properties": {
         "development": {
           "type": "object",
           "properties": {
             "initialProjectKey": {
-              "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envdevelopmentinitialprojectkey",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envdevelopmentinitialprojectkey",
               "type": "string"
             },
             "teamId": {
@@ -120,15 +120,15 @@
           "type": "object",
           "properties": {
             "applicationId": {
-              "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envproductionapplicationid",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envproductionapplicationid",
               "type": "string"
             },
             "url": {
-              "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envproductionurl",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envproductionurl",
               "type": "string"
             },
             "cdnUrl": {
-              "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envproductioncdnurl",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envproductioncdnurl",
               "type": "string"
             }
           },
@@ -140,15 +140,15 @@
       "required": ["development", "production"]
     },
     "additionalEnv": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionalenv",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionalenv",
       "type": "object"
     },
     "headers": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headers",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headers",
       "type": "object",
       "properties": {
         "csp": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headerscsp",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headerscsp",
           "type": "object",
           "properties": {
             "connect-src": {
@@ -174,34 +174,34 @@
           "required": ["connect-src"]
         },
         "permissionsPolicies": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headerspermissionspolicies",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headerspermissionspolicies",
           "type": "object"
         },
         "strictTransportSecurity": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headersstricttransportsecurity",
           "type": "array",
           "items": {
             "enum": ["includeSubDomains", "preload"]
           },
-          "uniqueItems": true
+          "uniqueItems": true,
+          "deprecated": true
         }
       },
       "additionalProperties": false
     },
     "icon": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#icon",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#icon",
       "type": "string"
     },
     "mainMenuLink": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulink",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulink",
       "type": "object",
       "properties": {
         "defaultLabel": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulinkdefaultlabel",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulinkdefaultlabel",
           "type": "string"
         },
         "labelAllLocales": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulinklabelalllocales",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulinklabelalllocales",
           "type": "array",
           "default": [],
           "items": {
@@ -220,7 +220,7 @@
           }
         },
         "permissions": {
-          "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulinkpermissions",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulinkpermissions",
           "type": "array",
           "default": [],
           "items": {
@@ -232,22 +232,22 @@
       "required": ["defaultLabel", "labelAllLocales", "permissions"]
     },
     "submenuLinks": {
-      "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinks",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinks",
       "default": [],
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "uriPath": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinksuripath",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinksuripath",
             "type": "string"
           },
           "defaultLabel": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinksdefaultlabel",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinksdefaultlabel",
             "type": "string"
           },
           "labelAllLocales": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinkslabelalllocales",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinkslabelalllocales",
             "type": "array",
             "default": [],
             "items": {
@@ -266,7 +266,7 @@
             }
           },
           "permissions": {
-            "description": "See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinkspermissions",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinkspermissions",
             "type": "array",
             "default": [],
             "items": {

--- a/packages/application-config/custom-view.schema.json
+++ b/packages/application-config/custom-view.schema.json
@@ -14,27 +14,27 @@
   },
   "properties": {
     "name": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#name",
       "type": "string"
     },
     "description": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#description",
       "type": "string"
     },
     "cloudIdentifier": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#cloudidentifier",
       "type": "string"
     },
     "mcApiUrl": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#mcapiurl",
       "type": "string"
     },
     "oAuthScopes": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#oauthscopes",
       "type": "object",
       "properties": {
         "view": {
-          "description": "See https://docs.commercetools.com/TODO",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#oauthscopesview",
           "type": "array",
           "default": [],
           "items": {
@@ -44,7 +44,7 @@
           "uniqueItems": true
         },
         "manage": {
-          "description": "See https://docs.commercetools.com/TODO",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#oauthscopesmanage",
           "type": "array",
           "default": [],
           "items": {
@@ -58,7 +58,7 @@
       "required": ["view", "manage"]
     },
     "additionalOAuthScopes": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopes",
       "type": "array",
       "default": [],
       "uniqueItems": true,
@@ -66,11 +66,11 @@
         "type": "object",
         "properties": {
           "name": {
-            "description": "See https://docs.commercetools.com/TODO",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopesname",
             "type": "string"
           },
           "view": {
-            "description": "See https://docs.commercetools.com/TODO",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopesview",
             "type": "array",
             "default": [],
             "items": {
@@ -80,7 +80,7 @@
             "uniqueItems": true
           },
           "manage": {
-            "description": "See https://docs.commercetools.com/TODO",
+            "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopesmanage",
             "type": "array",
             "default": [],
             "items": {
@@ -95,21 +95,21 @@
       }
     },
     "env": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#env",
       "type": "object",
       "properties": {
         "development": {
           "type": "object",
           "properties": {
             "initialProjectKey": {
-              "description": "See https://docs.commercetools.com/TODO",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envdevelopmentinitialprojectkey",
               "type": "string"
             },
             "teamId": {
               "type": "string"
             },
             "hostUriPath": {
-              "description": "See https://docs.commercetools.com/TODO",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envdevelopmenthosturipath",
               "type": "string"
             }
           },
@@ -120,15 +120,15 @@
           "type": "object",
           "properties": {
             "customViewId": {
-              "description": "See https://docs.commercetools.com/TODO",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envproductioncustomviewid",
               "type": "string"
             },
             "url": {
-              "description": "See https://docs.commercetools.com/TODO",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envproductionurl",
               "type": "string"
             },
             "cdnUrl": {
-              "description": "See https://docs.commercetools.com/TODO",
+              "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envproductioncdnurl",
               "type": "string"
             }
           },
@@ -140,15 +140,15 @@
       "required": ["development", "production"]
     },
     "additionalEnv": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionalenv",
       "type": "object"
     },
     "headers": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headers",
       "type": "object",
       "properties": {
         "csp": {
-          "description": "See https://docs.commercetools.com/TODO",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headerscsp",
           "type": "object",
           "properties": {
             "connect-src": {
@@ -174,22 +174,22 @@
           "required": ["connect-src"]
         },
         "permissionsPolicies": {
-          "description": "See https://docs.commercetools.com/TODO",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headerspermissionspolicies",
           "type": "object"
         },
         "strictTransportSecurity": {
-          "description": "See https://docs.commercetools.com/TODO",
           "type": "array",
           "items": {
             "enum": ["includeSubDomains", "preload"]
           },
-          "uniqueItems": true
+          "uniqueItems": true,
+          "deprecated": true
         }
       },
       "additionalProperties": false
     },
     "labelAllLocales": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#labelalllocales",
       "type": "array",
       "default": [],
       "items": {
@@ -208,23 +208,23 @@
       }
     },
     "type": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#type",
       "type": "string",
       "enum": ["CustomPanel"]
     },
     "typeSettings": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#typesettings",
       "type": "object",
       "properties": {
         "size": {
-          "description": "See https://docs.commercetools.com/TODO",
+          "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#typesettingssize",
           "type": "string",
           "enum": ["SMALL", "LARGE"]
         }
       }
     },
     "locators": {
-      "description": "See https://docs.commercetools.com/TODO",
+      "description": "See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#locators",
       "type": "array",
       "default": [],
       "items": {

--- a/packages/application-config/src/schemas/generated/custom-application.schema.ts
+++ b/packages/application-config/src/schemas/generated/custom-application.schema.ts
@@ -5,93 +5,93 @@ export type CspDirective = string[];
 
 export interface JSONSchemaForCustomApplicationConfigurationFiles {
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#name
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#name
    */
   name: string;
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#description
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#description
    */
   description?: string;
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#entrypointuripath
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#entrypointuripath
    */
   entryPointUriPath: string;
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#cloudidentifier
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#cloudidentifier
    */
   cloudIdentifier: string;
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mcapiurl
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mcapiurl
    */
   mcApiUrl?: string;
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#oauthscopes
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#oauthscopes
    */
   oAuthScopes: {
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#oauthscopesview
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#oauthscopesview
      */
     view: string[];
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#oauthscopesmanage
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#oauthscopesmanage
      */
     manage: string[];
   };
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopes
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopes
    */
   additionalOAuthScopes?: {
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopesname
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopesname
      */
     name: string;
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopesview
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopesview
      */
     view: string[];
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionaloauthscopesmanage
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionaloauthscopesmanage
      */
     manage: string[];
   }[];
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#env
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#env
    */
   env: {
     development: {
       /**
-       * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envdevelopmentinitialprojectkey
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envdevelopmentinitialprojectkey
        */
       initialProjectKey: string;
       teamId?: string;
     };
     production: {
       /**
-       * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envproductionapplicationid
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envproductionapplicationid
        */
       applicationId: string;
       /**
-       * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envproductionurl
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envproductionurl
        */
       url: string;
       /**
-       * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#envproductioncdnurl
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#envproductioncdnurl
        */
       cdnUrl?: string;
     };
   };
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#additionalenv
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#additionalenv
    */
   additionalEnv?: {
     [k: string]: unknown;
   };
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headers
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headers
    */
   headers?: {
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headerscsp
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headerscsp
      */
     csp?: {
       'connect-src': CspDirective;
@@ -102,62 +102,62 @@ export interface JSONSchemaForCustomApplicationConfigurationFiles {
       'frame-src'?: CspDirective;
     };
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headerspermissionspolicies
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headerspermissionspolicies
      */
     permissionsPolicies?: {
       [k: string]: unknown;
     };
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#headersstricttransportsecurity
+     * @deprecated
      */
     strictTransportSecurity?: ('includeSubDomains' | 'preload')[];
   };
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#icon
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#icon
    */
   icon: string;
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulink
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulink
    */
   mainMenuLink: {
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulinkdefaultlabel
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulinkdefaultlabel
      */
     defaultLabel: string;
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulinklabelalllocales
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulinklabelalllocales
      */
     labelAllLocales: {
       locale: 'en' | 'de' | 'es' | 'fr-FR' | 'pt-BR';
       value: string;
     }[];
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#mainmenulinkpermissions
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#mainmenulinkpermissions
      */
     permissions: string[];
     [k: string]: unknown;
   };
   /**
-   * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinks
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinks
    */
   submenuLinks: {
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinksuripath
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinksuripath
      */
     uriPath: string;
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinksdefaultlabel
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinksdefaultlabel
      */
     defaultLabel: string;
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinkslabelalllocales
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinkslabelalllocales
      */
     labelAllLocales: {
       locale: 'en' | 'de' | 'es' | 'fr-FR' | 'pt-BR';
       value: string;
     }[];
     /**
-     * See https://docs.commercetools.com/merchant-center-customizations/api-reference/custom-application-config#submenulinkspermissions
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#submenulinkspermissions
      */
     permissions: string[];
     [k: string]: unknown;

--- a/packages/application-config/src/schemas/generated/custom-view.schema.ts
+++ b/packages/application-config/src/schemas/generated/custom-view.schema.ts
@@ -5,93 +5,93 @@ export type CspDirective = string[];
 
 export interface JSONSchemaForCustomViewConfigurationFiles {
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#name
    */
   name: string;
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#description
    */
   description?: string;
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#cloudidentifier
    */
   cloudIdentifier: string;
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#mcapiurl
    */
   mcApiUrl?: string;
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#oauthscopes
    */
   oAuthScopes: {
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#oauthscopesview
      */
     view: string[];
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#oauthscopesmanage
      */
     manage: string[];
   };
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopes
    */
   additionalOAuthScopes?: {
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopesname
      */
     name: string;
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopesview
      */
     view: string[];
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionaloauthscopesmanage
      */
     manage: string[];
   }[];
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#env
    */
   env: {
     development: {
       /**
-       * See https://docs.commercetools.com/TODO
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envdevelopmentinitialprojectkey
        */
       initialProjectKey: string;
       teamId?: string;
       /**
-       * See https://docs.commercetools.com/TODO
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envdevelopmenthosturipath
        */
       hostUriPath?: string;
     };
     production: {
       /**
-       * See https://docs.commercetools.com/TODO
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envproductioncustomviewid
        */
       customViewId: string;
       /**
-       * See https://docs.commercetools.com/TODO
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envproductionurl
        */
       url: string;
       /**
-       * See https://docs.commercetools.com/TODO
+       * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#envproductioncdnurl
        */
       cdnUrl?: string;
     };
   };
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#additionalenv
    */
   additionalEnv?: {
     [k: string]: unknown;
   };
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headers
    */
   headers?: {
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headerscsp
      */
     csp?: {
       'connect-src': CspDirective;
@@ -102,39 +102,39 @@ export interface JSONSchemaForCustomViewConfigurationFiles {
       'frame-src'?: CspDirective;
     };
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headerspermissionspolicies
      */
     permissionsPolicies?: {
       [k: string]: unknown;
     };
     /**
-     * See https://docs.commercetools.com/TODO
+     * @deprecated
      */
     strictTransportSecurity?: ('includeSubDomains' | 'preload')[];
   };
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#labelalllocales
    */
   labelAllLocales: {
     locale: 'en' | 'de' | 'es' | 'fr-FR' | 'pt-BR';
     value: string;
   }[];
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#type
    */
   type: 'CustomPanel';
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#typesettings
    */
   typeSettings?: {
     /**
-     * See https://docs.commercetools.com/TODO
+     * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#typesettingssize
      */
     size?: 'SMALL' | 'LARGE';
     [k: string]: unknown;
   };
   /**
-   * See https://docs.commercetools.com/TODO
+   * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#locators
    */
   locators: string[];
   [k: string]: unknown;

--- a/packages/application-config/test/fixtures/custom-applications/config-full.json
+++ b/packages/application-config/test/fixtures/custom-applications/config-full.json
@@ -38,9 +38,8 @@
       "connect-src": ["https://track.avengers.app"]
     },
     "permissionsPolicies": {
-      "microphone": "()"
-    },
-    "strictTransportSecurity": ["includeSubDomains"]
+      "microphone": "*"
+    }
   },
   "icon": "<svg><path fill=\"#000000\" /></svg>",
   "mainMenuLink": {

--- a/packages/application-config/test/process-config-custom-application.spec.js
+++ b/packages/application-config/test/process-config-custom-application.spec.js
@@ -389,9 +389,8 @@ describe('processing a full config', () => {
           'style-src': [],
         },
         permissionsPolicies: {
-          microphone: '()',
+          microphone: '*',
         },
-        strictTransportSecurity: ['includeSubDomains'],
       },
     });
   });
@@ -456,9 +455,8 @@ describe('processing a full config', () => {
             'style-src': ['https://avengers.app/', 'https://cdn.avengers.app/'],
           },
           permissionsPolicies: {
-            microphone: '()',
+            microphone: '*',
           },
-          strictTransportSecurity: ['includeSubDomains'],
         },
       });
     });
@@ -549,9 +547,8 @@ describe('processing a full config', () => {
             'style-src': [],
           },
           permissionsPolicies: {
-            microphone: '()',
+            microphone: '*',
           },
-          strictTransportSecurity: ['includeSubDomains'],
         },
       });
     });
@@ -618,9 +615,8 @@ describe('processing a full config', () => {
             'style-src': ['https://avengers.app/', 'https://cdn.avengers.app/'],
           },
           permissionsPolicies: {
-            microphone: '()',
+            microphone: '*',
           },
-          strictTransportSecurity: ['includeSubDomains'],
         },
       });
     });

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -304,11 +304,13 @@ export const STORAGE_KEYS = {
 } as const;
 
 export const HTTP_SECURITY_HEADERS = {
+  'Referrer-Policy': 'same-origin',
+  'Permissions-Policy':
+    'microphone=(), camera=(), payment=(), usb=(), geolocation=()',
   'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
   'X-XSS-Protection': '1; mode=block',
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'SAMEORIGIN',
-  'Referrer-Policy': 'same-origin',
 } as const;
 
 // Custom Views events (messages sent between the host application and the custom view)

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -102,7 +102,7 @@ describe('permissionsPolicies', () => {
       ...defaultApplicationConfig,
       headers: {
         permissionsPolicies: {
-          microphone: '()',
+          microphone: '*',
           camera: '(self)',
         },
       },
@@ -112,25 +112,6 @@ describe('permissionsPolicies', () => {
 
     expect(
       processedApplicationConfig['Permissions-Policy']
-    ).toMatchInlineSnapshot(`"microphone=(), camera=(self)"`);
-  });
-});
-describe('strictTransportSecurity', () => {
-  it('should add extra options', () => {
-    const testApplicationConfig = {
-      ...defaultApplicationConfig,
-      headers: {
-        strictTransportSecurity: ['includeSubDomains'],
-      },
-    };
-
-    // @ts-ignore
-    const processedApplicationConfig = processHeaders(testApplicationConfig);
-
-    expect(
-      processedApplicationConfig['Strict-Transport-Security']
-    ).toMatchInlineSnapshot(
-      `"max-age=31536000; includeSubDomains; preload; includeSubDomains"`
-    );
+    ).toMatchInlineSnapshot(`"microphone=*, camera=(self)"`);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9493,7 +9493,7 @@ packages:
       history: 4.10.1
       prop-types: 15.8.1
       react: 17.0.2
-      react-intl: 6.4.7(react@17.0.2)(typescript@5.7.2)
+      react-intl: 6.4.7(react@17.0.2)(typescript@5.0.4)
       react-router-dom: 5.3.4(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
@@ -9869,7 +9869,7 @@ packages:
       '@emotion/react': 11.11.4(@types/react@17.0.83)(react@17.0.2)
       prop-types: 15.8.1
       react: 17.0.2
-      react-intl: 6.4.7(react@17.0.2)(typescript@5.7.2)
+      react-intl: 6.4.7(react@17.0.2)(typescript@5.0.4)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -11191,7 +11191,7 @@ packages:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 17.0.2
-      react-intl: 6.4.7(react@17.0.2)(typescript@5.7.2)
+      react-intl: 6.4.7(react@17.0.2)(typescript@5.0.4)
       warning: 4.0.3
     transitivePeerDependencies:
       - '@types/react'


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SHIELD-1580

This is a follow up of some improvements we are doing around the security headers.

There is no need to override the `Strict-Transport-Security` header, so we are deprecating the config option.
