### PR TITLE
chore(appkit): accessibility improvements to navbar

### DIFF
--- a/.changeset/small-chicken-count.md
+++ b/.changeset/small-chicken-count.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/i18n': patch
+---
+
+Improve Navbar component accessibility

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -1232,8 +1232,8 @@ describe('navbar menu links interactions', () => {
 
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
     const submenuContainer = container.querySelector(`#group-${groupId}`);
-    // The submenu container should not be expanded when the menu is not active.
-    expect(submenuContainer).toHaveAttribute('aria-expanded', 'false');
+    // Verify the submenu container has the correct role for accessibility
+    expect(submenuContainer).toHaveAttribute('role', 'menu');
 
     const getMainMenuItem = getMenuItemBasedOnTooltipLabel(mainMenuLabel);
 
@@ -1241,15 +1241,20 @@ describe('navbar menu links interactions', () => {
       .getAllByRole('menuitem')
       .find(getMainMenuItem);
 
+    // Verify menu item has accessibility attributes
+    expect(menuItem).toHaveAttribute('role', 'menuitem');
+    expect(menuItem).toHaveAttribute('aria-label');
+
     // Hover over menu item
     fireEvent.mouseOver(menuItem);
-    // The submenu container should be expanded
-    expect(submenuContainer).toHaveAttribute('aria-expanded', 'true');
 
     const submenuLink = within(container)
       .getByText(mainSubmenuLabel.value)
       // eslint-disable-next-line testing-library/no-node-access
       .closest('a');
+
+    // Verify submenu link has accessibility attributes
+    expect(submenuLink).toHaveAttribute('aria-label');
 
     // Go to the link
     fireEvent.click(submenuLink);

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -13,6 +13,7 @@ import { Global } from '@emotion/react';
 import { useFlagVariation } from '@flopflip/react-broadcast';
 import type { TFlagVariation } from '@flopflip/types';
 import classnames from 'classnames';
+import { useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import type {
   TNormalizedMenuVisibilities,
@@ -49,6 +50,7 @@ import {
   TextLinkSublistWrapper,
   NavlinkClickableContent,
 } from './menu-items.styles';
+import messages from './messages';
 import { Icon, IconWrapper, ItemIconText, Title } from './shared.styles';
 
 type TProjectPermissions = {
@@ -144,6 +146,8 @@ const getIcon = ({ isMenuOpen }: MenuExpanderProps) => {
 };
 
 const MenuExpander = (props: MenuExpanderProps) => {
+  const { formatMessage } = useIntl();
+
   return (
     <Expander key="expander" isVisible={props.isVisible} role="menuitem">
       <ExpanderIcon
@@ -155,7 +159,11 @@ const MenuExpander = (props: MenuExpanderProps) => {
         }}
         tabIndex={0}
         data-testid="menu-expander"
-        aria-label={props.isMenuOpen ? 'Collapse menu' : 'Expand menu'}
+        aria-label={
+          props.isMenuOpen
+            ? formatMessage(messages['NavBar.MenuExpander.collapseMenu'])
+            : formatMessage(messages['NavBar.MenuExpander.expandMenu'])
+        }
       >
         {getIcon(props)}
       </ExpanderIcon>

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -164,6 +164,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
             ? formatMessage(messages['NavBar.MenuExpander.collapseMenu'])
             : formatMessage(messages['NavBar.MenuExpander.expandMenu'])
         }
+        aria-expanded={props.isMenuOpen}
       >
         {getIcon(props)}
       </ExpanderIcon>

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -145,7 +145,7 @@ const getIcon = ({ isMenuOpen }: MenuExpanderProps) => {
 
 const MenuExpander = (props: MenuExpanderProps) => {
   return (
-    <Expander key="expander" isVisible={props.isVisible}>
+    <Expander key="expander" isVisible={props.isVisible} role="menuitem">
       <ExpanderIcon
         onClick={props.onClick}
         onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
@@ -155,6 +155,7 @@ const MenuExpander = (props: MenuExpanderProps) => {
         }}
         tabIndex={0}
         data-testid="menu-expander"
+        aria-label={props.isMenuOpen ? 'Collapse menu' : 'Expand menu'}
       >
         {getIcon(props)}
       </ExpanderIcon>
@@ -197,10 +198,6 @@ const MenuGroup = forwardRef<HTMLUListElement, MenuGroupProps>((props, ref) => {
       id={`group-${props.id}`}
       data-testid={`group-${props.id}`}
       role="menu"
-      aria-expanded={
-        isSublistActiveWhileIsMenuExpanded ||
-        isSublistActiveWhileIsMenuCollapsed
-      }
       onKeyDown={props.handleKeyDown}
       className={classnames(
         {
@@ -253,11 +250,13 @@ type MenuItemProps = {
   identifier?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLLIElement>) => void;
   onMouseMove?: MouseEventHandler<HTMLLIElement>;
+  ariaLabel?: string;
 };
 const MenuItem = (props: MenuItemProps) => {
   return (
     <MenuListItem
       role="menuitem"
+      aria-label={props.ariaLabel}
       onClick={props.onClick}
       onMouseEnter={props.onMouseEnter as MouseEventHandler<HTMLElement>}
       onMouseLeave={props.onMouseLeave as MouseEventHandler<HTMLElement>}
@@ -288,6 +287,7 @@ export type MenuItemLinkProps = {
   useFullRedirectsForLinks?: boolean;
   isSubmenuLink?: boolean;
   isSubmenuFocused?: boolean;
+  ariaLabel?: string;
 };
 
 const NavLinkWrapper = (props: MenuItemLinkProps) => {
@@ -312,6 +312,7 @@ const MenuItemLink = ({ exactMatch = false, ...props }: MenuItemLinkProps) => {
           data-link-level={linkLevel}
           css={getMenuItemLinkStyles(Boolean(props.isSubmenuLink))}
           tabIndex={props.isSubmenuLink && !props.isSubmenuFocused ? -1 : 0}
+          aria-label={props.ariaLabel}
           onClick={(event) => {
             if (props.linkTo && props.useFullRedirectsForLinks) {
               event.preventDefault();

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -164,7 +164,6 @@ const MenuExpander = (props: MenuExpanderProps) => {
             ? formatMessage(messages['NavBar.MenuExpander.collapseMenu'])
             : formatMessage(messages['NavBar.MenuExpander.expandMenu'])
         }
-        aria-expanded={props.isMenuOpen}
       >
         {getIcon(props)}
       </ExpanderIcon>

--- a/packages/application-shell/src/components/navbar/messages.ts
+++ b/packages/application-shell/src/components/navbar/messages.ts
@@ -5,4 +5,12 @@ export default defineMessages({
     id: 'NavBar.MCSupport.title',
     defaultMessage: 'Support',
   },
+  'NavBar.MenuExpander.collapseMenu': {
+    id: 'NavBar.MenuExpander.collapseMenu',
+    defaultMessage: 'Collapse menu',
+  },
+  'NavBar.MenuExpander.expandMenu': {
+    id: 'NavBar.MenuExpander.expandMenu',
+    defaultMessage: 'Expand menu',
+  },
 });

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -215,6 +215,12 @@
   "NavBar.MCSupport.title": {
     "string": "Support"
   },
+  "NavBar.MenuExpander.collapseMenu": {
+    "string": "Collapse menu"
+  },
+  "NavBar.MenuExpander.expandMenu": {
+    "string": "Expand menu"
+  },
   "Notification.hideNotification": {
     "developer_comment": "Label for button to hide notification",
     "string": "Hide notification"


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary
Fixes accessibility issues in application shell navbar component by adding proper ARIA attributes and accessible names to interactive elements.

## Description
Resolves multiple ARIA accessibility violations in the navbar component:

- **MenuExpander**: Added `role="menuitem"` and localized `aria-label` for expand/collapse actions
- **MenuGroup**: Removed conflicting `aria-expanded` attribute that caused ARIA role validation errors  
- **MenuItem & MenuItemLink**: Added `ariaLabel` props and `aria-label` attributes for accessible names
- **Support link**: Added localized `aria-label` attribute
- **Helper function**: Created `getMenuAccessibleLabel()` to consistently extract localized menu labels
- **Localization**: Added new message keys for menu expander actions with proper i18n support

All changes are backward compatible with optional props. Fixes "ARIA commands must have accessible names", "Links must have discernible text", and "Certain ARIA roles must contain particular children" violations. Accessibility violations from page scans went from 5 to 1 (the last being unrelated to the navbar).

It's effectively an AppKit-flavored port of [these changes from Identity](https://github.com/commercetools/identity/pull/356), because they both use the same navbar design