### PR TITLE
Craft fld skip percy checks for renovate [skip percy]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
   "separateMajorMinor": true,
+  "prTitle": "Renovate: {{depName}} is updating from {{currentVersion}} to {{newVersion}} [skip percy]",
   "packageRules": [
     {
       "packagePatterns": ["*"],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,8 @@ jobs:
         uses: ./.github/actions/ci
 
       - name: Building Visual Regression Tests application for UI components
+      # This step is skipped if the event is a pull request, and the title contains "[skip percy]"
+        if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
         run: pnpm visual-testing-app:build
 
       # Explicitly install the Chrome binary in case it's not available yet.
@@ -78,6 +80,8 @@ jobs:
           PUPPETEER_DOWNLOAD_BASE_URL: https://storage.googleapis.com/chrome-for-testing-public
 
       - name: Running Visual Regression Tests for UI components
+      # This step is skipped if the event is a pull request, and the title contains "[skip percy]"
+        if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
         run: pnpm vrt:components
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_UI_COMPONENTS }}


### PR DESCRIPTION
#### Summary

This pull request allows Renovate PRs to skip visual regression tests using a special PR title, and ensures that visual regression steps are conditionally executed in the workflow.

**CI/CD and Workflow Improvements:**

* Updated the GitHub Actions workflow (`main.yml`) to skip the "Building Visual Regression Tests application for UI components" and "Running Visual Regression Tests for UI components" steps if a pull request title contains "[skip percy]", preventing unnecessary visual test runs for certain automated PRs [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R71-R72) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R83-R84).

* Modified the Renovate configuration (`renovate.json`) to add "[skip percy]" to the PR title when dependencies are updated, enabling automated PRs to bypass visual regression tests.

