### PR TITLE
FEC-220 - Update file output of build assets

### DIFF
--- a/.changeset/witty-birds-pump.md
+++ b/.changeset/witty-birds-pump.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': minor
+---
+
+Update build-vite script to output build files directly under the public folder

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -45,6 +45,8 @@ async function run() {
     },
     build: {
       outDir: 'public',
+      // Outputs all build assets directly under the `/public` folder.
+      assetsDir: '',
       rollupOptions: {
         // This is necessary to instruct Vite that the `index.html` (template)
         // is located in the `/public` folder.


### PR DESCRIPTION
As part of the migration from Webpack to Vite, we will be updating the Vite configuration to output all build assets directly under the `public` folder (as opposed to the default nested assets directory).

This approach ensures compatibility with our existing scripts and avoids requiring updates across all consuming applications 
