### PR TITLE
CRAFT 1756 | allow `media-src` CSP in `custom-application-config.mjs` and `custom-view-config.mjs`

### DIFF
--- a/.changeset/metal-mirrors-occur.md
+++ b/.changeset/metal-mirrors-occur.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Enable configuration of `media-src` content security policy in `headers.csp['media-src']` field of `custom-application-config.mjs` and `custom-view-config.mjs`

--- a/packages/application-config/custom-application.schema.json
+++ b/packages/application-config/custom-application.schema.json
@@ -168,6 +168,9 @@
             },
             "frame-src": {
               "$ref": "#/definitions/cspDirective"
+            },
+            "media-src": {
+              "$ref": "#/definitions/cspDirective"
             }
           },
           "additionalProperties": false,

--- a/packages/application-config/custom-view.schema.json
+++ b/packages/application-config/custom-view.schema.json
@@ -168,6 +168,9 @@
             },
             "frame-src": {
               "$ref": "#/definitions/cspDirective"
+            },
+            "media-src": {
+              "$ref": "#/definitions/cspDirective"
             }
           },
           "additionalProperties": false,

--- a/packages/application-config/src/schemas/generated/custom-application.schema.ts
+++ b/packages/application-config/src/schemas/generated/custom-application.schema.ts
@@ -100,6 +100,7 @@ export interface JSONSchemaForCustomApplicationConfigurationFiles {
       'script-src'?: CspDirective;
       'style-src'?: CspDirective;
       'frame-src'?: CspDirective;
+      'media-src'?: CspDirective;
     };
     /**
      * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-application-config#headerspermissionspolicies

--- a/packages/application-config/src/schemas/generated/custom-view.schema.ts
+++ b/packages/application-config/src/schemas/generated/custom-view.schema.ts
@@ -100,6 +100,7 @@ export interface JSONSchemaForCustomViewConfigurationFiles {
       'script-src'?: CspDirective;
       'style-src'?: CspDirective;
       'frame-src'?: CspDirective;
+      'media-src'?: CspDirective;
     };
     /**
      * See https://docs.commercetools.com/merchant-center-customizations/tooling-and-configuration/custom-view-config#headerspermissionspolicies


### PR DESCRIPTION
#### Summary

Updates `packages/application-config/custom-application.schema.json` and `packages/application-config/custom-view.schema.json` to allow configuring a `media-src` CSP.

#### Description

In response to [this support ticket](https://commercetools.atlassian.net/browse/SUPPORT-35141).

Available CSP's in `custom-app-config` on `main` (no `media-src`):
<img width="608" height="258" alt="Screenshot 2025-09-12 at 12 27 24 PM" src="https://github.com/user-attachments/assets/6221b6aa-ccdc-448b-b406-51d64f602fd5" />

Available CSP's in `custom-app-config` on this branch (has `media-src`):
<img width="710" height="288" alt="Screenshot 2025-09-12 at 12 26 13 PM" src="https://github.com/user-attachments/assets/ded1a8b2-4880-47a6-aca2-508bf2dacaf6" />

