### PR TITLE
[mc-scripts] Update Vite config when running applications locally

### DIFF
--- a/.changeset/six-dragons-grow.md
+++ b/.changeset/six-dragons-grow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+`Vite` configuration has been updated to automatically open a browser with the application when running it locally to match the behaviour we currently have when using `webpack`.

--- a/packages/mc-scripts/src/commands/start-vite.ts
+++ b/packages/mc-scripts/src/commands/start-vite.ts
@@ -43,6 +43,7 @@ async function run() {
       'process.env.NODE_ENV': JSON.stringify('development'),
     },
     server: {
+      open: true,
       port: DEFAULT_PORT,
       headers: compiledHeaders,
     },


### PR DESCRIPTION
#### Summary

Update Vite config when running applications locally.

#### Description

This PR suggests to update the `vite` configuration so when running an application locally, a browser will automatically open to match the behaviour we currently have with `webpack`.
