### PR TITLE
ci(release): replace dotansimha fork with upstream changesets/action + aggregate release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -67,18 +67,54 @@ jobs:
 
       - name: Creating release pull request or publishing release to npm registry
         id: changesets
-        # uses: changesets/action@v1.3.0
-        uses: dotansimha/changesets-action@v1.5.2
+        uses: changesets/action@v1.7.0
         with:
           publish: pnpm changeset publish
           version: pnpm changeset:version-and-format
           commit: "ci(changesets): version packages"
-          createGithubReleases: aggregate
-          githubReleaseName: v${{ steps.release_version.outputs.VALUE }}
-          githubTagName: v${{ steps.release_version.outputs.VALUE }}
+          createGithubReleases: false
+          commitMode: "github-api"
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           SKIP_POSTINSTALL_DEV_SETUP: true
+
+      - name: Create aggregate GitHub release
+        if: steps.changesets.outputs.published == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.release_version.outputs.VALUE }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          tag="v${RELEASE_VERSION}"
+          body_file=$(mktemp)
+          map_file=$(mktemp)
+          while IFS= read -r pkg_json; do
+            name=$(jq -r '.name // empty' "$pkg_json" 2>/dev/null || true)
+            if [ -n "$name" ]; then
+              printf '%s\t%s\n' "$name" "$(dirname "$pkg_json")" >> "$map_file"
+            fi
+          done < <(find . -name package.json -not -path '*/node_modules/*' -type f)
+          while IFS= read -r pkg; do
+            name=$(echo "$pkg" | jq -r '.name')
+            version=$(echo "$pkg" | jq -r '.version')
+            path=$(awk -F'\t' -v n="$name" '$1 == n { print $2; exit }' "$map_file")
+            section=""
+            if [ -n "$path" ] && [ -f "$path/CHANGELOG.md" ]; then
+              section=$(awk -v v="$version" '
+                /^## / {
+                  if (in_section) exit
+                  h = $0; sub(/^## /, "", h)
+                  if (h == v) in_section = 1
+                  next
+                }
+                in_section { print }
+              ' "$path/CHANGELOG.md")
+            fi
+            printf '## %s@%s\n\n%s\n\n' "$name" "$version" "$section" >> "$body_file"
+          done < <(echo "$PUBLISHED_PACKAGES" | jq -c '.[]')
+          gh release create "$tag" --title "$tag" --notes-file "$body_file"
 
       # Publish canary releases only if the packages weren't published already
       - name: Publishing canary releases to npm registry

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -80,41 +80,11 @@ jobs:
 
       - name: Create aggregate GitHub release
         if: steps.changesets.outputs.published == 'true'
-        shell: bash
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           RELEASE_VERSION: ${{ steps.release_version.outputs.VALUE }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        run: |
-          set -euo pipefail
-          tag="v${RELEASE_VERSION}"
-          body_file=$(mktemp)
-          map_file=$(mktemp)
-          while IFS= read -r pkg_json; do
-            name=$(jq -r '.name // empty' "$pkg_json" 2>/dev/null || true)
-            if [ -n "$name" ]; then
-              printf '%s\t%s\n' "$name" "$(dirname "$pkg_json")" >> "$map_file"
-            fi
-          done < <(find . -name package.json -not -path '*/node_modules/*' -type f)
-          while IFS= read -r pkg; do
-            name=$(echo "$pkg" | jq -r '.name')
-            version=$(echo "$pkg" | jq -r '.version')
-            path=$(awk -F'\t' -v n="$name" '$1 == n { print $2; exit }' "$map_file")
-            section=""
-            if [ -n "$path" ] && [ -f "$path/CHANGELOG.md" ]; then
-              section=$(awk -v v="$version" '
-                /^## / {
-                  if (in_section) exit
-                  h = $0; sub(/^## /, "", h)
-                  if (h == v) in_section = 1
-                  next
-                }
-                in_section { print }
-              ' "$path/CHANGELOG.md")
-            fi
-            printf '## %s@%s\n\n%s\n\n' "$name" "$version" "$section" >> "$body_file"
-          done < <(echo "$PUBLISHED_PACKAGES" | jq -c '.[]')
-          gh release create "$tag" --title "$tag" --notes-file "$body_file"
+        run: ./scripts/create-aggregate-github-release.sh
 
       # Publish canary releases only if the packages weren't published already
       - name: Publishing canary releases to npm registry

--- a/scripts/create-aggregate-github-release.sh
+++ b/scripts/create-aggregate-github-release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Create a single aggregate GitHub release from changesets/action's
+# publishedPackages output.
+#
+# Replaces the fork-only `createGithubReleases: aggregate` behavior from
+# dotansimha/changesets-action with an upstream-compatible equivalent.
+#
+# Required env vars:
+#   RELEASE_VERSION     e.g. "27.4.0" — used as the release tag/title (prefixed with "v")
+#   PUBLISHED_PACKAGES  JSON array from steps.changesets.outputs.publishedPackages,
+#                       e.g. '[{"name":"@scope/pkg","version":"1.2.3"}, ...]'
+#   GITHUB_TOKEN        Token with contents:write on the repo (not required when DRY_RUN=true).
+#
+# Optional env vars:
+#   DRY_RUN             If "true", print the assembled release body to stdout
+#                       instead of creating the GitHub release. Used by the
+#                       accompanying .test.sh file.
+
+set -euo pipefail
+
+: "${RELEASE_VERSION:?RELEASE_VERSION is required}"
+: "${PUBLISHED_PACKAGES:?PUBLISHED_PACKAGES is required}"
+if [ "${DRY_RUN:-false}" != "true" ]; then
+  : "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+fi
+
+tag="v${RELEASE_VERSION}"
+body_file=$(mktemp)
+map_file=$(mktemp)
+
+# Build a name -> path map from every workspace package.json.
+while IFS= read -r pkg_json; do
+  name=$(jq -r '.name // empty' "$pkg_json" 2>/dev/null || true)
+  if [ -n "$name" ]; then
+    printf '%s\t%s\n' "$name" "$(dirname "$pkg_json")" >> "$map_file"
+  fi
+done < <(find . -name package.json -not -path '*/node_modules/*' -type f)
+
+# For each published package, extract its CHANGELOG section for the published
+# version and append to the aggregate release body.
+#
+# The awk block skips blank lines before the first content, buffers interior
+# blank lines (flushing them only when followed by real content), and exits on
+# the next `## ` heading — so trailing blanks before the next version don't
+# leak into the output.
+while IFS= read -r pkg; do
+  name=$(echo "$pkg" | jq -r '.name')
+  version=$(echo "$pkg" | jq -r '.version')
+  path=$(awk -F'\t' -v n="$name" '$1 == n { print $2; exit }' "$map_file")
+  section=""
+  if [ -n "$path" ] && [ -f "$path/CHANGELOG.md" ]; then
+    section=$(awk -v v="$version" '
+      /^## / {
+        if (in_section) exit
+        h = $0; sub(/^## /, "", h)
+        if (h == v) in_section = 1
+        next
+      }
+      in_section {
+        if (!started && $0 == "") next
+        started = 1
+        if ($0 == "") { pending = pending "\n"; next }
+        print pending $0
+        pending = ""
+      }
+    ' "$path/CHANGELOG.md")
+  fi
+  printf '## %s@%s\n\n%s\n\n' "$name" "$version" "$section" >> "$body_file"
+done < <(echo "$PUBLISHED_PACKAGES" | jq -c '.[]')
+
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  cat "$body_file"
+  exit 0
+fi
+
+gh release create "$tag" --title "$tag" --notes-file "$body_file"

--- a/scripts/create-aggregate-github-release.test.sh
+++ b/scripts/create-aggregate-github-release.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Tests create-aggregate-github-release.sh against a fake workspace.
+# Run: bash scripts/create-aggregate-github-release.test.sh
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$script_dir/create-aggregate-github-release.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+cd "$test_dir"
+
+mkdir -p packages/pkg-a packages/pkg-b packages/pkg-c
+
+cat > packages/pkg-a/package.json <<'JSON'
+{"name": "@scope/pkg-a", "version": "1.2.3"}
+JSON
+
+cat > packages/pkg-a/CHANGELOG.md <<'MD'
+# @scope/pkg-a
+
+## 1.2.3
+
+### Minor Changes
+
+- [#42](https://example.com/pr/42) Add widget
+
+## 1.2.2
+
+### Patch Changes
+
+- [#41] Old fix
+MD
+
+cat > packages/pkg-b/package.json <<'JSON'
+{"name": "@scope/pkg-b", "version": "0.5.0"}
+JSON
+
+cat > packages/pkg-b/CHANGELOG.md <<'MD'
+# @scope/pkg-b
+
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @scope/pkg-a@1.2.3
+MD
+
+# pkg-c: no CHANGELOG (empty section scenario)
+cat > packages/pkg-c/package.json <<'JSON'
+{"name": "@scope/pkg-c", "version": "0.0.1"}
+JSON
+
+export RELEASE_VERSION="1.2.3"
+export PUBLISHED_PACKAGES='[{"name":"@scope/pkg-a","version":"1.2.3"},{"name":"@scope/pkg-b","version":"0.5.0"},{"name":"@scope/pkg-c","version":"0.0.1"}]'
+export DRY_RUN="true"
+
+actual=$("$script")
+
+expected='## @scope/pkg-a@1.2.3
+
+### Minor Changes
+
+- [#42](https://example.com/pr/42) Add widget
+
+## @scope/pkg-b@0.5.0
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @scope/pkg-a@1.2.3
+
+## @scope/pkg-c@0.0.1'
+
+if [ "$actual" != "$expected" ]; then
+  echo "FAIL: release body differs from expected" >&2
+  diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
+  exit 1
+fi
+
+echo "PASS: create-aggregate-github-release.sh body matches expected"


### PR DESCRIPTION
## Summary

- Swap `dotansimha/changesets-action@v1.5.2` for upstream `changesets/action@v1.7.0`
- Add `commitMode: 'github-api'` to produce signed changeset commits (needed for the org-wide "Require signed commits" ruleset enforced 2026-04-10)
- Set `createGithubReleases: false` since upstream doesn't support the fork's `aggregate` mode
- Add `scripts/create-aggregate-github-release.sh` that rebuilds the single consolidated GitHub release from `steps.changesets.outputs.publishedPackages` + each package's `CHANGELOG.md`
- Add `scripts/create-aggregate-github-release.test.sh` with `DRY_RUN=true` support — verifies the release body format against a fake workspace

Proof of approach: commercetools/nimbus#1380

**Why v1.7.0 specifically** — earlier versions (including v1.5.3) error with `Unexpected executable file at scripts/print_release_version.sh` when any executable files live in the tree. [changesets/action#563](https://github.com/changesets/action/pull/563) ("Don't error on already committed symlinks and executables that stay untouched") lands in v1.7.0.

Closes FEC-828
Parent: FEC-822

## Test plan

- [ ] Local: `bash scripts/create-aggregate-github-release.test.sh` → `PASS`
- [ ] Next changeset release produces a `changeset-release/main` branch whose bot commit shows a green **Verified** badge
- [ ] The published aggregate GitHub release matches the structure of the previous fork-generated releases (one `## @scope/pkg@X.Y.Z` section per published package)
- [ ] Version PR merges without "signed commits required" blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)