### PR TITLE
fix: modals and dialogs with default attributes added by radix-ui

### DIFF
--- a/.changeset/fifty-chairs-pull.md
+++ b/.changeset/fifty-chairs-pull.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Remove default html attributes added by `radix-ui` to modals and dialogs

--- a/packages/application-components/src/components/dialogs/internals/dialog-container.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-container.tsx
@@ -98,8 +98,9 @@ const DialogContainer = ({
                 props.onClose as DialogContentProps['onPointerDownOutside']
               }
               aria-describedby={undefined}
-              aria-labelledby=""
+              aria-labelledby={undefined}
               aria-label={dialogAccessibleLabel}
+              id={undefined}
             >
               <GridArea name="top" />
               <GridArea name="left" />

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.tsx
@@ -158,8 +158,9 @@ const ModalPage = ({
                 e.preventDefault();
               }
             }}
-            aria-labelledby=""
+            aria-labelledby={undefined}
             aria-label={props.title}
+            id={undefined}
           >
             {/* FIXME: Temporary workaround for https://github.com/radix-ui/primitives/issues/2986
               Radix UI's DialogContent requires rendering a DialogTitle, which renders as <h2>.


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Hoping to fix error happening in CI: 
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/5e6d1ee0-2681-4a17-8446-5c5b06cca039" />

