### PR TITLE
fix: preview deployment workflow

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -15,8 +15,7 @@ jobs:
     if: |
       github.event.issue.pull_request && 
       startsWith(github.event.comment.body, '[preview_deployment]') &&
-      github.event.comment.author_association == 'MEMBER' &&
-      github.event.issue.pull_request.head.repo.full_name == github.repository
+      github.event.comment.author_association == 'MEMBER'
     runs-on: ubuntu-latest
 
     timeout-minutes: 15


### PR DESCRIPTION
#### Summary

Removed a condition to fix an issue with the preview deployment workflow trigger.

#### Description

The condition `github.event.issue.pull_request.head.repo.full_name == github.repository` was causing problems in the workflow. It was added by me in a previous PR. Removing this check resolves the issue and ensures the preview deployment workflow triggers correctly when a member comments with [preview_deployment] on a pull request.