### PR TITLE
fix: upgrade uuid from 9.0.1 to 14.0.0 (CVE-2026-41907)

### DIFF
--- a/.changeset/upgrade-uuid-cve-2026-41907.md
+++ b/.changeset/upgrade-uuid-cve-2026-41907.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/application-shell-connectors': patch
+'@commercetools-frontend/cypress': patch
+'@commercetools-frontend/sdk': patch
+---
+
+Upgrade `uuid` from 9.0.1 to 14.0.0 to address CVE-2026-41907 (High). Remove `@types/uuid` as uuid@14 ships its own type definitions.

--- a/jest.test.config.js
+++ b/jest.test.config.js
@@ -48,8 +48,8 @@ module.exports = {
         'packages/eslint-config-mc-app/index.spec.js',
       ],
       transformIgnorePatterns: [
-        // Transpile also our local packages as they are only symlinked.
-        'node_modules/(?!(@commercetools-[frontend|backend]+)/)',
+        // Transpile local symlinked packages and ESM-only deps (uuid).
+        'node_modules/(?!\\.pnpm/uuid@)(?!(@commercetools-[frontend|backend]+|uuid)/)',
       ],
       testEnvironment: 'jsdom',
     },

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "@types/node": "^22.13.2",
     "@types/rosie": "^0.0.45",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@types/uuid": "^9.0.3",
     "@types/webpack-env": "^1.18.8",
     "autoprefixer": "^10.4.15",
     "babel-plugin-import-graphql": "^2.8.1",

--- a/packages/application-shell-connectors/package.json
+++ b/packages/application-shell-connectors/package.json
@@ -39,7 +39,7 @@
     "omit-empty-es": "1.2.0",
     "prop-types": "15.8.1",
     "tiny-warning": "1.0.3",
-    "uuid": "9.0.1",
+    "uuid": "14.0.0",
     "wait-for-observables": "1.0.3"
   },
   "devDependencies": {

--- a/packages/application-shell-connectors/src/utils/get-correlation-id/get-correlation-id.ts
+++ b/packages/application-shell-connectors/src/utils/get-correlation-id/get-correlation-id.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/named
 import { v4 as uuid } from 'uuid';
 import selectProjectKeyFromUrl from '../select-project-key-from-url';
 

--- a/packages/application-shell/package.json
+++ b/packages/application-shell/package.json
@@ -78,7 +78,6 @@
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
     "@types/redux-logger": "3.0.13",
-    "@types/uuid": "^9.0.3",
     "classnames": "^2.3.2",
     "common-tags": "1.8.2",
     "debounce-async": "0.0.2",
@@ -101,7 +100,7 @@
     "redux-thunk": "3.1.0",
     "tiny-invariant": "1.3.3",
     "unfetch": "4.2.0",
-    "uuid": "9.0.1"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@apollo/client": "3.13.9",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -43,7 +43,7 @@
     "@manypkg/get-packages": "1.1.3",
     "@types/semver": "^7.5.1",
     "semver": "7.7.2",
-    "uuid": "9.0.1"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,12 +38,11 @@
     "prop-types": "15.8.1",
     "qss": "2.0.3",
     "unfetch": "4.2.0",
-    "uuid": "9.0.1"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@emotion/react": "^11.14.0",
     "@testing-library/react": "16.1.0",
-    "@types/uuid": "^9.0.3",
     "jest-mock": "29.7.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       '@types/testing-library__jest-dom':
         specifier: ^5.14.9
         version: 5.14.9
-      '@types/uuid':
-        specifier: ^9.0.3
-        version: 9.0.8
       '@types/webpack-env':
         specifier: ^1.18.8
         version: 1.18.8
@@ -1717,9 +1714,6 @@ importers:
       '@types/redux-logger':
         specifier: 3.0.13
         version: 3.0.13
-      '@types/uuid':
-        specifier: ^9.0.3
-        version: 9.0.8
       classnames:
         specifier: ^2.3.2
         version: 2.5.1
@@ -1787,8 +1781,8 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       uuid:
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@apollo/client':
         specifier: 3.13.9
@@ -1887,8 +1881,8 @@ importers:
         specifier: 1.0.3
         version: 1.0.3
       uuid:
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 14.0.0
+        version: 14.0.0
       wait-for-observables:
         specifier: 1.0.3
         version: 1.0.3
@@ -2151,8 +2145,8 @@ importers:
         specifier: 7.7.2
         version: 7.7.2
       uuid:
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@tsconfig/node22':
         specifier: ^22.0.0
@@ -3018,8 +3012,8 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       uuid:
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@emotion/react':
         specifier: ^11.14.0
@@ -3027,9 +3021,6 @@ importers:
       '@testing-library/react':
         specifier: 16.1.0
         version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@types/uuid':
-        specifier: ^9.0.3
-        version: 9.0.8
       jest-mock:
         specifier: 29.7.0
         version: 29.7.0
@@ -3378,9 +3369,6 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
-      '@types/uuid':
-        specifier: ^9.0.3
-        version: 9.0.8
       '@vitejs/plugin-react':
         specifier: 4.7.0
         version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
@@ -3412,8 +3400,8 @@ importers:
         specifier: 5.3.4
         version: 5.3.4(react@19.0.0)
       uuid:
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 14.0.0
+        version: 14.0.0
       vite:
         specifier: ~6.4.2
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1)
@@ -7526,9 +7514,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/webpack-bundle-analyzer@4.7.0':
     resolution: {integrity: sha512-c5i2ThslSNSG8W891BRvOd/RoCjI2zwph8maD22b1adtSns20j+0azDDMCK06DiVrzTgnwiDl5Ntmu1YRJw8Sg==}
