### PR TITLE
chore(codeowners): change ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,5 @@
-# BOTS (default)
-* @commercetools/bots-team-engineers
-
-# First Contact
-/packages/application-components/src/components/detail-pages/ @commercetools/craft-team-fe
-/packages/application-components/src/components/dialogs/ @commercetools/craft-team-fe
-/packages/application-components/src/components/drawer/ @commercetools/craft-team-fe
-/packages/application-components/src/components/internals/ @commercetools/craft-team-fe
-/packages/application-components/src/components/main-pages/ @commercetools/craft-team-fe
-/packages/application-components/src/components/maintenance-page-layout/ @commercetools/craft-team-fe
-/packages/application-components/src/components/modal-pages/ @commercetools/craft-team-fe
-/packages/application-components/src/components/page-content-containers/ @commercetools/craft-team-fe
-/packages/application-components/src/components/portals-container/ @commercetools/craft-team-fe
-/packages/application-components/src/components/project-stamp/ @commercetools/craft-team-fe
-/packages/application-components/src/components/public-page-layout/ @commercetools/craft-team-fe
-/packages/application-components/src/components/tab-header/ @commercetools/craft-team-fe
-/visual-testing-app/ @commercetools/craft-team-fe
-/website/ @commercetools/craft-team-fe
-/packages/react-notifications/ @commercetools/craft-team-fe
+# Craft (default)
+* @commercetools/craft-team-fe
 
 # Hooks
 /packages/application-components/src/hooks/ @commercetools/bots-team-engineers @commercetools/craft-team-fe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Craft (default)
 * @commercetools/craft-team-fe
-
-# Hooks
-/packages/application-components/src/hooks/ @commercetools/bots-team-engineers @commercetools/craft-team-fe


### PR DESCRIPTION
#### Summary
This pull request updates the `.github/CODEOWNERS` file to assign the Craft team as the new default code owners, replacing the Bots team and removing several explicit path assignments to the Craft team. The main effect is to simplify ownership and ensure the Craft team is responsible for the majority of the codebase by default.

Ownership updates:

* Changed the default code owners from `@commercetools/bots-team-engineers` to `@commercetools/craft-team-fe`, and removed explicit path-based assignments to the Craft team, consolidating ownership under a single default rule.

_Note: Along with this change, the #design-system-technical Slack channel was subscribed to `issues` for this repo._