### PR TITLE
fix: pnpm v9 regression with linking workspace packages

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -48,13 +48,8 @@ jobs:
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
 
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            provenance=true
-            email=npmjs@commercetools.com
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
+      - name: Setting up authorization to NPM registry (.npmrc)
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,8 @@ jobs:
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
 
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            provenance=true
-            email=npmjs@commercetools.com
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
+      - name: Setting up authorization to NPM registry (.npmrc)
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ typings/
 
 # Optional npm cache directory
 .npm
-.npmrc
 
 # Optional eslint cache
 .eslintcache

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# NPM configuration
+provenance=true
+email=npmjs@commercetools.com
+
+# PNPM configuration
+link-workspace-packages=true


### PR DESCRIPTION
Regression after upgrading to PNPM v9 (#3695).

The error occurs when bumping the version in one of the workspace packages which hasn't been published to the NPM registry.

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/cb3c1511-e78f-41ae-a22f-129852a91583" />

In [v9](https://github.com/orgs/pnpm/discussions/7932) they changed the following setting:

<img width="855" alt="image" src="https://github.com/user-attachments/assets/ee3a7ab3-1902-45b0-ba02-3fe3d0558db7" />

Therefore, we are configuring the setting `link-workspace-packages=true` to restore the previous behavior.

Since PNPM config relies on `.npmrc` file, we also need to commit that. The release CI jobs have also been amended to "inject" the NPM auth token.

PS: using the `workspace` protocol is actually our intention as well. However, there were some issues with Changesets where packages would be published with the `workspace` protocol in the dependencies.
Maybe we need to revisit this setup and see if we can make it work again.