### PR TITLE
fix(mc-scripts): skip `processConfig()` when `--handle-auth-routes=false`

### DIFF
--- a/.changeset/fec-820-serve-skip-config-when-auth-disabled.md
+++ b/.changeset/fec-820-serve-skip-config-when-auth-disabled.md
@@ -2,4 +2,6 @@
 '@commercetools-frontend/mc-scripts': patch
 ---
 
-`mc-scripts serve` now skips loading the application config when invoked with `--handle-auth-routes=false`. The application config is only consumed by the built-in `/login*` / `/logout*` handlers, so disabling those handlers also makes `processConfig()` (and the dotenv files / `${env:...}` substitutions it requires) unnecessary. Consumers that own the auth routes themselves (e.g. `application-authentication`) can now run `mc-scripts serve --handle-auth-routes=false` as a pure static file server with no environment wiring.
+`mc-scripts serve` now skips loading the application config when invoked with `--handle-auth-routes=false`. The application config is consumed only by the built-in `/login*` / `/logout*` handlers, so disabling those handlers also makes `processConfig()` (and the dotenv files / `${env:...}` substitutions it requires) unnecessary. Consumers that own the auth routes themselves (e.g. `application-authentication`) can now run `mc-scripts serve --handle-auth-routes=false` as a pure static file server with no environment wiring.
+
+Internally, the decision lives in `cli.ts`: the `serve` action now calls `processConfig()` only when `handleAuthRoutes` is on, and passes the resulting `applicationConfig` (or `undefined`) into the `serve` command. `serve.ts` itself no longer imports `processConfig`; its `applicationConfig` option stays optional and the auth-route branch is gated on it being present.

