### PR TITLE
refactor: evaluate `window.app` lazily for defining user agents

### DIFF
--- a/.changeset/eleven-hounds-appear.md
+++ b/.changeset/eleven-hounds-appear.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+---
+
+Evaluate `window.app` lazily. This is useful when the package is not being used within the Merchant Center context.

--- a/packages/application-shell-connectors/src/apollo-links/header-link.ts
+++ b/packages/application-shell-connectors/src/apollo-links/header-link.ts
@@ -38,19 +38,27 @@ type QueryVariables = {
   featureFlag?: string;
 };
 
-const userAgent = createHttpUserAgent({
-  name: 'apollo-client',
-  // version: apolloVersion,
-  libraryName: [
-    typeof window !== 'undefined'
-      ? window.app.applicationName
-      : 'unknown-application-name',
-    'application-shell',
-  ].join('/'),
-  libraryVersion: version,
-  contactUrl: 'https://git.io/fjuyC', // points to the appkit repo issues
-  contactEmail: 'support@commercetools.com',
-});
+let _userAgent: string | null;
+const getUserAgent = () => {
+  if (!_userAgent) {
+    _userAgent = createHttpUserAgent({
+      name: 'apollo-client',
+      // version: apolloVersion,
+      libraryName: [
+        typeof window !== 'undefined'
+          ? window.app?.applicationName ?? 'unknown-application-name'
+          : undefined,
+        'application-shell',
+      ]
+        .filter(Boolean)
+        .join('/'),
+      libraryVersion: version,
+      contactUrl: 'https://git.io/fjuyC', // points to the appkit repo issues
+      contactEmail: 'support@commercetools.com',
+    });
+  }
+  return _userAgent;
+};
 
 const isKnownGraphQlTarget = (target?: TGraphQLTargets) =>
   target ? Object.values(GRAPHQL_TARGETS).includes(target) : false;
@@ -113,7 +121,7 @@ const headerLink = new ApolloLink((operation, forward) => {
 
   operation.setContext(
     createHttpClientOptions({
-      userAgent,
+      userAgent: getUserAgent(),
       headers: omitEmpty<THeaders>({
         // Other headers that are allowed in the CORS rules of the MC API.
         ...apolloContext.headers,

--- a/packages/application-shell-connectors/src/utils/http-client.ts
+++ b/packages/application-shell-connectors/src/utils/http-client.ts
@@ -133,13 +133,19 @@ export type TFetcher<Data> = (
   options: TOptions
 ) => Promise<TFetcherResponse<Data>>;
 
-const defaultUserAgent = createHttpUserAgent({
-  name: 'unknown-http-client',
-  libraryName:
-    typeof window !== 'undefined'
-      ? window.app.applicationName
-      : 'unknown-application-name',
-});
+let _userAgent: string | null;
+const getUserAgent = () => {
+  if (!_userAgent) {
+    _userAgent = createHttpUserAgent({
+      name: 'unknown-http-client',
+      libraryName:
+        typeof window !== 'undefined'
+          ? window.app?.applicationName ?? 'unknown-application-name'
+          : undefined,
+    });
+  }
+  return _userAgent;
+};
 
 const defaultForwardToVersion: TForwardToConfigVersion = 'v2';
 const defaultForwardToAudiencePolicy: TForwardToAudiencePolicy =
@@ -187,7 +193,7 @@ function createHttpClientOptions(config: TConfig = {}): TOptions {
   const sessionToken = oidcStorage.getSessionToken();
   const projectKey = config.projectKey ?? selectProjectKeyFromUrl();
   const userId = selectUserId();
-  const userAgent = config?.userAgent || defaultUserAgent;
+  const userAgent = config?.userAgent || getUserAgent();
 
   return {
     credentials: 'include',


### PR DESCRIPTION
This is helpful in case the package is not used within the Merchant Center context, in particular for SSR.