### PR TITLE
fix: add control check for commenter author association

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -14,13 +14,19 @@ jobs:
   release:
     if: |
       github.event.issue.pull_request && 
-      startsWith(github.event.comment.body, '[preview_deployment]') &&
-      github.event.comment.author_association == 'MEMBER'
+      startsWith(github.event.comment.body, '[preview_deployment]')
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
 
     steps:
+      - name: Control Check: Validate Comment Author Association
+        run: |
+          if [[ "${{ github.event.comment.author_association }}" != "MEMBER" ]]; then
+            echo "Commenter is not a trusted member. Exiting workflow."
+            exit 1
+          fi
+
       # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
@@ -45,7 +51,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
           token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Installing dependencies and building packages


### PR DESCRIPTION
#### Summary

Added a control check to validate the comment author's association.

#### Description

Reverted all previous changes to the preview workflow because `github.event.pull_request.head.sha` was incorrectly referencing the main branch instead of the pull request branch. The only remaining change is the addition of a control check to ensure that the comment author is a trusted member (i.e., has a MEMBER association) before proceeding with the workflow. These changes address the previous security issue, and the updated workflow has been verified locally using CodeQL cli. 

For reference, [this version of the workflow file](https://github.com/commercetools/merchant-center-application-kit/blob/0692aeea2a34263e1878f369ae3489d2125b7fe7/.github/workflows/preview-release-on-comment.yml) had the preview logic working correctly, but lacked the necessary security validation.

As this workflow could only be tested after being merged into `main`, which is why the issue wasn't caught earlier.