### PR TITLE
fix(eslint-config-mc-app): add typescript resolver to base config for JS/JSX files

### DIFF
--- a/.changeset/add-ts-resolver-base-config.md
+++ b/.changeset/add-ts-resolver-base-config.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/eslint-config-mc-app': patch
+---
+
+Add `eslint-import-resolver-typescript` to the base ESLint config block so JS/JSX files can resolve non-hoisted pnpm packages and packages using only the `exports` field.

--- a/jest.test.config.js
+++ b/jest.test.config.js
@@ -6,7 +6,7 @@ process.env.ENABLE_NEW_JSX_TRANSFORM = 'true';
  *
  *  - "test"         — the main suite (jsdom). Uses the MC app preset which
  *                     sets up window.app, localStorage mocks, etc.
- *  - "eslint-rules" — custom ESLint rule tests (node). These use ESLint's
+ *  - "eslint-rules" — ESLint config and rule tests (node). These use ESLint's
  *                     RuleTester which requires `structuredClone` (available
  *                     in Node but not in jsdom) and has no DOM dependencies.
  *                     The MC app preset's setup files also assume jsdom
@@ -45,6 +45,7 @@ module.exports = {
         '/node_modules/',
         // Excluded here because these tests need the node environment (see below).
         'packages/eslint-config-mc-app/rules/',
+        'packages/eslint-config-mc-app/index.spec.js',
       ],
       transformIgnorePatterns: [
         // Transpile also our local packages as they are only symlinked.
@@ -58,7 +59,10 @@ module.exports = {
     {
       displayName: 'eslint-rules',
       testEnvironment: 'node',
-      testMatch: ['<rootDir>/packages/eslint-config-mc-app/rules/**/*.spec.js'],
+      testMatch: [
+        '<rootDir>/packages/eslint-config-mc-app/rules/**/*.spec.js',
+        '<rootDir>/packages/eslint-config-mc-app/index.spec.js',
+      ],
       transform: {},
     },
   ],

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -135,6 +135,9 @@ module.exports = [
     },
     settings: {
       'import/resolver': {
+        typescript: {
+          alwaysTryTypes: true,
+        },
         node: {
           extensions: allSupportedExtensions,
         },

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -135,6 +135,8 @@ module.exports = [
     },
     settings: {
       'import/resolver': {
+        // The node resolver alone can't resolve non-hoisted pnpm packages
+        // or packages that only use the `exports` field (no main/module).
         typescript: {
           alwaysTryTypes: true,
         },

--- a/packages/eslint-config-mc-app/index.spec.js
+++ b/packages/eslint-config-mc-app/index.spec.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment node
+ */
+const config = require('./index');
+
+describe('eslint-config-mc-app flat config', () => {
+  const baseConfig = config.find(
+    (block) =>
+      Array.isArray(block.files) &&
+      block.files.some((f) => f.includes('{js,jsx,ts,tsx,cjs,mjs}'))
+  );
+
+  it('should include typescript resolver in the base config block', () => {
+    expect(baseConfig.settings['import/resolver']).toEqual(
+      expect.objectContaining({
+        typescript: {
+          alwaysTryTypes: true,
+        },
+      })
+    );
+  });
+
+  it('should still include node resolver in the base config block', () => {
+    expect(baseConfig.settings['import/resolver']).toEqual(
+      expect.objectContaining({
+        node: expect.objectContaining({
+          extensions: expect.any(Array),
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `eslint-import-resolver-typescript` to the base ESLint config block that covers all file types (`**/*.{js,jsx,ts,tsx,cjs,mjs}`)
- Previously only the `.ts` and `.tsx` config blocks used the typescript resolver — JS/JSX files only had `eslint-import-resolver-node`, which can't resolve non-hoisted pnpm packages or packages using only the `exports` field
- The package already had `eslint-import-resolver-typescript` as a direct dependency; this just wires it into the base config
- Adds tests verifying the base config includes both resolvers

Closes FEC-928

## Test plan
- [x] New unit tests verify the base config block includes the `typescript` resolver
- [x] All existing eslint-config-mc-app tests pass (50/50)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)