### PR TITLE
Fix rendering fallback as string

### DIFF
--- a/.changeset/sour-rings-call.md
+++ b/.changeset/sour-rings-call.md
@@ -2,4 +2,4 @@
 "@commercetools-frontend/application-shell": patch
 ---
 
-Fix rendering fallback as string
+Fix rendering fallback as string in the `ProtectedRoute` and `SuspendedProtectedRoute` components.

--- a/.changeset/sour-rings-call.md
+++ b/.changeset/sour-rings-call.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-frontend/application-shell": patch
+---
+
+Fix rendering fallback as string

--- a/packages/application-shell/src/components/suspended-route/protected-route.tsx
+++ b/packages/application-shell/src/components/suspended-route/protected-route.tsx
@@ -1,5 +1,5 @@
-import { Route, RouteProps } from "react-router-dom";
-import { PageUnauthorized } from "@commercetools-frontend/application-components";
+import { Route, RouteProps } from 'react-router-dom';
+import { PageUnauthorized } from '@commercetools-frontend/application-components';
 
 type TProtectedRouteProps = {
   condition: boolean;

--- a/packages/application-shell/src/components/suspended-route/protected-route.tsx
+++ b/packages/application-shell/src/components/suspended-route/protected-route.tsx
@@ -12,7 +12,7 @@ const ProtectedRoute: React.FC<TProtectedRouteProps> = ({
   children,
   ...routeProps
 }) => {
-  return condition ? <Route {...routeProps}>{children}</Route> : <>fallback</>;
+  return condition ? <Route {...routeProps}>{children}</Route> : <>{fallback}</>;
 };
 
 export { ProtectedRoute, type TProtectedRouteProps };

--- a/packages/application-shell/src/components/suspended-route/protected-route.tsx
+++ b/packages/application-shell/src/components/suspended-route/protected-route.tsx
@@ -1,5 +1,5 @@
-import { Route, RouteProps } from 'react-router-dom';
-import { PageUnauthorized } from '@commercetools-frontend/application-components';
+import { Route, RouteProps } from "react-router-dom";
+import { PageUnauthorized } from "@commercetools-frontend/application-components";
 
 type TProtectedRouteProps = {
   condition: boolean;
@@ -12,7 +12,11 @@ const ProtectedRoute: React.FC<TProtectedRouteProps> = ({
   children,
   ...routeProps
 }) => {
-  return condition ? <Route {...routeProps}>{children}</Route> : <>{fallback}</>;
+  return condition ? (
+    <Route {...routeProps}>{children}</Route>
+  ) : (
+    <>{fallback}</>
+  );
 };
 
 export { ProtectedRoute, type TProtectedRouteProps };


### PR DESCRIPTION

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fixes rendering the string fallback instead of the value from props. 
