### PR TITLE
Update console messages handling in tests

### DIFF
--- a/.changeset/thirty-crabs-mix.md
+++ b/.changeset/thirty-crabs-mix.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/jest-preset-mc-app': minor
+---
+
+We've updated how `console` messages are handled in local environments: previously, `console.warn` and `console.error` messages did not make tests to fail locally but they did in CI; this behaviour led to several cases where we did not realize about an issue until some code reached CI whereas it could be detected locally.
+
+With this change we expect some errors to be caught earlier in the development lifecycle and thus shorten the time to fix them.

--- a/packages/jest-preset-mc-app/setup-test-framework.js
+++ b/packages/jest-preset-mc-app/setup-test-framework.js
@@ -66,13 +66,10 @@ function shouldNotThrowWarnings(...messages) {
 
 failOnConsole({
   shouldFailOnLog: Boolean(process.env.CI),
-  shouldFailOnInfo: Boolean(process.env.CI),
-  shouldFailOnWarn: Boolean(process.env.CI),
-  shouldFailOnError: Boolean(process.env.CI),
+  shouldFailOnInfo: true,
+  shouldFailOnWarn: true,
+  shouldFailOnError: true,
   silenceMessage: (message) => {
-    if (!process.env.CI) {
-      return false;
-    }
     return shouldSilenceWarnings(message);
   },
   logButNotThrowMessage: (message) => {


### PR DESCRIPTION
#### Summary

Update console messages handling in tests.

#### Description

We've updated how `console` messages are handled in local environments: previously, `console.warn` and `console.error` messages did not make tests to fail locally but they did in CI; this behaviour led to several cases where we did not realize about an issue until some code reached CI whereas it could be detected locally.

With this change we expect some errors to be caught earlier in the development lifecycle and thus shorten the time to fix them.

