### PR TITLE
refactor: simplify jwks validation with jose, no extra libs

### DIFF
--- a/.changeset/chatty-jeans-prove.md
+++ b/.changeset/chatty-jeans-prove.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-backend/loggers': patch
+---
+
+Define `engines.node` version requirement

--- a/.changeset/curly-nails-raise.md
+++ b/.changeset/curly-nails-raise.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-backend/express': patch
+---
+
+Define `engines.node` version requirement.
+
+Additionally, simplify the JWT token validation using `jose`. As a result, the option `jwks` of `createSessionMiddleware` is no longer needed and is marked as deprecated.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,21 @@ jobs:
       - name: Running static type checking (Starter Template)
         run: pnpm typecheck:starters
 
-      - name: Running linters and tests
-        run: pnpm jest --projects jest.{eslint,stylelint,test}.config.js --reporters jest-silent-reporter
+      - name: Running linters
+        run: pnpm jest --projects jest.{eslint,stylelint}.config.js --reporters jest-silent-reporter
+        env:
+          CI: true
+
+      - name: Running tests for frontend packages
+        run: pnpm run test --reporters jest-silent-reporter
         env:
           CI: true
           RTL_ASYNC_UTIL_TIMEOUT: 5000
+
+      - name: Running tests for node packages
+        run: pnpm run test:node
+        env:
+          CI: true
 
   test_visual:
     runs-on: ubuntu-latest

--- a/jest.test-node.config.ts
+++ b/jest.test-node.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  displayName: 'test-node',
+  testEnvironment: 'node',
+  moduleDirectories: ['packages-backend/', 'node_modules'],
+  modulePathIgnorePatterns: [
+    '.cache',
+    'build/',
+    'dist/',
+    'packages/',
+    'application-templates/',
+    'custom-views-templates/',
+    'playground/',
+    'visual-testing-app/',
+  ],
+  testMatch: ['**/*.spec.js', '**/*.spec.ts'],
+  watchPlugins: ['jest-watch-typeahead/filename'],
+  reporters: [['github-actions', { silent: false }], 'default'],
+};
+
+export default config;

--- a/jest.test.config.js
+++ b/jest.test.config.js
@@ -6,13 +6,20 @@ process.env.ENABLE_NEW_JSX_TRANSFORM = 'true';
 module.exports = {
   preset: '@commercetools-frontend/jest-preset-mc-app/typescript',
   moduleDirectories: [
-    'application-templates',
-    'packages',
-    'packages-backend',
-    'playground',
-    'node_modules',
+    'application-templates/',
+    'custom-views-templates/',
+    'packages/',
+    'playground/',
+    'node_modules/',
   ],
-  modulePathIgnorePatterns: ['.cache', 'build', 'dist', 'public/', 'examples'],
+  modulePathIgnorePatterns: [
+    '.cache',
+    'build',
+    'dist',
+    'public/',
+    'examples',
+    'packages-backend/',
+  ],
   transformIgnorePatterns: [
     // Transpile also our local packages as they are only symlinked.
     'node_modules/(?!(@commercetools-[frontend|backend]+)/)',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "changeset": "changeset",
     "changeset:version-and-format": "changeset version && prettier --write --parser json '**/package.json' && pnpm install --lockfile-only",
     "test": "jest --config jest.test.config.js",
+    "test:node": "jest --config jest.test-node.config.ts",
     "test:watch": "jest --config jest.test.config.js --watch",
     "test:visual": "jest --config jest.visual.config.js --runInBand --testTimeout 10000",
     "test:jest-preview": "jest-preview",

--- a/packages-backend/express/package.json
+++ b/packages-backend/express/package.json
@@ -22,14 +22,15 @@
     "@babel/runtime-corejs3": "^7.22.15",
     "@types/express": "^4.17.17",
     "@types/node": "^22.13.2",
-    "express": "4.20.0",
-    "express-jwt": "8.4.1",
-    "jwks-rsa": "2.1.5"
+    "express": "^4.21.2",
+    "jose": "^5.10.0"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
-    "@types/jsonwebtoken": "^9.0.2",
-    "jose": "2.0.7",
+    "typescript": "^5.2.2",
     "msw": "0.49.3"
+  },
+  "engines": {
+    "node": "18.x || 20.x || >=22.0.0"
   }
 }

--- a/packages-backend/express/src/middlewares/fixtures/jwt-token.ts
+++ b/packages-backend/express/src/middlewares/fixtures/jwt-token.ts
@@ -1,20 +1,109 @@
-// @ts-expect-error: migrate to jose v5
-import { JWT, JWK, JWKS } from 'jose';
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
+import {
+  type JWK,
+  type JWTPayload,
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  importPKCS8,
+} from 'jose';
 
-const keyRS256 = JWK.generateSync('RSA', 2048, { use: 'sig', alg: 'RS256' });
+const signingKey = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {
+    type: 'spki',
+    format: 'pem',
+  },
+  privateKeyEncoding: {
+    type: 'pkcs8',
+    format: 'pem',
+  },
+});
 
-const jwksStore = new JWKS.KeyStore([keyRS256]);
+export type JWKS = {
+  keys: JWK[];
+};
 
-const createToken = (options: { issuer: string; audience: string }) =>
-  JWT.sign(
-    {
-      sub: 'user-id',
-      iss: options.issuer,
-      aud: options.audience,
-      [`${options.issuer}/claims/project_key`]: 'project-key',
-    },
-    keyRS256,
-    { algorithm: 'RS256' }
-  );
+export type TestTokens = {
+  tokenRS256: string;
+  toJWKS: () => Promise<JWKS>;
+};
 
