### PR TITLE
Accept an env var for the MC project key in the login command

### DIFF
--- a/.changeset/small-balloons-film.md
+++ b/.changeset/small-balloons-film.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/mc-scripts': minor
+---
+
+Allow the `login` command to read the optional `projectKey` from an env variable (`CTP_PROJECT_KEY`).
+
+This is an internal experimental feature that might be removed in the future without notice.

--- a/packages/mc-scripts/src/commands/login.ts
+++ b/packages/mc-scripts/src/commands/login.ts
@@ -91,8 +91,7 @@ async function run() {
     const scopes = ['openid'];
     if (projectKey) {
       scopes.push(`project_key:${projectKey}`);
-      scopes.push(`view_project_settings:${projectKey}`);
-      scopes.push(`manage_project:${projectKey}`);
+      scopes.push('view:view_project_settings');
     }
 
     const authUrl = new URL('/login/authorize', mcApiUrl);


### PR DESCRIPTION
### Summary

Accept an env var for the MC project key in the login command

### Description

For some internal use cases we need to use this command outside of a Custom Application and we need to be able to get a token bound to a project.
In this PR we're introducing the ability to read an env var (`CTP_PROJECT_KEY`) to get that value within the command.

This won't be documented as we don't know yet if this would be temporary or permanent.
