### PR TITLE
fix: update jest preset to handle ESM-only uuid v14

### DIFF
--- a/.changeset/fix-jest-preset-esm-uuid.md
+++ b/.changeset/fix-jest-preset-esm-uuid.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/jest-preset-mc-app': patch
+---
+
+fix: handle ESM-only dependencies (uuid v14) in jest preset
+
+Add `transformIgnorePatterns` to the shared jest preset so that ESM-only packages like `uuid` v14 are transpiled by babel-jest. Also add `ts` and `tsx` to the base preset's `moduleFileExtensions` so JavaScript starter templates can resolve TypeScript dependencies.

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -73,6 +73,11 @@ runs:
       shell: bash
       run: pnpm test -- "${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/**/*.spec.{js,ts,tsx}"
 
+    - name: Running template tests with local jest config (mirrors end-user yarn test)
+      shell: bash
+      working-directory: ${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}
+      run: pnpm jest --config jest.test.config.js --no-coverage
+
     # https://github.com/bahmutov/cypress-gh-action-split-install/blob/ca3916d4e7240ebdc337825d2d78eb354855464b/.github/workflows/tests.yml#L23-L30
     # https://github.com/marketplace/actions/cypress-io#custom-install
     - name: Restoring Cypress cache

--- a/packages/jest-preset-mc-app/jest-preset.js
+++ b/packages/jest-preset-mc-app/jest-preset.js
@@ -20,7 +20,7 @@ const defaultModuleExportsResolver = resolveRelativePath(
 
 module.exports = {
   displayName: 'test',
-  moduleFileExtensions: ['js', 'mjs', 'cjs', 'jsx', 'json'],
+  moduleFileExtensions: ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx', 'json'],
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
@@ -42,6 +42,7 @@ module.exports = {
     url: 'https://mc.europe-west1.gcp.commercetools.com/',
   },
   testPathIgnorePatterns: ['node_modules', 'cypress'],
+  transformIgnorePatterns: ['node_modules/(?!(uuid|\\.pnpm))'],
   testRegex: '\\.spec\\.jsx?$',
   transform: {
     '^.+\\.(js|jsx|mjs|ts|tsx)$': defaultTransformBabelJest,

--- a/packages/jest-preset-mc-app/typescript/jest-preset.js
+++ b/packages/jest-preset-mc-app/typescript/jest-preset.js
@@ -2,6 +2,12 @@ const defaultPreset = require('../jest-preset');
 
 module.exports = {
   ...defaultPreset,
-  moduleFileExtensions: ['ts', 'tsx', ...defaultPreset.moduleFileExtensions],
+  moduleFileExtensions: [
+    'ts',
+    'tsx',
+    ...defaultPreset.moduleFileExtensions.filter(
+      (ext) => ext !== 'ts' && ext !== 'tsx'
+    ),
+  ],
   testRegex: '\\.spec\\.[j|t]sx?$',
 };


### PR DESCRIPTION
## Summary

- Add `transformIgnorePatterns` to the shared `jest-preset-mc-app` so ESM-only packages (uuid v14) are transpiled by babel-jest. The pattern `node_modules/(?!(uuid|\.pnpm))` works for both **yarn** and **pnpm** directory layouts.
- Add `ts` and `tsx` to the base preset's `moduleFileExtensions` so JavaScript starter templates can resolve TypeScript dependencies.
- Deduplicate extensions in the TypeScript preset (now inherited from base).
- Add a CI step that runs each template's tests using its **local** jest config (`jest.test.config.js`), mirroring what end users run with `yarn test`. This prevents the root jest config from masking preset regressions.

### Why CI didn't catch this

CI runs `pnpm test` which uses the root `jest.test.config.js`. That config already had uuid in its `transformIgnorePatterns` (added in #4012), but the shared preset consumed by end users was never updated — so CI passed while fresh projects created from the template failed.

## Test plan

- [x] All 4 starter templates pass with their local jest configs (app JS, app TS, custom-views JS, custom-views TS)
- [x] Full monorepo test suite passes (120 suites, 994 tests)
- [x] CI template jobs run the new local-config step successfully