### PR TITLE
fix(application-config): allow module references outside workspace dir

### DIFF
--- a/.changeset/two-bushes-speak.md
+++ b/.changeset/two-bushes-speak.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-config': patch
+---
+
+Allow module resolution from outside of workspace.

--- a/packages/application-config/src/substitute-variable-placeholders.ts
+++ b/packages/application-config/src/substitute-variable-placeholders.ts
@@ -151,16 +151,22 @@ const substituteFilePathVariablePlaceholder = (
 
   const relativePath = path.relative(workspaceRoot, normalizedPath);
 
-  // Path is safe if it's within the workspace root.
-  // Use path.relative() to avoid string prefix vulnerabilities (e.g., "/app" vs "/app-evil")
-  const isSafePath =
-    !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+  const isModuleName =
+    !filePathOrModule.startsWith('.') && !filePathOrModule.startsWith('/');
 
-  if (!isSafePath) {
-    throw new Error(
-      `Access to files outside workspace directory is not allowed: ${filePathOrModule}`
-    );
+  if (!isModuleName) {
+    // Path is safe if it's within the workspace root.
+    // Use path.relative() to avoid string prefix vulnerabilities (e.g., "/app" vs "/app-evil")
+    const isSafePath =
+      !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+
+    if (!isSafePath) {
+      throw new Error(
+        `Access to files outside workspace directory is not allowed: ${filePathOrModule}`
+      );
+    }
   }
+
   const content = fs.readFileSync(normalizedPath, {
     encoding: 'utf-8',
   });

--- a/packages/application-config/src/substitute-variable-placeholders.ts
+++ b/packages/application-config/src/substitute-variable-placeholders.ts
@@ -114,48 +114,67 @@ const substituteFilePathVariablePlaceholder = (
   loadingOptions: LoadingConfigOptions
 ) => {
   const [, filePathOrModule] = valueOfPlaceholder.split(':');
-  const resolvedPath = require.resolve(filePathOrModule, {
-    paths: [loadingOptions.applicationPath],
-  });
 
   // Security check: Prevent path traversal attacks.
-  // require.resolve() already provides protection by only resolving modules
-  // accessible from the applicationPath. However, we add an extra layer to
-  // prevent access to sensitive system files outside the workspace.
-  const normalizedPath = path.normalize(resolvedPath);
-  const applicationPath = path.normalize(loadingOptions.applicationPath);
-
-  // Find workspace root by traversing up from applicationPath until we find
-  // package.json, pnpm-workspace.yaml, or reach root
-  let workspaceRoot = applicationPath;
-  let currentPath = applicationPath;
-  const rootPath = path.parse(currentPath).root;
-
-  while (currentPath !== rootPath) {
-    const hasPackageJson = fs.existsSync(
-      path.join(currentPath, 'package.json')
-    );
-    const hasWorkspaceConfig =
-      fs.existsSync(path.join(currentPath, 'pnpm-workspace.yaml')) ||
-      fs.existsSync(path.join(currentPath, 'lerna.json'));
-
-    if (hasPackageJson) {
-      workspaceRoot = currentPath;
-      if (hasWorkspaceConfig) {
-        // Found workspace root
-        break;
-      }
-    }
-    currentPath = path.dirname(currentPath);
-  }
-
-  const relativePath = path.relative(workspaceRoot, normalizedPath);
-
+  // Two strategies depending on whether the specifier is a bare module name
+  // (e.g. "@scope/pkg/file.svg") or a relative/absolute path (e.g. "./app.svg").
   const isModuleName =
     !filePathOrModule.startsWith('.') && !filePathOrModule.startsWith('/');
 
+  if (isModuleName) {
+    // Bare module specifiers are resolved by require.resolve through
+    // node_modules, linked packages, or Yarn PnP — all legitimate locations
+    // that may be outside the workspace root (e.g. hoisted deps in CI).
+    // We skip the workspace root check for these, but we must block ".."
+    // segments in the specifier itself — those are the only way to make
+    // require.resolve escape module directories and reach arbitrary files
+    // (e.g. "some-pkg/../../../../etc/passwd" resolves through node_modules
+    // to /etc/passwd).
+    const normalizedSpecifier = path.posix.normalize(filePathOrModule);
+    if (normalizedSpecifier.startsWith('..')) {
+      throw new Error(
+        `Path traversal in module specifiers is not allowed: ${filePathOrModule}`
+      );
+    }
+  }
+
+  const resolvedPath = require.resolve(filePathOrModule, {
+    paths: [loadingOptions.applicationPath],
+  });
+  const normalizedPath = path.normalize(resolvedPath);
+
   if (!isModuleName) {
-    // Path is safe if it's within the workspace root.
+    // For relative/absolute paths, verify the resolved path is within the
+    // workspace root. require.resolve() already provides some protection by
+    // only resolving from applicationPath, but we add an extra layer to
+    // prevent access to sensitive system files outside the workspace.
+    const applicationPath = path.normalize(loadingOptions.applicationPath);
+
+    // Find workspace root by traversing up from applicationPath until we find
+    // package.json, pnpm-workspace.yaml, or reach root
+    let workspaceRoot = applicationPath;
+    let currentPath = applicationPath;
+    const rootPath = path.parse(currentPath).root;
+
+    while (currentPath !== rootPath) {
+      const hasPackageJson = fs.existsSync(
+        path.join(currentPath, 'package.json')
+      );
+      const hasWorkspaceConfig =
+        fs.existsSync(path.join(currentPath, 'pnpm-workspace.yaml')) ||
+        fs.existsSync(path.join(currentPath, 'lerna.json'));
+
+      if (hasPackageJson) {
+        workspaceRoot = currentPath;
+        if (hasWorkspaceConfig) {
+          // Found workspace root
+          break;
+        }
+      }
+      currentPath = path.dirname(currentPath);
+    }
+
+    const relativePath = path.relative(workspaceRoot, normalizedPath);
     // Use path.relative() to avoid string prefix vulnerabilities (e.g., "/app" vs "/app-evil")
     const isSafePath =
       !relativePath.startsWith('..') && !path.isAbsolute(relativePath);

--- a/packages/application-config/test/substitute-variable-placeholders.spec.js
+++ b/packages/application-config/test/substitute-variable-placeholders.spec.js
@@ -110,6 +110,69 @@ describe('providing a config with env variable placeholders', () => {
   });
 });
 
+describe('path variable placeholder security', () => {
+  it('should block path traversal in bare module specifiers', () => {
+    expect(() => {
+      substituteVariablePlaceholders(
+        {
+          icon: '${path:some-pkg/../../../../etc/passwd}',
+        },
+        {
+          processEnv: {},
+          applicationPath,
+        }
+      );
+    }).toThrow('Path traversal in module specifiers is not allowed');
+  });
+
+  it('should block path traversal with nested segments in bare module specifiers', () => {
+    expect(() => {
+      substituteVariablePlaceholders(
+        {
+          icon: '${path:some-pkg/sub/../../../../../../etc/shadow}',
+        },
+        {
+          processEnv: {},
+          applicationPath,
+        }
+      );
+    }).toThrow('Path traversal in module specifiers is not allowed');
+  });
+
+  it('should allow bare module specifiers without path traversal (e.g. hoisted CI deps)', () => {
+    // Bare module specifiers like "@scope/pkg/file.svg" pass the security
+    // check even when they resolve outside the workspace root (e.g. to
+    // /layers/google.nodejs.yarn/yarn_modules/node_modules/).
+    // Here the module doesn't exist, so require.resolve throws — but the
+    // error must be MODULE_NOT_FOUND, not the security gate.
+    expect(() => {
+      substituteVariablePlaceholders(
+        {
+          icon: '${path:nonexistent-external-pkg/icon.svg}',
+        },
+        {
+          processEnv: {},
+          applicationPath,
+        }
+      );
+    }).toThrow(/Cannot (?:find|resolve) module/);
+  });
+
+  it('should allow scoped bare module specifiers without path traversal', () => {
+    expect(() => {
+      substituteVariablePlaceholders(
+        {
+          icon: '${path:@nonexistent-scope/pkg/icon.svg}',
+        },
+        {
+          processEnv: {},
+          applicationPath,
+        }
+      );
+    }).toThrow(/Cannot (?:find|resolve) module/);
+  });
+});
+
 describe('providing a config without env variable placeholders', () => {
   it('should return the config as-is', () => {
     const result = substituteVariablePlaceholders(


### PR DESCRIPTION
#### Summary

At Connect, Merchant Center Custom Applications are built from source using [Cloud Native Buildpacks](https://buildpacks.io/) with [Google Cloud buildpacks](https://docs.cloud.google.com/docs/buildpacks/overview) build image, no `Dockerfile` is required. The buildpack detects the Node.js runtime, installs dependencies, and runs the `build` script, but unlike a local environment, `node_modules` are placed in a separate folder at `/layers/google.nodejs.yarn/yarn_modules/node_modules/` rather than inside the application folder, in the case of the buildpack environment at `/workspace`.

Affected versions: >=v25.2.0

#### Observed behavior

The security check introduced in #3917, the function `substituteFilePathVariablePlaceholder` fails when the application is built using GCP Cloud Buildpacks. The function resolves module paths via `require.resolve()` and then checks whether the resolved path is within the workspace root, but GCP buildpacks installs `node_modules` outside the workspace at:

```
/layers/google.nodejs.yarn/yarn_modules/node_modules/
```

This causes `path.relative(workspaceRoot, resolvedPath)` to return a path starting with `..`, which the security check correctly identifies as "outside workspace" and throws:

```
Error: Access to files outside workspace directory is not allowed: @commercetools-frontend/assets/application-icons/rocket.svg
```

Even though the reference is a legitimate installed package, not a path traversal attack.

#### Expected behavior

The workspace boundary check does not distinguish between:

- **Direct file paths** (e.g. `path:../../etc/passwd`) — where the check is necessary
- **Module references** (e.g. `{path:@commercetools-frontend/assets/application-icons/rocket.svg}`)

The expected behavior is not to throw an exception when the module lives outside the application folder.

#### Technical debt & future

None

#### How to reproduce

Code:

```typescript
/* eslint-disable prettier/prettier */
/* eslint-disable @typescript-eslint/no-explicit-any */
const fs = require('fs');
const path = require('path');

// Safe regex pattern escaping function
const escapeRegExp = (string: string) => {
  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
};

const substituteFilePathVariablePlaceholder = (
  valueOfPlaceholder: string,
  matchedString: string,
  valueOfEnvConfig: string,
  loadingOptions: any
) => {
  const [, filePathOrModule] = valueOfPlaceholder.split(':');
  const resolvedPath = require.resolve(filePathOrModule, {
    paths: [loadingOptions.applicationPath],
  });

  console.dir({ resolvedPath })

  // Security check: Prevent path traversal attacks.
  // require.resolve() already provides protection by only resolving modules
  // accessible from the applicationPath. However, we add an extra layer to
  // prevent access to sensitive system files outside the workspace.
  const normalizedPath = path.normalize(resolvedPath);
  const applicationPath = path.normalize(loadingOptions.applicationPath);

  // Find workspace root by traversing up from applicationPath until we find
  // package.json, pnpm-workspace.yaml, or reach root
  let workspaceRoot = applicationPath;
  let currentPath = applicationPath;
  const rootPath = path.parse(currentPath).root;

  while (currentPath !== rootPath) {
    const hasPackageJson = fs.existsSync(
      path.join(currentPath, 'package.json')
    );
    const hasWorkspaceConfig =
      fs.existsSync(path.join(currentPath, 'pnpm-workspace.yaml')) ||
      fs.existsSync(path.join(currentPath, 'lerna.json'));

    if (hasPackageJson) {
      workspaceRoot = currentPath;
      if (hasWorkspaceConfig) {
        // Found workspace root
        break;
      }
    }
    currentPath = path.dirname(currentPath);
  }

  const relativePath = path.relative(workspaceRoot, normalizedPath);

  console.dir({ relativePath });

  // Path is safe if it's within the workspace root.
  // Use path.relative() to avoid string prefix vulnerabilities (e.g., "/app" vs "/app-evil")
  const isSafePath =
    !relativePath.startsWith('..') && !path.isAbsolute(relativePath);

  if (!isSafePath) {
    throw new Error(
      `Access to files outside workspace directory is not allowed: ${filePathOrModule}`
    );
  }

  const content = fs.readFileSync(normalizedPath, {
    encoding: 'utf-8',
  });

  return valueOfEnvConfig.replace(
    new RegExp(escapeRegExp(matchedString), 'g'),
    content
  );
};

const applicationPath = path.join(__dirname); // Adjust this to point to the application root

console.dir({ applicationPath }); 

const output = substituteFilePathVariablePlaceholder(
  'path:@commercetools-frontend/assets/application-icons/rocket.svg',
  '${path:@commercetools-frontend/assets/application-icons/rocket.svg}',
  '${path:@commercetools-frontend/assets/application-icons/rocket.svg}',
  {
    applicationPath,
    processEnv: {},
  },
);

console.dir({ output }, { depth: null });
```

package.json:

```json
{
  "name": "my-new-custom-application-project",
  "version": "1.0.0",
  "description": "",
  "private": true,
  "scripts": {
    "gcp-build": "node test.cts",
    "build": "node test.cts",
    "start": "node test.cts"
  },
  "engines": {
    "node": ">=22"
  },
  "dependencies": {
    "@commercetools-frontend/assets": "27.5.1"
  }
}
```

**Local output (passes):**

Command:
```
node test.cts
```

Output:
```
{ applicationPath: '/Users/andreabreu/workspace/sandbox/test-mc-app' }
{
  relativePath: 'test-mc-app/node_modules/@commercetools-frontend/assets/application-icons/rocket.svg'
}
{
  output: '<svg width="24" height="24" viewBox="0 0 24 24" ...>...</svg>'
}
```

**GCP buildpack output (fails before fix):**

Command:
```
# Install pack CLI at https://buildpacks.io/docs/tools/pack/

pack build test-mc-app \
  --builder gcr.io/buildpacks/builder@sha256:5977b4bd47d3e9ff729eefe9eb99d321d4bba7aa3b14986323133f40b622aef1 \
  --path .
``` 

Output:
``` 
[builder] { applicationPath: '/workspace' }
[builder] {
[builder]   relativePath: '../layers/google.nodejs.yarn/yarn_modules/node_modules/@commercetools-frontend/assets/application-icons/rocket.svg'
[builder] }
[builder] Error: Access to files outside workspace directory is not allowed: @commercetools-frontend/assets/application-icons/rocket.svg
[builder]     at substituteFilePathVariablePlaceholder (/workspace/test.cts:64:11)
[builder] Node.js v24.15.0
[builder] error Command failed with exit code 1.
```
