### PR TITLE
Remove graphql debug query param

### DIFF
--- a/.changeset/perfect-pianos-greet.md
+++ b/.changeset/perfect-pianos-greet.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/application-shell-connectors': patch
+---
+
+Remove the operation name query parameter we had introduced in the `/graphql` endpoint as it was forcing consumers to update part of their codebases.
+
+As an alternative we recommend using any browser extension that provides customized information for GraphQL requests ([here](https://chromewebstore.google.com/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln)'s an example for Chromium based browsers).

--- a/packages/application-shell-connectors/src/configure-apollo.ts
+++ b/packages/application-shell-connectors/src/configure-apollo.ts
@@ -23,29 +23,10 @@ type TApolloClientOptions = {
   restLink?: ApolloLink;
 };
 
-// Inspired by https://www.apollographql.com/docs/react/api/link/apollo-link-http#dynamic-uri
-const customFetch: WindowOrWorkerGlobalScope['fetch'] = (uri, options) => {
-  const searchParams = new URLSearchParams();
-  // We attempt to read the GraphQL `operationName` to append it as a query parameter.
-  // This is only useful for debugging purposes (network tab) and does not have any functional implication.
-  if (options?.body)
-    try {
-      const parsed = JSON.parse(options.body as string);
-      searchParams.set('op', parsed.operationName);
-    } catch {
-      // noop
-    }
-
-  return fetch(
-    searchParams.size > 0 ? `${uri}?${searchParams.toString()}` : uri,
-    options
-  );
-};
-
 const createApolloLink = (options: TApolloClientOptions = {}) => {
   const httpLink = createHttpLink({
     uri: `${getMcApiUrl()}/graphql`,
-    fetch: customFetch,
+    fetch,
   });
 
   // The order of links is IMPORTANT!


### PR DESCRIPTION
#### Summary

Remove graphql debug query param

#### Description

This PR rolls back the change introduced in the `/graphql` endpoint that added the operation name query parameter (
[reference](https://github.com/commercetools/merchant-center-application-kit/pull/3679)).

The reasons behind it are:
* We noticed this change is actually affecting consumers (eg: some tests asserting GraphQL request not expecting any query parameter)
* We are changing some runtime contract between frontend and backend to improve DX when that can be achieved by using tailored tools such as [this Chromium plugin](https://chromewebstore.google.com/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln).
* We are introducing more code (to maintain) in the repository when we can achieve the same DX by using tailored tools.
* Maybe not in this specific case, but changing URLs should be because of application logic reason (is possible) since (generally speaking) it could potentially affect balancers, proxies or caches.
