### PR TITLE
refactor: migrate CLIs from `cac` to `commander`

### DIFF
--- a/.changeset/spotty-elephants-think.md
+++ b/.changeset/spotty-elephants-think.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+'@commercetools-frontend/mc-scripts': patch
+'@commercetools-frontend/codemod': patch
+---
+
+Migrate CLI program to `commander`.

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "babel-plugin-import-graphql": "^2.8.1",
     "babel-plugin-transform-rename-import": "^2.3.0",
     "babel-plugin-typescript-to-proptypes": "1.4.2",
-    "cac": "6.7.14",
     "cross-env": "7.0.3",
     "cypress": "12.17.4",
     "dotenv": "16.4.5",

--- a/packages/codemod/bin/mc-codemod.js
+++ b/packages/codemod/bin/mc-codemod.js
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
 
+process.env.NODE_ENV = 'production';
+
 require('../').cli();

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@babel/core": "^7.22.17",
     "@babel/preset-env": "^7.22.15",
-    "cac": "6.7.14",
+    "commander": "^13.1.0",
     "glob": "8.1.0",
     "jscodeshift": "0.15.2",
     "prettier": "2.8.8"

--- a/packages/create-mc-app/package.json
+++ b/packages/create-mc-app/package.json
@@ -24,7 +24,7 @@
     "@commercetools-frontend/application-config": "^23.1.0",
     "@types/babel__core": "^7.20.1",
     "@types/semver": "^7.5.1",
-    "cac": "6.7.14",
+    "commander": "^13.1.0",
     "execa": "5.1.1",
     "listr2": "5.0.8",
     "prettier": "2.8.8",

--- a/packages/create-mc-app/src/cli.ts
+++ b/packages/create-mc-app/src/cli.ts
@@ -1,4 +1,4 @@
-import { cac } from 'cac';
+import { program } from 'commander';
 import { Listr, type ListrTask } from 'listr2';
 import pkgJson from '../package.json';
 import { applicationTypes, availableTemplates } from './constants';
@@ -12,7 +12,12 @@ import { throwIfNodeVersionIsNotSupported } from './validations';
 
 throwIfNodeVersionIsNotSupported(process.versions.node, pkgJson.engines.node);
 
