### PR TITLE
Local custom views init issue

### DIFF
--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -50,7 +50,6 @@ const CustomPanelIframe = styled.iframe`
 `;
 
 function CustomViewLoader(props: TCustomViewLoaderProps) {
-  console.log('[CustomViewLoader] CustomViewLoader render');
   const iFrameElementRef = useRef<HTMLIFrameElement>(null);
   const dataLocale = useApplicationContext((context) => context.dataLocale);
   const projectKey = useApplicationContext((context) => context.project?.key);
@@ -66,7 +65,6 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
       window.location.href,
       [iFrameCommunicationChannel.current.port2]
     );
-    console.log('[CustomViewLoader] sent bootstrap message to iFrame');
 
     // Send the initialization message to the iFrame
     iFrameCommunicationChannel.current.port1.postMessage({
@@ -83,7 +81,6 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
         },
       },
     } as TCustomViewIframeMessage);
-    console.log('[CustomViewLoader] sent initialization message to iFrame');
   }, [dataLocale, featureFlags, props.customView, props.hostUrl, projectKey]);
 
   const messageFromIFrameHandler = useCallback(
@@ -112,7 +109,6 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
       });
       return;
     }
-    console.log('[CustomViewLoader] iFrame is ready');
 
     // Listen for messages from the iFrame
     iFrameCommunicationChannel.current.port1.onmessage =

--- a/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
+++ b/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
@@ -140,7 +140,6 @@ const isLocalProdMode =
   process.env.NODE_ENV === 'production' && window.app.env === 'development';
 
 function CustomViewShell(props: TCustomViewShellProps) {
-  console.log('[CustomViewShell] CustomViewShell render');
   const [hostContext, setHostContext] = useState<THostContext>();
   const iFrameCommunicationPort = useRef<MessagePort | undefined>(null);
   const notificationsGlobalRef = useRef<HTMLDivElement>(null);
@@ -155,7 +154,6 @@ function CustomViewShell(props: TCustomViewShellProps) {
 
   const hostMessageHandler = useCallback(
     (event: MessageEvent<THostEventData>) => {
-      console.log('[CustomViewShell] hostMessageHandler', { event });
       if (
         event.data.eventName ===
         CUSTOM_VIEWS_EVENTS_NAMES.CUSTOM_VIEW_INITIALIZATION
@@ -194,9 +192,6 @@ function CustomViewShell(props: TCustomViewShellProps) {
         // Once bootstraped, we don't want to listen for global messages anymore.
         // We will only listen to messages coming through the MessageChannel port.
         window.removeEventListener('message', bootstrapMessageHandler);
-        console.log(
-          '[CustomViewShell] Not listening for global messages anymore'
-        );
       } else {
         console.warn(
           'CustomViewShell: Received an event that is not allowed.',
@@ -206,7 +201,6 @@ function CustomViewShell(props: TCustomViewShellProps) {
     };
 
     window.addEventListener('message', bootstrapMessageHandler);
-    console.log('[CustomViewShell] Now listening for bootstrap message');
     return () => {
       window.removeEventListener('message', bootstrapMessageHandler);
     };


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Try to make Custom View starter templates work again.

#### Description

Custom Views seems to work when running the Playground locally and also in production (the code for the React 19 source branch is already in production) but it also seems that running a Custom View starter template locally does not work: when we try to open the Custom View, the content keeps loading forever.

Comparing what works with what does not work, I see that we send the initialization message from the host application to the CustomView (iFrame) when it's still not listening for messages (in the starter templates).

In this PR I'm proposing a nasty trick which is delaying sending the init message a bit to give time to the CustomView to be listening for it.

Despite this working locally (including the starter templates, at least in my machine), the e2e tests are still failing.
