### PR TITLE
feat(mc-scripts): add `--handle-auth-routes` flag to `serve` command

### DIFF
--- a/.changeset/fec-820-handle-auth-routes-flag.md
+++ b/.changeset/fec-820-handle-auth-routes-flag.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Add a `--handle-auth-routes` flag to `mc-scripts serve`. When set, requests to `/login*` and `/logout*` are passed through to the SPA fallback instead of being intercepted by the built-in localhost-redirect / clear-session-text / 404 handlers. Use this for applications that own those routes themselves (e.g. `application-authentication`). Default behavior is unchanged.

--- a/.changeset/fec-820-handle-auth-routes-flag.md
+++ b/.changeset/fec-820-handle-auth-routes-flag.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/mc-scripts': patch
 ---
 
-Add a `--handle-auth-routes` flag to `mc-scripts serve`. When set, requests to `/login*` and `/logout*` are passed through to the SPA fallback instead of being intercepted by the built-in localhost-redirect / clear-session-text / 404 handlers. Use this for applications that own those routes themselves (e.g. `application-authentication`). Default behavior is unchanged.
+Add a `--handle-auth-routes <enabled>` option to `mc-scripts serve` (default `true`). Pass `--handle-auth-routes false` to let `/login*` and `/logout*` requests fall through to the SPA fallback instead of being intercepted by the built-in localhost-redirect / clear-session-text / 404 handlers. Use this for applications that own those routes themselves (e.g. `application-authentication`). Default behavior is unchanged.

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -148,6 +148,14 @@ async function run() {
       '(optional) If defined, requests to `/login*` and `/logout*` are passed through to the SPA fallback instead of being intercepted by the built-in login/logout handlers. Use this for applications that own the auth routes themselves (e.g. `application-authentication`).',
       false
     )
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ mc-scripts serve
+  $ mc-scripts serve --handle-auth-routes
+`
+    )
     .action(async (options: TCliCommandServeOptions) => {
       const globalOptions = program.opts<TCliGlobalOptions>();
 

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -148,14 +148,6 @@ async function run() {
       '(optional) If defined, requests to `/login*` and `/logout*` are passed through to the SPA fallback instead of being intercepted by the built-in login/logout handlers. Use this for applications that own the auth routes themselves (e.g. `application-authentication`).',
       false
     )
-    .addHelpText(
-      'after',
-      `
-Examples:
-  $ mc-scripts serve
-  $ mc-scripts serve --handle-auth-routes
-`
-    )
     .action(async (options: TCliCommandServeOptions) => {
       const globalOptions = program.opts<TCliGlobalOptions>();
 

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -144,9 +144,9 @@ async function run() {
       'Serves previously built and compiled application from the "public" folder.'
     )
     .option(
-      '--handle-auth-routes',
-      '(optional) If defined, requests to `/login*` and `/logout*` are passed through to the SPA fallback instead of being intercepted by the built-in login/logout handlers. Use this for applications that own the auth routes themselves (e.g. `application-authentication`).',
-      false
+      '--handle-auth-routes <enabled>',
+      '(optional) Whether `/login*` and `/logout*` are intercepted by the built-in login/logout handlers (`true`, the default) or passed through to the SPA fallback (`false`). Set to `false` for applications that own those routes themselves (e.g. `application-authentication`).',
+      'true'
     )
     .action(async (options: TCliCommandServeOptions) => {
       const globalOptions = program.opts<TCliGlobalOptions>();
@@ -160,7 +160,7 @@ async function run() {
 
       const serveCommand = await import('./commands/serve');
       const server = await serveCommand.default({
-        handleAuthRoutes: options.handleAuthRoutes,
+        handleAuthRoutes: options.handleAuthRoutes !== 'false',
       });
       const address = server.address();
       const boundPort =

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -12,6 +12,7 @@ import type {
   TCliCommandConfigSyncCIOptions,
   TCliCommandSetDeploymentPreviewOptions,
   TCliCommandLoginOptions,
+  TCliCommandServeOptions,
 } from './types';
 import doesFileExist from './utils/does-file-exist';
 
@@ -142,7 +143,12 @@ async function run() {
     .description(
       'Serves previously built and compiled application from the "public" folder.'
     )
-    .action(async () => {
+    .option(
+      '--handle-auth-routes',
+      '(optional) If defined, requests to `/login*` and `/logout*` are passed through to the SPA fallback instead of being intercepted by the built-in login/logout handlers. Use this for applications that own the auth routes themselves (e.g. `application-authentication`).',
+      false
+    )
+    .action(async (options: TCliCommandServeOptions) => {
       const globalOptions = program.opts<TCliGlobalOptions>();
 
       // Load dotenv files into the process environment.
@@ -153,7 +159,9 @@ async function run() {
       process.env.NODE_ENV = 'production';
 
       const serveCommand = await import('./commands/serve');
-      const server = await serveCommand.default();
+      const server = await serveCommand.default({
+        handleAuthRoutes: options.handleAuthRoutes,
+      });
       const address = server.address();
       const boundPort =
         address && typeof address === 'object' ? address.port : '?';

--- a/packages/mc-scripts/src/commands/serve.spec.ts
+++ b/packages/mc-scripts/src/commands/serve.spec.ts
@@ -327,18 +327,18 @@ describe('mc-scripts serve', () => {
     });
   });
 
-  // --- handleAuthRoutes opt-in --------------------------------------------
+  // --- handleAuthRoutes opt-out -------------------------------------------
   // Intent: applications that own the `/login*` / `/logout*` route shape
   // themselves (e.g. `application-authentication`) need the static server
   // to stop intercepting those paths so the SPA fallback can handle them.
-  // Setting `handleAuthRoutes: true` (CLI: `--handle-auth-routes`) disables
-  // all three auth-route branches as a bundle, regardless of whether
-  // `mcApiUrl` is localhost. The favicon rewrite is unaffected.
+  // Setting `handleAuthRoutes: false` (CLI: `--handle-auth-routes false`)
+  // disables all three auth-route branches as a bundle, regardless of
+  // whether `mcApiUrl` is localhost. The favicon rewrite is unaffected.
 
-  describe('with handleAuthRoutes enabled (localhost mcApiUrl)', () => {
+  describe('with handleAuthRoutes disabled (localhost mcApiUrl)', () => {
     beforeEach(async () => {
       context = await startServer(fixtureDir, 'http://localhost:8080', {
-        handleAuthRoutes: true,
+        handleAuthRoutes: false,
       });
     });
 
@@ -373,10 +373,10 @@ describe('mc-scripts serve', () => {
     });
   });
 
-  describe('with handleAuthRoutes enabled (non-localhost mcApiUrl)', () => {
+  describe('with handleAuthRoutes disabled (non-localhost mcApiUrl)', () => {
     beforeEach(async () => {
       context = await startServer(fixtureDir, 'https://mc.example.com', {
-        handleAuthRoutes: true,
+        handleAuthRoutes: false,
       });
     });
 

--- a/packages/mc-scripts/src/commands/serve.spec.ts
+++ b/packages/mc-scripts/src/commands/serve.spec.ts
@@ -73,13 +73,19 @@ const writeServedFiles = (): string => {
 
 const startServer = async (
   publicPath: string,
-  mcApiUrl: string
+  mcApiUrl: string,
+  extraOptions: { handleAuthRoutes?: boolean } = {}
 ): Promise<ServerContext> => {
   const applicationConfig = {
     env: { mcApiUrl },
   } as unknown as ApplicationRuntimeConfig;
 
-  const server = await run({ port: 0, publicPath, applicationConfig });
+  const server = await run({
+    port: 0,
+    publicPath,
+    applicationConfig,
+    ...extraOptions,
+  });
   const address = server.address();
   if (!address || typeof address !== 'object') {
     throw new Error('Expected server to bind to an address');
@@ -318,6 +324,74 @@ describe('mc-scripts serve', () => {
     it('returns 404 for /logout (no SPA fallback)', async () => {
       const res = await fetch(`${context!.baseUrl}/logout`);
       expect(res.status).toBe(404);
+    });
+  });
+
+  // --- handleAuthRoutes opt-in --------------------------------------------
+  // Intent: applications that own the `/login*` / `/logout*` route shape
+  // themselves (e.g. `application-authentication`) need the static server
+  // to stop intercepting those paths so the SPA fallback can handle them.
+  // Setting `handleAuthRoutes: true` (CLI: `--handle-auth-routes`) disables
+  // all three auth-route branches as a bundle, regardless of whether
+  // `mcApiUrl` is localhost. The favicon rewrite is unaffected.
+
+  describe('with handleAuthRoutes enabled (localhost mcApiUrl)', () => {
+    beforeEach(async () => {
+      context = await startServer(fixtureDir, 'http://localhost:8080', {
+        handleAuthRoutes: true,
+      });
+    });
+
+    it('falls through /login/authorize to the SPA instead of redirecting', async () => {
+      const res = await fetch(
+        `${context!.baseUrl}/login/authorize?foo=bar&baz=qux`,
+        { redirect: 'manual' }
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/text\/html/);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('falls through /logout to the SPA instead of returning the clear-session text', async () => {
+      const res = await fetch(`${context!.baseUrl}/logout`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/text\/html/);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('falls through bare /login to the SPA instead of returning 404', async () => {
+      const res = await fetch(`${context!.baseUrl}/login`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('still rewrites /favicon.ico to /favicon.png', async () => {
+      const res = await fetch(`${context!.baseUrl}/favicon.ico`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toBe('image/png');
+      expect(Buffer.from(await res.arrayBuffer())).toEqual(FAVICON_PNG);
+    });
+  });
+
+  describe('with handleAuthRoutes enabled (non-localhost mcApiUrl)', () => {
+    beforeEach(async () => {
+      context = await startServer(fixtureDir, 'https://mc.example.com', {
+        handleAuthRoutes: true,
+      });
+    });
+
+    it('falls through /login/authorize to the SPA instead of returning 404', async () => {
+      const res = await fetch(`${context!.baseUrl}/login/authorize?foo=bar`, {
+        redirect: 'manual',
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('falls through /logout to the SPA instead of returning 404', async () => {
+      const res = await fetch(`${context!.baseUrl}/logout`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_HTML);
     });
   });
 });

--- a/packages/mc-scripts/src/commands/serve.ts
+++ b/packages/mc-scripts/src/commands/serve.ts
@@ -12,6 +12,7 @@ type RunOptions = {
   port?: number;
   publicPath?: string;
   applicationConfig?: ApplicationRuntimeConfig;
+  handleAuthRoutes?: boolean;
 };
 
 async function run(options: RunOptions = {}): Promise<http.Server> {
@@ -19,6 +20,7 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
   const publicPath = options.publicPath ?? paths.appBuild;
   const applicationConfig =
     options.applicationConfig ?? (await processConfig());
+  const handleAuthRoutes = options.handleAuthRoutes ?? false;
   const isLocalMcApi =
     applicationConfig.env.mcApiUrl.startsWith('http://localhost');
 
@@ -31,28 +33,33 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
   });
 
   const server = http.createServer((request, response) => {
-    // Localhost-only: inline replacement for the login/logout UI that
-    // `mc-dev-authentication` used to ship as static HTML (#3734).
-    if (isLocalMcApi && request.url?.startsWith('/login/authorize')) {
-      const redirectTo = new URL(request.url, applicationConfig.env.mcApiUrl);
-      response.writeHead(301, { Location: redirectTo.toString() }).end();
-      return;
-    }
-    if (isLocalMcApi && request.url?.startsWith('/logout')) {
-      response.end('Please clear your session storage.');
-      return;
-    }
+    // Apps that own the `/login*` / `/logout*` routes themselves (e.g.
+    // `application-authentication`) opt out of all auth-route handling so
+    // those paths flow through to the SPA fallback like any other route.
+    if (!handleAuthRoutes) {
+      // Localhost-only: inline replacement for the login/logout UI that
+      // `mc-dev-authentication` used to ship as static HTML (#3734).
+      if (isLocalMcApi && request.url?.startsWith('/login/authorize')) {
+        const redirectTo = new URL(request.url, applicationConfig.env.mcApiUrl);
+        response.writeHead(301, { Location: redirectTo.toString() }).end();
+        return;
+      }
+      if (isLocalMcApi && request.url?.startsWith('/logout')) {
+        response.end('Please clear your session storage.');
+        return;
+      }
 
-    // Preserve the pre-swap contract: any other `/login*` or `/logout*`
-    // request (bare `/login`, non-localhost auth callbacks, etc.) must NOT
-    // fall back to the SPA — that would mask OAuth callback
-    // misconfigurations by rendering the app on a URL the backend owns.
-    if (
-      request.url?.startsWith('/login') ||
-      request.url?.startsWith('/logout')
-    ) {
-      response.writeHead(404).end();
-      return;
+      // Preserve the pre-swap contract: any other `/login*` or `/logout*`
+      // request (bare `/login`, non-localhost auth callbacks, etc.) must NOT
+      // fall back to the SPA — that would mask OAuth callback
+      // misconfigurations by rendering the app on a URL the backend owns.
+      if (
+        request.url?.startsWith('/login') ||
+        request.url?.startsWith('/logout')
+      ) {
+        response.writeHead(404).end();
+        return;
+      }
     }
 
     // Absorb `/favicon*` variants (e.g. `/favicon.ico`, `/favicon-32x32.png`)

--- a/packages/mc-scripts/src/commands/serve.ts
+++ b/packages/mc-scripts/src/commands/serve.ts
@@ -20,7 +20,7 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
   const publicPath = options.publicPath ?? paths.appBuild;
   const applicationConfig =
     options.applicationConfig ?? (await processConfig());
-  const handleAuthRoutes = options.handleAuthRoutes ?? false;
+  const handleAuthRoutes = options.handleAuthRoutes ?? true;
   const isLocalMcApi =
     applicationConfig.env.mcApiUrl.startsWith('http://localhost');
 
@@ -34,9 +34,9 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
 
   const server = http.createServer((request, response) => {
     // Apps that own the `/login*` / `/logout*` routes themselves (e.g.
-    // `application-authentication`) opt out of all auth-route handling so
+    // `application-authentication`) opt out via `handleAuthRoutes: false` so
     // those paths flow through to the SPA fallback like any other route.
-    if (!handleAuthRoutes) {
+    if (handleAuthRoutes) {
       // Localhost-only: inline replacement for the login/logout UI that
       // `mc-dev-authentication` used to ship as static HTML (#3734).
       if (isLocalMcApi && request.url?.startsWith('/login/authorize')) {

--- a/packages/mc-scripts/src/types.ts
+++ b/packages/mc-scripts/src/types.ts
@@ -20,7 +20,7 @@ export type TCliCommandConfigSyncCIOptions = {
 };
 
 export type TCliCommandServeOptions = {
-  handleAuthRoutes: boolean;
+  handleAuthRoutes: string;
 };
 
 export type TCliCommandLoginOptions = {

--- a/packages/mc-scripts/src/types.ts
+++ b/packages/mc-scripts/src/types.ts
@@ -19,6 +19,10 @@ export type TCliCommandConfigSyncCIOptions = {
   dryRun: boolean;
 };
 
+export type TCliCommandServeOptions = {
+  handleAuthRoutes: boolean;
+};
+
 export type TCliCommandLoginOptions = {
   mcApiUrl?: string;
   projectKey?: string;


### PR DESCRIPTION
## Summary

Adds one new CLI option to `mc-scripts serve`:

- **`--handle-auth-routes <enabled>`** (default `true`). When set to `false`, requests to `/login*` and `/logout*` fall through to the SPA fallback instead of being intercepted by the built-in localhost-redirect / clear-session-text / 404 handlers.

Default behavior is unchanged. Only the auth-route branches in the request handler are gated; the favicon rewrite and the `sirv` static + SPA fallback are unaffected.

6 new tests in `serve.spec.ts` covering the `handleAuthRoutes` opt-out under both localhost and non-localhost `mcApiUrl`. The existing 19-test suite already exercises non-default port handling via `run({ port: 0 })` and non-default `publicPath` (every test writes to a temp fixture dir).

## Motivation (FEC-820)

PR #3979 swapped `serve-handler` → `sirv` in `mc-scripts serve` while preserving the prior behavior of returning 404 (or applying inline localhost handlers) on `/login*` / `/logout*`. That behavior is wrong for applications that host their own React routes under those paths — they need plain SPA fallback there.

## Usage

**Default — every standard MC application.** Auth routes keep their existing intercept/404 contract:

```jsonc
// package.json
{
  "scripts": {
    "start:prod:local": "pnpm compile-html:local && mc-scripts serve"
  }
}
```

**Opt-out — applications that own `/login*` and `/logout*` themselves.** Required when migrating off the standalone `serve` npm package for an app like `application-authentication`, whose React routes live under those paths and would otherwise 404 against the default contract:

```jsonc
// packages-application/application-authentication/package.json
{
  "scripts": {
    // Was: `serve -s -l 3001 public`
    "start:prod:local": "pnpm compile-html:local && mc-scripts serve --handle-auth-routes false"
  },
  "devDependencies": {
    // The standalone `serve` npm package can be dropped — `mc-scripts serve`
    // covers this contract now: same default port (3001 = `developmentPort`)
    // and same default folder (`public` = `paths.appBuild`).
  }
}
```

## Test plan

- [x] `pnpm test packages/mc-scripts/src/commands/serve.spec.ts` — 25/25 pass (19 existing + 6 auth-route opt-out)
- [x] `pnpm typecheck` — clean
- [ ] Smoke-test locally with the opt-out: `mc-scripts serve --handle-auth-routes false`, hit a `/login/*` route, confirm the SPA shell loads (not 404)
- [ ] Smoke-test without the option, confirm `/login/authorize` still redirects under localhost `mcApiUrl` and bare `/login` still 404s