### PR TITLE
Include a new tag in Sentry context

### DIFF
--- a/.changeset/itchy-houses-vanish.md
+++ b/.changeset/itchy-houses-vanish.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/sentry': patch
+---
+
+We are adding a new tag to the Sentry context named `applicationName` that can help when filtering logs in a multi-application context.

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 // eslint-disable-next-line import/order
-import { BrowserTracing } from '@sentry/browser'; // Must import after `@sentry/react`
+import { globalHandlersIntegration } from '@sentry/browser'; // Must import after `@sentry/react`
 import type { Extra, Extras, Event } from '@sentry/types';
 import history from '@commercetools-frontend/browser-history';
 import type { ApplicationWindow } from '@commercetools-frontend/constants';
@@ -89,12 +89,12 @@ export const boot = () => {
         /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
       ],
       integrations: [
-        new Sentry.Integrations.GlobalHandlers({
+        globalHandlersIntegration({
           onunhandledrejection: false,
           onerror: false,
         }),
-        new BrowserTracing({
-          routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
+        Sentry.reactRouterV5BrowserTracingIntegration({
+          history,
         }),
       ],
       // Sending 5% of transactions. We can adjust that as we see a need to.
@@ -107,9 +107,9 @@ export const boot = () => {
         return redactUnsafeEventFields(event);
       },
     });
-    Sentry.configureScope((scope) => {
-      scope.setTag('role', 'frontend');
-    });
+    const sentryScope = Sentry.getCurrentScope();
+    sentryScope.setTag('role', 'frontend');
+    sentryScope.setTag('applicationName', window.app.applicationName);
   }
 };
 


### PR DESCRIPTION
#### Summary

Include a new tag in Sentry context.

#### Description

This is a **proposal** for adding a new `tag` in Sentry's context that can help filtering error logs in a multi-application context.

Since I noticed we were using some deprecated APIs I also took the time to update those ones:

![Screenshot 2025-03-06 at 18 01 49](https://github.com/user-attachments/assets/961b44a9-d903-42eb-99b8-d6e26c958e4b)

