### PR TITLE
refactor: deprecated and remove `x-xss-protection` from default security headers

### DIFF
--- a/.changeset/violet-impalas-travel.md
+++ b/.changeset/violet-impalas-travel.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/constants': patch
+---
+
+Deprecate `X-XSS-Protection` security header, do not include it in the default security headers.
+
+The header is not supported anymore by the browsers and is de-facto replaced by the Content Security Policy (CSP) header.

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -308,12 +308,13 @@ export const STORAGE_KEYS = {
 
 export const HTTP_SECURITY_HEADER_KEYS = {
   'Content-Security-Policy': 'Content-Security-Policy',
-  'Referrer-Policy': 'Referrer-Policy',
   'Permissions-Policy': 'Permissions-Policy',
+  'Referrer-Policy': 'Referrer-Policy',
   'Strict-Transport-Security': 'Strict-Transport-Security',
-  'X-XSS-Protection': 'X-XSS-Protection',
   'X-Content-Type-Options': 'X-Content-Type-Options',
   'X-Frame-Options': 'X-Frame-Options',
+  // @deprecated: this header is not supported by the browser anymore. Use `Content-Security-Policy` instead.
+  'X-XSS-Protection': 'X-XSS-Protection',
 } as const;
 export type THttpSecurityHeaders = keyof typeof HTTP_SECURITY_HEADER_KEYS;
 export const HTTP_SECURITY_HEADERS = {
@@ -324,7 +325,6 @@ export const HTTP_SECURITY_HEADERS = {
     'microphone=(self), camera=(self), payment=(self), usb=(self), geolocation=(self)',
   [HTTP_SECURITY_HEADER_KEYS['Strict-Transport-Security']]:
     'max-age=31536000; includeSubDomains; preload',
-  [HTTP_SECURITY_HEADER_KEYS['X-XSS-Protection']]: '1; mode=block',
   [HTTP_SECURITY_HEADER_KEYS['X-Content-Type-Options']]: 'nosniff',
   [HTTP_SECURITY_HEADER_KEYS['X-Frame-Options']]: 'SAMEORIGIN',
 } as const;

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -316,7 +316,10 @@ export const HTTP_SECURITY_HEADER_KEYS = {
   // @deprecated: this header is not supported by the browser anymore. Use `Content-Security-Policy` instead.
   'X-XSS-Protection': 'X-XSS-Protection',
 } as const;
-export type THttpSecurityHeaders = keyof typeof HTTP_SECURITY_HEADER_KEYS;
+export type THttpSecurityHeaders = Exclude<
+  keyof typeof HTTP_SECURITY_HEADER_KEYS,
+  'X-XSS-Protection'
+>;
 export const HTTP_SECURITY_HEADERS = {
   [HTTP_SECURITY_HEADER_KEYS['Referrer-Policy']]: 'same-origin',
   [HTTP_SECURITY_HEADER_KEYS['Permissions-Policy']]:


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection