### PR TITLE
Update `app-shell` test utils

### DIFF
--- a/.changeset/mean-dolls-pretend.md
+++ b/.changeset/mean-dolls-pretend.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+The `test-utils` package used for rendering apps in the test environment creates an _in-memory_ router by default. We're adding a new property to it ([getUserConfirmation](https://v5.reactrouter.com/web/api/MemoryRouter/getuserconfirmation-func)) to cover for cases when logic wants to be used before a navigation is executed (eg: "warn on leave").

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -348,7 +348,10 @@ function createApplicationProviders<
   const memoryHistory =
     history ??
     createEnhancedHistory(
-      createMemoryHistory({ initialEntries: [initialRoute || '/'] })
+      createMemoryHistory({
+        initialEntries: [initialRoute || '/'],
+        getUserConfirmation: (_message, callback) => callback(true),
+      })
     );
 
   const ApplicationProviders = (props: TApplicationProvidersProps) => (


### PR DESCRIPTION
#### Summary

Update `app-shell` test utils.

#### Description

The `test-utils` package used for rendering apps in the test environment creates an _in-memory_ router by default. We're adding a new property to it ([getUserConfirmation](https://v5.reactrouter.com/web/api/MemoryRouter/getuserconfirmation-func)) to cover for cases when logic wants to be used before a navigation is executed (eg: "warn on leave").