-export { jwksStore, createToken };
+let tokens: TestTokens;
+
+async function getTokens(options: { issuer: string; audience: string }) {
+  // Lazily initialize tokens
+  if (!tokens) {
+    await createTestTokens(options);
+  }
+  return tokens;
+}
+
+function clearTokens() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  tokens = null;
+}
+
+async function createTestTokens(options: {
+  issuer: string;
+  audience: string;
+}): Promise<void> {
+  const privateKey = await importPKCS8(signingKey.privateKey, 'RS256');
+  const publicKey = createPublicKey({
+    key: signingKey.privateKey,
+    format: 'pem',
+  });
+  const jwk = await exportJWK(publicKey);
+  const kid = await calculateJwkThumbprint(jwk);
+
+  async function signToken(jwtPayload: JWTPayload): Promise<string> {
+    const token = await new SignJWT(jwtPayload)
+      .setProtectedHeader({
+        alg: 'RS256',
+        kid,
+      })
+      .sign(privateKey);
+    return token;
+  }
+
+  async function toJWKS(): Promise<JWKS> {
+    const keys = [
+      {
+        ...jwk,
+        kid,
+        alg: 'RS256',
+        use: 'sig',
+      },
+    ];
+    return { keys };
+  }
+
+  const tokenRS256 = await signToken({
+    sub: 'user-id',
+    iss: options.issuer,
+    aud: options.audience,
+    [`${options.issuer}/claims/project_key`]: 'project-key',
+  });
+
+  tokens = {
+    tokenRS256,
+    toJWKS,
+  };
+}
+
+export { createTestTokens, getTokens, clearTokens };
+
+// const createToken = (options: { issuer: string; audience: string }) =>
+//   JWT.sign(
+//     {
+//       sub: 'user-id',
+//       iss: options.issuer,
+//       aud: options.audience,
+//       [`${options.issuer}/claims/project_key`]: 'project-key',
+//     },
+//     keyRS256,
+//     { algorithm: 'RS256' }
+//   );
+
+// export { jwksStore, createToken };

