### PR TITLE
fix(mc-scripts): allow setToken to write credentials when MC_ACCESS_TOKEN is set

### DIFF
--- a/.changeset/fix-settoken-env-guard.md
+++ b/.changeset/fix-settoken-env-guard.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix `setToken` silently discarding credentials when `MC_ACCESS_TOKEN` environment variable is set. Previously, running `mc-scripts login --force` with the env var set would complete successfully but not persist the token. The env var guard is now removed from `setToken`, and file creation logic is extracted so `setToken` works regardless of whether the credentials file already exists.

--- a/packages/mc-scripts/src/utils/credentials-storage.spec.ts
+++ b/packages/mc-scripts/src/utils/credentials-storage.spec.ts
@@ -61,6 +61,32 @@ describe('when session is expired', () => {
   });
 });
 
+describe('when MC_ACCESS_TOKEN is set and login --force is used', () => {
+  beforeEach(() => {
+    process.env.MC_ACCESS_TOKEN = 'ci-token';
+    // No credentials file exists (CI environment)
+    vol.fromJSON({});
+    mocked(os.homedir).mockImplementation(() => testHomedir);
+  });
+
+  afterEach(() => {
+    delete process.env.MC_ACCESS_TOKEN;
+  });
+
+  it('should write the token to the credentials file', () => {
+    const credentialsStorage = new CredentialsStorage();
+    const newSessionData = {
+      token: 'login-token',
+      expiresAt: Math.floor(Date.now() / 1000) + 60 * 60 * 36,
+    };
+    credentialsStorage.setToken(mcApiUrl, newSessionData);
+
+    // Clear env var and verify the token was persisted
+    delete process.env.MC_ACCESS_TOKEN;
+    expect(credentialsStorage.getToken(mcApiUrl)).toBe('login-token');
+  });
+});
+
 describe('when credentials file is missing', () => {
   beforeEach(() => {
     vol.fromJSON({});

--- a/packages/mc-scripts/src/utils/credentials-storage.ts
+++ b/packages/mc-scripts/src/utils/credentials-storage.ts
@@ -22,12 +22,15 @@ class CredentialsStorage {
     );
 
     // Ensure the credentials file is present (skip if using env var token)
-    if (
-      !process.env[MC_ACCESS_TOKEN_ENV_VAR] &&
-      !doesFileExist(this.credentialsFilePath)
-    ) {
+    if (!process.env[MC_ACCESS_TOKEN_ENV_VAR]) {
+      this._ensureCredentialsFileExists();
+    }
+  }
+
+  _ensureCredentialsFileExists() {
+    if (!doesFileExist(this.credentialsFilePath)) {
+      const credentialsFolderPath = path.dirname(this.credentialsFilePath);
       fs.mkdirSync(credentialsFolderPath, { recursive: true });
-      // Initialize with an empty object
       this._writeCredentials();
     }
   }
@@ -62,10 +65,7 @@ class CredentialsStorage {
   }
 
   setToken(environmentKey: string, credentials: TMcCliAuthToken) {
-    // Don't write credentials if using env var token
-    if (process.env[MC_ACCESS_TOKEN_ENV_VAR]) {
-      return;
-    }
+    this._ensureCredentialsFileExists();
     const allCredentials = this._loadCredentials();
     allCredentials[environmentKey] = credentials;
     this._writeCredentials(allCredentials);


### PR DESCRIPTION
## Summary
- Remove the `MC_ACCESS_TOKEN` env var guard from `setToken` so credentials are persisted even when the env var is set (e.g. `mc-scripts login --force` in a CI-like environment)
- Extract file-creation logic into `_ensureCredentialsFileExists` so `setToken` works regardless of whether the constructor created the credentials file
- Add test covering the `MC_ACCESS_TOKEN` + `setToken` scenario

## Test plan
- [x] New test: `setToken` persists token when `MC_ACCESS_TOKEN` is set and no credentials file exists
- [x] Existing tests pass (valid session, expired session, missing credentials file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)