### PR TITLE
Report unhandled GraphQL errors to sentry

### DIFF
--- a/application-templates/starter-typescript/src/components/channel-details/channel-details.spec.tsx
+++ b/application-templates/starter-typescript/src/components/channel-details/channel-details.spec.tsx
@@ -232,6 +232,7 @@ describe('rendering', () => {
     });
   });
   it('should display a key field validation message if the submitted key value is duplicated', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
     useMockServerHandlers([
       fetchChannelDetailsQueryHandler,
       updateChannelDetailsHandlerWithDuplicateFieldError,
@@ -289,6 +290,7 @@ describe('notifications', () => {
     within(notification).getByText(/channel .+ updated/i);
   });
   it('should render an error notification if fetching channel details resulted in an error', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
     useMockServerHandlers([fetchChannelDetailsQueryHandlerWithError]);
     renderApp();
     await screen.findByText(

--- a/application-templates/starter/src/components/channel-details/channel-details.spec.js
+++ b/application-templates/starter/src/components/channel-details/channel-details.spec.js
@@ -228,6 +228,7 @@ describe('rendering', () => {
     });
   });
   it('should display a key field validation message if the submitted key value is duplicated', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
     useMockServerHandlers(
       fetchChannelDetailsQueryHandler,
       updateChannelDetailsHandlerWithDuplicateFieldError
@@ -279,6 +280,7 @@ describe('notifications', () => {
     within(notification).getByText(/channel .+ updated/i);
   });
   it('should render an error notification if fetching channel details resulted in an error', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
     useMockServerHandlers(fetchChannelDetailsQueryHandlerWithError);
     renderApp();
     await screen.findByText(

--- a/packages/application-shell-connectors/src/apollo-links/error-link.spec.js
+++ b/packages/application-shell-connectors/src/apollo-links/error-link.spec.js
@@ -5,9 +5,13 @@ import {
   LOGOUT_REASONS,
   GRAPHQL_TARGETS,
 } from '@commercetools-frontend/constants';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import errorLink from './error-link';
 
 jest.mock('@commercetools-frontend/browser-history');
+jest.mock('@commercetools-frontend/sentry', () => ({
+  reportErrorToSentry: jest.fn(),
+}));
 
 const query = gql`
   {
@@ -216,7 +220,8 @@ describe('with unhandled error', () => {
     await waitFor(execute(link, { query }));
   });
 
-  it('should do nothing', () => {
+  it('should report the error to Sentry', () => {
     expect(history.push).not.toHaveBeenCalled();
+    expect(reportErrorToSentry).toHaveBeenCalled();
   });
 });

--- a/packages/application-shell-connectors/src/apollo-links/error-link.ts
+++ b/packages/application-shell-connectors/src/apollo-links/error-link.ts
@@ -4,6 +4,7 @@ import {
   STATUS_CODES,
   LOGOUT_REASONS,
 } from '@commercetools-frontend/constants';
+import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import type { TApolloContext } from '../utils/apollo-context';
 import {
   forwardTokenRetryHeader,
@@ -57,6 +58,25 @@ const errorLink = onError(
           // retry the request, returning the new observable
           return forward(operation);
         }
+      }
+    }
+
+    // Report unhandled errors to Sentry
+    if (networkError) {
+      reportErrorToSentry(networkError, {
+        extra: {
+          operationName: operation.operationName,
+        },
+      });
+    }
+
+    if (graphQLErrors) {
+      for (const err of graphQLErrors) {
+        reportErrorToSentry(err, {
+          extra: {
+            operationName: operation.operationName,
+          },
+        });
       }
     }
 

--- a/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
+++ b/packages/application-shell-connectors/src/components/project-extension-image-regex/project-extension-image-regex.tsx
@@ -8,7 +8,6 @@ import {
 import { useQuery } from '@apollo/client/react';
 import warning from 'tiny-warning';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import type {
   TFetchProjectExtensionImageRegexQuery,
   TFetchProjectExtensionImageRegexQueryVariables,
@@ -53,7 +52,6 @@ const ProjectExtensionProviderForImageRegex = (props: ProviderProps) => {
     TFetchProjectExtensionImageRegexQueryVariables
   >(FetchProjectExtensionImageRegex, {
     skip: props.skip,
-    onError: reportErrorToSentry,
     context: { target: GRAPHQL_TARGETS.SETTINGS_SERVICE },
   });
 

--- a/packages/application-shell/src/components/fetch-project/fetch-project.tsx
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import type { ApolloError } from '@apollo/client/errors';
 import { useMcQuery } from '@commercetools-frontend/application-shell-connectors';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import type {
   TFetchProjectQuery,
   TFetchProjectQueryVariables,
@@ -25,7 +24,6 @@ const FetchProject = (props: TFetchProjectProps) => {
     TFetchProjectQuery,
     TFetchProjectQueryVariables
   >(ProjectQuery, {
-    onError: reportErrorToSentry,
     variables: {
       projectKey: props.projectKey,
     },

--- a/packages/application-shell/src/components/fetch-user/fetch-user.tsx
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import type { ApolloError } from '@apollo/client/errors';
 import { useMcQuery } from '@commercetools-frontend/application-shell-connectors';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import type {
   TFetchLoggedInUserQuery,
   TFetchLoggedInUserQueryVariables,
@@ -23,7 +22,6 @@ const FetchUser = (props: TFetchUserProps) => {
     TFetchLoggedInUserQuery,
     TFetchLoggedInUserQueryVariables
   >(LoggedInUserQuery, {
-    onError: reportErrorToSentry,
     context: { target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND },
   });
   return (

--- a/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
+++ b/packages/application-shell/src/components/navbar/use-navbar-state-manager.ts
@@ -15,7 +15,6 @@ import {
   GRAPHQL_TARGETS,
   STORAGE_KEYS,
 } from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import { WINDOW_SIZES } from '../../constants';
 import useApplicationsMenu from '../../hooks/use-applications-menu';
 import type { TFetchProjectQuery } from '../../types/generated/mc';
@@ -99,9 +98,6 @@ const useNavbarStateManager = (props: HookProps) => {
   const applicationsNavBarMenuGroups = useApplicationsMenu<'navBarGroups'>(
     'navBarGroups',
     {
-      queryOptions: {
-        onError: reportErrorToSentry,
-      },
       environment: props.environment,
     }
   );
@@ -114,7 +110,6 @@ const useNavbarStateManager = (props: HookProps) => {
       target: GRAPHQL_TARGETS.SETTINGS_SERVICE,
     },
     fetchPolicy: 'cache-and-network',
-    onError: reportErrorToSentry,
   });
 
   const allCustomApplicationsNavbarMenu =

--- a/packages/application-shell/src/components/project-switcher/project-switcher.tsx
+++ b/packages/application-shell/src/components/project-switcher/project-switcher.tsx
@@ -15,7 +15,6 @@ import {
 } from '@commercetools-frontend/application-shell-connectors';
 import type { ApplicationWindow } from '@commercetools-frontend/constants';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 import { designTokens } from '@commercetools-uikit/design-system';
 import SelectInput, { TOption } from '@commercetools-uikit/select-input';
@@ -150,7 +149,6 @@ const ProjectSwitcher = (props: Props) => {
     TFetchUserProjectsQuery,
     TFetchUserProjectsQueryVariables
   >(ProjectsQuery, {
-    onError: reportErrorToSentry,
     context: {
       target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
     },

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -14,7 +14,6 @@ import {
   NO_VALUE_FALLBACK,
   SUPPORT_PORTAL_URL,
 } from '@commercetools-frontend/constants';
-import { reportErrorToSentry } from '@commercetools-frontend/sentry';
 import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 import Avatar from '@commercetools-uikit/avatar';
 import { designTokens as uikitDesignTokens } from '@commercetools-uikit/design-system';
@@ -185,9 +184,6 @@ const UserSettingsMenuBody = (props: MenuBodyProps) => {
   const environment = useApplicationContext((context) => context.environment);
 
   const applicationsAppBarMenu = useApplicationsMenu<'appBar'>('appBar', {
-    queryOptions: {
-      onError: reportErrorToSentry,
-    },
     environment,
   });
   const accountMenuItems = applicationsAppBarMenu ?? [];

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.spec.tsx
@@ -222,25 +222,17 @@ describe('for production usage', () => {
       console.error = jest.fn();
       mocked(reportErrorToSentry).mockClear();
       const error = new Error('Oops');
-      renderApp(
-        <AppBarTest
-          environment={environment}
-          queryOptions={{
-            onError: reportErrorToSentry,
-          }}
-        />,
-        {
-          disableRoutePermissionCheck: true,
-          mocks: [
-            {
-              request: {
-                query: FetchApplicationsMenu,
-              },
-              error,
+      renderApp(<AppBarTest environment={environment} />, {
+        disableRoutePermissionCheck: true,
+        mocks: [
+          {
+            request: {
+              query: FetchApplicationsMenu,
             },
-          ],
-        }
-      );
+            error,
+          },
+        ],
+      });
       await screen.findByText('loading');
       await waitFor(() => {
         expect(reportErrorToSentry).toHaveBeenCalled();

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
@@ -26,9 +26,6 @@ export type MenuLoaderResult<Key extends MenuKey> = Key extends 'appBar'
   : never;
 export type Config = {
   environment: TApplicationContext<{}>['environment'];
-  queryOptions?: {
-    onError?: QueryFunctionOptions['onError'];
-  };
 };
 type TAdditionalEnvironmentProperties = {
   mcProxyApiUrl?: string;
@@ -171,7 +168,6 @@ function useApplicationsMenu<Key extends MenuKey>(
         false
       : // Development environment
         !hasWrittenToCache,
-    onError: config.queryOptions?.onError,
     fetchPolicy: config.environment.servedByProxy
       ? 'cache-first'
       : 'cache-only',


### PR DESCRIPTION
#### Summary

Report unhandled GraphQL errors to sentry.

#### Description

As part of the initiative to move away from the `onError` callback in the `useQuery` and `useLazyQuery` Apollo React client hooks because it has been deprecated ([reference](https://github.com/apollographql/apollo-client/issues/12352)), we decided to extend the global error Apollo client link to report to Sentry (if it's enabled) unhandled GraphQL errors.
