### PR TITLE
fix(ci): use regex for jest testPathPattern in template tests

### DIFF
--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -71,7 +71,7 @@ runs:
 
     - name: Running integration tests
       shell: bash
-      run: pnpm test -- "${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/**/*.spec.{js,ts,tsx}"
+      run: pnpm test -- "${{ inputs.application-type == 'custom-application' && 'application-templates' || 'custom-views-templates'}}/${{ inputs.template-name }}/.*\\.spec\\.(js|ts|tsx)$"
 
     - name: Running template tests with local jest config (mirrors end-user yarn test)
       shell: bash


### PR DESCRIPTION
## Summary

- Fix the test pattern in the CI template action to use a proper regex instead of bash glob syntax
- The `{js,ts,tsx}` brace expansion inside quotes was passed literally to Jest's `--testPathPattern`, which expects a regex — causing "Invalid testPattern" warnings and Jest falling back to running **all** tests instead of just the template's tests

## Test plan

- [x] Verified locally that the regex pattern `.*\.spec\.(js|ts|tsx)$` correctly matches only template test files
- [x] CI template jobs should now show the correct number of matched test suites (not "Running all tests instead")