@@ -12028,6 +12013,7 @@ packages:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -15581,13 +15567,12 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -22378,8 +22363,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1)':
     dependencies:
@@ -32018,9 +32001,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
-  uuid@9.0.1: {}
+  uuid@8.3.2: {}
 
   uvu@0.5.6:
     dependencies:

--- a/visual-testing-app/package.json
+++ b/visual-testing-app/package.json
@@ -35,7 +35,6 @@
     "@types/react": "^19.0.3",
     "@types/react-dom": "^19.0.2",
     "@types/react-router-dom": "^5.3.3",
-    "@types/uuid": "^9.0.3",
     "@vitejs/plugin-react": "4.7.0",
     "formik": "2.4.6",
     "graphql": "^16.8.1",
@@ -46,7 +45,7 @@
     "react-intl": "^7.1.4",
     "react-redux": "7.2.9",
     "react-router-dom": "5.3.4",
-    "uuid": "9.0.1",
+    "uuid": "14.0.0",
     "vite": "~6.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrades `uuid` from `9.0.1` to `14.0.0` across 5 packages to address CVE-2026-41907 (High)
- Removes `@types/uuid` from 4 locations — uuid@14 ships its own type definitions
- Removes stale `eslint-disable` comment in `get-correlation-id.ts`
- Updates Jest `transformIgnorePatterns` to handle uuid@14's ESM-only distribution via pnpm

### Affected packages
- `@commercetools-frontend/application-shell`
- `@commercetools-frontend/application-shell-connectors`
- `@commercetools-frontend/sdk`
- `@commercetools-frontend/cypress`
- `visual-testing-app` (private)

### Note
A transitive `uuid@8.3.2` remains via `launchdarkly-js-sdk-common` (pulled in by `@flopflip`) — this is an upstream dependency outside our control.

## Test plan
- [x] Correlation ID tests pass (5 tests)
- [x] SDK test-utils tests pass (8 tests)
- [x] TypeScript compiles cleanly for application-shell, application-shell-connectors, and sdk
- [x] Pre-commit hooks (lint, prettier, tsc) pass
- [x] CI passes