### PR TITLE
refactor: to remove suspense boundary on project container

### DIFF
--- a/packages/application-shell/src/components/project-container/project-container.tsx
+++ b/packages/application-shell/src/components/project-container/project-container.tsx
@@ -1,4 +1,4 @@
-import { JSX, ReactNode, Suspense, useEffect, useState } from 'react';
+import { JSX, ReactNode, useEffect, useState } from 'react';
 import isNil from 'lodash/isNil';
 import ReactDOM from 'react-dom';
 import { useIntl } from 'react-intl';
@@ -118,85 +118,83 @@ const ProjectContainer = (props: TProjectContainerProps) => {
 
   return (
     <ErrorBoundary pathname={location.pathname}>
-      <Suspense fallback={<ApplicationLoader />}>
-        <FetchProject
-          skip={!props.user || !props.user.defaultProjectKey}
-          projectKey={projectKey}
-        >
-          {({ isLoading: isProjectLoading, project }) => {
-            // TODO: do something if there is an `error`?
-            if (isProjectLoading) return <ApplicationLoader />;
-            if (!project) return <ProjectNotFound />;
-            if (project.suspension && project.suspension.isActive)
-              return (
-                <ProjectSuspended
-                  isTemporary={
-                    project.suspension.reason ===
-                    SUSPENSION_REASONS.TEMPORARY_MAINTENANCE
-                  }
-                />
-              );
-            if (project.expiry && project.expiry.isActive)
-              return <ProjectExpired />;
-            if (project.initialized === false) return <ProjectNotInitialized />;
-
+      <FetchProject
+        skip={!props.user || !props.user.defaultProjectKey}
+        projectKey={projectKey}
+      >
+        {({ isLoading: isProjectLoading, project }) => {
+          // TODO: do something if there is an `error`?
+          if (isProjectLoading) return <ApplicationLoader />;
+          if (!project) return <ProjectNotFound />;
+          if (project.suspension && project.suspension.isActive)
             return (
-              <ProjectDataLocale locales={project.languages}>
-                {({ locale, setProjectDataLocale }) => (
-                  <ApplicationContextProvider
-                    user={props.user}
-                    project={project}
-                    projectDataLocale={locale}
-                    environment={props.environment}
-                  >
-                    <>
-                      {shouldShowNotificationForTrialExpired(
-                        project.expiry.daysLeft ?? undefined
-                      ) && (
-                        <Notifier
-                          kind="warning"
-                          domain={DOMAINS.GLOBAL}
-                          text={intl.formatMessage(messages.trialDaysLeft, {
-                            daysLeft: project.expiry.daysLeft || 0,
-                          })}
-                        />
-                      )}
-                      {/* Render <LocaleSwitcher> using a portal */}
-                      {localeSwitcherNode &&
-                        // Render the `<LocaleSwitcher>` only if the project has more
-                        // than one language.
-                        project.languages.length > 1 &&
-                        ReactDOM.createPortal(
-                          <LocaleSwitcher
-                            // Be explicit on listing the props so that we can better assert it.
-                            projectDataLocale={locale}
-                            setProjectDataLocale={setProjectDataLocale}
-                            availableLocales={project.languages}
-                          />,
-                          localeSwitcherNode
-                        )}
-                      {/**
-                       * NOTE: we don't need to explicitly pass the `locale`,
-                       * it's enough to trigger a re-render.
-                       * The `locale` can then be read from the localStorage.
-                       */}
-                      <ApplicationEntryPoint
-                        environment={props.environment}
-                        disableRoutePermissionCheck={
-                          props.disableRoutePermissionCheck
-                        }
-                        render={props.render}
-                      >
-                        {props.children}
-                      </ApplicationEntryPoint>
-                    </>
-                  </ApplicationContextProvider>
-                )}
-              </ProjectDataLocale>
+              <ProjectSuspended
+                isTemporary={
+                  project.suspension.reason ===
+                  SUSPENSION_REASONS.TEMPORARY_MAINTENANCE
+                }
+              />
             );
-          }}
-        </FetchProject>
-      </Suspense>
+          if (project.expiry && project.expiry.isActive)
+            return <ProjectExpired />;
+          if (project.initialized === false) return <ProjectNotInitialized />;
+
+          return (
+            <ProjectDataLocale locales={project.languages}>
+              {({ locale, setProjectDataLocale }) => (
+                <ApplicationContextProvider
+                  user={props.user}
+                  project={project}
+                  projectDataLocale={locale}
+                  environment={props.environment}
+                >
+                  <>
+                    {shouldShowNotificationForTrialExpired(
+                      project.expiry.daysLeft ?? undefined
+                    ) && (
+                      <Notifier
+                        kind="warning"
+                        domain={DOMAINS.GLOBAL}
+                        text={intl.formatMessage(messages.trialDaysLeft, {
+                          daysLeft: project.expiry.daysLeft || 0,
+                        })}
+                      />
+                    )}
+                    {/* Render <LocaleSwitcher> using a portal */}
+                    {localeSwitcherNode &&
+                      // Render the `<LocaleSwitcher>` only if the project has more
+                      // than one language.
+                      project.languages.length > 1 &&
+                      ReactDOM.createPortal(
+                        <LocaleSwitcher
+                          // Be explicit on listing the props so that we can better assert it.
+                          projectDataLocale={locale}
+                          setProjectDataLocale={setProjectDataLocale}
+                          availableLocales={project.languages}
+                        />,
+                        localeSwitcherNode
+                      )}
+                    {/**
+                     * NOTE: we don't need to explicitly pass the `locale`,
+                     * it's enough to trigger a re-render.
+                     * The `locale` can then be read from the localStorage.
+                     */}
+                    <ApplicationEntryPoint
+                      environment={props.environment}
+                      disableRoutePermissionCheck={
+                        props.disableRoutePermissionCheck
+                      }
+                      render={props.render}
+                    >
+                      {props.children}
+                    </ApplicationEntryPoint>
+                  </>
+                </ApplicationContextProvider>
+              )}
+            </ProjectDataLocale>
+          );
+        }}
+      </FetchProject>
     </ErrorBoundary>
   );
 };


### PR DESCRIPTION
#### Summary

This removes a second suspense boundary lower in the component tree we might not need.

#### Description

At the moment our structure is as follows

```
- ApplicationShell
  - ApplicationShellProvider
    - Suspense (1st)
      - ApplicationShellAuthenticated
        - FetchUser
          - if userLoading renders MainContainer with ApplicationLoader
          - else renders if route matches path="/:projectKey"
            - Suspense (2nd)
```

Out understanding is that each Suspense boundary adds a 300ms timeout to prevent loading flickering with React v19. 

We can see these idle times in the performance tab

![Screenshot 2025-06-05 at 15 19 37@2x](https://github.com/user-attachments/assets/53067a45-66c8-4c19-b5e3-7f0fef2181a7)
