### PR TITLE
feat(cypress): define configurable timeouts for login command interactions

### DIFF
--- a/.changeset/six-parents-invent.md
+++ b/.changeset/six-parents-invent.md
@@ -1,0 +1,14 @@
+---
+'@commercetools-frontend/cypress': minor
+---
+
+Allow to configure timeouts for the login command interactions.
+
+```ts
+cy.loginToMerchantCenter({
+  // ...
+  timeouts: {
+    waitForPasswordInput: 10000,
+  },
+});
+```

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -260,20 +260,23 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                   args: {
                     userCredentials,
                     identityUrl,
+                    timeouts: commandOptions.timeouts,
                   },
                 },
                 ({
                   userCredentials,
                   identityUrl,
+                  timeouts,
                 }: {
                   userCredentials: LoginCredentials;
                   identityUrl: string;
+                  timeouts?: LoginCommandTimeouts;
                 }) => {
                   cy.url().should('include', `${identityUrl}/login`);
                   // Fill in the email and click Next
                   cy.get('input[name="identifier"]', {
                     timeout:
-                      commandOptions.timeouts?.waitForEmailInput ??
+                      timeouts?.waitForEmailInput ??
                       defaultTimeouts.waitForEmailInput,
                   }).type(userCredentials.email);
                   cy.get('button').contains('Next').click();
@@ -281,7 +284,7 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                   // Wait for the password form to appear
                   cy.get('input[name="password"]', {
                     timeout:
-                      commandOptions.timeouts?.waitForPasswordInput ??
+                      timeouts?.waitForPasswordInput ??
                       defaultTimeouts.waitForPasswordInput,
                   }).should('be.visible');
                   // Fill in the password and submit
@@ -307,14 +310,17 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                   args: {
                     userCredentials,
                     mcUrl,
+                    timeouts: commandOptions.timeouts,
                   },
                 },
                 ({
                   userCredentials,
                   mcUrl,
+                  timeouts,
                 }: {
                   userCredentials: LoginCredentials;
                   mcUrl: string;
+                  timeouts?: LoginCommandTimeouts;
                 }) => {
                   cy.url().should('include', `${mcUrl}/login`);
 
@@ -322,7 +328,7 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                   // eslint-disable-next-line cypress/unsafe-to-chain-command
                   cy.get('input[name=email]', {
                     timeout:
-                      commandOptions.timeouts?.waitForEmailInput ??
+                      timeouts?.waitForEmailInput ??
                       defaultTimeouts.waitForEmailInput,
                   })
                     // We use `force` as the MC login UI (production) in tests renders the
@@ -333,7 +339,7 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                   // eslint-disable-next-line cypress/unsafe-to-chain-command
                   cy.get('input[name=password]', {
                     timeout:
-                      commandOptions.timeouts?.waitForPasswordInput ??
+                      timeouts?.waitForPasswordInput ??
                       defaultTimeouts.waitForPasswordInput,
                   })
                     // We use `force` as the MC login UI (production) in tests renders the

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -261,16 +261,19 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                     userCredentials,
                     identityUrl,
                     timeouts: commandOptions.timeouts,
+                    defaultTimeouts,
                   },
                 },
                 ({
                   userCredentials,
                   identityUrl,
                   timeouts,
+                  defaultTimeouts,
                 }: {
                   userCredentials: LoginCredentials;
                   identityUrl: string;
                   timeouts?: LoginCommandTimeouts;
+                  defaultTimeouts: LoginCommandTimeouts;
                 }) => {
                   cy.url().should('include', `${identityUrl}/login`);
                   // Fill in the email and click Next
@@ -311,16 +314,19 @@ function loginByForm(commandOptions: CommandLoginOptions) {
                     userCredentials,
                     mcUrl,
                     timeouts: commandOptions.timeouts,
+                    defaultTimeouts,
                   },
                 },
                 ({
                   userCredentials,
                   mcUrl,
                   timeouts,
+                  defaultTimeouts,
                 }: {
                   userCredentials: LoginCredentials;
                   mcUrl: string;
                   timeouts?: LoginCommandTimeouts;
+                  defaultTimeouts: LoginCommandTimeouts;
                 }) => {
                   cy.url().should('include', `${mcUrl}/login`);
 

--- a/packages/cypress/src/add-commands/login.ts
+++ b/packages/cypress/src/add-commands/login.ts
@@ -95,6 +95,7 @@ export type LoginToMerchantCenterForCustomViewCommandLoginOptions = Omit<
 export type CommandLoginByOidcOptions = CommandLoginOptions;
 
 const defaultTimeouts: LoginCommandTimeouts = {
+  waitForEmailInput: 4000,
   waitForPasswordInput: 8000,
 };
 


### PR DESCRIPTION
By default the `cy.get` command waits for 4s. In Identity, the login is a 2-step flow and the loading of the second step might take a bit longer.

The PR adds a new command option `timeouts` to allow to configure timeouts for the login command interactions.

Options:
* `waitForEmailInput` (defaults to `4000`)
* `waitForPasswordInput` (defaults to `8000`)

Example:
```ts
cy.loginToMerchantCenter({
  // ...
  timeouts: {
    waitForPasswordInput: 10000,
  },
});
```




