### PR TITLE
feat: add onCustomViewClose callback for data refresh

### DIFF
--- a/.changeset/lucky-sheep-cough.md
+++ b/.changeset/lucky-sheep-cough.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+Adds an optional `onCustomViewClose` callback prop to `TabularDetailPage`

--- a/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
@@ -27,6 +27,7 @@ type TCustomViewSelectorWithRequiredProps = {
   customViewLocatorCode: string;
   margin?: string;
   onCustomViewsResolved?: TCustomViewSelectorProps['onCustomViewsResolved'];
+  onCustomViewClose?: TCustomViewSelectorProps['onCustomViewClose'];
 };
 
 type TWrapperProps = {
@@ -162,6 +163,9 @@ function CustomViewSelector(props: TCustomViewSelectorWithRequiredProps) {
               customView={selectedCustomView}
               onClose={() => {
                 setSelectedCustomView(null);
+                if (props.onCustomViewClose) {
+                  props.onCustomViewClose();
+                }
               }}
             />
           )}

--- a/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
@@ -13,4 +13,5 @@ export type TCustomViewSelectorProps = {
   customViewLocatorCode?: string;
   customViewLocatorCodes?: Record<string, TCustomViewLocatorCode>;
   margin?: string;
+  onCustomViewClose?: () => void;
 };

--- a/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.tsx
+++ b/packages/application-components/src/components/detail-pages/tabular-detail-page/tabular-detail-page.tsx
@@ -63,6 +63,10 @@ type TTabularDetailPageProps = {
    * These codes are used to configure which Custom Views are available for every tab.
    */
   customViewLocatorCodes?: TCustomViewSelectorProps['customViewLocatorCodes'];
+  /**
+   * Optional function called when a Custom View closes.
+   */
+  onCustomViewClose?: () => void;
 
   // PageTopBar props:
   /**
@@ -118,6 +122,7 @@ const TabularDetailPage = ({
         <CustomViewsSelector
           margin={`${uiKitDesignTokens.spacing30} 0 0 0`}
           customViewLocatorCodes={props.customViewLocatorCodes}
+          onCustomViewClose={props.onCustomViewClose}
         />
       </CustomViewsSelectorWrapper>
       <ContentWrapper>{props.children}</ContentWrapper>


### PR DESCRIPTION
#### Summary

Added an optional `onCustomViewClose` callback prop to the `TabularDetailPage` component that allows host applications to refresh their data when Custom Views are closed.

#### Description

This enhancement enables better data synchronization between Custom Views and their host applications. When a Custom View closes, the optional `onCustomViewClose` function is triggered, allowing the ability for the host applications to refresh their data after Custom View closure.

The implementation maintains full backward compatibility. Existing code continues to work without any changes. The callback is passed through the component hierarchy from TabularDetailPage → CustomViewsSelector → CustomViewLoader, ensuring it's triggered at the appropriate time when Custom Views close.

An [RFC](https://commercetools.atlassian.net/wiki/spaces/shield/pages/1570734207/RFC+Update+parent+page+data+on+Custom+View+changes) has been written that considered some other alternatives as well