### PR TITLE
fix(mc-scripts): resolve Vite bundler chunk cycle crash (FEC-832)

### DIFF
--- a/.changeset/fec-832-vite-chunk-cycle-fix.md
+++ b/.changeset/fec-832-vite-chunk-cycle-fix.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Fix Vite production build crashing at startup with a TDZ `TypeError` (e.g. `"aM is undefined"`) in `@commercetools-uikit/icons` caused by a chunk-level cycle between the `icons` and `app-shell` chunks.
+
+The Vite build no longer passes `output.manualChunks` to Rollup — the declarative form did not claim transitive deps, so shared packages (`@babel/runtime-corejs3`, `@emotion/react`, uikit internals) could land in one chunk that was also imported back from another, producing a runtime cycle on first evaluation. Rollup's default chunking handles co-location correctly. The Webpack build is unchanged.
+
+Adds `vite-plugin-chunk-cycle-check`, a build-time regression guard that fails the build if the emitted chunk graph contains circular imports.

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -102,3 +102,31 @@ runs:
         APP_ID: ${{ inputs.playground-application-id }}
         MC_API_URL: ${{ inputs.mc-api-url }}
         CTP_INITIAL_PROJECT_KEY: ${{ inputs.cypress-project-key }}
+
+    # --- Experimental Vite bundler coverage -------------------------------
+    # The Webpack path is exercised above. The Vite bundler is opt-in via
+    # `ENABLE_EXPERIMENTAL_VITE_BUNDLER=true` and historically had a gap in
+    # CI (FEC-832) — a chunk-level cycle produced a TDZ crash at startup
+    # that no build-time check caught. These two steps close that gap:
+    #
+    #   1. Build the template with the flag set. Overwrites `public/` with
+    #      Vite output; the Webpack Cypress run above has already completed
+    #      so nothing downstream depends on Webpack artifacts.
+    #   2. Serve the Vite build and load the app in a headless browser.
+    #      Any uncaught runtime error (TDZ, missing symbol, circular chunk
+    #      init) fails the job.
+    - name: Building Starter template with experimental Vite bundler
+      shell: bash
+      run: pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:build
+      env:
+        ENABLE_EXPERIMENTAL_VITE_BUNDLER: 'true'
+        CTP_INITIAL_PROJECT_KEY: ${{ inputs.cypress-project-key }}
+
+    - name: Smoke-testing Vite production build (catches runtime chunk cycles)
+      shell: bash
+      run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'node ./scripts/smoke-test-templates.mjs http://127.0.0.1:3001'
+      env:
+        HOST_GCP_STAGING: ${{ inputs.host-gcp-staging }}
+        APP_ID: ${{ inputs.playground-application-id }}
+        MC_API_URL: ${{ inputs.mc-api-url }}
+        CTP_INITIAL_PROJECT_KEY: ${{ inputs.cypress-project-key }}

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -122,6 +122,18 @@ runs:
         ENABLE_EXPERIMENTAL_VITE_BUNDLER: 'true'
         CTP_INITIAL_PROJECT_KEY: ${{ inputs.cypress-project-key }}
 
+    # Explicitly install the Chrome binary in case it's not available yet.
+    # Same workaround as the visual-regression-tests job uses — the CI
+    # composite action's `pnpm install` sets PUPPETEER_DOWNLOAD_BASE_URL but
+    # puppeteer's postinstall doesn't always land Chrome in the cache dir
+    # that `puppeteer.launch()` looks in. See
+    # https://github.com/puppeteer/puppeteer/issues/9533.
+    - name: Installing Chrome via Puppeteer
+      shell: bash
+      run: pnpm -C node_modules/puppeteer run postinstall
+      env:
+        PUPPETEER_DOWNLOAD_BASE_URL: https://storage.googleapis.com/chrome-for-testing-public
+
     - name: Smoke-testing Vite production build (catches runtime chunk cycles)
       shell: bash
       run: pnpm start-server-and-test 'pnpm template-${{ inputs.application-type }}-${{ inputs.template-name }}:start:prod:local' http-get://127.0.0.1:3001 'node ./scripts/smoke-test-templates.mjs http://127.0.0.1:3001'

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -7,9 +7,9 @@ import { build, PluginOption, type Plugin } from 'vite';
 import { analyzer } from 'vite-bundle-analyzer';
 import { packageLocation as applicationStaticAssetsPath } from '@commercetools-frontend/assets';
 import { generateTemplate } from '@commercetools-frontend/mc-html-template';
