### PR TITLE
fix: updated public-page-layout to send props correctly

### DIFF
--- a/.changeset/brown-singers-build.md
+++ b/.changeset/brown-singers-build.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+Fix `PublicPageLayoutContent` component usage to ensure proper prop forwarding

--- a/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
+++ b/packages/application-components/src/components/public-page-layout/public-page-layout.tsx
@@ -73,7 +73,9 @@ const PublicPageLayout: FC<TProps> = ({
           </ContainerColumn>
         )}
         <Spacings.Stack scale="xl">
-          <PublicPageLayoutContent {...props} />
+          <PublicPageLayoutContent contentScale={contentScale}>
+            {props.children}
+          </PublicPageLayoutContent>
           <PublicPageLayoutContent contentScale={contentScale}>
             <Spacings.Stack
               scale="xs"


### PR DESCRIPTION
Regression of #3676 

#### Summary

The login screen card was compressed and and moved to the left

#### Description

The props were not being passed in `PublicPageLayoutContent` due to which `ContainerColumn` was being applied instead of `ContainerColumnWide`. This PR fixes the issues by ensuring that `contentScale` is passed correctly

Existing layout: 

<img width="1439" alt="Screenshot 2025-01-29 at 16 51 46" src="https://github.com/user-attachments/assets/b1c72c77-685a-4e29-9c1a-d5ed28673df3" />

