### PR TITLE
fix(mc-scripts): resolve URL relative to file when referenced in CSS files

### DIFF
--- a/.changeset/calm-socks-attack.md
+++ b/.changeset/calm-socks-attack.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Use relative URLs for assets referenced from CSS files.
+
+If a package has a CSS file that references a URL, we need to make sure it can resolve it correctly as does not inject the `runtime: "window.__toCdnUrl()"` part.

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -72,10 +72,21 @@ async function run() {
     experimental: {
       // https://vitejs.dev/guide/build.html#advanced-base-options
       renderBuiltUrl(filename, { hostType }) {
-        if (hostType === 'html') {
-          return `__CDN_URL__${filename}`;
+        switch (hostType) {
+          case 'html': {
+            return `__CDN_URL__${filename}`;
+          }
+          case 'css':
+            // Vite does not support `{ runtime: ... }` for assets referenced from CSS
+            // (e.g. KaTeX fonts pulled in via CopilotKit → streamdown). Use relative URLs.
+            return {
+              relative: true,
+            };
+          default:
+            return {
+              runtime: `window.__toCdnUrl(${JSON.stringify(filename)})`,
+            };
         }
-        return { runtime: `window.__toCdnUrl(${JSON.stringify(filename)})` };
       },
     },
     plugins: [


### PR DESCRIPTION
Example build error:

```
[vite:css-post] { runtime: "window.__toCdnUrl("KaTeX_AMS-Regular-BQhdFMY1.woff2")" } is not supported for assets in css files: KaTeX_AMS-Regular-BQhdFMY1.woff2
```