### PR TITLE
fix(renovate): set renovate to never rebase

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
   "separateMajorMinor": true,
+  "rebaseWhen": "never",
   "packageRules": [
     {
       "packagePatterns": ["*"],


### PR DESCRIPTION
#### Summary

This pull request prevents automatic rebasing of dependency update pull requests by setting the `rebaseWhen` option to "never".
