### PR TITLE
Update React Vite plugin config

### DIFF
--- a/.changeset/metal-peas-cross.md
+++ b/.changeset/metal-peas-cross.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Updated the [vite-plugin-react-swc](vite-plugin-react-swc) `vite` plugin (we use it to run applications locally) configuration to use the `@emotion/react` `jsx` import instead of the `react` [default one](https://github.com/vitejs/vite-plugin-react-swc?tab=readme-ov-file#jsximportsource) as we use `emotion` is some of our consumer applications.

--- a/packages/mc-scripts/src/commands/start-vite.ts
+++ b/packages/mc-scripts/src/commands/start-vite.ts
@@ -49,7 +49,9 @@ async function run() {
     },
     plugins: [
       pluginGraphql() as Plugin,
-      pluginReact(),
+      pluginReact({
+        jsxImportSource: '@emotion/react',
+      }),
       pluginSvgr(),
       pluginMerchantCenterCustomization(applicationConfig),
     ],


### PR DESCRIPTION
#### Summary

Update React Vite plugin config

#### Description

Updated the [vite-plugin-react-swc](vite-plugin-react-swc) `vite` plugin (we use it to run applications locally) configuration to use the `@emotion/react` `jsx` import instead of the `react` [default one](https://github.com/vitejs/vite-plugin-react-swc?tab=readme-ov-file#jsximportsource) as we use `emotion` is some of our consumer applications.

