### PR TITLE
refactor: add service tag to be sent to sentry

### DIFF
--- a/.changeset/fresh-sheep-remain.md
+++ b/.changeset/fresh-sheep-remain.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/sentry": patch
+---
+
+Add service tag to be sent to sentry.

--- a/packages/sentry/src/sentry.ts
+++ b/packages/sentry/src/sentry.ts
@@ -110,6 +110,10 @@ export const boot = () => {
     const sentryScope = Sentry.getCurrentScope();
     sentryScope.setTag('role', 'frontend');
     sentryScope.setTag('applicationName', window.app.applicationName);
+    sentryScope.setTag(
+      'service',
+      `merchant-center-frontend-${window.app.applicationName}`
+    );
   }
 };
 


### PR DESCRIPTION
#### Summary

Tags are useful for filtering in Sentry. We can also tie them to an internal service catalog using the service tag.

As the service tag in its nature needs to be more precise it's longer than the application tag. As a result I suggest to keep both. Open for alternative views of course.