### PR TITLE
Update preview releases NPM dist-tag every time we release a new RC version

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -63,6 +63,7 @@ jobs:
           PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/^preview\///')
           pnpm changeset version --snapshot ${PREVIEW_TAG}
           pnpm changeset publish --tag ${PREVIEW_TAG}
+          node ./scripts/update-npm-tag.mjs ${PREVIEW_TAG}
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           BRANCH_NAME: ${{ steps.comment-branch.outputs.head_ref }}

--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
     "stylelint-value-no-unknown-custom-properties": "4.0.0",
     "tsc-files": "1.1.4",
     "typescript": "5.0.4",
-    "vfile-message": "3.1.4"
+    "vfile-message": "3.1.4",
+    "workspace-tools": "0.38.1"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,7 +301,7 @@ importers:
         specifier: 3.1.4
         version: 3.1.4
       workspace-tools:
-        specifier: ^0.38.1
+        specifier: 0.38.1
         version: 0.38.1
 
   application-templates/starter:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       vfile-message:
         specifier: 3.1.4
         version: 3.1.4
+      workspace-tools:
+        specifier: ^0.38.1
+        version: 0.38.1
 
   application-templates/starter:
     dependencies:
@@ -5486,7 +5489,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5499,7 +5502,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7518,7 +7521,7 @@ packages:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
     dev: false
 
   /@changesets/errors@0.2.0:
@@ -7570,7 +7573,7 @@ packages:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       spawndamnit: 2.0.0
     dev: false
 
@@ -7713,15 +7716,15 @@ packages:
       - typescript
     dev: false
 
-  /@commercetools-frontend/application-config@22.39.0(@types/node@18.17.14)(typescript@5.7.3):
-    resolution: {integrity: sha512-Ld+ChiThMYdXsHSpbVz/njIKkkTh4ttv2UMu72oDcam0trNYKBUiwLk1X4sth2TNJQwGW0W5jx9gOF78yaC+Aw==}
+  /@commercetools-frontend/application-config@22.39.1(@types/node@18.17.14)(typescript@5.7.3):
+    resolution: {integrity: sha512-KhrKwHUypWWbEqWwbPVcliw5xt5IewFEzDk7LViIDHoq8ERycWjNVtCghoeTnKtdg8PQBXx8rSF/Fc/lz6Oz+g==}
     engines: {node: 16.x || >=18.0.0}
     dependencies:
       '@babel/core': 7.25.2
       '@babel/register': 7.22.15(@babel/core@7.25.2)
       '@babel/runtime': 7.24.5
       '@babel/runtime-corejs3': 7.22.15
-      '@commercetools-frontend/constants': 22.39.0
+      '@commercetools-frontend/constants': 22.39.1
       '@types/dompurify': 2.4.0
       '@types/lodash': 4.17.4
       '@types/react': 17.0.83
@@ -7742,8 +7745,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@commercetools-frontend/constants@22.39.0:
-    resolution: {integrity: sha512-+cwknChujEUyvkECdfqCgfrW3/nRItqi11p902rV45I8533yxwvMhXPQUPdh1LB7R8VOWI+0tOLQ/XyOaXLcew==}
+  /@commercetools-frontend/constants@22.39.1:
+    resolution: {integrity: sha512-IsLRXhsQ9xctw5NTySBFJ/uRWEbTnYFOxYDk8rrnpUkMPgaUZqwTtQ4pK3agrQUa3/V+rPnpHhQ3aBq5iSk8nA==}
     dependencies:
       '@babel/runtime': 7.24.5
       '@babel/runtime-corejs3': 7.22.15
@@ -7816,8 +7819,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       '@babel/runtime-corejs3': 7.22.15
-      '@commercetools-frontend/application-config': 22.39.0(@types/node@18.17.14)(typescript@5.7.3)
-      '@commercetools-frontend/constants': 22.39.0
+      '@commercetools-frontend/application-config': 22.39.1(@types/node@18.17.14)(typescript@5.7.3)
+      '@commercetools-frontend/constants': 22.39.1
       '@commercetools-test-data/commons': 8.2.3
       '@commercetools-test-data/core': 8.2.3
       '@commercetools-test-data/graphql-types': 8.2.3
@@ -12995,7 +12998,7 @@ packages:
       '@graphql-tools/utils': 9.2.1(graphql@16.8.2)
       graphql: 16.8.2
       is-glob: 4.0.3
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       tslib: 2.6.2
       unixify: 1.0.0
     transitivePeerDependencies:
@@ -13604,7 +13607,7 @@ packages:
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -13796,7 +13799,7 @@ packages:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pirates: 4.0.5
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -17098,6 +17101,10 @@ packages:
   /@xtuc/long@4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  /@yarnpkg/lockfile@1.1.0:
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+    dev: false
+
   /@zxing/text-encoding@0.9.0:
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
     requiresBuild: true
