### PR TITLE
fix: scope rollup pnpm override to rollup@^4

### DIFF
--- a/.changeset/fix-rollup-override-scope.md
+++ b/.changeset/fix-rollup-override-scope.md
@@ -1,0 +1,23 @@
+---
+'@commercetools-frontend/actions-global': patch
+'@commercetools-frontend/application-components': patch
+'@commercetools-frontend/application-config': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/browser-history': patch
+'@commercetools-frontend/constants': patch
+'@commercetools-frontend/i18n': patch
+'@commercetools-frontend/l10n': patch
+'@commercetools-frontend/mc-html-template': patch
+'@commercetools-frontend/mc-scripts': patch
+'@commercetools-frontend/notifications': patch
+'@commercetools-frontend/permissions': patch
+'@commercetools-frontend/react-notifications': patch
+'@commercetools-frontend/sdk': patch
+'@commercetools-frontend/sentry': patch
+'@commercetools-frontend/url-utils': patch
+---
+
+Scope the `rollup` pnpm override to `rollup@^4` so it only affects Rollup 4.x consumers.
+
+The unscoped `"rollup": "^4.59.0"` override introduced in 27.5.3 forced `@preconstruct/cli`'s `rollup@^2` dependency to resolve to Rollup 4.x. Rollup 4 no longer emits `Object.defineProperty(exports, '__esModule', { value: true })` in CJS output by default, which broke `jest.spyOn` on namespace imports (`import * as X from 'module'`) in downstream consumers.

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
       "minimatch@^10": "^10.2.3",
       "path-to-regexp@^6": "^6.3.0",
       "picomatch@^4": "^4.0.4",
-      "rollup": "^4.59.0",
+      "rollup@^4": "^4.59.0",
       "semver@^6": "^6.3.1",
       "svgo": ">=2.8.1",
       "systeminformation": ">=5.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   minimatch@^10: ^10.2.3
   path-to-regexp@^6: ^6.3.0
   picomatch@^4: ^4.0.4
-  rollup: ^4.59.0
+  rollup@^4: ^4.59.0
   semver@^6: ^6.3.1
   svgo: '>=2.8.1'
   systeminformation: '>=5.31.0'
@@ -6734,13 +6734,13 @@ packages:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/plugin-commonjs@15.1.0':
     resolution: {integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^2.22.0
 
   '@rollup/plugin-graphql@2.0.5':
     resolution: {integrity: sha512-NMx9uVIheYMOQHV9Aann0sk/2+henT8T5JUbHneOvbD3iUrVUC7AaZ1B1ELJ/1vhqUe2OQIkRtGHzOQwBLoCvg==}
@@ -6755,24 +6755,24 @@ packages:
   '@rollup/plugin-json@4.1.0':
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0 || ^2.0.0
 
   '@rollup/plugin-node-resolve@11.2.1':
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0 || ^2.0.0
 
   '@rollup/pluginutils@3.1.0':
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -14221,6 +14221,11 @@ packages:
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
+  rollup@2.80.0:
+    resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -21276,11 +21281,11 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/runtime': 7.28.6
       '@preconstruct/hook': 0.4.0
-      '@rollup/plugin-alias': 3.1.9(rollup@4.60.3)
-      '@rollup/plugin-commonjs': 15.1.0(rollup@4.60.3)
-      '@rollup/plugin-json': 4.1.0(rollup@4.60.3)
-      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.60.3)
-      '@rollup/plugin-replace': 2.4.2(rollup@4.60.3)
+      '@rollup/plugin-alias': 3.1.9(rollup@2.80.0)
+      '@rollup/plugin-commonjs': 15.1.0(rollup@2.80.0)
+      '@rollup/plugin-json': 4.1.0(rollup@2.80.0)
+      '@rollup/plugin-node-resolve': 11.2.1(rollup@2.80.0)
+      '@rollup/plugin-replace': 2.4.2(rollup@2.80.0)
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -21302,7 +21307,7 @@ snapshots:
       parse-json: 5.2.0
       quick-lru: 5.1.1
       resolve-from: 5.0.0
-      rollup: 4.60.3
+      rollup: 2.80.0
       semver: 7.7.2
       terser: 5.46.0
       v8-compile-cache: 2.4.0
@@ -21552,21 +21557,21 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rollup/plugin-alias@3.1.9(rollup@4.60.3)':
+  '@rollup/plugin-alias@3.1.9(rollup@2.80.0)':
     dependencies:
-      rollup: 4.60.3
+      rollup: 2.80.0
       slash: 3.0.0
 
-  '@rollup/plugin-commonjs@15.1.0(rollup@4.60.3)':
+  '@rollup/plugin-commonjs@15.1.0(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.11
-      rollup: 4.60.3
+      rollup: 2.80.0
 
   '@rollup/plugin-graphql@2.0.5(graphql@16.11.0)(rollup@4.60.3)':
     dependencies:
@@ -21576,33 +21581,33 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.3
 
-  '@rollup/plugin-json@4.1.0(rollup@4.60.3)':
+  '@rollup/plugin-json@4.1.0(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
-      rollup: 4.60.3
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      rollup: 2.80.0
 
-  '@rollup/plugin-node-resolve@11.2.1(rollup@4.60.3)':
+  '@rollup/plugin-node-resolve@11.2.1(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
-      rollup: 4.60.3
+      rollup: 2.80.0
 
-  '@rollup/plugin-replace@2.4.2(rollup@4.60.3)':
+  '@rollup/plugin-replace@2.4.2(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       magic-string: 0.25.9
-      rollup: 4.60.3
+      rollup: 2.80.0
 
-  '@rollup/pluginutils@3.1.0(rollup@4.60.3)':
+  '@rollup/pluginutils@3.1.0(rollup@2.80.0)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.2
-      rollup: 4.60.3
+      rollup: 2.80.0
 
   '@rollup/pluginutils@5.2.0(rollup@4.60.3)':
     dependencies:
@@ -30391,6 +30396,10 @@ snapshots:
   rollup-pluginutils@2.8.2:
     dependencies:
       estree-walker: 0.6.1
+
+  rollup@2.80.0:
+    optionalDependencies:
+      fsevents: 2.3.3
 
   rollup@4.60.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Scopes the `rollup` pnpm override from `"rollup": "^4.59.0"` to `"rollup@^4": "^4.59.0"` so it only affects Rollup 4.x consumers
- The unscoped override (introduced in 27.5.3) forced `@preconstruct/cli`'s `rollup@^2` dependency to resolve to Rollup 4.x
- Rollup 4 no longer emits `Object.defineProperty(exports, '__esModule', { value: true })` in CJS output by default, which broke `jest.spyOn` on namespace imports (`import * as X from 'module'`) in downstream consumers

## Root cause

The unscoped override caused preconstruct to use Rollup 4 instead of Rollup 2 when building appkit packages. Rollup 4 changed the default for `output.esModule` from `true` to `'if-default-prop'`, which stops emitting the `__esModule` marker in CJS bundles. Without this marker, Babel's `_interopRequireWildcard` creates a shallow copy of the module namespace instead of returning the original exports object, causing `jest.spyOn` patches to target a different object than the one used by named imports.

## Test plan

- [x] Verified preconstruct now resolves to `rollup@2.80.0` while Vite/other v4 consumers still get `rollup@4.60.3`
- [x] Verified `__esModule` marker is restored in all CJS package builds
- [x] All 994 appkit tests pass
- [ ] Verify mc-frontend test failures from #20642 are resolved after upgrading to this patch