### PR TITLE
fix(cypress): wait for custom views bar before Percy snapshot

### DIFF
--- a/cypress/e2e/playground/application-shell.cy.ts
+++ b/cypress/e2e/playground/application-shell.cy.ts
@@ -47,6 +47,7 @@ describe('navigation menu', () => {
   it('should stay collapsed for small viewports', () => {
     cy.viewport(900, 800);
     cy.findAllByText('Initial').should('exist');
+    cy.findByText('Custom Views:').should('be.visible');
     cy.percySnapshot(
       // @ts-ignore
       cy.state('runnable').fullTitle(),


### PR DESCRIPTION
## Summary

- Fix flaky Percy snapshot in "navigation menu should stay collapsed for small viewports" test
- The snapshot was captured before the async custom views query resolved, causing the "Custom Views:" bar to intermittently be absent from the screenshot
- Added a `cy.findByText('Custom Views:').should('be.visible')` assertion before the snapshot to ensure the page is fully settled

## Test plan

- [ ] Percy snapshot for "should stay collapsed for small viewports" should consistently include the Custom Views bar
- [ ] No other e2e tests regress