### PR TITLE
mock crypto.randomuuid in test environment

### DIFF
--- a/.changeset/short-panthers-remember.md
+++ b/.changeset/short-panthers-remember.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/jest-preset-mc-app': patch
+---
+
+Mock `crypto.randomUUID` function in `jest` environment.

--- a/packages/jest-preset-mc-app/package.json
+++ b/packages/jest-preset-mc-app/package.json
@@ -41,7 +41,8 @@
     "jest-watch-typeahead": "2.2.2",
     "raf": "3.4.1",
     "setimmediate": "1.0.5",
-    "unfetch": "4.2.0"
+    "unfetch": "4.2.0",
+    "uuid": "9.0.1"
   },
   "devDependencies": {
     "@testing-library/react": "12.1.5",

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -12,6 +12,8 @@ global.Headers = global.Headers || require('node-fetch').Headers;
 global.Request = global.Request || require('node-fetch').Request;
 global.Response = global.Response || require('node-fetch').Response;
 
+// The jsdom version we're using does not support the crypto.randomUUID function, so we need to mock it.
+// We need to wait to use Jest v30, which uses a more recent version of jsdom, to remove this mock.
 global.crypto.randomUUID = () => uuid.v4();
 
 // Fix missing globals when `jsdom` is used in a test environment.

--- a/packages/jest-preset-mc-app/setup-tests.js
+++ b/packages/jest-preset-mc-app/setup-tests.js
@@ -1,5 +1,6 @@
 const util = require('util');
 const MutationObserver = require('@sheerun/mutationobserver-shim');
+const uuid = require('uuid');
 
 global.window.app = {
   applicationName: 'my-app',
@@ -10,6 +11,8 @@ window.MutationObserver = MutationObserver;
 global.Headers = global.Headers || require('node-fetch').Headers;
 global.Request = global.Request || require('node-fetch').Request;
 global.Response = global.Response || require('node-fetch').Response;
+
+global.crypto.randomUUID = () => uuid.v4();
 
 // Fix missing globals when `jsdom` is used in a test environment.
 // See https://github.com/jsdom/jsdom/issues/2524#issuecomment-1108991178.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2413,6 +2413,9 @@ importers:
       unfetch:
         specifier: 4.2.0
         version: 4.2.0
+      uuid:
+        specifier: 9.0.1
+        version: 9.0.1
     devDependencies:
       '@testing-library/react':
         specifier: 12.1.5


### PR DESCRIPTION
#### Summary

Mock `crypto.randomUUID` function in test environment

#### Description

We're stating to use `crypto.randomUUID` function in some the the `app-kit` consumers and currently it is not implemented in the underlying `jsdom` library `jest` uses in the testing context.

The `jsdom` library added support for it in its `22.1.0` [version](https://github.com/jsdom/jsdom/blob/95c80863618dfa43f29166134e263da16433ce05/Changelog.md#2210), but `jest` is currently using the `20.x` version and won't use the `22.x` until its next major release.

In the meantime, I thought it would be helpful to mock this function at `app-kit` level so we don't have to do it at the consumer level.
