### PR TITLE
Add backwards compatible bidirectional initialization of Custom Views

### DIFF
--- a/.changeset/quick-clocks-cover.md
+++ b/.changeset/quick-clocks-cover.md
@@ -1,0 +1,9 @@
+---
+"@commercetools-frontend/application-components": patch
+"@commercetools-frontend/application-shell": patch
+---
+
+Add backwards compatible bidirectional initialization of Custom Views
+
+This improves the stability of the initialization of Custom Views but requires old Custom View to be updated to this version so they communicate about their ready state with the host. It's recommended to update to this version if possible specifically if you encounter initialization issues with Custom Views.
+

--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -137,10 +137,6 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
       return;
     }
 
-    // Listen for messages from the iFrame
-    iFrameCommunicationChannel.current.port1.onmessage =
-      messageFromIFrameHandler;
-
     // This is for backwards compatibility with custom view shell older than v24.0.0
     // where the custom-view-shell does not send the CUSTOM_VIEW_READY message yet.
     setTimeout(() => {
@@ -154,7 +150,14 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
   useEffect(() => {
     // Close the channel when the component unmounts
     const communicationChannel = iFrameCommunicationChannel.current;
+
+    // Listen for messages from the iFrame
+    iFrameCommunicationChannel.current!.port1.onmessage =
+      messageFromIFrameHandler;
+    window.addEventListener('message', messageFromIFrameHandler);
+
     return () => {
+      window.removeEventListener('message', messageFromIFrameHandler);
       communicationChannel?.port1.close();
     };
   }, []);

--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -49,12 +49,23 @@ const CustomPanelIframe = styled.iframe`
   border: none;
 `;
 
+/**
+ * Provides a singleton MessageChannel instance for communication between Custom View iFrame and the host application.
+ */
+let messageChannelInstance: MessageChannel | null = null;
+function getMessageChannel(): MessageChannel {
+  if (!messageChannelInstance) {
+    messageChannelInstance = new MessageChannel();
+  }
+
+  return messageChannelInstance;
+}
 function CustomViewLoader(props: TCustomViewLoaderProps) {
   const iFrameElementRef = useRef<HTMLIFrameElement>(null);
   const dataLocale = useApplicationContext((context) => context.dataLocale);
   const projectKey = useApplicationContext((context) => context.project?.key);
   const featureFlags = useAllFeatureToggles();
-  const iFrameCommunicationChannel = useRef(new MessageChannel());
+  const iFrameCommunicationChannel = useRef(getMessageChannel());
   const showNotification = useShowNotification();
   const intl = useIntl();
 

--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -54,7 +54,7 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
   const dataLocale = useApplicationContext((context) => context.dataLocale);
   const projectKey = useApplicationContext((context) => context.project?.key);
   const featureFlags = useAllFeatureToggles();
-  const iFrameCommunicationChannel = useRef<MessageChannel>(new MessageChannel());
+  const iFrameCommunicationChannel = useRef(new MessageChannel());
   const showNotification = useShowNotification();
   const intl = useIntl();
   const hasSentInitializationMessages = useRef(false);

--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -90,10 +90,16 @@ function CustomViewLoader(props: TCustomViewLoaderProps) {
           case CUSTOM_VIEWS_EVENTS_NAMES.CUSTOM_VIEW_CLOSE:
             props.onClose();
             break;
+          // This message will only be sent by custom view shell older than v24.x
+          // For backwards compatibility we will send the initialization messages
+          // after 500ms if this message was not received by then.
+          case CUSTOM_VIEWS_EVENTS_NAMES.CUSTOM_VIEW_READY: {
+            sendInitializationMessages();
+          }
         }
       }
     },
-    [props]
+    [props, sendInitializationMessages]
   );
 
   // onLoad handler is called from the iFrame even where the URL is not valid

--- a/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
+++ b/packages/application-components/src/components/custom-views/custom-view-loader/custom-view-loader.tsx
@@ -49,23 +49,12 @@ const CustomPanelIframe = styled.iframe`
   border: none;
 `;
 
-/**
- * Provides a singleton MessageChannel instance for communication between Custom View iFrame and the host application.
- */
-let messageChannelInstance: MessageChannel | null = null;
-function getMessageChannel(): MessageChannel {
-  if (!messageChannelInstance) {
-    messageChannelInstance = new MessageChannel();
-  }
-
-  return messageChannelInstance;
-}
 function CustomViewLoader(props: TCustomViewLoaderProps) {
   const iFrameElementRef = useRef<HTMLIFrameElement>(null);
   const dataLocale = useApplicationContext((context) => context.dataLocale);
   const projectKey = useApplicationContext((context) => context.project?.key);
   const featureFlags = useAllFeatureToggles();
-  const iFrameCommunicationChannel = useRef(getMessageChannel());
+  const iFrameCommunicationChannel = useRef<MessageChannel>(new MessageChannel());
   const showNotification = useShowNotification();
   const intl = useIntl();
   const hasSentInitializationMessages = useRef(false);

--- a/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
+++ b/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
@@ -201,6 +201,14 @@ function CustomViewShell(props: TCustomViewShellProps) {
     };
 
     window.addEventListener('message', bootstrapMessageHandler);
+
+    // This notifies the custom view loader that the iframe is ready.
+    // This is only supported by custom view loader in the host application older than v24.x
+    window.parent.postMessage({
+      origin: window.location.origin,
+      eventName: CUSTOM_VIEWS_EVENTS_NAMES.CUSTOM_VIEW_READY,
+    });
+
     return () => {
       window.removeEventListener('message', bootstrapMessageHandler);
     };

--- a/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
+++ b/packages/application-shell/src/components/custom-view-shell/custom-view-shell.tsx
@@ -203,7 +203,7 @@ function CustomViewShell(props: TCustomViewShellProps) {
     window.addEventListener('message', bootstrapMessageHandler);
 
     // This notifies the custom view loader that the iframe is ready.
-    // This is only supported by custom view loader in the host application older than v24.x
+    // This is only supported by custom view loader in the host application from v24.x onwards
     window.parent.postMessage({
       origin: window.location.origin,
       eventName: CUSTOM_VIEWS_EVENTS_NAMES.CUSTOM_VIEW_READY,


### PR DESCRIPTION
#### Summary

This improves Custom View initialization by a backwards compatible bidirectional communication in which the Custom View (managed by `custom-view-shell`) informs the host application (managed by `custom-view-loader`).

#### Description

This is a follow-up from the React v19 migration in which we initially tried to implement a bidirectional approach but reverted it as we _can not assume_ Custom Views to be updated. As a result this communication needs to be backwards compatible. Hence, even if the Custom View does not send a "ready message" the host has to assume - in this case after 500ms - for the Custom View to be ready. 

##### Changes made

1. Add a ready message sent from Custom View to host
2. Adjust the host to be able to react to the ready message to send initialization message and payload
3. Host to remain backwards compatible to send initialization message after 500ms if Custom View has not sent ready message
4. Expand on host to keep track on whether initialization messages have been sent to avoid sending them multiple times
    - In StrictMode, which isn't supported yet, this may need to reset while also the channel can likely not be closed. This is not in scope of this change however. 
6. Refactor message channel generation to ensure message channel is only generated once using a singleton
7. Change host application to listen to messages earlier (to useEffect) as otherwise the Custom View can already send the ready message before the host started listening

##### Testing

This is verified by existing tests in my opinion and would be hard to test End-to-End due to the timing concerns. I've debugged this at length in the Playground and I can see that the Custom View _always_ send the ready message before the host times out to instruct initialization as a last resort. 