### PR TITLE
Update Graphql errors reporting to Sentry

### DIFF
--- a/.changeset/good-mayflies-exist.md
+++ b/.changeset/good-mayflies-exist.md
@@ -1,0 +1,21 @@
+---
+'@commercetools-frontend/application-shell-connectors': minor
+---
+
+We're updating the way the Apollo error link reports unhandled GraphQL errors to Sentry.
+In a previous version we configured it so every unhandled error would be reported but now we're changing that implementation so no errors will be reported unless the query includes the (_boolean_) `enableSentryErrorReporting` parameter in the query context.
+Example:
+
+```ts
+const { loading, data, error } = useMcQuery<
+  TFetchLoggedInUserQuery,
+  TFetchLoggedInUserQueryVariables
+>(LoggedInUserQuery, {
+  context: {
+    target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+    enableSentryErrorReporting: true,
+  },
+});
+```
+
+This allows for a more granular control of the errors reported to Sentry which is more close to what we had before with the usage of the (now deprecated) `onError` callback of the `useQuery` hook.

--- a/.changeset/lovely-monkeys-relate.md
+++ b/.changeset/lovely-monkeys-relate.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Adjust the queries for fetching current user and project to report to Sentry in case of a GraphQL error.
+This is related to the change introduced in the `@commercetools-frontend/application-shell-connectors` package.

--- a/packages/application-shell-connectors/src/apollo-links/error-link.spec.js
+++ b/packages/application-shell-connectors/src/apollo-links/error-link.spec.js
@@ -209,18 +209,25 @@ describe('with unhandled error', () => {
   let terminatingLinkStub;
   let link;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     history.push.mockClear();
     terminatingLinkStub = jest.fn(
       () => new Observable((o) => o.error(badRequestError))
     );
 
     link = ApolloLink.from([errorLink, terminatingLinkStub]);
-
-    await waitFor(execute(link, { query }));
   });
 
-  it('should report the error to Sentry', () => {
+  it('should not report the error to Sentry by default', async () => {
+    await waitFor(execute(link, { query }));
+    expect(history.push).not.toHaveBeenCalled();
+    expect(reportErrorToSentry).not.toHaveBeenCalled();
+  });
+
+  it('should report the error to Sentry when when enabling it in the context', async () => {
+    await waitFor(
+      execute(link, { query, context: { enableSentryErrorReporting: true } })
+    );
     expect(history.push).not.toHaveBeenCalled();
     expect(reportErrorToSentry).toHaveBeenCalled();
   });

--- a/packages/application-shell-connectors/src/apollo-links/error-link.ts
+++ b/packages/application-shell-connectors/src/apollo-links/error-link.ts
@@ -32,9 +32,8 @@ const errorLink = onError(
     // https://www.apollographql.com/docs/link/links/error/#retrying-failed-requests
     // We need to do this as the `token-retry-link` only works for network errors.
     // https://www.apollographql.com/docs/link/links/retry/
+    const context = operation.getContext() as TApolloContext;
     if (graphQLErrors && isGraphQLError(graphQLErrors)) {
-      const context = operation.getContext() as TApolloContext;
-
       for (const err of graphQLErrors) {
         const isNonAuthenticatedViaExtensionCode =
           err?.extensions?.code === 'UNAUTHENTICATED';
@@ -62,7 +61,7 @@ const errorLink = onError(
     }
 
     // Report unhandled errors to Sentry
-    if (networkError) {
+    if (context.enableSentryErrorReporting && networkError) {
       reportErrorToSentry(networkError, {
         extra: {
           operationName: operation.operationName,
@@ -70,7 +69,7 @@ const errorLink = onError(
       });
     }
 
-    if (graphQLErrors) {
+    if (context.enableSentryErrorReporting && graphQLErrors) {
       for (const err of graphQLErrors) {
         reportErrorToSentry(err, {
           extra: {

--- a/packages/application-shell-connectors/src/utils/apollo-context.ts
+++ b/packages/application-shell-connectors/src/utils/apollo-context.ts
@@ -12,6 +12,7 @@ export type TApolloContext = {
   projectKey?: string;
   teamId?: string;
   featureFlag?: string;
+  enableSentryErrorReporting?: boolean;
 };
 
 const createApolloContextForProxyForwardTo = (

--- a/packages/application-shell/src/components/fetch-project/fetch-project.tsx
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.tsx
@@ -29,6 +29,7 @@ const FetchProject = (props: TFetchProjectProps) => {
     },
     context: {
       target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+      enableSentryErrorReporting: true,
     },
     skip: props.skip === true,
   });

--- a/packages/application-shell/src/components/fetch-user/fetch-user.tsx
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.tsx
@@ -22,7 +22,10 @@ const FetchUser = (props: TFetchUserProps) => {
     TFetchLoggedInUserQuery,
     TFetchLoggedInUserQueryVariables
   >(LoggedInUserQuery, {
-    context: { target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND },
+    context: {
+      target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+      enableSentryErrorReporting: true,
+    },
   });
   return (
     <>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

We're updating the way we report unhandled GraphQL errors to Sentry.

#### Description

In a previous PR ([reference](https://github.com/commercetools/merchant-center-application-kit/pull/3768)) we introduced a change for reporting all the errors happening in GraphQL operations to Sentry (if the latter is enabled).

We've realized this is a very wide decision which can uncover potential problems in consumers that would be difficult to address all at once.

In this PR we change the approach to not report those errors by default and allow consumers to configure this behaviour with a new `context` (_boolean_) property named `enableSentryErrorReporting`.

Here's an example:
```ts
const { loading, data, error } = useMcQuery<
  TFetchLoggedInUserQuery,
  TFetchLoggedInUserQueryVariables
>(LoggedInUserQuery, {
  context: {
    target: GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
    enableSentryErrorReporting: true,
  },
});
```