--- a/.changeset/fec-820-serve-skip-config-when-auth-disabled.md
+++ b/.changeset/fec-820-serve-skip-config-when-auth-disabled.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+`mc-scripts serve` now skips loading the application config when invoked with `--handle-auth-routes=false`. The application config is only consumed by the built-in `/login*` / `/logout*` handlers, so disabling those handlers also makes `processConfig()` (and the dotenv files / `${env:...}` substitutions it requires) unnecessary. Consumers that own the auth routes themselves (e.g. `application-authentication`) can now run `mc-scripts serve --handle-auth-routes=false` as a pure static file server with no environment wiring.

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -145,7 +145,7 @@ async function run() {
     )
     .option(
       '--handle-auth-routes <enabled>',
-      '(optional) Whether `/login*` and `/logout*` are intercepted by the built-in login/logout handlers (`true`, the default) or passed through to the SPA fallback (`false`). Set to `false` for applications that own those routes themselves (e.g. `application-authentication`).',
+      '(optional) Whether `/login*` and `/logout*` are intercepted by the built-in login/logout handlers (`true`, the default) or passed through to the SPA fallback (`false`). Set to `false` for applications that own those routes themselves (e.g. `application-authentication`); doing so also skips loading the application config entirely, so the command can run as a pure static file server with no dotenv files or `${env:...}` substitutions configured.',
       'true'
     )
     .action(async (options: TCliCommandServeOptions) => {

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -158,9 +158,23 @@ async function run() {
       // Do this as the first thing so that any code reading it knows the right env.
       process.env.NODE_ENV = 'production';
 
+      const handleAuthRoutes = options.handleAuthRoutes !== 'false';
+
+      // The application config is consumed only by `serve`'s auth-route
+      // handlers. When those are disabled, skip `processConfig()` entirely
+      // so the command can run as a pure static file server with no dotenv
+      // files or `${env:...}` substitutions configured (the
+      // `application-authentication` use case).
+      const applicationConfig = handleAuthRoutes
+        ? await (
+            await import('@commercetools-frontend/application-config')
+          ).processConfig()
+        : undefined;
+
       const serveCommand = await import('./commands/serve');
       const server = await serveCommand.default({
-        handleAuthRoutes: options.handleAuthRoutes !== 'false',
+        handleAuthRoutes,
+        applicationConfig,
       });
       const address = server.address();
       const boundPort =

--- a/packages/mc-scripts/src/commands/serve.spec.ts
+++ b/packages/mc-scripts/src/commands/serve.spec.ts
@@ -49,6 +49,20 @@ import fetch from 'node-fetch';
 import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
 import run from './serve';
 
+// Make `processConfig()` throw if anything reaches it. The serve command
+// should call it only when `handleAuthRoutes` is true AND no
+// `applicationConfig` is provided — every test in this file either sets
+// `handleAuthRoutes: false` or passes an explicit `applicationConfig`, so
+// the real `processConfig` (which reads dotenv files / `${env:...}`
+// substitutions from disk) must never run.
+jest.mock('@commercetools-frontend/application-config', () => ({
+  processConfig: jest.fn(() => {
+    throw new Error(
+      'processConfig() should not be called: tests must either pass an explicit applicationConfig or disable handleAuthRoutes'
+    );
+  }),
+}));
+
 // 1x1 transparent PNG (smallest valid PNG).
 const FAVICON_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
@@ -391,6 +405,59 @@ describe('mc-scripts serve', () => {
     it('falls through /logout to the SPA instead of returning 404', async () => {
       const res = await fetch(`${context!.baseUrl}/logout`);
       expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+  });
+
+  // --- handleAuthRoutes disabled without application config ---------------
+  // Intent: with `handleAuthRoutes: false`, the command must not touch the
+  // application config — no `processConfig()` call, no dotenv files, no
+  // `${env:...}` substitutions. This unblocks consumers like
+  // `application-authentication` that own the auth routes themselves and
+  // want `mc-scripts serve` to act as a pure static file server. The mock
+  // at the top of the file would throw if `processConfig` were called.
+
+  describe('with handleAuthRoutes disabled and no applicationConfig', () => {
+    beforeEach(async () => {
+      const server = await run({
+        port: 0,
+        publicPath: fixtureDir,
+        handleAuthRoutes: false,
+      });
+      const address = server.address();
+      if (!address || typeof address !== 'object') {
+        throw new Error('Expected server to bind to an address');
+      }
+      context = { server, baseUrl: `http://127.0.0.1:${address.port}` };
+    });
+
+    it('starts the server without resolving the application config', async () => {
+      // Reaching this point already proves `processConfig()` was not called
+      // (it would throw — see the jest.mock at the top of this file). Sanity
+      // check the server is actually listening.
+      const res = await fetch(`${context!.baseUrl}/`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('falls through /login to the SPA', async () => {
+      const res = await fetch(`${context!.baseUrl}/login`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/text\/html/);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('falls through /logout to the SPA', async () => {
+      const res = await fetch(`${context!.baseUrl}/logout`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/text\/html/);
+      expect(await res.text()).toBe(INDEX_HTML);
+    });
+
+    it('falls through arbitrary deep links to the SPA', async () => {
+      const res = await fetch(`${context!.baseUrl}/some/nested/route`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/text\/html/);
       expect(await res.text()).toBe(INDEX_HTML);
     });
   });

--- a/packages/mc-scripts/src/commands/serve.spec.ts
+++ b/packages/mc-scripts/src/commands/serve.spec.ts
@@ -49,20 +49,6 @@ import fetch from 'node-fetch';
 import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
 import run from './serve';
 
-// Make `processConfig()` throw if anything reaches it. The serve command
-// should call it only when `handleAuthRoutes` is true AND no
-// `applicationConfig` is provided — every test in this file either sets
-// `handleAuthRoutes: false` or passes an explicit `applicationConfig`, so
-// the real `processConfig` (which reads dotenv files / `${env:...}`
-// substitutions from disk) must never run.
-jest.mock('@commercetools-frontend/application-config', () => ({
-  processConfig: jest.fn(() => {
-    throw new Error(
-      'processConfig() should not be called: tests must either pass an explicit applicationConfig or disable handleAuthRoutes'
-    );
-  }),
-}));
-
 // 1x1 transparent PNG (smallest valid PNG).
 const FAVICON_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
@@ -410,12 +396,12 @@ describe('mc-scripts serve', () => {
   });
 
   // --- handleAuthRoutes disabled without application config ---------------
-  // Intent: with `handleAuthRoutes: false`, the command must not touch the
-  // application config — no `processConfig()` call, no dotenv files, no
-  // `${env:...}` substitutions. This unblocks consumers like
-  // `application-authentication` that own the auth routes themselves and
-  // want `mc-scripts serve` to act as a pure static file server. The mock
-  // at the top of the file would throw if `processConfig` were called.
+  // Intent: pin `serve.ts`'s contract that it accepts an _optional_
+  // `applicationConfig` and acts as a pure static file server when none is
+  // supplied — the auth-route branch is skipped. This is the shape the CLI
+  // relies on to invoke `serve` as a pure static server when
+  // `--handle-auth-routes=false` is passed (no `processConfig()` call, no
+  // dotenv files, no `${env:...}` substitutions).
 
   describe('with handleAuthRoutes disabled and no applicationConfig', () => {
     beforeEach(async () => {
@@ -431,10 +417,7 @@ describe('mc-scripts serve', () => {
       context = { server, baseUrl: `http://127.0.0.1:${address.port}` };
     });
 
-    it('starts the server without resolving the application config', async () => {
-      // Reaching this point already proves `processConfig()` was not called
-      // (it would throw — see the jest.mock at the top of this file). Sanity
-      // check the server is actually listening.
+    it('starts and serves the SPA without an applicationConfig', async () => {
       const res = await fetch(`${context!.baseUrl}/`);
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(INDEX_HTML);

--- a/packages/mc-scripts/src/commands/serve.ts
+++ b/packages/mc-scripts/src/commands/serve.ts
@@ -18,11 +18,20 @@ type RunOptions = {
 async function run(options: RunOptions = {}): Promise<http.Server> {
   const port = options.port ?? DEFAULT_PORT;
   const publicPath = options.publicPath ?? paths.appBuild;
-  const applicationConfig =
-    options.applicationConfig ?? (await processConfig());
   const handleAuthRoutes = options.handleAuthRoutes ?? true;
-  const isLocalMcApi =
-    applicationConfig.env.mcApiUrl.startsWith('http://localhost');
+  // Only resolve the application config when the auth-route handlers actually
+  // need it. With `handleAuthRoutes: false`, the server is a pure static file
+  // server — skipping `processConfig()` lets consumers (e.g.
+  // `application-authentication`) run `serve` without wiring up dotenv files
+  // or the `${env:...}` substitutions that `processConfig` would otherwise
+  // demand.
+  let applicationConfig: ApplicationRuntimeConfig | undefined;
+  let isLocalMcApi = false;
+  if (handleAuthRoutes) {
+    applicationConfig = options.applicationConfig ?? (await processConfig());
+    isLocalMcApi =
+      applicationConfig.env.mcApiUrl.startsWith('http://localhost');
+  }
 
   // `single: true` gives us the SPA fallback — any unmatched path is served as
   // the root `index.html`. This replaces the complex glob workaround that
@@ -36,7 +45,7 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
     // Apps that own the `/login*` / `/logout*` routes themselves (e.g.
     // `application-authentication`) opt out via `handleAuthRoutes: false` so
     // those paths flow through to the SPA fallback like any other route.
-    if (handleAuthRoutes) {
+    if (handleAuthRoutes && applicationConfig) {
       // Localhost-only: inline replacement for the login/logout UI that
       // `mc-dev-authentication` used to ship as static HTML (#3734).
       if (isLocalMcApi && request.url?.startsWith('/login/authorize')) {

--- a/packages/mc-scripts/src/commands/serve.ts
+++ b/packages/mc-scripts/src/commands/serve.ts
@@ -1,9 +1,6 @@
 import http from 'http';
 import sirv from 'sirv';
-import {
-  type ApplicationRuntimeConfig,
-  processConfig,
-} from '@commercetools-frontend/application-config';
+import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
 import paths from '../config/paths';
 
 const DEFAULT_PORT = 3001;
@@ -19,19 +16,9 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
   const port = options.port ?? DEFAULT_PORT;
   const publicPath = options.publicPath ?? paths.appBuild;
   const handleAuthRoutes = options.handleAuthRoutes ?? true;
-  // Only resolve the application config when the auth-route handlers actually
-  // need it. With `handleAuthRoutes: false`, the server is a pure static file
-  // server — skipping `processConfig()` lets consumers (e.g.
-  // `application-authentication`) run `serve` without wiring up dotenv files
-  // or the `${env:...}` substitutions that `processConfig` would otherwise
-  // demand.
-  let applicationConfig: ApplicationRuntimeConfig | undefined;
-  let isLocalMcApi = false;
-  if (handleAuthRoutes) {
-    applicationConfig = options.applicationConfig ?? (await processConfig());
-    isLocalMcApi =
-      applicationConfig.env.mcApiUrl.startsWith('http://localhost');
-  }
+  const { applicationConfig } = options;
+  const isLocalMcApi =
+    applicationConfig?.env.mcApiUrl.startsWith('http://localhost') ?? false;
 
   // `single: true` gives us the SPA fallback — any unmatched path is served as
   // the root `index.html`. This replaces the complex glob workaround that
@@ -42,9 +29,13 @@ async function run(options: RunOptions = {}): Promise<http.Server> {
   });
 
   const server = http.createServer((request, response) => {
-    // Apps that own the `/login*` / `/logout*` routes themselves (e.g.
-    // `application-authentication`) opt out via `handleAuthRoutes: false` so
-    // those paths flow through to the SPA fallback like any other route.
+    // The auth-route handlers are the only consumer of `applicationConfig`,
+    // so the branch is entered only when both the flag is on AND the caller
+    // supplied a config. The CLI pairs the two — see `serve` action in
+    // `cli.ts`. Apps that own the `/login*` / `/logout*` routes themselves
+    // (e.g. `application-authentication`) opt out via
+    // `--handle-auth-routes=false` so those paths flow through to the SPA
+    // fallback like any other route.
     if (handleAuthRoutes && applicationConfig) {
       // Localhost-only: inline replacement for the login/logout UI that
       // `mc-dev-authentication` used to ship as static HTML (#3734).


### PR DESCRIPTION
## Summary

`mc-scripts serve` was calling `processConfig()` unconditionally at startup, even when `--handle-auth-routes=false` was passed. That call substitutes `${env:...}` placeholders from `custom-application-config` and validates the resulting URLs — work that is only consumed by the built-in `/login*` / `/logout*` handlers, which are entirely bypassed when the flag is `false`.

This PR makes `mc-scripts serve --handle-auth-routes=false` runnable as a pure static file server with no dotenv files or `${env:...}` substitutions configured. The decision lives at one explicit seam in the CLI: the `serve` action calls `processConfig()` only when `handleAuthRoutes` is on, and passes the resulting `applicationConfig` (or `undefined`) into the `serve` command. `serve.ts` no longer imports `processConfig` at all — its `applicationConfig` option stays optional and the auth-route branch is gated on it being present.

This is the small follow-up suggested in the consumer-side rollout commercetools/merchant-center-frontend#20619 (FEC-820 step 3), which currently has to add `--env=...` flags AND an `MC_APP_ENV=development` workaround purely to satisfy `processConfig()`'s validation of a config it then throws away. With this change merged + released, that script collapses back to:

```sh
pnpm compile-html:local && mc-scripts serve --handle-auth-routes=false
```

and the env-loading boilerplate goes away.

### Why CLI, not serve.ts

An earlier draft of this PR put the `processConfig()` skip *inside* `serve.ts`, gated on `handleAuthRoutes`. That worked but coupled two concerns under one flag: `--handle-auth-routes=false` would have meant both "disable the route handlers" AND "skip loading the config" — only the first is telegraphed by the flag name. A future maintainer adding any other consumer of `applicationConfig` to `serve.ts` would silently break the static-only mode.

Pushing the decision up to `cli.ts` makes the coupling explicit at a single seam: the CLI is the only caller that maps a flag to "should I load the config?" and `serve.ts` just accepts whatever it's given. The flag's documented behavior is now purely about route handling.

### Implementation

`packages/mc-scripts/src/cli.ts` — `serve` action:

```ts
const handleAuthRoutes = options.handleAuthRoutes !== 'false';

const applicationConfig = handleAuthRoutes
  ? await (
      await import('@commercetools-frontend/application-config')
    ).processConfig()
  : undefined;

const server = await serveCommand.default({
  handleAuthRoutes,
  applicationConfig,
});
```

`packages/mc-scripts/src/commands/serve.ts`:

```ts
const handleAuthRoutes = options.handleAuthRoutes ?? true;
const { applicationConfig } = options;
const isLocalMcApi =
  applicationConfig?.env.mcApiUrl.startsWith('http://localhost') ?? false;
// ...
if (handleAuthRoutes && applicationConfig) {
  // existing /login/authorize, /logout, /login* | /logout* branches
}
```

The favicon rewrite and sirv static handler are unaffected.

### Tests

`serve.spec.ts` keeps the existing 25-test suite untouched (all pass an explicit `applicationConfig`) and adds a new `describe('with handleAuthRoutes disabled and no applicationConfig')` block that pins `serve.ts`'s public contract: starts the server with neither `applicationConfig` nor any env wiring and asserts that `/`, `/login`, `/logout`, and an arbitrary deep link all serve through the SPA fallback. This is the shape the CLI relies on when `--handle-auth-routes=false` is passed.

29/29 tests pass (25 existing + 4 new).

## Test plan

- [x] `pnpm jest packages/mc-scripts/src/commands/serve.spec.ts` — 29/29 green.
- [x] `tsc --noEmit -p packages/mc-scripts/tsconfig.json` — no new errors in touched files.
- [ ] Cross-repo smoke test once published: drop `--env` flags + `MC_APP_ENV` from the `start:prod:local` script in commercetools/merchant-center-frontend#20619 and verify the server still boots and serves `/login`, `/logout`, and arbitrary paths.

## Cross-references

- Consumer that motivated this: commercetools/merchant-center-frontend#20619
- JIRA: [FEC-820](https://commercetools.atlassian.net/browse/FEC-820)
- Builds on: #3985 (the `--handle-auth-routes` flag itself)

[FEC-820]: https://commercetools.atlassian.net/browse/FEC-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