-import { getViteCacheGroups } from '../config/optimizations';
 import paths from '../config/paths';
 import nonNullable from '../utils/non-nullable';
+import pluginChunkCycleCheck from '../vite-plugins/vite-plugin-chunk-cycle-check';
 import pluginDynamicBaseAssetsGlobals from '../vite-plugins/vite-plugin-dynamic-base-assets-globals';
 import pluginI18nMessageCompilation from '../vite-plugins/vite-plugin-i18n-message-compilation';
 import pluginPostCleanup from '../vite-plugins/vite-plugin-post-cleanup';
@@ -33,11 +33,6 @@ async function run() {
   // Write `index.html` (template) into the `/public` folder.
   fs.writeFileSync(paths.appIndexHtml, html, { encoding: 'utf8' });
 
-  const appDependencies = require(paths.appPackageJson).dependencies as Record<
-    string,
-    string
-  >;
-
   await build({
     root: paths.appRoot,
     base: './', // <-- Important to allow configuring the runtime base path.
@@ -55,7 +50,12 @@ async function run() {
         // NOTE that after the build, Vite will write the `index.html` (template)
         // at the `/public/public/index.html` location. See `fs.renameSync` below.
         input: paths.appIndexHtml,
-        output: { manualChunks: getViteCacheGroups(appDependencies) },
+        // NOTE: we intentionally do not set `output.manualChunks` here. The
+        // declarative form does not claim transitive deps, so shared packages
+        // (babel-runtime, emotion, uikit internals) can land in a chunk that
+        // also imports back from another chunk — producing a TDZ cycle at
+        // runtime (historical "aM is undefined" crash with the icons/app-shell
+        // split). Rollup's default chunking handles co-location correctly.
         // Reduce the memory footprint when building sourcemaps.
         // https://github.com/vitejs/vite/issues/2433#issuecomment-1361094727
         cache: false,
@@ -116,6 +116,10 @@ async function run() {
       }),
       pluginDynamicBaseAssetsGlobals(),
       pluginI18nMessageCompilation(),
+      // Fail the build if the emitted chunk graph contains circular imports.
+      // Chunk cycles are silent at build time but crash at runtime with TDZ
+      // errors (historical "aM is undefined" from the icons/app-shell split).
+      pluginChunkCycleCheck(),
       process.env.ANALYZE_BUNDLE === 'true' &&
         analyzer({ defaultSizes: 'stat', openAnalyzer: true }),
       process.env.ANALYZE_BUNDLE_TREE === 'true' &&

--- a/packages/mc-scripts/src/config/optimizations.ts
+++ b/packages/mc-scripts/src/config/optimizations.ts
@@ -1,9 +1,17 @@
 import chalk from 'chalk';
 
-// Dependencies to be split/grouped into separate chunks.
-// This is useful to reduce the main bundle size and have more
-// dedicated caching strategy for specific chunks.
-const manualChunks = {
+// Dependencies to be split/grouped into separate chunks for the Webpack build.
+// This is useful to reduce the main bundle size and have more dedicated
+// caching strategy for specific chunks.
+//
+// NOTE: this is intentionally Webpack-only. The Vite build does NOT use
+// manualChunks — Rollup's declarative manualChunks form does not claim
+// transitive deps, which caused a chunk-level cycle (icons ↔ app-shell) that
+// crashed at runtime with a TDZ ("aM is undefined") error. Rollup's default
+// chunking handles co-location correctly; Webpack's splitChunks with a regex
+// test has different, cycle-safe semantics (shared modules are hoisted into a
+// shared chunk automatically).
+const manualChunks: Record<string, string[]> = {
   'commercetools-uikit-icons': ['@commercetools-uikit/icons'],
   moment: ['moment', 'moment-timezone'],
   'app-shell': [
@@ -35,14 +43,6 @@ const removeNonExistantDependencies = (
     {} as Record<string, string[]>
   );
 };
-
-// Reference: https://rollupjs.org/configuration-options/#output-manualchunks
-export function getViteCacheGroups(appDependencies: Record<string, string>) {
-  return removeNonExistantDependencies(
-    manualChunks,
-    Object.keys(appDependencies)
-  );
-}
 
 // Reference: https://webpack.js.org/plugins/split-chunks-plugin/
 export function getWepbackCacheGroups(appDependencies: Record<string, string>) {

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-chunk-cycle-check.spec.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-chunk-cycle-check.spec.ts
@@ -1,0 +1,188 @@
+import type { Plugin } from 'vite';
+import pluginChunkCycleCheck, {
+  findChunkCycles,
+} from './vite-plugin-chunk-cycle-check';
+
+type FakeBundle = Parameters<typeof findChunkCycles>[0];
+
+/** Build a minimal bundle whose chunks only carry `imports` edges. */
+const makeBundle = (imports: Record<string, string[]>): FakeBundle => {
+  const bundle: Record<string, unknown> = {};
+  for (const [fileName, deps] of Object.entries(imports)) {
+    bundle[fileName] = {
+      type: 'chunk',
+      fileName,
+      imports: deps,
+      dynamicImports: [],
+    };
+  }
+  return bundle as FakeBundle;
+};
+
+/**
+ * Invoke the plugin's `generateBundle` hook with a stubbed PluginContext.
+ * `this.error` throws (matches Rollup's real behavior) so tests can assert
+ * via `.toThrow(...)`.
+ */
+const triggerGenerateBundle = (plugin: Plugin, bundle: FakeBundle) => {
+  const ctx = {
+    error: jest.fn((msg: string) => {
+      throw new Error(msg);
+    }),
+    warn: jest.fn(),
+  };
+  const hook = plugin.generateBundle;
+  if (typeof hook !== 'function') {
+    throw new Error('plugin.generateBundle must be a function for this test');
+  }
+  (
+    hook as unknown as (
+      this: unknown,
+      opts: unknown,
+      bundle: FakeBundle
+    ) => void
+  ).call(ctx, {}, bundle);
+  return ctx;
+};
+
+describe('findChunkCycles', () => {
+  it('returns [] for an empty bundle', () => {
+    expect(findChunkCycles(makeBundle({}))).toEqual([]);
+  });
+
+  it('returns [] for a DAG', () => {
+    const bundle = makeBundle({
+      'entry.js': ['lib.js', 'util.js'],
+      'lib.js': ['util.js'],
+      'util.js': [],
+    });
+    expect(findChunkCycles(bundle)).toEqual([]);
+  });
+
+  it('detects the icons/app-shell two-chunk cycle', () => {
+    const bundle = makeBundle({
+      'app-shell-BLbbVDlI.js': ['commercetools-uikit-icons-n8uksAy1.js'],
+      'commercetools-uikit-icons-n8uksAy1.js': ['app-shell-BLbbVDlI.js'],
+    });
+    const cycles = findChunkCycles(bundle);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0]).toEqual(
+      expect.arrayContaining([
+        'app-shell-BLbbVDlI.js',
+        'commercetools-uikit-icons-n8uksAy1.js',
+      ])
+    );
+  });
+
+  it('detects a 3-chunk cycle', () => {
+    const bundle = makeBundle({
+      'a.js': ['b.js'],
+      'b.js': ['c.js'],
+      'c.js': ['a.js'],
+    });
+    const cycles = findChunkCycles(bundle);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0]).toEqual(expect.arrayContaining(['a.js', 'b.js', 'c.js']));
+  });
+
+  it('reports multiple independent cycles in a single bundle', () => {
+    const bundle = makeBundle({
+      'a.js': ['b.js'],
+      'b.js': ['a.js'],
+      'x.js': ['y.js'],
+      'y.js': ['x.js'],
+      // innocent bystander
+      'entry.js': ['a.js', 'x.js'],
+    });
+    const cycles = findChunkCycles(bundle);
+    expect(cycles).toHaveLength(2);
+  });
+
+  it('reports each elementary cycle only once regardless of DFS entry point', () => {
+    const bundle = makeBundle({
+      'a.js': ['b.js'],
+      'b.js': ['a.js'],
+    });
+    expect(findChunkCycles(bundle)).toHaveLength(1);
+  });
+
+  it('ignores imports to entries that are not chunks (CSS/assets/externals)', () => {
+    const bundle = makeBundle({
+      'entry.js': ['style.css', 'not-a-chunk.json', 'lib.js'],
+      'lib.js': [],
+    });
+    expect(findChunkCycles(bundle)).toEqual([]);
+  });
+
+  it('ignores self-loops (Rollup does not emit them, but the algo should be defensive)', () => {
+    const bundle = makeBundle({ 'a.js': ['a.js'] });
+    // A self-loop IS technically a cycle; assert the behavior explicitly so
+    // anyone changing it has to update the test.
+    const cycles = findChunkCycles(bundle);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0]).toEqual(['a.js', 'a.js']);
+  });
+});
+
+describe('pluginChunkCycleCheck', () => {
+  describe('plugin structure', () => {
+    it('has the expected name and build-only apply', () => {
+      const plugin = pluginChunkCycleCheck();
+      expect(plugin.name).toBe('vite-plugin-chunk-cycle-check');
+      expect(plugin.apply).toBe('build');
+      expect(typeof plugin.generateBundle).toBe('function');
+    });
+  });
+
+  describe('behavior with default options (onCycle: error)', () => {
+    it('does not touch the context for a clean bundle', () => {
+      const plugin = pluginChunkCycleCheck();
+      const bundle = makeBundle({
+        'entry.js': ['lib.js'],
+        'lib.js': [],
+      });
+      const ctx = triggerGenerateBundle(plugin, bundle);
+      expect(ctx.error).not.toHaveBeenCalled();
+      expect(ctx.warn).not.toHaveBeenCalled();
+    });
+
+    it('throws via this.error when a cycle is detected', () => {
+      const plugin = pluginChunkCycleCheck();
+      const bundle = makeBundle({
+        'app-shell.js': ['icons.js'],
+        'icons.js': ['app-shell.js'],
+      });
+      expect(() => triggerGenerateBundle(plugin, bundle)).toThrow(
+        /circular imports between output chunks/
+      );
+    });
+
+    it('includes each cycle node in the error message', () => {
+      const plugin = pluginChunkCycleCheck();
+      const bundle = makeBundle({
+        'app-shell.js': ['icons.js'],
+        'icons.js': ['app-shell.js'],
+      });
+      expect(() => triggerGenerateBundle(plugin, bundle)).toThrow(
+        /app-shell\.js/
+      );
+      expect(() => triggerGenerateBundle(plugin, bundle)).toThrow(/icons\.js/);
+    });
+  });
+
+  describe('behavior with onCycle: warn', () => {
+    it('warns instead of throwing', () => {
+      const plugin = pluginChunkCycleCheck({ onCycle: 'warn' });
+      const bundle = makeBundle({
+        'a.js': ['b.js'],
+        'b.js': ['a.js'],
+      });
+      const ctx = triggerGenerateBundle(plugin, bundle);
+      expect(ctx.warn).toHaveBeenCalledTimes(1);
+      expect(ctx.warn).toHaveBeenCalledWith(
+        expect.stringContaining('circular imports between output chunks')
+      );
+      expect(ctx.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-chunk-cycle-check.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-chunk-cycle-check.ts
@@ -1,0 +1,122 @@
+import type { Plugin } from 'vite';
+
+// Structural subset of Rollup's OutputChunk / OutputBundle. We avoid
+// importing the real types because Rollup is a transitive dep via Vite and
+// is not declared in mc-scripts' own `dependencies`. We only touch three
+// fields, so a local type is cheaper than adding a dep.
+type MinimalChunk = {
+  type: 'chunk';
+  fileName: string;
+  imports: string[];
+};
+type MinimalBundleEntry = MinimalChunk | { type: 'asset' };
+type MinimalBundle = Record<string, MinimalBundleEntry>;
+
+type Options = {
+  /**
+   * What to do when a chunk cycle is detected.
+   * - `'error'` (default) — fail the build. Safe default for CI because
+   *   chunk-level cycles produce TDZ runtime errors (e.g. "aM is undefined").
+   * - `'warn'` — log to stderr and continue. Use this in exploratory configs
+   *   where you need to ship a build that you know has cycles.
+   */
+  onCycle?: 'error' | 'warn';
+};
+
+/**
+ * Health check: after Rollup produces the output bundle, verify that the
+ * graph of cross-chunk imports is a DAG. Chunk-level cycles are a class of
+ * bug that doesn't fail at build time but crashes at runtime the moment one
+ * chunk reads a variable from its partner before that partner finishes
+ * initializing (TDZ). The historical failure mode was `@commercetools-uikit/icons`
+ * ↔ `app-shell` under `manualChunks`.
+ */
+function pluginChunkCycleCheck(options: Options = {}): Plugin {
+  const onCycle = options.onCycle ?? 'error';
+
+  return {
+    name: 'vite-plugin-chunk-cycle-check',
+    apply: 'build',
+    // `generateBundle` runs once the chunk graph is final but before files
+    // hit disk — the cheapest place to inspect it.
+    generateBundle(_, bundle) {
+      const cycles = findChunkCycles(bundle as MinimalBundle);
+      if (cycles.length === 0) return;
+
+      const formatted = cycles
+        .map((cycle) => `  ${cycle.join(' → ')}`)
+        .join('\n');
+      const message =
+        `Detected circular imports between output chunks:\n${formatted}\n` +
+        `\nChunk cycles produce TDZ runtime errors (e.g. "X is undefined") ` +
+        `because Rollup emits real ESM and one chunk can observe another ` +
+        `chunk's not-yet-initialized top-level vars mid-evaluation. ` +
+        `Review \`output.manualChunks\` or any plugin assigning chunks.`;
+
+      if (onCycle === 'error') {
+        this.error(message);
+      } else {
+        this.warn(message);
+      }
+    },
+  };
+}
+
+export default pluginChunkCycleCheck;
+
+/**
+ * Pure graph algorithm extracted for direct unit testing. Builds the
+ * chunk-to-chunk import graph and returns every elementary cycle found.
+ */
+export function findChunkCycles(bundle: MinimalBundle): string[][] {
+  const chunks = Object.values(bundle).filter(
+    (entry): entry is MinimalChunk => entry.type === 'chunk'
+  );
+  const graph = new Map<string, string[]>();
+  for (const chunk of chunks) {
+    // `imports` covers static imports between chunks. `dynamicImports` are
+    // deliberately ignored — those create legitimate lazy boundaries that
+    // can back-reference the parent without a runtime cycle.
+    graph.set(chunk.fileName, chunk.imports);
+  }
+
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const name of graph.keys()) color.set(name, WHITE);
+
+  const cycles: string[][] = [];
+  const seenCycleKeys = new Set<string>();
+  const pathStack: string[] = [];
+
+  const visit = (node: string): void => {
+    color.set(node, GRAY);
+    pathStack.push(node);
+    for (const next of graph.get(node) ?? []) {
+      // Imports may reference assets or chunks outside our map (e.g. CSS).
+      if (!graph.has(next)) continue;
+      const nextColor = color.get(next);
+      if (nextColor === GRAY) {
+        const startIdx = pathStack.indexOf(next);
+        const cycle = pathStack.slice(startIdx).concat(next);
+        // Normalize so we report each elementary cycle only once regardless
+        // of which node in the cycle DFS entered from.
+        const key = [...cycle].slice(0, -1).sort().join('|');
+        if (!seenCycleKeys.has(key)) {
+          seenCycleKeys.add(key);
+          cycles.push(cycle);
+        }
+      } else if (nextColor === WHITE) {
+        visit(next);
+      }
+    }
+    pathStack.pop();
+    color.set(node, BLACK);
+  };
+
+  for (const node of graph.keys()) {
+    if (color.get(node) === WHITE) visit(node);
+  }
+  return cycles;
+}

--- a/scripts/smoke-test-templates.mjs
+++ b/scripts/smoke-test-templates.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Load a URL in a headless browser and exit non-zero if any uncaught runtime
+// error fires during page evaluation. Purpose: catch chunk-level TDZ failures
+// and other top-level crashes that a build-time check cannot see (e.g. the
+// "aM is undefined" regression from FEC-832 when the Vite bundler emits
+// circular chunk imports).
+//
+// Usage:
+//   node scripts/smoke-test-templates.mjs <url> [--timeout=30000] [--settle=2000]
+//
+// Exit codes:
+//   0 - page loaded with no uncaught exceptions
+//   1 - one or more uncaught exceptions observed
+//   2 - usage / launch / navigation failure
+import puppeteer from 'puppeteer';
+
+const args = process.argv.slice(2);
+const url = args.find((a) => !a.startsWith('--'));
+if (!url) {
+  console.error(
+    'Usage: smoke-test-templates.mjs <url> [--timeout=30000] [--settle=2000]'
+  );
+  process.exit(2);
+}
+
+const getFlag = (name, fallback) => {
+  const match = args.find((a) => a.startsWith(`--${name}=`));
+  return match ? Number(match.split('=')[1]) : fallback;
+};
+const navTimeoutMs = getFlag('timeout', 30_000);
+const settleMs = getFlag('settle', 2_000);
+
+const uncaught = [];
+
+let browser;
+try {
+  browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+} catch (err) {
+  console.error('[smoke] failed to launch browser:', err.message);
+  process.exit(2);
+}
+
+try {
+  const page = await browser.newPage();
+
+  // `pageerror` fires on every uncaught exception that reaches the window.
+  // That's the exact signal we want — a TDZ crash in a chunk propagates here.
+  page.on('pageerror', (err) => {
+    uncaught.push({
+      kind: 'pageerror',
+      message: err.message,
+      stack: err.stack,
+    });
+  });
+
+  // We intentionally do NOT fail on `console.error` calls: the MC app is
+  // expected to log warnings (missing auth, missing API) when served via
+  // `mc-scripts serve` without a real backend. Uncaught errors are the
+  // clean signal.
+
+  try {
+    await page.goto(url, {
+      waitUntil: 'networkidle2',
+      timeout: navTimeoutMs,
+    });
+  } catch (err) {
+    // Navigation itself failed (timeout, network). Not what we're watching
+    // for, but also not OK — report and exit 2.
+    console.error(`[smoke] navigation to ${url} failed:`, err.message);
+    process.exit(2);
+  }
+
+  // Give top-level polyfill / init chains a beat to execute after
+  // networkidle. The TDZ crash we most care about fires synchronously on
+  // first chunk evaluation, but letting any late async boot run gives us
+  // a little extra coverage.
+  await new Promise((resolve) => setTimeout(resolve, settleMs));
+
+  if (uncaught.length > 0) {
+    console.error(
+      `[smoke] ${uncaught.length} uncaught error(s) observed at ${url}:`
+    );
+    for (const err of uncaught) {
+      console.error(`\n- ${err.message}`);
+      if (err.stack) console.error(err.stack);
+    }
+    process.exit(1);
+  }
+
+  console.log(`[smoke] OK — no uncaught errors at ${url}`);
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Summary

- Drop `output.manualChunks` from the Vite build so Rollup's default chunking handles co-location. The declarative `manualChunks` form does not claim transitive deps, letting shared packages (`@babel/runtime-corejs3`, `@emotion/react`, uikit internals) land in a chunk that is also imported back — producing a TDZ cycle at runtime ("aM is undefined" in the icons/app-shell split). The Webpack build is untouched; `splitChunks.cacheGroups` is cycle-safe by construction.
- Add `vite-plugin-chunk-cycle-check` as a build-time regression guard. Runs in `generateBundle`, walks the chunk-import graph with a 3-color DFS, fails the build with a readable error if any elementary cycle is found. Has 13 unit tests covering the pure algorithm and the plugin hook.
- Close the CI gap that let this through: the existing `test-template-action` only exercised the Webpack path. Append two steps — a build with `ENABLE_EXPERIMENTAL_VITE_BUNDLER=true` and a headless Puppeteer smoke (`scripts/smoke-test-templates.mjs`) that fails on any uncaught runtime error from the served Vite build. Runs across all four templates.

Closes #3980. Tracked as FEC-832.

## Why this shape of fix

Option 1 discussed on the ticket was to broaden the icons chunk to claim more uikit/shared packages. Every attempt there still leaked *some* shared dep to an unclaimed chunk — ultimately fragile across Rollup / pnpm / Node versions. Dropping `manualChunks` removes the ambiguity class entirely. The caching benefit it provided was marginal for a single-entry app (all chunks load on first visit). The regression guard protects the future: any new config or plugin that reintroduces chunk cycles will be caught at build time, and the CI smoke test catches runtime-only crashes the plugin cannot see.

## Test plan

- [ ] `pnpm --filter @commercetools-frontend/mc-scripts run test` — all 60 tests green locally (includes the 13 new chunk-cycle-check tests).
- [ ] `pnpm typecheck` clean.
- [ ] `application-templates/starter-typescript`: `ENABLE_EXPERIMENTAL_VITE_BUNDLER=true pnpm build && pnpm start:prod:local` — app loads without the `Uncaught TypeError: Cannot set properties of undefined` crash.
- [ ] `application-templates/starter`: same drill for the JS template.
- [ ] `custom-views-templates/starter` and `starter-typescript`: build + serve under the Vite flag; no runtime errors.
- [ ] CI: the new "Building Starter template with experimental Vite bundler" and "Smoke-testing Vite production build" steps pass for all four template variants.
- [x] Manually reintroduce a cycle (restore old `manualChunks` + a uikit/icons version that triggers the reverse edge) → `pnpm build` fails with the plugin's cycle message, not a silent success.