### PR TITLE
chore(appkit): 

### DIFF
--- a/application-templates/starter/package.json
+++ b/application-templates/starter/package.json
@@ -84,9 +84,9 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-intl": "^7.1.4",
-    "react-redux": "7.2.9",
+    "react-redux": "9.2.0",
     "react-router-dom": "5.3.4",
-    "redux": "4.2.1"
+    "redux": "5.0.1"
   },
   "resolutions": {
     "@emotion/react": "^11.14.0",

--- a/packages/actions-global/package.json
+++ b/packages/actions-global/package.json
@@ -28,18 +28,18 @@
     "@types/react": "^19.0.3",
     "@types/react-redux": "^7.1.26",
     "lodash": "4.17.21",
-    "redux-thunk": "2.4.2"
+    "redux-thunk": "3.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "jest": "29.7.0",
     "react": "19.0.0",
-    "react-redux": "7.2.9",
-    "redux": "4.2.1"
+    "react-redux": "9.2.0",
+    "redux": "5.0.1"
   },
   "peerDependencies": {
     "react": "19.x",
-    "react-redux": "7.x",
-    "redux": "4.x"
+    "react-redux": "7.x || 9.x",
+    "redux": "4.x || 5.x"
   }
 }

--- a/packages/actions-global/src/hooks/use-on-action-error.ts
+++ b/packages/actions-global/src/hooks/use-on-action-error.ts
@@ -6,7 +6,10 @@ import handleActionError from '../actions/handle-action-error';
 export default function useOnActionError() {
   const dispatch = useDispatch();
   return useCallback(
-    (error: ActionError) => dispatch(handleActionError(error)),
+    (error: ActionError) =>
+      dispatch(
+        handleActionError(error) as unknown as Parameters<typeof dispatch>[0]
+      ),
     [dispatch]
   );
 }

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -68,7 +68,7 @@
     "@flopflip/memory-adapter": "15.1.2",
     "@flopflip/react-broadcast": "15.1.2",
     "@flopflip/types": "15.1.2",
-    "@reduxjs/toolkit": "1.9.7",
+    "@reduxjs/toolkit": "2.9.0",
     "@types/common-tags": "^1.8.2",
     "@types/history": "^4.7.11",
     "@types/lodash": "^4.14.198",
@@ -99,7 +99,7 @@
     "react-required-if": "1.0.3",
     "react-select": "5.10.2",
     "redux-logger": "3.0.6",
-    "redux-thunk": "2.4.2",
+    "redux-thunk": "3.1.0",
     "tiny-invariant": "1.3.3",
     "unfetch": "4.2.0",
     "uuid": "9.0.1"
@@ -115,9 +115,9 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-intl": "^7.1.4",
-    "react-redux": "7.2.9",
+    "react-redux": "9.2.0",
     "react-router-dom": "5.3.4",
