### PR TITLE
feat: update compatibility of mc-create-app to work with yarn 3 and 4

### DIFF
--- a/packages/create-mc-app/src/tasks/install-dependencies.ts
+++ b/packages/create-mc-app/src/tasks/install-dependencies.ts
@@ -1,12 +1,23 @@
 import execa from 'execa';
 import type { ListrTask } from 'listr2';
 import type { TCliTaskOptions } from '../types';
-import { getInstallCommand } from '../utils';
+import {
+  getInstallCommand,
+  configureYarn,
+  getPreferredPackageManager,
+} from '../utils';
 
 function installDependencies(options: TCliTaskOptions): ListrTask {
   return {
     title: 'Installing dependencies (this might take a while)',
-    task: () => {
+    task: async () => {
+      const packageManager = getPreferredPackageManager(options);
+
+      // Only configure Yarn if it's the selected package manager
+      if (packageManager === 'yarn') {
+        await configureYarn(options.projectDirectoryPath);
+      }
+
       const installCommand = getInstallCommand(options);
 
       // TODO: we could check for min yarn/npm versions

--- a/packages/create-mc-app/src/utils.ts
+++ b/packages/create-mc-app/src/utils.ts
@@ -26,6 +26,30 @@ const shouldUseYarn = () => {
   }
 };
 
+const getYarnVersion = () => {
+  try {
+    const result = execa.commandSync('yarn --version', { encoding: 'utf-8' });
+    return result.stdout.trim();
+  } catch (error) {
+    return null;
+  }
+};
+
+const configureYarn = async (projectDirectoryPath: string) => {
+  const yarnVersion = getYarnVersion();
+  if (!yarnVersion) return;
+
+  // Check if Yarn version is 3 or higher
+  const majorVersion = parseInt(yarnVersion.split('.')[0], 10);
+  if (majorVersion >= 3) {
+    // Create or update .yarnrc.yml to use node_modules
+    const yarnrcPath = `${projectDirectoryPath}/.yarnrc.yml`;
+    const yarnrcContent = 'nodeLinker: "node-modules"\n';
+
+    fs.writeFileSync(yarnrcPath, yarnrcContent);
+  }
+};
+
 const getPreferredPackageManager = (
   options: TCliTaskOptions
 ): TPackageManager => {
@@ -76,6 +100,8 @@ const isCustomView = (applicationType: TApplicationType) =>
 export {
   isSemVer,
   shouldUseYarn,
+  getYarnVersion,
+  configureYarn,
   slugify,
   wordify,
   upperFirst,


### PR DESCRIPTION
#### Summary

Fix compatibility issues with Yarn 3 and Yarn 4 in App Kit starter templates by configuring `nodeLinker` to use `node-modules`.

#### Description

Custom Applications created using the App Kit starter templates currently only work reliably with Yarn 1. Users running Yarn 3 or Yarn 4 encounter various issues during local development, such as missing dependencies in IDEs after running yarn install and errors like “We could not find this Project” in the UI. This PR adds a `.yarnrc.yml` file with `nodeLinker: "node-modules"` to the starter templates. This restores the traditional `node_modules/` behavior, ensuring compatibility. This change ensures a smoother developer experience regardless of the globally installed Yarn version.