### PR TITLE
chore: update CODEOWNERS to reflect team ownership for various components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,24 @@
-* @commercetools/shield-team-fe
+# Shield
+/packages/application-components/src/components/custom-views/ @commercetools/shield-team-fe
+/packages/application-components/src/components/page-not-found/ @commercetools/shield-team-fe
+/packages/application-components/src/components/page-unauthorized/ @commercetools/shield-team-fe
+
+# First Contact
+/packages/application-components/src/components/detail-pages/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/dialogs/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/drawer/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/internals/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/main-pages/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/maintenance-page-layout/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/modal-pages/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/page-content-containers/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/portals-container/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/project-stamp/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/public-page-layout/ @commercetools/first-contact-team-fe
+/packages/application-components/src/components/tab-header/ @commercetools/first-contact-team-fe
+/visual-testing-app/ @commercetools/first-contact-team-fe
+/website/ @commercetools/first-contact-team-fe
+/packages/react-notifications/ @commercetools/first-contact-team-fe
+
+# Hooks
+/packages/application-components/src/hooks/ @commercetools/shield-team-fe @commercetools/first-contact-team-fe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,5 @@
-# Shield
-/packages/application-components/src/components/custom-views/ @commercetools/shield-team-fe
-/packages/application-components/src/components/page-not-found/ @commercetools/shield-team-fe
-/packages/application-components/src/components/page-unauthorized/ @commercetools/shield-team-fe
+# Shield (default)
+* @commercetools/shield-team-fe
 
 # First Contact
 /packages/application-components/src/components/detail-pages/ @commercetools/first-contact-team-fe


### PR DESCRIPTION
#### Summary

update CODEOWNERS to reflect team ownership for various components. This change reflects the decision taken by both the First-contact and Shield team as seen in the [miro board](https://miro.com/app/board/uXjVIWRWTV0=/)

See the github [documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more information on CODEOWNERS file.