-const cli = cac('create-mc-app');
+program
+  .name('create-mc-app')
+  .description(
+    'CLI to create a new Merchant Center customizations project based on the pre-defined templates.'
+  )
+  .version(pkgJson.version);
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -32,58 +37,50 @@ const messagesByApplicationType = {
 
 const run = () => {
   // Default command
-  cli
-    .command('[project-directory]')
-    .usage(
-      '[project-directory]\n\n  Bootstraps a new project using one of the predefined templates.'
-    )
+  program
+    .argument('<project-directory>')
     .option(
-      '--application-type <type>',
+      '--application-type [type]',
       '(optional) The type of the application to create: custom-application (default) or custom-view.',
-      { default: applicationTypes['custom-application'] }
+      applicationTypes['custom-application']
     )
     .option(
-      '--template <name>',
+      '--template [name]',
       '(optional) The name of the template to install.',
-      { default: availableTemplates.starter }
+      availableTemplates.starter
     )
     .option(
-      '--template-version <version>',
+      '--template-version [version]',
       '(optional) The version of the template to install (either a git tag or a git branch of the "commercetools/merchant-center-application-kit" repository).',
-      { default: 'main' }
+      'main'
     )
     .option(
       '--skip-install',
       '(optional) Skip installing the dependencies after cloning the template.',
-      { default: false }
+      false
     )
     .option(
       '--yes',
       '(optional) If set, the prompt options with default values will be skipped.',
-      { default: false }
+      false
     )
     .option(
-      '--entry-point-uri-path <value>',
+      '--entry-point-uri-path [value]',
       '(optional) The version of the template to install. (default: starter-<hash>)'
     )
     .option(
-      '--initial-project-key <value>',
+      '--initial-project-key [value]',
       '(optional) A commercetools project key used for the initial login in development. By default, the value is prompted in the terminal.'
     )
     .option(
-      '--cloud-identifier <value>',
-      '(optional) Cloud region identifier. (default: gcp-eu)'
+      '--cloud-identifier [value]',
+      '(optional) Cloud region identifier. By default, the value is prompted in the terminal'
     )
     .option(
-      '--package-manager <value>',
+      '--package-manager [value]',
       '(optional) The preferred package manager to use: npm, yarn, pnpm.'
     )
-    .action(async (projectDirectory, options: TCliCommandOptions) => {
-      if (!projectDirectory) {
-        cli.outputHelp();
-        return;
-      }
-
+    .action(async (projectDirectory: string, options: TCliCommandOptions) => {
       const releaseVersion = await getLatestReleaseVersion();
 
       hintOutdatedVersion(pkgJson.version, releaseVersion);
@@ -132,10 +129,7 @@ const run = () => {
       );
     });
 
-  cli.help();
-  cli.version(pkgJson.version);
-
-  cli.parse();
+  program.parse();
 };
 
 export default run;

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -74,7 +74,7 @@
     "babel-loader": "8.3.0",
     "babel-plugin-formatjs": "^10.5.25",
     "browserslist": "^4.21.10",
-    "cac": "6.7.14",
+    "commander": "^13.1.0",
     "chalk": "4.1.2",
     "core-js": "^3.32.2",
     "css-loader": "6.11.0",

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { cac } from 'cac';
+import { program } from 'commander';
 import dotenv from 'dotenv';
 import dotenvExpand from 'dotenv-expand';
 import pkgJson from '../package.json';
@@ -13,7 +13,14 @@ import type {
 } from './types';
 import doesFileExist from './utils/does-file-exist';
 
-const cli = cac('mc-scripts');
+program
+  .name('mc-scripts')
+  .description('CLI to develop and build Merchant Center customizations.')
+  .version(pkgJson.version)
+  .option(
+    '--env [path]',
+    `(optional) Parses the file path as a dotenv file and adds the variables to the environment. Multiple flags are allowed.`
+  );
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -26,30 +33,19 @@ process.on('unhandledRejection', (err) => {
 const applicationDirectory = fs.realpathSync(process.cwd());
 
 async function run() {
-  cli.option(
-    '--env <path>',
-    `(optional) Parses the file path as a dotenv file and adds the variables to the environment. Multiple flags are allowed.`
-  );
-
-  // Default command
-  cli
-    .command('')
-    .usage('\n\n  Develop and build Custom Applications.')
-    .action(() => {
-      cli.outputHelp();
-    });
-
   // Command: start
-  const usageStart =
-    'Starts the application in development mode using Webpack Dev Server.';
-  cli
-    .command('start', usageStart)
-    .usage(`\n\n  ${usageStart}`)
+  program
+    .command('start')
     .alias('dev')
-    .action(async (options: TCliGlobalOptions) => {
+    .description(
+      'Starts the application in development mode using Webpack Dev Server.'
+    )
+    .action(async () => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
+
       // Load dotenv files into the process environment.
       // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-      loadDotEnvFiles(options);
+      loadDotEnvFiles(globalOptions);
 
       // Do this as the first thing so that any code reading it knows the right env.
       process.env.BABEL_ENV = 'development';
@@ -69,20 +65,21 @@ async function run() {
     });
 
   // Command: build
-  const usageBuild =
-    'Bundles the application in production mode. Outputs a "public" folder.';
-  cli
-    .command('build', usageBuild)
-    .usage(`\n\n  ${usageBuild}`)
+  program
+    .command('build')
+    .description(
+      'Bundles the application in production mode. Outputs a "public" folder.'
+    )
     .option(
       '--build-only',
       '(optional) If defined, the command only creates the production bundles without compiling the "index.html".',
-      { default: false }
+      false
     )
-    .action(async (options: TCliCommandBuildOptions & TCliGlobalOptions) => {
+    .action(async (options: TCliCommandBuildOptions) => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
       // Load dotenv files into the process environment.
       // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-      loadDotEnvFiles(options);
+      loadDotEnvFiles(globalOptions);
 
       // Do this as the first thing so that any code reading it knows the right env.
       process.env.BABEL_ENV = 'production';
@@ -109,44 +106,46 @@ async function run() {
     });
 
   // Command: compile-html
-  const usageCompileHtml =
-    'Compiles "index.html.template" file into a "index.html" with all the required runtime configuration. The security headers are also compiled and injected into the "index.html".';
-  cli
-    .command('compile-html', usageCompileHtml)
-    .usage(`\n\n  ${usageCompileHtml}`)
+  program
+    .command('compile-html')
+    .description(
+      'Compiles "index.html.template" file into a "index.html" with all the required runtime configuration. The security headers are also compiled and injected into the "index.html".'
+    )
     .option(
-      '--transformer <path>',
+      '--transformer [path]',
       '(optional) The path to a JS module that can be used to generate a configuration for a specific cloud provider (e.g. Vercel, Netlify).'
     )
     .option(
       '--print-security-headers',
       '(optional) If defined, the compiled security headers are printed to stdout.',
-      { default: false }
+      false
     )
-    .action(
-      async (options: TCliCommandCompileHtmlOptions & TCliGlobalOptions) => {
-        // Load dotenv files into the process environment.
-        // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-        loadDotEnvFiles(options);
+    .action(async (options: TCliCommandCompileHtmlOptions) => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
 
-        // Do this as the first thing so that any code reading it knows the right env.
-        process.env.NODE_ENV = 'production';
-
-        const compileHtmlCommand = await import('./commands/compile-html');
-        await compileHtmlCommand.default(options);
-      }
-    );
-
-  // Command: serve
-  const usageServe =
-    'Serves previously built and compiled application from the "public" folder.';
-  cli
-    .command('serve', usageServe)
-    .usage(`\n\n  ${usageServe}`)
-    .action(async (options: TCliGlobalOptions) => {
       // Load dotenv files into the process environment.
       // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-      loadDotEnvFiles(options);
+      loadDotEnvFiles(globalOptions);
+
+      // Do this as the first thing so that any code reading it knows the right env.
+      process.env.NODE_ENV = 'production';
+
+      const compileHtmlCommand = await import('./commands/compile-html');
+      await compileHtmlCommand.default(options);
+    });
+
+  // Command: serve
+  program
+    .command('serve')
+    .description(
+      'Serves previously built and compiled application from the "public" folder.'
+    )
+    .action(async () => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
+
+      // Load dotenv files into the process environment.
+      // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
+      loadDotEnvFiles(globalOptions);
 
       // Do this as the first thing so that any code reading it knows the right env.
       process.env.NODE_ENV = 'production';
@@ -156,15 +155,17 @@ async function run() {
     });
 
   // Command: login
-  const usageLogin =
-    'Log in to your Merchant Center account through the CLI, using the cloud environment information from the Merchant Center customization config file. An API token is generated and stored in a configuration file for the related cloud environment, and valid for 36 hours.';
-  cli
-    .command('login', usageLogin)
-    .usage(`\n\n  ${usageLogin}`)
-    .action(async (options: TCliGlobalOptions) => {
+  program
+    .command('login')
+    .description(
+      'Log in to your Merchant Center account through the CLI, using the cloud environment information from the Merchant Center customization config file. An API token is generated and stored in a configuration file for the related cloud environment, and valid for 36 hours.'
+    )
+    .action(async () => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
+
       // Load dotenv files into the process environment.
       // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-      loadDotEnvFiles(options);
+      loadDotEnvFiles(globalOptions);
 
       // Do this as the first thing so that any code reading it knows the right env.
       process.env.NODE_ENV = 'production';
@@ -174,72 +175,66 @@ async function run() {
     });
 
   // Command: config:sync
-  const usageConfigSync =
-    'Synchronizes the local Merchant Center customization config with the Merchant Center. A new Merchant Center customization will be created if none existed, otherwise it will be updated.';
-  cli
-    .command('config:sync', usageConfigSync)
-    .usage(`\n\n  ${usageConfigSync}`)
+  program
+    .command('config:sync')
+    .description(
+      'Synchronizes the local Merchant Center customization config with the Merchant Center. A new Merchant Center customization will be created if none existed, otherwise it will be updated.'
+    )
     .option(
       '--dry-run',
       '(optional) Executes the command but does not send any mutation request.',
-      { default: false }
+      false
     )
-    .action(
-      async (options: TCliCommandConfigSyncOptions & TCliGlobalOptions) => {
-        // Load dotenv files into the process environment.
-        // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-        loadDotEnvFiles(options);
+    .action(async (options: TCliCommandConfigSyncOptions) => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
 
-        // Do this as the first thing so that any code reading it knows the right env.
-        process.env.NODE_ENV = 'production';
+      // Load dotenv files into the process environment.
+      // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
+      loadDotEnvFiles(globalOptions);
 
-        const configSyncCommand = await import('./commands/config-sync');
-        await configSyncCommand.default(options);
-      }
-    );
+      // Do this as the first thing so that any code reading it knows the right env.
+      process.env.NODE_ENV = 'production';
+
+      const configSyncCommand = await import('./commands/config-sync');
+      await configSyncCommand.default(options);
+    });
 
   // Command: deployment-previews:set
-  const usageDeploymentPreviewsSet =
-    'Creates or updates a deployment preview for the Custom Application.';
-  cli
-    .command('deployment-previews:set', usageDeploymentPreviewsSet)
-    .usage(`\n\n  ${usageDeploymentPreviewsSet}`)
+  program
+    .command('deployment-previews:set')
+    .description(
+      'Creates or updates a deployment preview for the Custom Application.'
+    )
     .option(
-      '--alias <deployment-preview-alias>',
+      '--alias [deployment-preview-alias]',
       "(optional) Alias to be used for the deployment preview. If you don't provide an alias, the command will prompt you for it."
     )
     .option(
-      '--url <deployment-preview-url>',
+      '--url [deployment-preview-url]',
       "(optional) URL to be used for the deployment preview. If you don't provide a URL, the command will prompt you for it."
     )
     .option(
       '--dry-run',
       '(optional) Executes the command but does not send any mutation request.',
-      { default: false }
+      false
     )
-    .action(
-      async (
-        options: TCliCommandSetDeploymentPreviewOptions & TCliGlobalOptions
-      ) => {
-        // Load dotenv files into the process environment.
-        // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
-        loadDotEnvFiles(options);
+    .action(async (options: TCliCommandSetDeploymentPreviewOptions) => {
+      const globalOptions = program.opts<TCliGlobalOptions>();
 
-        // Do this as the first thing so that any code reading it knows the right env.
-        process.env.NODE_ENV = 'production';
+      // Load dotenv files into the process environment.
+      // This is essentially what `dotenv-cli` does, but it's now built into this CLI.
+      loadDotEnvFiles(globalOptions);
 
-        const deploymentsSetCommand = await import(
-          './commands/deployment-previews-set'
-        );
-        await deploymentsSetCommand.default(options);
-      }
-    );
+      // Do this as the first thing so that any code reading it knows the right env.
+      process.env.NODE_ENV = 'production';
 
-  cli.help();
-  cli.version(pkgJson.version);
+      const deploymentsSetCommand = await import(
+        './commands/deployment-previews-set'
+      );
+      await deploymentsSetCommand.default(options);
+    });
 
-  cli.parse(process.argv, { run: false });
-  await cli.runMatchedCommand();
+  program.parse();
 }
 
 // Load dotenv files into the process environment.

--- a/packages/mc-scripts/src/types.ts
+++ b/packages/mc-scripts/src/types.ts
@@ -1,5 +1,4 @@
 export type TCliGlobalOptions = {
-  '--'?: string[];
   env?: string[];
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,6 @@ importers:
       babel-plugin-typescript-to-proptypes:
         specifier: 1.4.2
         version: 1.4.2(patch_hash=lqszx5kvqxa52t7l2zddujkdkq)(@babel/core@7.22.17)(typescript@5.0.4)
-      cac:
-        specifier: 6.7.14
-        version: 6.7.14
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -2079,9 +2076,9 @@ importers:
       '@babel/preset-env':
         specifier: ^7.22.15
         version: 7.22.15(@babel/core@7.22.17)
-      cac:
-        specifier: 6.7.14
-        version: 6.7.14
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
       glob:
         specifier: 8.1.0
         version: 8.1.0
@@ -2153,9 +2150,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.1
         version: 7.5.1
-      cac:
-        specifier: 6.7.14
-        version: 6.7.14
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
       execa:
         specifier: 5.1.1
         version: 5.1.1
@@ -2657,12 +2654,12 @@ importers:
       browserslist:
         specifier: ^4.21.10
         version: 4.21.10
-      cac:
-        specifier: 6.7.14
-        version: 6.7.14
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
       core-js:
         specifier: ^3.32.2
         version: 3.32.2
@@ -8652,10 +8649,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
     engines: {node: '>=14.16'}
@@ -8929,6 +8922,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -26016,8 +26013,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  cac@6.7.14: {}
-
   cacheable-lookup@7.0.0: {}
 
   cacheable-request@10.2.9:
@@ -26334,6 +26329,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@13.1.0: {}
 
   commander@2.20.3: {}
 


### PR DESCRIPTION
Unfortunately the `cac` library hasn't been actively maintained in the past years. So we're back at using `commander`, which actually has a very similar API of `cac` so switching between them is pretty simple.