@@ -18168,14 +18175,13 @@ packages:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   /braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.1.1
-    dev: false
 
   /breakword@1.0.5:
     resolution: {integrity: sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==}
@@ -18525,7 +18531,7 @@ packages:
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -21417,7 +21423,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -21427,7 +21433,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -21561,18 +21567,11 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      to-regex-range: 5.0.1
-
   /fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: false
 
   /finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
@@ -21682,7 +21681,7 @@ packages:
   /find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
     dependencies:
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pkg-dir: 4.2.0
     dev: false
 
@@ -21692,7 +21691,7 @@ packages:
     dependencies:
       detect-file: 1.0.0
       is-glob: 4.0.3
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       resolve-dir: 1.0.1
     dev: false
 
@@ -22085,6 +22084,19 @@ packages:
   /git-repo-info@2.1.1:
     resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
     engines: {node: '>= 4.0'}
+    dev: false
+
+  /git-up@7.0.0:
+    resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
+    dependencies:
+      is-ssh: 1.4.0
+      parse-url: 8.1.0
+    dev: false
+
+  /git-url-parse@13.1.1:
+    resolution: {integrity: sha512-PCFJyeSSdtnbfhSNRw9Wk96dDCNx+sogTe4YNXeXSJxt7xz5hvXekuRn9JX7m+Mf4OscCu8h+mtAl3+h5Fo8lQ==}
+    dependencies:
+      git-up: 7.0.0
     dev: false
 
   /glob-base@0.3.0:
@@ -22813,7 +22825,7 @@ packages:
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
     transitivePeerDependencies:
       - debug
     dev: false
@@ -23427,6 +23439,12 @@ packages:
     dependencies:
       call-bind: 1.0.7
 
+  /is-ssh@1.4.0:
+    resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
+    dependencies:
+      protocols: 2.0.1
+    dev: false
+
   /is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
@@ -23756,7 +23774,7 @@ packages:
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       parse-json: 5.2.0
       pretty-format: 29.7.0
       slash: 3.0.0
@@ -23797,7 +23815,7 @@ packages:
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       parse-json: 5.2.0
       pretty-format: 29.7.0
       slash: 3.0.0
@@ -23925,7 +23943,7 @@ packages:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -23960,7 +23978,7 @@ packages:
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -24184,7 +24202,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
     dev: false
 
   /jest-util@29.5.0:
@@ -25751,7 +25769,6 @@ packages:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-    dev: false
 
   /mime-db@1.33.0:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
@@ -26771,6 +26788,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /parse-path@7.0.0:
+    resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
+    dependencies:
+      protocols: 2.0.1
+    dev: false
+
+  /parse-url@8.1.0:
+    resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
+    dependencies:
+      parse-path: 7.0.0
+    dev: false
+
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
@@ -27542,6 +27571,10 @@ packages:
 
   /proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+    dev: false
+
+  /protocols@2.0.1:
+    resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
     dev: false
 
   /proxy-addr@2.0.7:
@@ -30911,7 +30944,7 @@ packages:
   /urlpattern-polyfill@6.0.2:
     resolution: {integrity: sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==}
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
     dev: false
 
   /use-composed-ref@1.3.0(react@17.0.2):
@@ -31624,6 +31657,18 @@ packages:
   /word-wrap@1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
+
+  /workspace-tools@0.38.1:
+    resolution: {integrity: sha512-EZWlrYrZcxd4XRQOMnARo9DOBRT37XWfGkRz+mTOH8z+WKJBgtovRjyVbWhdTe/8DkthrHa8v30FOjCAE021AA==}
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      fast-glob: 3.3.1
+      git-url-parse: 13.1.1
+      globby: 11.1.0
+      jju: 1.4.0
+      js-yaml: 4.1.0
+      micromatch: 4.0.8
+    dev: false
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}