-    "redux": "4.2.1"
+    "redux": "5.0.1"
   },
   "peerDependencies": {
     "@apollo/client": "3.x",
@@ -125,9 +125,9 @@
     "react": "19.x",
     "react-dom": "19.x",
     "react-intl": "7.x",
-    "react-redux": "7.x",
+    "react-redux": "7.x || 9.x",
     "react-router-dom": "5.x",
-    "redux": "4.x"
+    "redux": "4.x || 5.x"
   },
   "engines": {
     "node": "18.x || 20.x || >=22.0.0"

--- a/packages/application-shell/src/configure-store.ts
+++ b/packages/application-shell/src/configure-store.ts
@@ -9,7 +9,7 @@ import {
 } from '@reduxjs/toolkit';
 import mapValues from 'lodash/mapValues';
 import omitEmpty from 'omit-empty-es';
-import thunk from 'redux-thunk';
+import { thunk } from 'redux-thunk';
 import {
   getCorrelationId,
   selectProjectKeyFromUrl,

--- a/packages/application-shell/src/configure-store.ts
+++ b/packages/application-shell/src/configure-store.ts
@@ -1,7 +1,6 @@
 import {
   configureStore,
   combineReducers,
-  applyMiddleware,
   type ReducersMapObject,
   type Store,
   type Middleware,
@@ -9,6 +8,7 @@ import {
 } from '@reduxjs/toolkit';
 import mapValues from 'lodash/mapValues';
 import omitEmpty from 'omit-empty-es';
+import { applyMiddleware } from 'redux';
 import { thunk } from 'redux-thunk';
 import {
   getCorrelationId,
@@ -35,7 +35,7 @@ import loggerMiddleware from './middleware/logger';
 interface ApplicationWindowWithDevtools extends ApplicationWindow {
   __REDUX_DEVTOOLS_EXTENSION__: (config?: {
     actionsBlacklist: string[];
-  }) => StoreEnhancer<unknown, {}>;
+  }) => StoreEnhancer;
 }
 declare let window: ApplicationWindowWithDevtools;
 
@@ -97,8 +97,8 @@ const createInternalReducer = (
   );
 
   // NOTE: since we don't know in advance which reducers will be injected,
-  // we pass an `unknown` type to express this uncertainty and make the compiler happy.
-  return combineReducers<unknown>({
+  // we let TypeScript infer the type from the reducer map.
+  return combineReducers({
     requestsInFlight: requestsInFlightReducer,
     notifications: notificationsReducer,
     ...injectedReducers,
@@ -119,12 +119,8 @@ export const createReduxStore = (
     devTools: {
       actionsDenylist: [SHOW_LOADING, HIDE_LOADING],
     },
-    middleware: (getDefaultMiddleware) => [
-      ...additionalMiddlewares,
-      hideNotificationsMiddleware,
-      notificationsMiddleware,
-      sdkMiddleware,
-      ...getDefaultMiddleware({
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
         // https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data
         serializableCheck: false,
         // This default check is logging warnings to console for some MC FE tests, probably
@@ -133,9 +129,12 @@ export const createReduxStore = (
         // to turn it off.
         // https://redux-toolkit.js.org/api/immutabilityMiddleware
         immutableCheck: false,
-      }),
-      loggerMiddleware,
-    ],
+      })
+        .prepend(sdkMiddleware as Middleware)
+        .prepend(notificationsMiddleware as Middleware)
+        .prepend(hideNotificationsMiddleware as Middleware)
+        .prepend(...(additionalMiddlewares as Middleware[]))
+        .concat(loggerMiddleware as Middleware),
   });
 
   const enhancedStore = store as TEnhancedStore;

--- a/packages/application-shell/src/test-utils/test-utils.spec.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.spec.tsx
@@ -481,7 +481,9 @@ describe('renderAppWithRedux', () => {
   it('should be able to use storeState render option', () => {
     const TestComponent = () => {
       const store = useStore();
-      const state = store.getState();
+      const state = store.getState() as unknown as {
+        products: { currentVisible: { id: string } };
+      };
       return state.products.currentVisible.id;
     };
     renderAppWithRedux(

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -19,6 +19,7 @@ import { createMemoryHistory } from 'history';
 import { IntlProvider } from 'react-intl';
 import { Provider as StoreProvider } from 'react-redux';
 import { Router } from 'react-router-dom';
+import type { Middleware } from 'redux';
 import invariant from 'tiny-invariant';
 import { entryPointUriPathToPermissionKeys } from '@commercetools-frontend/application-config/ssr';
 import {
@@ -520,7 +521,9 @@ function createReduxProviders<
     if (sdkMocks.length === 0) return createReduxStore(storeState);
 
     const testingMiddleware = createSdkTestMiddleware(sdkMocks);
-    return createReduxStore(storeState, [testingMiddleware]);
+    return createReduxStore(storeState, [
+      testingMiddleware as unknown as Middleware,
+    ]);
   })();
 
   const ReduxProviders = (props: { children: ReactNode }) => (

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -22,9 +22,9 @@
     "@babel/runtime-corejs3": "^7.22.15"
   },
   "devDependencies": {
-    "redux": "4.2.1"
+    "redux": "5.0.1"
   },
   "peerDependencies": {
-    "redux": "4.x"
+    "redux": "4.x || 5.x"
   }
 }

--- a/packages/notifications/src/notifications.spec.ts
+++ b/packages/notifications/src/notifications.spec.ts
@@ -17,9 +17,15 @@ describe('dispatching add/remove notification actions', () => {
     const store = createStore<
       TNotificationState<FooNotification>,
       TNotificationAction<FooNotification>,
-      unknown,
-      unknown
-    >(reducer, undefined, applyMiddleware(middleware));
+      {},
+      {}
+    >(
+      reducer,
+      undefined,
+      applyMiddleware(
+        middleware as unknown as Parameters<typeof applyMiddleware>[0]
+      )
+    );
     expect(store.getState()).toEqual([]);
     const action = addNotification(notification, {
       dismissAfter: 100,
@@ -38,9 +44,15 @@ describe('dispatching add/remove notification actions', () => {
     const store = createStore<
       TNotificationState<FooNotification>,
       TNotificationAction<FooNotification>,
-      unknown,
-      unknown
-    >(reducer, undefined, applyMiddleware(middleware));
+      {},
+      {}
+    >(
+      reducer,
+      undefined,
+      applyMiddleware(
+        middleware as unknown as Parameters<typeof applyMiddleware>[0]
+      )
+    );
     expect(store.getState()).toEqual([]);
     const action = addNotification(notification, {
       onDismiss(notificationId) {

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -18,11 +18,13 @@ export interface TAddNotificationAction<Payload extends TNotification>
   payload: Payload;
   meta?: TNotificationMetaOptions;
   dismiss?: () => void;
+  [key: string]: unknown;
 }
 
 export interface TRemoveNotificationAction
   extends Action<typeof REMOVE_NOTIFICATION> {
   payload: TNotification;
+  [key: string]: unknown;
 }
 
 export type TNotificationAction<Payload extends TNotification> =

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -56,14 +56,14 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-intl": "^7.1.4",
-    "react-redux": "7.2.9",
+    "react-redux": "9.2.0",
     "react-router-dom": "5.3.4"
   },
   "peerDependencies": {
     "react": "19.x",
     "react-dom": "19.x",
     "react-intl": "7.x",
-    "react-redux": "7.x",
+    "react-redux": "7.x || 9.x",
     "react-router-dom": "5.x"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -48,13 +48,13 @@
     "jest-mock": "29.7.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-redux": "7.2.9",
-    "redux": "4.2.1",
-    "redux-thunk": "2.4.2"
+    "react-redux": "9.2.0",
+    "redux": "5.0.1",
+    "redux-thunk": "3.1.0"
   },
   "peerDependencies": {
     "react": "19.x",
-    "react-redux": "7.x",
-    "redux": "4.x"
+    "react-redux": "7.x || 9.x",
+    "redux": "4.x || 5.x"
   }
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -37,10 +37,12 @@ export type TSdkActionPayload =
 export type TSdkActionGetForUri = {
   type: 'SDK';
   payload: TSdkActionPayloadForUri & TSdkActionPayloadMethod<'GET'>;
+  [key: string]: unknown;
 };
 export type TSdkActionGetForService = {
   type: 'SDK';
   payload: TSdkActionPayloadForService & TSdkActionPayloadMethod<'GET'>;
+  [key: string]: unknown;
 };
 export type TSdkActionGet = TSdkActionGetForUri | TSdkActionGetForService;
 
@@ -49,22 +51,26 @@ export type TSdkActionPostForUri = {
   payload: TSdkActionPayloadForUri &
     TSdkActionPayloadMethod<'POST'> &
     TSdkActionPayloadBody;
+  [key: string]: unknown;
 };
 export type TSdkActionPostForService = {
   type: 'SDK';
   payload: TSdkActionPayloadForService &
     TSdkActionPayloadMethod<'POST'> &
     TSdkActionPayloadBody;
+  [key: string]: unknown;
 };
 export type TSdkActionPost = TSdkActionPostForUri | TSdkActionPostForService;
 
 export type TSdkActionDeleteForUri = {
   type: 'SDK';
   payload: TSdkActionPayloadForUri & TSdkActionPayloadMethod<'DELETE'>;
+  [key: string]: unknown;
 };
 export type TSdkActionDeleteForService = {
   type: 'SDK';
   payload: TSdkActionPayloadForService & TSdkActionPayloadMethod<'DELETE'>;
+  [key: string]: unknown;
 };
 export type TSdkActionDelete =
   | TSdkActionDeleteForUri
@@ -73,10 +79,12 @@ export type TSdkActionDelete =
 export type TSdkActionHeadForUri = {
   type: 'SDK';
   payload: TSdkActionPayloadForUri & TSdkActionPayloadMethod<'HEAD'>;
+  [key: string]: unknown;
 };
 export type TSdkActionHeadForService = {
   type: 'SDK';
   payload: TSdkActionPayloadForService & TSdkActionPayloadMethod<'HEAD'>;
+  [key: string]: unknown;
 };
 export type TSdkActionHead = TSdkActionHeadForUri | TSdkActionHeadForService;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,14 +495,14 @@ importers:
         specifier: ^7.1.4
         version: 7.1.11(react@19.0.0)(typescript@5.9.2)
       react-redux:
-        specifier: 7.2.9
-        version: 7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 9.2.0
+        version: 9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1)
       react-router-dom:
         specifier: 5.3.4
         version: 5.3.4(react@19.0.0)
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
 
   application-templates/starter-typescript:
     dependencies:
@@ -1305,8 +1305,8 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
       redux-thunk:
-        specifier: 2.4.2
-        version: 2.4.2(redux@4.2.1)
+        specifier: 3.1.0
+        version: 3.1.0(redux@5.0.1)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1318,11 +1318,11 @@ importers:
         specifier: 19.0.0
         version: 19.0.0
       react-redux:
-        specifier: 7.2.9
-        version: 7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 9.2.0
+        version: 9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1)
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
 
   packages/application-components:
     dependencies:
@@ -1674,8 +1674,8 @@ importers:
         specifier: 15.1.2
         version: 15.1.2(typescript@5.9.2)
       '@reduxjs/toolkit':
-        specifier: 1.9.7
-        version: 1.9.7(react-redux@7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        specifier: 2.9.0
+        version: 2.9.0(react-redux@9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
       '@types/common-tags':
         specifier: ^1.8.2
         version: 1.8.2
@@ -1767,8 +1767,8 @@ importers:
         specifier: 3.0.6
         version: 3.0.6
       redux-thunk:
-        specifier: 2.4.2
-        version: 2.4.2(redux@4.2.1)
+        specifier: 3.1.0
+        version: 3.1.0(redux@5.0.1)
       tiny-invariant:
         specifier: 1.3.3
         version: 1.3.3
@@ -1810,14 +1810,14 @@ importers:
         specifier: ^7.1.4
         version: 7.1.11(react@19.0.0)(typescript@5.9.2)
       react-redux:
-        specifier: 7.2.9
-        version: 7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 9.2.0
+        version: 9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1)
       react-router-dom:
         specifier: 5.3.4
         version: 5.3.4(react@19.0.0)
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
 
   packages/application-shell-connectors:
     dependencies:
@@ -2789,8 +2789,8 @@ importers:
         version: 7.26.10
     devDependencies:
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
 
   packages/permissions:
     dependencies:
@@ -2959,8 +2959,8 @@ importers:
         specifier: ^7.1.4
         version: 7.1.11(react@19.0.0)(typescript@5.9.2)
       react-redux:
-        specifier: 7.2.9
-        version: 7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 9.2.0
+        version: 9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1)
       react-router-dom:
         specifier: 5.3.4
         version: 5.3.4(react@19.0.0)
@@ -3044,14 +3044,14 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
       react-redux:
-        specifier: 7.2.9
-        version: 7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 9.2.0
+        version: 9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1)
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
       redux-thunk:
-        specifier: 2.4.2
-        version: 2.4.2(redux@4.2.1)
+        specifier: 3.1.0
+        version: 3.1.0(redux@5.0.1)
 
   packages/sentry:
     dependencies:
@@ -6449,11 +6449,11 @@ packages:
     peerDependencies:
       react: 19.0.0
 
-  '@reduxjs/toolkit@1.9.7':
-    resolution: {integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==}
+  '@reduxjs/toolkit@2.9.0':
+    resolution: {integrity: sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==}
     peerDependencies:
       react: 19.0.0
-      react-redux: ^7.2.1 || ^8.0.2
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -6730,6 +6730,12 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@svgr/babel-plugin-add-jsx-attribute@6.5.1':
     resolution: {integrity: sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==}
@@ -10541,6 +10547,9 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
+  immer@10.1.3:
+    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
+
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
 
@@ -13300,10 +13309,10 @@ packages:
   redux-logger@3.0.6:
     resolution: {integrity: sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==}
 
-  redux-thunk@2.4.2:
-    resolution: {integrity: sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==}
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
-      redux: ^4
+      redux: ^5.0.0
 
   redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
@@ -13431,6 +13440,9 @@ packages:
 
   reselect@4.1.8:
     resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -20245,15 +20257,17 @@ snapshots:
       '@react-hook/passive-layout-effect': 1.2.1(react@19.0.0)
       react: 19.0.0
 
-  '@reduxjs/toolkit@1.9.7(react-redux@7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@reduxjs/toolkit@2.9.0(react-redux@9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1))(react@19.0.0)':
     dependencies:
-      immer: 9.0.21
-      redux: 4.2.1
-      redux-thunk: 2.4.2(redux@4.2.1)
-      reselect: 4.1.8
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      immer: 10.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
     optionalDependencies:
       react: 19.0.0
-      react-redux: 7.2.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-redux: 9.2.0(@types/react@19.1.3)(react@19.0.0)(redux@5.0.1)
 
   '@remix-run/node@1.4.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -20538,6 +20552,10 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.0
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.28.4)':
     dependencies:
@@ -25049,6 +25067,8 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  immer@10.1.3: {}
+
   immer@9.0.21: {}
 
   immutable@3.7.6: {}
@@ -28193,9 +28213,9 @@ snapshots:
     dependencies:
       deep-diff: 0.3.8
 
-  redux-thunk@2.4.2(redux@4.2.1):
+  redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
-      redux: 4.2.1
+      redux: 5.0.1
 
   redux@4.2.1:
     dependencies:
@@ -28342,6 +28362,8 @@ snapshots:
   requires-port@1.0.0: {}
 
   reselect@4.1.8: {}
+
+  reselect@5.1.1: {}
 
   resolve-cwd@3.0.0:
     dependencies:


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary

This PR does a few things:
1. Updates peer dependencies for packages to include redux 9.x and react-redux 5.x
2. Updates redux-centric packages.

Once released, the starter template's dependencies _should_ be able to be installed via npm rather than yarn or pnpm.