### PR TITLE
Retry login action on certain condition

### DIFF
--- a/.changeset/metal-clocks-sin.md
+++ b/.changeset/metal-clocks-sin.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-frontend/cypress": minor
+---
+
+Adds ability retry logins when using the `loginByForm` command. Retrying takes place automatically when using a login fails and the login response from the `/tokens` endpoint returns a 429. Another login attempt is scheduled 1 second after the prior plus a random offset value after the prior failed and the maximum number of attempts is not exceeded.
+
+The number of login attempts is limited to `3`. This value can be adjusted using the `maxLoginAttempts` Cypress configuration option. To disable login retries altogether set this value to `1`. 

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -332,6 +332,13 @@ function fillLoginForm(userCredentials: LoginCredentials) {
   // Intercept the login request so we can retry it if we receive a TOO_MANY_REQUESTS status code
   cy.intercept('POST', '**/tokens').as('loginRequest');
 
+  function getRandomDelayInSeconds() {
+    const minSeconds = 0.5;
+    const maxSeconds = 1.5;
+
+    return (Math.random() * (maxSeconds - minSeconds) + minSeconds) * 1000;
+  }
+
   function attemptLogin(attemptsLeft: number) {
     if (attemptsLeft <= 0) {
       throw new Error(
@@ -355,8 +362,8 @@ function fillLoginForm(userCredentials: LoginCredentials) {
       cy.log('Login request status code:', statusCode);
 
       if (statusCode === HTTP_STATUS_CODES.TOO_MANY_REQUESTS) {
-        // We wait for something between 1 and 2 seconds before retrying
-        cy.wait(1000 + Math.random() * 100);
+        // We wait for something between 0.5 and 1.5 seconds before retrying
+        cy.wait(getRandomDelayInSeconds());
         attemptLogin(attemptsLeft - 1);
       } else {
         cy.log('Login successful');

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -334,8 +334,10 @@ function fillLoginForm(userCredentials: LoginCredentials) {
     // Intercept the login request so we can retry it if we receive a TOO_MANY_REQUESTS status code
     cy.intercept('POST', '**/tokens').as('loginRequest');
 
-    cy.get('input[name=email]').type(userCredentials.email);
-    cy.get('input[name=password]').type(userCredentials.password, {
+    // eslint-disable-next-line cypress/unsafe-to-chain-command
+    cy.get('input[name=email]').clear().type(userCredentials.email);
+    // eslint-disable-next-line cypress/unsafe-to-chain-command
+    cy.get('input[name=password]').clear().type(userCredentials.password, {
       log: false,
     });
     cy.get('button').contains('Sign in').click();

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -327,11 +327,12 @@ function loginByOidc(
 
 /* Utilities */
 
+const maxLoginAttempts = Cypress.config('maxLoginAttempts') ?? 3;
 function fillLoginForm(userCredentials: LoginCredentials) {
   // Intercept the login request so we can retry it if we receive a TOO_MANY_REQUESTS status code
   cy.intercept('POST', '**/tokens').as('loginRequest');
 
-  function attemptLogin(attemptsLeft = 3) {
+  function attemptLogin(attemptsLeft: number) {
     if (attemptsLeft <= 0) {
       throw new Error(
         `All login attempts exhausted. Please check your credentials.`
@@ -363,7 +364,7 @@ function fillLoginForm(userCredentials: LoginCredentials) {
     });
   }
 
-  attemptLogin(Cypress.config('maxLoginAttempts'));
+  attemptLogin(maxLoginAttempts);
 }
 
 function isLocalhost() {

--- a/packages/cypress/src/constants.ts
+++ b/packages/cypress/src/constants.ts
@@ -5,3 +5,7 @@ export const STORAGE_KEYS = {
 } as const;
 
 export const OIDC_RESPONSE_TYPES = { ID_TOKEN: 'id_token' };
+
+export const HTTP_STATUS_CODES = {
+  TOO_MANY_REQUESTS: 429,
+} as const;


### PR DESCRIPTION
#### Summary

This PR refactors the `loginByForm` command so it retries the action if the login action fails and the login request sent to the server (`/tokens` endpoint) returns a 429.

#### Description

We've found some issues while running our e2e test suites regarding the backend login endpoint rejecting some legit attempts due to the fact that we run several tests in parallel using the same credentials and the backend only allows one login attempt with a set of credentials at a time.

In this PR we introduce an update to the `loginByForm` command that will retry the login attempt if the server responds with a 429 status code.
It will retry a configurable amount of times (3 by default) and it will wait between 1 and two seconds between each attempt.
