### PR TITLE
Add an iconLeftPrimaryButton prop to enable formDIalog display primary button with icon in the label

### DIFF
--- a/.changeset/lovely-donuts-mate.md
+++ b/.changeset/lovely-donuts-mate.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+Pass a new prop `iconLeftPrimaryButton`, to provide an icon to the left in the primary button of the form dialog.

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.spec.tsx
@@ -54,6 +54,17 @@ describe('rendering', () => {
       },
     }));
 
+  it('should show primaryButton Icon', () =>
+    validateComponent({
+      title: 'Lorem ipsus',
+      extraProps: {
+        iconLeftPrimaryButton: <div>button icon</div>,
+      },
+      extraChecks: () => {
+        screen.getByText('button icon');
+      },
+    }));
+
   it('should show additional content in footer', () =>
     validateComponent({
       title: 'Lorem ipsus',

--- a/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
+++ b/packages/application-components/src/components/dialogs/form-dialog/form-dialog.tsx
@@ -31,6 +31,7 @@ export type TFormDialogProps = {
   dataAttributesPrimaryButton?: { [key: string]: string };
   getParentSelector?: () => HTMLElement;
   iconLeftSecondaryButton?: ReactElement;
+  iconLeftPrimaryButton?: ReactElement;
   footerContent?: ReactNode;
 };
 
@@ -59,6 +60,7 @@ const FormDialog = ({
       dataAttributesSecondaryButton={props.dataAttributesSecondaryButton}
       dataAttributesPrimaryButton={props.dataAttributesPrimaryButton}
       iconLeftSecondaryButton={props.iconLeftSecondaryButton}
+      iconLeftPrimaryButton={props.iconLeftPrimaryButton}
       footerContent={props.footerContent}
     />
   </DialogContainer>

--- a/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
+++ b/packages/application-components/src/components/dialogs/internals/dialog-footer.tsx
@@ -26,6 +26,7 @@ type Props = {
   dataAttributesSecondaryButton?: { [key: string]: string };
   children?: never;
   iconLeftSecondaryButton?: ReactElement;
+  iconLeftPrimaryButton?: ReactElement;
   footerContent?: ReactNode;
 };
 
@@ -60,6 +61,7 @@ const DialogFooter = ({
           />
           <PrimaryButton
             label={getFormattedLabel(props.labelPrimary, intl)}
+            iconLeft={props.iconLeftPrimaryButton}
             onClick={props.onConfirm}
             isDisabled={isPrimaryButtonDisabled}
             {...filterDataAttributes(dataAttributesPrimaryButton)}


### PR DESCRIPTION
This pull request introduces a new prop `iconLeftPrimaryButton` to the `FormDialog` component in the `@commercetools-frontend/application-components` package. The new prop allows an icon to be displayed to the left of the primary button in the form dialog. The changes include updates to the component's type definitions, rendering logic, and tests.

### New Feature Addition:

* Added a new prop `iconLeftPrimaryButton` to the `FormDialog` component to allow an icon to be displayed to the left of the primary button.

### Screenshot:
<img width="649" alt="image" src="https://github.com/user-attachments/assets/d9d5659c-e686-4c68-afc6-58b9f53d26b6" />