--- a/packages-backend/express/src/middlewares/fixtures/jwt-token.ts
+++ b/packages-backend/express/src/middlewares/fixtures/jwt-token.ts
@@ -93,17 +93,3 @@ async function createTestTokens(options: {
 }
 
 export { createTestTokens, getTokens, clearTokens };
-
-// const createToken = (options: { issuer: string; audience: string }) =>
-//   JWT.sign(
-//     {
-//       sub: 'user-id',
-//       iss: options.issuer,
-//       aud: options.audience,
-//       [`${options.issuer}/claims/project_key`]: 'project-key',
-//     },
-//     keyRS256,
-//     { algorithm: 'RS256' }
-//   );
-
-// export { jwksStore, createToken };

--- a/packages-backend/express/src/middlewares/session-middleware.ts
+++ b/packages-backend/express/src/middlewares/session-middleware.ts
@@ -7,9 +7,9 @@ function createSessionMiddleware<Request extends TBaseRequest>(
 ) {
   const sessionAuthVerifier = createSessionAuthVerifier<Request>(options);
 
-  return async (request: Request, response: Response, next: NextFunction) => {
+  return async (request: Request, _response: Response, next: NextFunction) => {
     try {
-      await sessionAuthVerifier(request, response);
+      await sessionAuthVerifier(request);
       next();
     } catch (error) {
       next(error);

--- a/packages-backend/express/src/types.ts
+++ b/packages-backend/express/src/types.ts
@@ -1,5 +1,3 @@
-import type { ExpressJwtOptions } from 'jwks-rsa';
-
 import { CLOUD_IDENTIFIERS } from './constants';
 
 export type TAudience = string;
@@ -43,8 +41,10 @@ export type TSessionMiddlewareOptions<Request extends TBaseRequest> = {
   inferIssuer?: boolean;
   /**
    * Options for the `jwksRsa.expressJwtSecret`
+   *
+   * @deprecated
    */
-  jwks?: Omit<ExpressJwtOptions, 'jwksUri'>;
+  jwks?: unknown;
   /**
    * By default we assume that the `request` is a Node.js-like object having either
    * an `originalUrl` or `url` properties.

--- a/packages-backend/loggers/package.json
+++ b/packages-backend/loggers/package.json
@@ -39,6 +39,10 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/express": "^4.17.17",
-    "express": "4.20.0"
+    "express": "^4.21.2",
+    "typescript": "^5.2.2"
+  },
+  "engines": {
+    "node": "18.x || 20.x || >=22.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1255,27 +1255,21 @@ importers:
         specifier: ^22.13.2
         version: 22.13.2
       express:
-        specifier: 4.20.0
-        version: 4.20.0
-      express-jwt:
-        specifier: 8.4.1
-        version: 8.4.1
-      jwks-rsa:
-        specifier: 2.1.5
-        version: 2.1.5
+        specifier: ^4.21.2
+        version: 4.21.2
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
     devDependencies:
       '@tsconfig/node22':
         specifier: ^22.0.0
         version: 22.0.0
-      '@types/jsonwebtoken':
-        specifier: ^9.0.2
-        version: 9.0.2
-      jose:
-        specifier: 2.0.7
-        version: 2.0.7
       msw:
         specifier: 0.49.3
-        version: 0.49.3(typescript@4.9.5)
+        version: 0.49.3(typescript@5.7.3)
+      typescript:
+        specifier: ^5.2.2
+        version: 5.7.3
 
   packages-backend/loggers:
     dependencies:
@@ -1317,8 +1311,11 @@ importers:
         specifier: ^4.17.17
         version: 4.17.17
       express:
-        specifier: 4.20.0
-        version: 4.20.0
+        specifier: ^4.21.2
+        version: 4.21.2
+      typescript:
+        specifier: ^5.2.2
+        version: 5.7.3
 
   packages/actions-global:
     dependencies:
@@ -2033,7 +2030,7 @@ importers:
         version: 0.2.3(@babel/core@7.22.17)
       babel-plugin-formatjs:
         specifier: ^10.5.25
-        version: 10.5.30
+        version: 10.5.30(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))
       babel-plugin-lodash:
         specifier: ^3.3.4
         version: 3.3.4
@@ -2611,7 +2608,7 @@ importers:
         version: 11.13.5
       '@formatjs/cli-lib':
         specifier: ^6.3.8
-        version: 6.3.8
+        version: 6.3.8(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
         version: 0.5.15(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.2(webpack@5.94.0(@swc/core@1.10.16)))(webpack@5.94.0(@swc/core@1.10.16))
@@ -2653,7 +2650,7 @@ importers:
         version: 8.3.0(@babel/core@7.22.17)(webpack@5.94.0(@swc/core@1.10.16))
       babel-plugin-formatjs:
         specifier: ^10.5.25
-        version: 10.5.30
+        version: 10.5.30(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))
       browserslist:
         specifier: ^4.21.10
         version: 4.21.10
@@ -2740,7 +2737,7 @@ importers:
         version: 0.2.1
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.57.0)(typescript@5.0.4)(webpack@5.94.0(@swc/core@1.10.16))
+        version: 12.0.1(eslint@8.57.0)(typescript@5.7.3)(webpack@5.94.0(@swc/core@1.10.16))
       react-refresh:
         specifier: 0.14.2
         version: 0.14.2
@@ -2789,7 +2786,7 @@ importers:
     devDependencies:
       '@commercetools-test-data/custom-view':
         specifier: ^8.0.0
-        version: 8.2.3(@types/node@22.13.2)(typescript@5.0.4)
+        version: 8.2.3(@types/node@22.13.2)(typescript@5.7.3)
       '@tsconfig/node22':
         specifier: ^22.0.0
         version: 22.0.0
@@ -2825,7 +2822,7 @@ importers:
         version: 5.4.1
       msw:
         specifier: 0.49.3
-        version: 0.49.3(typescript@5.0.4)
+        version: 0.49.3(typescript@5.7.3)
       rimraf:
         specifier: 5.0.7
         version: 5.0.7
@@ -3643,10 +3640,6 @@ packages:
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.24.7':
-    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
@@ -3730,10 +3723,6 @@ packages:
     resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.23.6':
-    resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-compilation-targets@7.25.2':
     resolution: {integrity: sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==}
     engines: {node: '>=6.9.0'}
@@ -3809,12 +3798,6 @@ packages:
 
   '@babel/helper-module-transforms@7.22.17':
     resolution: {integrity: sha512-XouDDhQESrLHTpnBtCKExJdyY4gJCdrvH2Pyv8r8kovX2U8G0dRUOT45T9XlbLtuu9CLXP15eusnkprhoPV5iQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-module-transforms@7.24.5':
-    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3935,10 +3918,6 @@ packages:
 
   '@babel/helpers@7.22.15':
     resolution: {integrity: sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.24.5':
-    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.25.6':
@@ -6450,10 +6429,6 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jest/console@29.5.0':
-    resolution: {integrity: sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   '@jest/console@29.7.0':
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6466,10 +6441,6 @@ packages:
     peerDependenciesMeta:
       node-notifier:
         optional: true
-
-  '@jest/environment@29.5.0':
-    resolution: {integrity: sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/environment@29.6.4':
     resolution: {integrity: sha512-sQ0SULEjA1XUTHmkBRl7A1dyITM9yb1yb3ZNKPX3KlTd6IG7mWUe3e2yfExtC2Zz1Q+mMckOLHmL/qLiuQJrBQ==}
@@ -6485,10 +6456,6 @@ packages:
 
   '@jest/expect@29.7.0':
     resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jest/fake-timers@29.5.0':
-    resolution: {integrity: sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/fake-timers@29.6.4':
@@ -6767,10 +6734,6 @@ packages:
 
   '@open-draft/until@1.0.3':
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
-
-  '@panva/asn1.js@1.0.0':
-    resolution: {integrity: sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==}
-    engines: {node: '>=10.13.0'}
 
   '@peculiar/asn1-schema@2.3.6':
     resolution: {integrity: sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==}
@@ -7822,12 +7785,6 @@ packages:
   '@types/jsonfile@6.1.1':
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
 
-  '@types/jsonwebtoken@8.5.9':
-    resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
-
-  '@types/jsonwebtoken@9.0.2':
-    resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
-
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
@@ -8852,6 +8809,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
@@ -8860,9 +8821,6 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -9300,6 +9258,10 @@ packages:
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
   core-js-compat@3.32.2:
@@ -9947,9 +9909,6 @@ packages:
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
   edge-runtime@2.4.4:
     resolution: {integrity: sha512-uq1YdIxkMDsBYLdSSp/w62PciCL46ic4m1Z/2G6N8RcAPI8p35O8u6hJQT83j28Dnt4U5iyvmwFMYouHMK51uA==}
     engines: {node: '>=14'}
@@ -9957,6 +9916,11 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   electron-to-chromium@1.4.512:
     resolution: {integrity: sha512-1W8wRbYlQE4ph7eoj3TJ+uqwO6+xvAE/L+KGU7WTQQvX3tnSIGZAb90MTsMoJqzntamiwJhBAj4WZmygXhsOUg==}
@@ -10196,10 +10160,6 @@ packages:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escalade@3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
-    engines: {node: '>=6'}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -10502,13 +10462,6 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  express-jwt@8.4.1:
-    resolution: {integrity: sha512-IZoZiDv2yZJAb3QrbaSATVtTCYT11OcqgFGoTN4iKVyN6NBkBkhtVIixww5fmakF0Upt5HfOxJuS6ZmJVeOtTQ==}
-    engines: {node: '>= 8.0.0'}
-
-  express-unless@2.1.3:
-    resolution: {integrity: sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ==}
-
   express-winston@4.2.0:
     resolution: {integrity: sha512-EMD74g63nVHi7pFleQw7KHCxiA1pjF5uCwbCfzGqmFxs9KvlDPIVS3cMGpULm6MshExMT9TjC3SqmRGB9kb7yw==}
     engines: {node: '>= 6'}
@@ -10517,6 +10470,10 @@ packages:
 
   express@4.20.0:
     resolution: {integrity: sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==}
+    engines: {node: '>= 0.10.0'}
+
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
   extend@3.0.2:
@@ -10650,6 +10607,9 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  filelist@1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+
   filesize@8.0.7:
     resolution: {integrity: sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==}
     engines: {node: '>= 0.4.0'}
@@ -10664,6 +10624,10 @@ packages:
 
   finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+    engines: {node: '>= 0.8'}
+
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
   find-cache-dir@2.1.0:
@@ -11831,6 +11795,11 @@ packages:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
 
+  jake@10.9.2:
+    resolution: {integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -11990,10 +11959,6 @@ packages:
     resolution: {integrity: sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==}
     engines: {node: '>= 10.14.2'}
 
-  jest-util@29.5.0:
-    resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   jest-util@29.6.3:
     resolution: {integrity: sha512-QUjna/xSy4B32fzcKTSz1w7YYzgiHrjjJjevdRf61HYk998R5vVMMNmrHESYZVDS5DSWs+1srPLPKxXPkeSDOA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -12068,12 +12033,11 @@ packages:
   joi@17.12.2:
     resolution: {integrity: sha512-RonXAIzCiHLc8ss3Ibuz45u28GOsWE1UpfDXLbN/9NKbL4tCJf8TWYVKsoYuuh+sAUt7fsSNpA+r2+TBA6Wjmw==}
 
-  jose@2.0.7:
-    resolution: {integrity: sha512-5hFWIigKqC+e/lRyQhfnirrAqUdIPMB7SJRqflJaO29dW7q5DFvH1XCSTmv6PQ6pb++0k6MJlLRoS0Wv4s38Wg==}
-    engines: {node: '>=10.13.0 < 13 || >=13.7.0'}
-
   jose@4.13.2:
     resolution: {integrity: sha512-GMUKtV+l05F6NY/06nM7rucHM6Ktvw6sxnyRqINBNWS/hCM/bBk7kanOEckRP8xtC/jzuGfTRVZvkjjuy+g4dA==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -12203,6 +12167,7 @@ packages:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -12217,10 +12182,6 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
-  jsonwebtoken@9.0.0:
-    resolution: {integrity: sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==}
-    engines: {node: '>=12', npm: '>=6'}
-
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
@@ -12228,16 +12189,6 @@ packages:
   jsx-ast-utils@3.3.3:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
-
-  jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
-
-  jwks-rsa@2.1.5:
-    resolution: {integrity: sha512-IODtn1SwEm7n6GQZnQLY0oxKDrMh7n/jRH1MzE8mlxWMrh2NnMyOsXTebu8vJ1qCpmuTJcL4DdiE0E4h8jnwsA==}
-    engines: {node: '>=10 < 13 || >=14'}
-
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
@@ -12316,9 +12267,6 @@ packages:
     resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
     engines: {node: '>=14'}
 
-  limiter@1.1.5:
-    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
-
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -12389,9 +12337,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -12528,9 +12473,6 @@ packages:
   lru-cache@2.5.0:
     resolution: {integrity: sha512-dVmQmXPBlTgFw77hm60ud//l2bCuDKkqC2on1EBoM7s9Urm9IQDrnujwZ93NFnAq0dVZ0HBXTS7PwEG+YE7+EQ==}
 
-  lru-cache@4.0.2:
-    resolution: {integrity: sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==}
-
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -12548,9 +12490,6 @@ packages:
   lru-cache@9.1.2:
     resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
-
-  lru-memoizer@2.2.0:
-    resolution: {integrity: sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -13438,6 +13377,9 @@ packages:
 
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@1.8.0:
     resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
@@ -14605,6 +14547,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -14634,6 +14581,10 @@ packages:
 
   serve-static@1.16.0:
     resolution: {integrity: sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
 
   server-destroy@1.0.1:
@@ -15334,6 +15285,30 @@ packages:
 
   ts-invariant@0.4.4:
     resolution: {integrity: sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==}
+
+  ts-jest@29.2.6:
+    resolution: {integrity: sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
 
   ts-log@2.2.5:
     resolution: {integrity: sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==}
@@ -16350,11 +16325,6 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.1.1
 
-  '@babel/code-frame@7.24.7':
-    dependencies:
-      '@babel/highlight': 7.24.7
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.26.2':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
@@ -16392,15 +16362,15 @@ snapshots:
   '@babel/core@7.23.0':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.6
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.5
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.23.0)
       '@babel/helpers': 7.25.6
       '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
       '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       convert-source-map: 2.0.0
       debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -16412,7 +16382,7 @@ snapshots:
   '@babel/core@7.24.0':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.25.6
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.0)
@@ -16432,15 +16402,15 @@ snapshots:
   '@babel/core@7.24.5':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.6
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helpers': 7.24.5
-      '@babel/parser': 7.25.6
-      '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.5
+      '@babel/helper-compilation-targets': 7.26.5
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.24.5)
+      '@babel/helpers': 7.26.7
+      '@babel/parser': 7.26.7
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.26.7
+      '@babel/types': 7.26.7
       convert-source-map: 2.0.0
       debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -16452,7 +16422,7 @@ snapshots:
   '@babel/core@7.25.2':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.25.6
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
@@ -16506,14 +16476,14 @@ snapshots:
 
   '@babel/generator@7.24.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
   '@babel/generator@7.25.6':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -16536,7 +16506,7 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.22.15':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-compilation-targets@7.22.15':
     dependencies:
@@ -16546,19 +16516,11 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-compilation-targets@7.23.6':
+  '@babel/helper-compilation-targets@7.25.2':
     dependencies:
       '@babel/compat-data': 7.26.5
       '@babel/helper-validator-option': 7.25.9
       browserslist: 4.24.4
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-compilation-targets@7.25.2':
-    dependencies:
-      '@babel/compat-data': 7.25.4
-      '@babel/helper-validator-option': 7.24.8
-      browserslist: 4.23.3
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -16690,7 +16652,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.17)':
     dependencies:
       '@babel/core': 7.22.17
-      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
       debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
@@ -16701,7 +16663,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
       debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
@@ -16713,12 +16675,12 @@ snapshots:
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
-      '@babel/template': 7.25.0
-      '@babel/types': 7.25.6
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.7
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-member-expression-to-functions@7.23.0':
     dependencies:
@@ -16737,7 +16699,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.24.3':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
@@ -16762,64 +16724,62 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/helper-validator-identifier': 7.24.5
 
-  '@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5)':
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/helper-validator-identifier': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.22.17)':
     dependencies:
       '@babel/core': 7.22.17
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.6
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.6
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.24.0)':
     dependencies:
       '@babel/core': 7.24.0
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.6
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.6
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.6
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
@@ -16834,7 +16794,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
@@ -16896,18 +16856,18 @@ snapshots:
 
   '@babel/helper-simple-access@7.24.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/traverse': 7.26.7
+      '@babel/types': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     dependencies:
@@ -16922,7 +16882,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.24.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/helper-string-parser@7.24.1': {}
 
@@ -16958,14 +16918,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.24.5':
-    dependencies:
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helpers@7.25.6':
     dependencies:
       '@babel/template': 7.25.9
@@ -16978,7 +16930,7 @@ snapshots:
 
   '@babel/highlight@7.23.4':
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.25.9
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -16999,7 +16951,7 @@ snapshots:
 
   '@babel/parser@7.24.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
 
   '@babel/parser@7.25.6':
     dependencies:
@@ -17390,7 +17342,7 @@ snapshots:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.0)':
+  '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.24.0)':
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.25.9
@@ -18301,7 +18253,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.0)
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.0)
+      '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.24.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18619,9 +18571,9 @@ snapshots:
       pirates: 4.0.5
       source-map-support: 0.5.21
 
-  '@babel/register@7.22.15(@babel/core@7.25.2)':
+  '@babel/register@7.22.15(@babel/core@7.26.7)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.26.7
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -18663,15 +18615,15 @@ snapshots:
 
   '@babel/template@7.24.0':
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
 
   '@babel/template@7.25.0':
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
 
   '@babel/template@7.25.9':
     dependencies:
@@ -18696,14 +18648,14 @@ snapshots:
 
   '@babel/traverse@7.24.5':
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.6
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
       debug: 4.3.7(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -18711,7 +18663,7 @@ snapshots:
 
   '@babel/traverse@7.25.6':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.25.6
       '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
@@ -18741,8 +18693,8 @@ snapshots:
 
   '@babel/types@7.24.5':
     dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
       to-fast-properties: 2.0.0
 
   '@babel/types@7.25.6':
@@ -18994,10 +18946,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-frontend/application-config@22.40.0(@types/node@22.13.2)(typescript@5.0.4)':
+  '@commercetools-frontend/application-config@22.40.0(@types/node@22.13.2)(typescript@5.7.3)':
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/register': 7.22.15(@babel/core@7.25.2)
+      '@babel/core': 7.26.7
+      '@babel/register': 7.22.15(@babel/core@7.26.7)
       '@babel/runtime': 7.26.10
       '@babel/runtime-corejs3': 7.26.10
       '@commercetools-frontend/constants': 22.40.0
@@ -19006,8 +18958,8 @@ snapshots:
       '@types/react': 17.0.83
       ajv: 8.16.0
       core-js: 3.32.2
-      cosmiconfig: 9.0.0(typescript@5.0.4)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.2)(cosmiconfig@9.0.0(typescript@5.0.4))(typescript@5.0.4)
+      cosmiconfig: 9.0.0(typescript@5.7.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.2)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3)
       dompurify: 2.5.8
       jsdom: 21.1.2
       lodash: 4.17.21
@@ -19079,11 +19031,11 @@ snapshots:
       '@types/lodash': 4.17.4
       lodash: 4.17.21
 
-  '@commercetools-test-data/custom-view@8.2.3(@types/node@22.13.2)(typescript@5.0.4)':
+  '@commercetools-test-data/custom-view@8.2.3(@types/node@22.13.2)(typescript@5.7.3)':
     dependencies:
       '@babel/runtime': 7.26.10
       '@babel/runtime-corejs3': 7.26.10
-      '@commercetools-frontend/application-config': 22.40.0(@types/node@22.13.2)(typescript@5.0.4)
+      '@commercetools-frontend/application-config': 22.40.0(@types/node@22.13.2)(typescript@5.7.3)
       '@commercetools-frontend/constants': 22.40.0
       '@commercetools-test-data/commons': 8.2.3
       '@commercetools-test-data/core': 8.2.3
@@ -22316,13 +22268,13 @@ snapshots:
       '@types/node': 22.13.2
       chalk: 4.1.2
       cosmiconfig: 8.2.0
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@22.13.2)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.0.4))(typescript@5.7.2)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@22.13.2)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.0.4))(typescript@5.7.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.2)
-      typescript: 5.7.2
+      ts-node: 10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -22690,7 +22642,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.2.4
@@ -22881,10 +22833,10 @@ snapshots:
       launchdarkly-js-client-sdk: 3.4.0
       typescript: 5.7.3
 
-  '@formatjs/cli-lib@6.3.8':
+  '@formatjs/cli-lib@6.3.8(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.7.6
-      '@formatjs/ts-transformer': 3.13.12
+      '@formatjs/ts-transformer': 3.13.12(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))
       '@types/estree': 1.0.5
       '@types/fs-extra': 9.0.13
       '@types/json-stable-stringify': 1.0.34
@@ -22896,7 +22848,7 @@ snapshots:
       json-stable-stringify: 1.1.1
       loud-rejection: 2.2.0
       tslib: 2.6.2
-      typescript: 5.7.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - ts-jest
 
@@ -23066,7 +23018,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.3
 
-  '@formatjs/ts-transformer@3.13.12':
+  '@formatjs/ts-transformer@3.13.12(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.7.6
       '@types/json-stable-stringify': 1.0.34
@@ -23074,9 +23026,11 @@ snapshots:
       chalk: 4.1.2
       json-stable-stringify: 1.1.1
       tslib: 2.6.2
-      typescript: 5.7.2
+      typescript: 5.7.3
+    optionalDependencies:
+      ts-jest: 29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3)
 
-  '@formatjs/ts-transformer@3.13.27':
+  '@formatjs/ts-transformer@3.13.27(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.8
       '@types/json-stable-stringify': 1.0.34
@@ -23084,7 +23038,9 @@ snapshots:
       chalk: 4.1.2
       json-stable-stringify: 1.1.1
       tslib: 2.6.2
-      typescript: 5.7.2
+      typescript: 5.7.3
+    optionalDependencies:
+      ts-jest: 29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3)
 
   '@graphql-codegen/add@3.2.3(graphql@16.8.2)':
     dependencies:
@@ -23734,7 +23690,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.5
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -23763,15 +23719,6 @@ snapshots:
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
-
-  '@jest/console@29.5.0':
-    dependencies:
-      '@jest/types': 29.6.3
-      '@types/node': 22.13.2
-      chalk: 4.1.2
-      jest-message-util: 29.7.0
-      jest-util: 29.7.0
-      slash: 3.0.0
 
   '@jest/console@29.7.0':
     dependencies:
@@ -23959,16 +23906,9 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/environment@29.5.0':
-    dependencies:
-      '@jest/fake-timers': 29.6.4
-      '@jest/types': 29.6.3
-      '@types/node': 22.13.2
-      jest-mock: 29.7.0
-
   '@jest/environment@29.6.4':
     dependencies:
-      '@jest/fake-timers': 29.6.4
+      '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.13.2
       jest-mock: 29.7.0
@@ -23990,15 +23930,6 @@ snapshots:
       jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/fake-timers@29.5.0':
-    dependencies:
-      '@jest/types': 29.6.3
-      '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.13.2
-      jest-message-util: 29.7.0
-      jest-mock: 29.7.0
-      jest-util: 29.7.0
 
   '@jest/fake-timers@29.6.4':
     dependencies:
@@ -24068,7 +23999,7 @@ snapshots:
 
   '@jest/test-result@29.5.0':
     dependencies:
-      '@jest/console': 29.5.0
+      '@jest/console': 29.7.0
       '@jest/types': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       collect-v8-coverage: 1.0.1
@@ -24089,7 +24020,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.26.7
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -24473,8 +24404,6 @@ snapshots:
       - supports-color
 
   '@open-draft/until@1.0.3': {}
-
-  '@panva/asn1.js@1.0.0': {}
 
   '@peculiar/asn1-schema@2.3.6':
     dependencies:
@@ -25366,7 +25295,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@6.5.1':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       entities: 4.5.0
 
   '@svgr/plugin-jsx@6.5.1(@svgr/core@6.5.1)':
@@ -25560,7 +25489,7 @@ snapshots:
   '@types/babel__core@7.20.2':
     dependencies:
       '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.20.6
@@ -25740,14 +25669,6 @@ snapshots:
   '@types/json5@0.0.29': {}
 
   '@types/jsonfile@6.1.1':
-    dependencies:
-      '@types/node': 22.13.2
-
-  '@types/jsonwebtoken@8.5.9':
-    dependencies:
-      '@types/node': 22.13.2
-
-  '@types/jsonwebtoken@9.0.2':
     dependencies:
       '@types/node': 22.13.2
 
@@ -26867,7 +26788,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.22.17
 
-  babel-plugin-formatjs@10.5.30:
+  babel-plugin-formatjs@10.5.30(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3)):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
@@ -26875,7 +26796,7 @@ snapshots:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       '@formatjs/icu-messageformat-parser': 2.9.8
-      '@formatjs/ts-transformer': 3.13.27
+      '@formatjs/ts-transformer': 3.13.27(ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3))
       '@types/babel__core': 7.20.5
       '@types/babel__helper-plugin-utils': 7.10.3
       '@types/babel__traverse': 7.20.6
@@ -26902,7 +26823,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
@@ -27231,6 +27152,11 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+    optional: true
+
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -27238,8 +27164,6 @@ snapshots:
   btoa-lite@1.0.0: {}
 
   buffer-crc32@0.2.13: {}
-
-  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -27705,6 +27629,8 @@ snapshots:
 
   cookie@0.6.0: {}
 
+  cookie@0.7.1: {}
+
   core-js-compat@3.32.2:
     dependencies:
       browserslist: 4.23.3
@@ -27730,19 +27656,12 @@ snapshots:
       ts-node: 10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.0.4)
       typescript: 5.0.4
 
-  cosmiconfig-typescript-loader@4.3.0(@types/node@22.13.2)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.0.4))(typescript@5.7.2):
+  cosmiconfig-typescript-loader@4.3.0(@types/node@22.13.2)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.0.4))(typescript@5.7.3):
     dependencies:
       '@types/node': 22.13.2
       cosmiconfig: 8.2.0
       ts-node: 10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.0.4)
-      typescript: 5.7.2
-
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.2)(cosmiconfig@9.0.0(typescript@5.0.4))(typescript@5.0.4):
-    dependencies:
-      '@types/node': 22.13.2
-      cosmiconfig: 9.0.0(typescript@5.0.4)
-      jiti: 2.4.1
-      typescript: 5.0.4
+      typescript: 5.7.3
 
   cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.2)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
@@ -27802,15 +27721,6 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-
-  cosmiconfig@9.0.0(typescript@5.0.4):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 5.0.4
 
   cosmiconfig@9.0.0(typescript@5.7.3):
     dependencies:
@@ -28467,10 +28377,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
 
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
-
   edge-runtime@2.4.4:
     dependencies:
       '@edge-runtime/format': 2.1.0
@@ -28484,6 +28390,11 @@ snapshots:
       time-span: 4.0.0
 
   ee-first@1.1.1: {}
+
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.2
+    optional: true
 
   electron-to-chromium@1.4.512: {}
 
@@ -28754,8 +28665,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.24.2
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
-
-  escalade@3.1.2: {}
 
   escalade@3.2.0: {}
 
@@ -29260,14 +29169,6 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  express-jwt@8.4.1:
-    dependencies:
-      '@types/jsonwebtoken': 9.0.2
-      express-unless: 2.1.3
-      jsonwebtoken: 9.0.0
-
-  express-unless@2.1.3: {}
-
   express-winston@4.2.0(winston@3.13.0):
     dependencies:
       chalk: 2.4.2
@@ -29302,6 +29203,42 @@ snapshots:
       safe-buffer: 5.2.1
       send: 0.19.0
       serve-static: 1.16.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@4.21.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -29447,6 +29384,11 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  filelist@1.0.4:
+    dependencies:
+      minimatch: 5.1.6
+    optional: true
+
   filesize@8.0.7: {}
 
   fill-range@7.1.1:
@@ -29469,6 +29411,18 @@ snapshots:
     dependencies:
       debug: 2.6.9
       encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@1.3.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
@@ -29567,9 +29521,9 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.0.4)(webpack@5.94.0(@swc/core@1.10.16)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.7.3)(webpack@5.94.0(@swc/core@1.10.16)):
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@types/json-schema': 7.0.12
       chalk: 4.1.2
       chokidar: 3.6.0
@@ -29582,7 +29536,7 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.6.2
       tapable: 1.1.3
-      typescript: 5.0.4
+      typescript: 5.7.3
       webpack: 5.94.0(@swc/core@1.10.16)
     optionalDependencies:
       eslint: 8.57.0
@@ -30804,6 +30758,14 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jake@10.9.2:
+    dependencies:
+      async: 3.2.5
+      chalk: 4.1.2
+      filelist: 1.0.4
+      minimatch: 3.1.2
+    optional: true
+
   jest-changed-files@29.7.0:
     dependencies:
       execa: 5.1.1
@@ -31139,12 +31101,12 @@ snapshots:
 
   jest-environment-node@29.5.0:
     dependencies:
-      '@jest/environment': 29.5.0
-      '@jest/fake-timers': 29.5.0
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.13.2
       jest-mock: 29.7.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
 
   jest-environment-node@29.7.0:
     dependencies:
@@ -31200,7 +31162,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -31367,10 +31329,10 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/generator': 7.25.6
+      '@babel/generator': 7.26.5
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.26.7)
-      '@babel/types': 7.25.6
+      '@babel/types': 7.26.7
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -31397,15 +31359,6 @@ snapshots:
       graceful-fs: 4.2.11
       is-ci: 2.0.0
       micromatch: 4.0.8
-
-  jest-util@29.5.0:
-    dependencies:
-      '@jest/types': 29.6.3
-      '@types/node': 22.13.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.1
 
   jest-util@29.6.3:
     dependencies:
@@ -31464,7 +31417,7 @@ snapshots:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       string-length: 4.0.2
 
   jest-watcher@29.7.0:
@@ -31591,11 +31544,9 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
-  jose@2.0.7:
-    dependencies:
-      '@panva/asn1.js': 1.0.0
-
   jose@4.13.2: {}
+
+  jose@5.10.0: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -31791,13 +31742,6 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
-  jsonwebtoken@9.0.0:
-    dependencies:
-      jws: 3.2.2
-      lodash: 4.17.21
-      ms: 2.1.3
-      semver: 7.6.2
-
   jsprim@2.0.2:
     dependencies:
       assert-plus: 1.0.0
@@ -31809,28 +31753,6 @@ snapshots:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
-
-  jwa@1.4.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jwks-rsa@2.1.5:
-    dependencies:
-      '@types/express': 4.17.17
-      '@types/jsonwebtoken': 8.5.9
-      debug: 4.3.4(supports-color@8.1.1)
-      jose: 2.0.7
-      limiter: 1.1.5
-      lru-memoizer: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  jws@3.2.2:
-    dependencies:
-      jwa: 1.4.1
-      safe-buffer: 5.2.1
 
   jwt-decode@3.1.2: {}
 
@@ -31901,8 +31823,6 @@ snapshots:
   lilconfig@2.1.0: {}
 
   lilconfig@3.1.1: {}
-
-  limiter@1.1.5: {}
 
   lines-and-columns@1.2.4: {}
 
@@ -32013,8 +31933,6 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
-  lodash.clonedeep@4.5.0: {}
-
   lodash.debounce@4.0.8: {}
 
   lodash.difference@4.5.0: {}
@@ -32121,11 +32039,6 @@ snapshots:
 
   lru-cache@2.5.0: {}
 
-  lru-cache@4.0.2:
-    dependencies:
-      pseudomap: 1.0.2
-      yallist: 2.1.2
-
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -32142,11 +32055,6 @@ snapshots:
   lru-cache@7.18.3: {}
 
   lru-cache@9.1.2: {}
-
-  lru-memoizer@2.2.0:
-    dependencies:
-      lodash.clonedeep: 4.5.0
-      lru-cache: 4.0.2
 
   lz-string@1.5.0: {}
 
@@ -33152,7 +33060,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -33207,6 +33115,8 @@ snapshots:
       minipass: 6.0.2
 
   path-to-regexp@0.1.10: {}
+
+  path-to-regexp@0.1.12: {}
 
   path-to-regexp@1.8.0:
     dependencies:
@@ -33759,7 +33669,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.0.4)(webpack@5.94.0(@swc/core@1.10.16)):
+  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.7.3)(webpack@5.94.0(@swc/core@1.10.16)):
     dependencies:
       '@babel/code-frame': 7.22.13
       address: 1.2.2
@@ -33770,7 +33680,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.0.4)(webpack@5.94.0(@swc/core@1.10.16))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.7.3)(webpack@5.94.0(@swc/core@1.10.16))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -33787,7 +33697,7 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.94.0(@swc/core@1.10.16)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -34475,6 +34385,9 @@ snapshots:
 
   semver@7.6.2: {}
 
+  semver@7.7.1:
+    optional: true
+
   send@0.18.0:
     dependencies:
       debug: 2.6.9
@@ -34520,7 +34433,7 @@ snapshots:
   sentry-testkit@5.0.9:
     dependencies:
       body-parser: 1.20.2
-      express: 4.20.0
+      express: 4.21.2
     transitivePeerDependencies:
       - supports-color
 
@@ -34562,6 +34475,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.2:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 
@@ -35356,6 +35278,26 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
+  ts-jest@29.2.6(@babel/core@7.22.17)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.17))(jest@29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3)))(typescript@5.7.3):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@22.13.2)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.1
+      typescript: 5.7.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.22.17
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.22.17)
+    optional: true
+
   ts-log@2.2.5: {}
 
   ts-morph@12.0.0:
@@ -35443,6 +35385,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.10.16
+    optional: true
 
   ts-node@10.9.1(@swc/core@1.10.16)(@types/node@22.13.2)(typescript@5.7.3):
     dependencies:
@@ -35463,7 +35406,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.10.16
-    optional: true
 
   ts-node@8.9.1(typescript@4.3.4):
     dependencies:
@@ -35751,7 +35693,7 @@ snapshots:
   update-browserslist-db@1.0.11(browserslist@4.21.10):
     dependencies:
       browserslist: 4.21.10
-      escalade: 3.1.2
+      escalade: 3.2.0
       picocolors: 1.1.1
 
   update-browserslist-db@1.0.13(browserslist@4.23.0):
@@ -36114,7 +36056,7 @@ snapshots:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.20.0
+      express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.3.3
       http-proxy-middleware: 2.0.6(@types/express@4.17.17)


### PR DESCRIPTION
* Uses `jose` (ESM version)
* Because of ESM, we need to instruct Jest to transpile it correctly
  * Uses `babel-jest` by default
  * Separated Jest config for "node" related tests