--- a/scripts/update-npm-tag.mjs
+++ b/scripts/update-npm-tag.mjs
@@ -40,8 +40,8 @@ async function run() {
 
   // Update the dist-tag of all the public packages to the latest release
   for (const packageName of packagesNames) {
-    // exec(`npm dist-tag add ${packageName}@${latestVersion} ${distTag}`);
-    const result = shell.exec(`sleep 1 && echo "Updating NPM dist: ${packageName}@${latestVersion} ${distTag}"`);
+    // const result = shell.exec(`sleep 1 && echo "Updating NPM dist: ${packageName}@${latestVersion} ${distTag}"`);
+    const result = shell.exec(`npm dist-tag add ${packageName}@${latestVersion} ${distTag}`);
     if (result.code !== 0) {
       throw new Error(`Error updating NPM dist-tag "${distTag}" for ${packageName} with version "${latestVersion}"`);
     }

--- a/scripts/update-npm-tag.mjs
+++ b/scripts/update-npm-tag.mjs
@@ -35,11 +35,12 @@ async function run() {
   // Resolve the public packages of the repository
   const packagesNames = getPublicPackagesNames();
 
-  // Fetch the latest release of the received dist-tag
-  const latestVersion = await getLatestReleaseCandidate(packagesNames[0], distTag);
-
   // Update the dist-tag of all the public packages to the latest release
   for (const packageName of packagesNames) {
+    // Fetch the latest release of the received dist-tag for this package
+    const latestVersion = await getLatestReleaseCandidate(packageName, distTag);
+
+    // Update the dist-tag of all the public packages to the latest release
     const result = shell.exec(`npm dist-tag add ${packageName}@${latestVersion} ${distTag}`);
     if (result.code !== 0) {
       throw new Error(`Error updating NPM dist-tag "${distTag}" for ${packageName} with version "${latestVersion}"`);

--- a/scripts/update-npm-tag.mjs
+++ b/scripts/update-npm-tag.mjs
@@ -1,0 +1,53 @@
+import shell from 'shelljs';
+import { getPackageInfos } from "workspace-tools";
+
+function getPublicPackagesNames() {
+  const packages = getPackageInfos(import.meta.resolve('..'));
+  return Object.values(packages)
+    .filter((pkg) => !pkg.private)
+    .map((pkg) => pkg.name);
+}
+
+async function getLatestReleaseCandidate(packageName, distTag) {
+  const response = await fetch(`https://registry.npmjs.org/${packageName}`);
+  const packageDetails = await response.json();
+
+  const filteredVersions = Object.entries(packageDetails.time)
+    .filter(([version]) => version.includes(distTag))
+    .sort(([, dateTimeA], [, dateTimeB]) => new Date(dateTimeB).getTime() - new Date(dateTimeA).getTime());
+
+  if (filteredVersions.length === 0) {
+    throw new Error(`No release candidate found with dist-tag ${distTag}`);
+  }
+
+  return filteredVersions[0][0];
+}
+
+async function run() {
+
+  // Get the NPM dist-tag parameter
+  const distTag = process.argv[2];
+
+  if (!distTag) {
+    throw new Error("Please provide a NPM dist-tag as a parameter");
+  }
+
+  // Resolve the public packages of the repository
+  const packagesNames = getPublicPackagesNames();
+
+  // Fetch the latest release of the received dist-tag
+  const latestVersion = await getLatestReleaseCandidate(packagesNames[0], distTag);
+
+  // Update the dist-tag of all the public packages to the latest release
+  for (const packageName of packagesNames) {
+    // exec(`npm dist-tag add ${packageName}@${latestVersion} ${distTag}`);
+    const result = shell.exec(`sleep 1 && echo "Updating NPM dist: ${packageName}@${latestVersion} ${distTag}"`);
+    if (result.code !== 0) {
+      throw new Error(`Error updating NPM dist-tag "${distTag}" for ${packageName} with version "${latestVersion}"`);
+    }
+  }
+
+  process.exit(0);
+}
+
+run();

--- a/scripts/update-npm-tag.mjs
+++ b/scripts/update-npm-tag.mjs
@@ -40,7 +40,6 @@ async function run() {
 
   // Update the dist-tag of all the public packages to the latest release
   for (const packageName of packagesNames) {
-    // const result = shell.exec(`sleep 1 && echo "Updating NPM dist: ${packageName}@${latestVersion} ${distTag}"`);
     const result = shell.exec(`npm dist-tag add ${packageName}@${latestVersion} ${distTag}`);
     if (result.code !== 0) {
       throw new Error(`Error updating NPM dist-tag "${distTag}" for ${packageName} with version "${latestVersion}"`);


### PR DESCRIPTION
#### Summary

Update preview releases NPM dist-tag every time we release a new RC version

#### Description

Out current [GH job](https://github.com/commercetools/merchant-center-application-kit/blob/main/.github/workflows/preview-release-on-comment.yml) to release preview RC candidates to NPM publishes release candidates versions to NPM and also creates a `dist-tag` the first time and links it to the very first released RC.

There's an issue though because, when we release a new RC, the `dist-tag` is not updated to point to the new RC version. This mean we can't get automatically the most recent version in the consumers, forcing us to go to each one and update the version manually.

In this PR we include a script that we use in the GH job so we make sure the `dist-tag` is updated every time we publish a new RC version. This means that consumers can link to it by `dist-tag` (eg: `fec-156-react19`) rather than by version (eg: `0.0.0-fec-156-react19-20250128154337`).
