### PR TITLE
Fix Custom Views integration

### DIFF
--- a/.changeset/rare-apples-compete.md
+++ b/.changeset/rare-apples-compete.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+We fix an error in the `CustomViewLoader` component which prevented Custom Views to be correctly initialized.

--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -115,25 +115,25 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
       return;
     }
 
-    // Listen for messages from the iFrame
-    iFrameCommunicationChannel.current!.port1.onmessage =
-      messageFromIFrameHandler;
-
-    window.addEventListener('message', messageFromIFrameHandler);
-
     // We want the effect to run only once so we don't need the dependencies array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     iFrameCommunicationChannel.current = new MessageChannel();
+
+    // Listen for messages from the iFrame
+    iFrameCommunicationChannel.current!.port1.onmessage =
+      messageFromIFrameHandler;
+    window.addEventListener('message', messageFromIFrameHandler);
+
     // Close the channel when the component unmounts
     const communicationChannel = iFrameCommunicationChannel.current;
     return () => {
       communicationChannel?.port1.close();
       window.removeEventListener('message', messageFromIFrameHandler);
     };
-  }, []);
+  }, [messageFromIFrameHandler]);
 
   // Currently we only support custom panels
   if (props.customView.type !== 'CustomPanel') {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fix Custom Views integration

#### Description

We found an issue with the integration of Custom Views which made them unusable.

The issue is related to how the communication between the host application and a Custom View is managed: there are a number of events exchanged between both systems and the readiness one form the Custom View was sent before the host application was actually listening for events so the initialization never happened.

In this PR we change when the host application starts listening for messages (way earlier) so we overcome the situation.