### PR TITLE
Refactor `SuspendedProctedRoute` to support loader and fallback component

### DIFF
--- a/.changeset/polite-mugs-peel.md
+++ b/.changeset/polite-mugs-peel.md
@@ -1,0 +1,17 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+You can now specify a `fallback` component on `ProtectedRoute` which defaults to `<PageUnauthorized />`.
+
+```tsx
+<ProtectedRoute condition={canManageProjectSettings} fallback={<MyOwnComponent />} />
+```
+
+**⚠️ Change in `ProtectedSuspendedRoute`'s `fallback` prop**
+
+There is change to `ProtectedSuspendedRoute` if you used the `fallback` property as it is now renamed to `loader`. 
+
+If you specified a custom `fallback` component on `ProtectedSuspendedRoute` then rename this property to `loader`. 
+
+This allows the `ProtectedSuspendedRoute` to have both a `fallback` (similar to `ProtectedRoute`) and `loader` property. 

--- a/packages/application-shell/src/components/suspended-route/protected-route.tsx
+++ b/packages/application-shell/src/components/suspended-route/protected-route.tsx
@@ -3,18 +3,16 @@ import { PageUnauthorized } from '@commercetools-frontend/application-components
 
 type TProtectedRouteProps = {
   condition: boolean;
+  fallback?: React.ReactNode;
 } & RouteProps;
 
 const ProtectedRoute: React.FC<TProtectedRouteProps> = ({
   condition,
+  fallback = <PageUnauthorized />,
   children,
   ...routeProps
 }) => {
-  return condition ? (
-    <Route {...routeProps}>{children}</Route>
-  ) : (
-    <PageUnauthorized />
-  );
+  return condition ? <Route {...routeProps}>{children}</Route> : <>fallback</>;
 };
 
 export { ProtectedRoute, type TProtectedRouteProps };

--- a/packages/application-shell/src/components/suspended-route/suspended-protected-route.tsx
+++ b/packages/application-shell/src/components/suspended-route/suspended-protected-route.tsx
@@ -1,18 +1,21 @@
 import { Suspense } from 'react';
+import { PageUnauthorized } from '@commercetools-frontend/application-components';
 import LoadingSpinner from '@commercetools-uikit/loading-spinner';
 import { ProtectedRoute, type TProtectedRouteProps } from './protected-route';
 
 type TSuspendedProtectedRouteProps = TProtectedRouteProps & {
+  loading?: React.ReactNode;
   fallback?: React.ReactNode;
 };
 
 const SuspendedProtectedRoute: React.FC<TSuspendedProtectedRouteProps> = ({
-  fallback = <LoadingSpinner />,
+  loading = <LoadingSpinner />,
+  fallback = <PageUnauthorized />,
   ...routeProps
 }) => {
   return (
-    <Suspense fallback={fallback}>
-      <ProtectedRoute {...routeProps} />
+    <Suspense fallback={loading}>
+      <ProtectedRoute fallback={fallback} {...routeProps} />
     </Suspense>
   );
 };


### PR DESCRIPTION
#### Summary

This refactors the ProtectedRoute and SuspendedProtectedRoute to both support a `fallback` component which is not the Suspense boundary but rather the fallback rendered whenever the condition is not met.