### PR TITLE
fix: use `moduleResolution: bundler` to be compatible with ESM packages

### DIFF
--- a/.changeset/kind-adults-learn.md
+++ b/.changeset/kind-adults-learn.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/create-mc-app': patch
+'@commercetools-frontend/mc-scripts': patch
+'@commercetools-frontend/codemod': patch
+---
+
+Use `moduleResolution: bundler` to be compatible with ESM packages.

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
-    "outDir": "./build"
+    "outDir": "./build",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/create-mc-app/tsconfig.json
+++ b/packages/create-mc-app/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler"
   }
 }

--- a/packages/mc-scripts/tsconfig.json
+++ b/packages/mc-scripts/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler"
   }
 }


### PR DESCRIPTION
<img width="912" alt="Screenshot 2025-03-26 at 09 55 05" src="https://github.com/user-attachments/assets/ad156c36-0f3e-4911-8210-f10e509822eb" />
<img width="977" alt="Screenshot 2025-03-26 at 09 55 47" src="https://github.com/user-attachments/assets/b2a52463-a627-45d0-b6b9-aad693998ce3" />
