### PR TITLE
fix(application-shell): add Suspense wrapper for IconSwitcher to avoid blocking apps loading

### DIFF
--- a/.changeset/rotten-dots-care.md
+++ b/.changeset/rotten-dots-care.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Adds Suspense boundary when rendering IconSwitcher to avoid blocking the whole app loading. Minimizes LCP increase after React 19 upgrade due to https://github.com/facebook/react/issues/31819

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -8,6 +8,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
   type SyntheticEvent,
+  Suspense,
 } from 'react';
 import { Global } from '@emotion/react';
 import { useFlagVariation } from '@flopflip/react-broadcast';
@@ -461,7 +462,9 @@ const ItemContainer = (props: ItemContainerProps) => {
     <ItemIconText>
       <IconWrapper>
         <Icon className="icon">
-          <IconSwitcher icon={props.icon} size="scale" />
+          <Suspense fallback={null}>
+            <IconSwitcher icon={props.icon} size="scale" />
+          </Suspense>
         </Icon>
       </IconWrapper>
       {props.isMenuOpen ? (


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
MC app LCP has increased after React 19 upgrade. I found that when loading app we are hit by new Suspense throttling behavior described in https://github.com/facebook/react/issues/31819

#### Description

This is a screenshot from MC Discounts. When `ListWithSearchIcon` is loaded the whole app is blocked for 300ms. By adding a Suspense boundary when rendering `IconSwitcher` we can avoid blocking the whole app loading.

![Screenshot 2025-06-04 at 11 08 28](https://github.com/user-attachments/assets/bd234bca-6685-47f8-8607-198cc0f00f67)

