### PR TITLE
refactor(components): lazy load custom view selector in modular tab components

### DIFF
--- a/.changeset/beige-coats-smoke.md
+++ b/.changeset/beige-coats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Lazy load Custom View selector in modular tab components. Skip loading component if `window.app` is not defined.

--- a/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
@@ -15,22 +15,18 @@ import { designTokens } from '@commercetools-uikit/design-system';
 import { WindowEyeIcon } from '@commercetools-uikit/icons';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
+import useCustomViewLocatorSelector from '../../../hooks/use-custom-view-locator-selector';
 import CustomViewLoader from '../custom-view-loader';
 import messages from './messages';
+import type { TCustomViewSelectorProps } from './types';
 import { useCustomViewsConnector } from './use-custom-views-connector';
 
 const COMPONENT_HEIGHT = '52px';
 
-type TCustomViewSelectorBaseProps = {
-  onCustomViewsResolved?: (customViews: CustomViewData[]) => void;
-};
-type TCustomViewSelectorProps = TCustomViewSelectorBaseProps & {
-  customViewLocatorCode?: string;
-  margin?: string;
-};
-type TCustomViewSelectorWithRequiredProps = TCustomViewSelectorBaseProps & {
+type TCustomViewSelectorWithRequiredProps = {
   customViewLocatorCode: string;
   margin?: string;
+  onCustomViewsResolved?: TCustomViewSelectorProps['onCustomViewsResolved'];
 };
 
 type TWrapperProps = {
@@ -177,13 +173,17 @@ function CustomViewSelector(props: TCustomViewSelectorWithRequiredProps) {
 CustomViewSelector.displayName = 'CustomViewSelector';
 
 const CustomViewSelectorOrNothing = (props: TCustomViewSelectorProps) => {
-  if (!props.customViewLocatorCode) {
+  const { currentCustomViewLocatorCode } = useCustomViewLocatorSelector(
+    props.customViewLocatorCodes
+  );
+
+  if (!currentCustomViewLocatorCode) {
     return null;
   }
   return (
     <CustomViewSelector
       {...props}
-      customViewLocatorCode={props.customViewLocatorCode}
+      customViewLocatorCode={currentCustomViewLocatorCode}
     />
   );
 };

--- a/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
@@ -177,15 +177,14 @@ const CustomViewSelectorOrNothing = (props: TCustomViewSelectorProps) => {
     props.customViewLocatorCodes
   );
 
-  if (!currentCustomViewLocatorCode) {
+  const locatorCode =
+    currentCustomViewLocatorCode ?? props.customViewLocatorCode;
+
+  if (!locatorCode) {
     return null;
   }
-  return (
-    <CustomViewSelector
-      {...props}
-      customViewLocatorCode={currentCustomViewLocatorCode}
-    />
-  );
+
+  return <CustomViewSelector {...props} customViewLocatorCode={locatorCode} />;
 };
 
 export default CustomViewSelectorOrNothing;

--- a/packages/application-components/src/components/custom-views/custom-views-selector/index.ts
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/index.ts
@@ -1,1 +1,15 @@
-export { default } from './custom-views-selector';
+import { lazy } from 'react';
+import type { ApplicationWindow } from '@commercetools-frontend/constants';
+
+declare let window: ApplicationWindow;
+
+const CustomViewSelector = lazy(() => {
+  if (typeof window !== 'undefined' && typeof window.app !== 'undefined') {
+    return import(
+      './custom-views-selector' /* webpackChunkName: "custom-views-selector" */
+    );
+  }
+  return Promise.resolve({ default: () => null });
+});
+
+export default CustomViewSelector;

--- a/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
@@ -10,6 +10,7 @@ export type TCustomViewLocatorCode =
 
 export type TCustomViewSelectorProps = {
   onCustomViewsResolved?: (customViews: CustomViewData[]) => void;
+  customViewLocatorCode?: string;
   customViewLocatorCodes?: Record<string, TCustomViewLocatorCode>;
   margin?: string;
 };

--- a/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
@@ -1,0 +1,15 @@
+import type { CustomViewData } from '@commercetools-frontend/constants';
+
+export type TCustomViewLocatorCodeLocationDescriptor = {
+  pathname?: string;
+  search?: string;
+};
+export type TCustomViewLocatorCode =
+  | string
+  | TCustomViewLocatorCodeLocationDescriptor;
+
+export type TCustomViewSelectorProps = {
+  onCustomViewsResolved?: (customViews: CustomViewData[]) => void;
+  customViewLocatorCodes?: Record<string, TCustomViewLocatorCode>;
+  margin?: string;
+};

--- a/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.tsx
+++ b/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.tsx
@@ -1,11 +1,10 @@
 import type { ReactElement, ReactNode, MouseEvent, KeyboardEvent } from 'react';
-import { LocationDescriptor } from 'history';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import Spacings from '@commercetools-uikit/spacings';
 import { warning } from '@commercetools-uikit/utils';
-import useCustomViewLocatorSelector from '../../../hooks/use-custom-view-locator-selector';
 import CustomViewsSelector from '../../custom-views/custom-views-selector';
+import type { TCustomViewSelectorProps } from '../../custom-views/custom-views-selector/types';
 import {
   FormPrimaryButton,
   FormSecondaryButton,
@@ -63,7 +62,7 @@ type TTabularDetailPageProps = {
   /**
    * These codes are used to configure which Custom Views are available for every tab.
    */
-  customViewLocatorCodes?: Record<string, LocationDescriptor>;
+  customViewLocatorCodes?: TCustomViewSelectorProps['customViewLocatorCodes'];
 
   // PageTopBar props:
   /**
@@ -82,10 +81,6 @@ const TabularDetailPage = ({
   hideControls = false,
   ...props
 }: TTabularDetailPageProps) => {
-  const { currentCustomViewLocatorCode } = useCustomViewLocatorSelector(
-    props.customViewLocatorCodes
-  );
-
   warning(
     props.title !== undefined || props.customTitleRow !== undefined,
     'TabularDetailPage: one of either `title` or `customTitleRow` is required but both their values are `undefined`'
@@ -122,7 +117,7 @@ const TabularDetailPage = ({
       <CustomViewsSelectorWrapper>
         <CustomViewsSelector
           margin={`${uiKitDesignTokens.spacing30} 0 0 0`}
-          customViewLocatorCode={currentCustomViewLocatorCode}
+          customViewLocatorCodes={props.customViewLocatorCodes}
         />
       </CustomViewsSelectorWrapper>
       <ContentWrapper>{props.children}</ContentWrapper>

--- a/packages/application-components/src/components/main-pages/tabular-main-page/tabular-main-page.tsx
+++ b/packages/application-components/src/components/main-pages/tabular-main-page/tabular-main-page.tsx
@@ -1,12 +1,11 @@
 import type { ReactElement, ReactNode } from 'react';
 import { css } from '@emotion/react';
-import type { LocationDescriptor } from 'history';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import Spacings from '@commercetools-uikit/spacings';
 import { warning } from '@commercetools-uikit/utils';
-import useCustomViewLocatorSelector from '../../../hooks/use-custom-view-locator-selector';
 import CustomViewsSelector from '../../custom-views/custom-views-selector';
+import type { TCustomViewSelectorProps } from '../../custom-views/custom-views-selector/types';
 import {
   FormPrimaryButton,
   FormSecondaryButton,
@@ -53,17 +52,13 @@ type TTabularMainPageProps = {
   /**
    * These codes are used to configure which Custom Views are available for every tab.
    */
-  customViewLocatorCodes?: Record<string, LocationDescriptor>;
+  customViewLocatorCodes?: TCustomViewSelectorProps['customViewLocatorCodes'];
 };
 
 const TabularMainPage = ({
   hideControls = false,
   ...props
 }: TTabularMainPageProps) => {
-  const { currentCustomViewLocatorCode } = useCustomViewLocatorSelector(
-    props.customViewLocatorCodes
-  );
-
   warning(
     props.title !== undefined || props.customTitleRow !== undefined,
     'TabularMainPage: one of either `title` or `customTitleRow` is required but both their values are `undefined`'
@@ -95,7 +90,7 @@ const TabularMainPage = ({
       <CustomViewsSelectorWrapper>
         <CustomViewsSelector
           margin={`${uiKitDesignTokens.spacing30} 0 0 0`}
-          customViewLocatorCode={currentCustomViewLocatorCode}
+          customViewLocatorCodes={props.customViewLocatorCodes}
         />
       </CustomViewsSelectorWrapper>
       <ContentWrapper

--- a/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/tabular-modal-page/tabular-modal-page.tsx
@@ -1,11 +1,10 @@
 import { ReactElement, ReactNode, SyntheticEvent } from 'react';
 import type { CSSObject } from '@emotion/react';
-import { LocationDescriptor } from 'history';
 import { sharedMessages } from '@commercetools-frontend/i18n';
 import { designTokens as uiKitDesignTokens } from '@commercetools-uikit/design-system';
 import Spacings from '@commercetools-uikit/spacings';
-import useCustomViewLocatorSelector from '../../../hooks/use-custom-view-locator-selector';
 import CustomViewsSelector from '../../custom-views/custom-views-selector';
+import type { TCustomViewSelectorProps } from '../../custom-views/custom-views-selector/types';
 import {
   FormPrimaryButton,
   FormSecondaryButton,
@@ -42,7 +41,7 @@ type Props = {
   /**
    * These codes are used to configure which Custom Views are available for every tab.
    */
-  customViewLocatorCodes?: Record<string, LocationDescriptor>;
+  customViewLocatorCodes?: TCustomViewSelectorProps['customViewLocatorCodes'];
   onClose?: (event: SyntheticEvent) => void;
   children: ReactNode;
   zIndex?: number;
@@ -67,10 +66,6 @@ type Props = {
 };
 
 const TabularModalPage = ({ hideControls = false, ...props }: Props) => {
-  const { currentCustomViewLocatorCode } = useCustomViewLocatorSelector(
-    props.customViewLocatorCodes
-  );
-
   return (
     <ModalPage
       title={props.title}
@@ -111,7 +106,7 @@ const TabularModalPage = ({ hideControls = false, ...props }: Props) => {
       <CustomViewsSelectorWrapper>
         <CustomViewsSelector
           margin={`${uiKitDesignTokens.spacing30} 0 0 0`}
-          customViewLocatorCode={currentCustomViewLocatorCode}
+          customViewLocatorCodes={props.customViewLocatorCodes}
         />
       </CustomViewsSelectorWrapper>
       <ModalContentWrapper>{props.children}</ModalContentWrapper>

--- a/packages/application-components/src/hooks/use-custom-view-locator-selector/use-custom-view-locator-selector.ts
+++ b/packages/application-components/src/hooks/use-custom-view-locator-selector/use-custom-view-locator-selector.ts
@@ -9,6 +9,10 @@ const useCustomViewLocatorSelector = (
 ) => {
   const location = useLocation();
 
+  if (!customViewLocatorCodes) {
+    return { currentCustomViewLocatorCode: undefined };
+  }
+
   const customViewLocator = Object.entries(customViewLocatorCodes).find(
     ([, locator]) => {
       return matchPath(location.pathname, {

--- a/packages/application-components/src/test-utils/test-utils.tsx
+++ b/packages/application-components/src/test-utils/test-utils.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import { ApolloClient, type NormalizedCacheObject } from '@apollo/client';
 import { ApolloProvider } from '@apollo/client/react';
 import { TestProviderFlopFlip } from '@flopflip/react-broadcast';
@@ -40,6 +40,8 @@ const defaultEnvironment = {
   servedByProxy: false,
 };
 
+const LoadingFallback = () => <>{'Loading...'}</>;
+
 const customRender = (
   node: ReactNode,
   {
@@ -68,7 +70,9 @@ const customRender = (
               .buildGraphql<TProjectGraphql>()}
           >
             <IntlProvider locale={locale}>
-              <Router history={history}>{node}</Router>
+              <Suspense fallback={<LoadingFallback />}>
+                <Router history={history}>{node}</Router>
+              </Suspense>
             </IntlProvider>
           </ApplicationContextProvider>
         </ApolloProvider>


### PR DESCRIPTION
Main goals:
* decouple loading of the Custom View selector when tabular component is used outside of MC (evaluate if `window.app` is defined)
* implies also a decoupling of react-router (used by the custom view selector)