### PR TITLE
CRAFT 1678 | Enable custom title component in `InfoModalPage`

### DIFF
--- a/.changeset/fifty-walls-explain.md
+++ b/.changeset/fifty-walls-explain.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': patch
+---
+
+Add `customTitleRow` prop to `InfoModalPage` component to allow setting a custom component as the title instead of the `PageHeaderTitle` component

--- a/packages/application-components/src/components/internals/page-header.tsx
+++ b/packages/application-components/src/components/internals/page-header.tsx
@@ -11,6 +11,10 @@ type Props = {
    * This code is used to configure which Custom Views are available for this page.
    */
   customViewLocatorCode?: string;
+  /**
+   * Replaces the title/subtitle row with a custom one (for special use cases)
+   */
+  customTitleRow?: ReactNode;
   children?: ReactNode;
 };
 
@@ -33,12 +37,14 @@ const PageHeader = (props: Props) => {
           }
         `}
       >
-        <PageHeaderTitle
-          title={props.title}
-          titleSize="big"
-          subtitle={props.subtitle}
-          truncate
-        />
+        {props.customTitleRow || (
+          <PageHeaderTitle
+            title={props.title}
+            titleSize="big"
+            subtitle={props.subtitle}
+            truncate
+          />
+        )}
         {props.children}
       </div>
       <CustomViewsSelector

--- a/packages/application-components/src/components/modal-pages/info-modal-page/info-modal-page.tsx
+++ b/packages/application-components/src/components/modal-pages/info-modal-page/info-modal-page.tsx
@@ -39,6 +39,10 @@ type Props = {
   topBarPreviousPathLabel?: Label;
   // Header Props
   subtitle?: string | ReactElement;
+  /**
+   * Replaces the title/subtitle row with a custom one (for special use cases)
+   */
+  customTitleRow?: ReactNode;
 };
 
 const InfoModalPage = (props: Props) => (
@@ -56,6 +60,7 @@ const InfoModalPage = (props: Props) => (
     <PageHeader
       title={props.title}
       subtitle={props.subtitle}
+      customTitleRow={props.customTitleRow}
       customViewLocatorCode={props.customViewLocatorCode}
     />
     <ModalContentWrapper>{props.children}</ModalContentWrapper>


### PR DESCRIPTION
In response to [this request by the connect team](https://commercetools.slack.com/archives/C03B6NKTA83/p1753963117209129), enables use of a custom title component in the `InfoModalPage` to be consistent with the `InfoDetailPage`.

This pull request adds support for providing a custom title and subtitle row in both the `PageHeader` and `InfoModalPage` components. This allows for greater flexibility in rendering headers for special use cases.

**Header Customization Enhancements:**

* Added an optional `customTitleRow` prop to the `PageHeader` component, allowing consumers to replace the default title/subtitle row with a custom React node. (`packages/application-components/src/components/internals/page-header.tsx`)
* Updated the `PageHeader` component to render the `customTitleRow` if provided, falling back to the default title/subtitle otherwise. (`packages/application-components/src/components/internals/page-header.tsx`)
* Added an optional `customTitleRow` prop to the `InfoModalPage` component, and passed it through to the underlying `PageHeader`. (`packages/application-components/src/components/modal-pages/info-modal-page/info-modal-page.tsx`) [[1]](diffhunk://#diff-1aa64e2cacf5b45235441e6f7d51047af641eedaef6befc47708007eb080d8f8R42-R45) [[2]](diffhunk://#diff-1aa64e2cacf5b45235441e6f7d51047af641eedaef6befc47708007eb080d8f8R63)