### PR TITLE
refactor(cli): clarify variadic option behavior

### DIFF
--- a/.changeset/mighty-parents-exercise.md
+++ b/.changeset/mighty-parents-exercise.md
@@ -1,0 +1,19 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Add option `-e` as short flag for `--env`.
+
+Note that when using the global option `--env` (one or multiple times) before a command, you need to declare it as following:
+
+- Separating the global options from the command with `--`, otherwise the command is considered an option of `--env`:
+
+```
+mc-scripts --env .env.local -- start
+```
+
+- Using the `=` separator for each `--env` option:
+
+```
+mc-scripts --env=.env.local --env=.env.defaults start
+```

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -18,7 +18,7 @@ program
   .description('CLI to develop and build Merchant Center customizations.')
   .version(pkgJson.version)
   .option(
-    '--env <path...>', // Variadic option. It allows multiple `--env` options to be provided.
+    '-e, --env <path...>', // Variadic option. It allows multiple `--env` options to be provided.
     `(optional) Parses the file path as a dotenv file and adds the variables to the environment. Multiple flags are allowed.`
   );
 
@@ -42,6 +42,7 @@ async function run() {
     )
     .action(async () => {
       const globalOptions = program.opts<TCliGlobalOptions>();
+      console.log(globalOptions);
 
       // Load dotenv files into the process environment.
       // This is essentially what `dotenv-cli` does, but it's now built into this CLI.

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -42,7 +42,6 @@ async function run() {
     )
     .action(async () => {
       const globalOptions = program.opts<TCliGlobalOptions>();
-      console.log(globalOptions);
 
       // Load dotenv files into the process environment.
       // This is essentially what `dotenv-cli` does, but it's now built into this CLI.


### PR DESCRIPTION
Follow up of #3749 to clarify the usage of variadic CLI option `--env`.