### PR TITLE
feat(ci): add github action to block merging by labels

### DIFF
--- a/.github/workflows/merge-blocking-labels.yml
+++ b/.github/workflows/merge-blocking-labels.yml
@@ -1,0 +1,23 @@
+name: Label Checker
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check_labels:
+    if: github.event_name == 'pull_request'
+    name: Prevent merge with blocking labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          none_of: '👁 👨‍🎨 Status: UI/UX Review,🖐 🖐 Status: On Hold,🛑 Status: blocked,🚧 Status: WIP'
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

This GitHub Action, once merged and configured as a branch protection, prevents merging PRs with these labels.

We want to synchronize the use of these labels and the GitHub Action across repos for the FE Chapter which as long-running PRs across repos which must not be merged.

I've made sure that all labels exist on the repo. I'll also setup branch protection after merging this.