### PR TITLE
ci: add package-shape baseline check (publint + attw)

### DIFF
--- a/.changeset/fec-951-package-shape-baseline.md
+++ b/.changeset/fec-951-package-shape-baseline.md
@@ -1,0 +1,9 @@
+---
+---
+
+Add CI gate that runs `publint` and `@arethetypeswrong/cli` against the packed
+tarball of every `@commercetools-frontend/*` and `@commercetools-backend/*`
+package on each PR. Findings are reported but do not gate merges
+(`REPORT_ONLY = true`); the flip to blocking happens in the metadata cleanup
+sibling once the baseline reaches zero. No published-package source changes —
+no version bump required.

--- a/.changeset/fec-951-package-shape-baseline.md
+++ b/.changeset/fec-951-package-shape-baseline.md
@@ -1,9 +1,0 @@
----
----
-
-Add CI gate that runs `publint` and `@arethetypeswrong/cli` against the packed
-tarball of every `@commercetools-frontend/*` and `@commercetools-backend/*`
-package on each PR. Findings are reported but do not gate merges
-(`REPORT_ONLY = true`); the flip to blocking happens in the metadata cleanup
-sibling once the baseline reaches zero. No published-package source changes —
-no version bump required.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Running static type checking (Starter Template)
         run: pnpm typecheck:starters
 
+      - name: Check package shape
+        run: pnpm check:package-shape
+
       - name: Running linters
         run: pnpm jest --projects jest.{eslint,stylelint}.config.js --reporters jest-silent-reporter
         env:

--- a/docs/package-shape-verification.md
+++ b/docs/package-shape-verification.md
@@ -1,0 +1,212 @@
+# Package Shape Verification
+
+The Merchant Center Application Kit runs a check on every CI build that
+validates the **published shape** of each publishable package — not the
+workspace-linked source. It packs each package the same way npm would, then
+runs two industry-standard linters against the resulting tarball.
+
+This is the safety net for toolchain changes (preconstruct upgrades, dependency
+upgrades, `package.json` `exports` map edits). It catches the class of bugs
+that workspace symlinks hide: CJS/ESM interop breakage, missing `exports`
+subpaths, types that don't match the runtime shape, and Node ESM resolution
+errors.
+
+## Quick Reference
+
+```bash
+# Run the check (CI runs this same command)
+pnpm check:package-shape
+```
+
+Requires the target packages to be built first (`pnpm build`).
+
+## How It Works
+
+The script (`scripts/check-package-shape.mjs`) does the following for each
+target package:
+
+1. Runs `pnpm pack --json` to produce a tarball identical to what npm would
+   publish.
+2. Runs **`@arethetypeswrong/cli` (attw)** against the tarball — validates that
+   TypeScript types resolve correctly across every module-resolution mode a
+   consumer might use.
+3. Runs **`publint`** against the tarball — validates `package.json` against the
+   npm spec.
+4. Cleans up the tarball.
+5. Buffers per-package output and prints it in declared order so the log stays
+   readable even when packages run in parallel.
+
+A `REPORT_ONLY` constant at the top of the script controls whether findings
+fail the check. While the baseline is being driven to zero (see [FEC-936
+mirror](https://commercetools.atlassian.net/browse/FEC-936) — the metadata
+normalization cleanup), `REPORT_ONLY = true`: CI surfaces findings but does not
+gate merges. Once the baseline reaches zero, the flag flips to `false` and the
+check starts blocking.
+
+## What Gets Tracked
+
+The check mirrors the `fixed` group in `.changeset/config.json` — every package
+the changeset bot ships in a release. That is the 29 publishable workspaces
+under `@commercetools-frontend/*` and `@commercetools-backend/*`. Private
+workspaces (`@commercetools-applications/*`, `@commercetools-local/*`,
+`@commercetools-website/*`) are excluded because they are not published.
+
+To add or remove a tracked package, edit the `PACKAGES` array at the top of
+`scripts/check-package-shape.mjs`.
+
+## The Tools
+
+### `@arethetypeswrong/cli` (attw)
+
+Validates that TypeScript types resolve correctly under every module-resolution
+mode a consumer might realistically use:
+
+- **`node10`** — Legacy TS/bundler resolution; Jest defaults.
+- **`node16` from CJS** — Modern Node when the consumer is CJS.
+- **`node16` from ESM** — Modern Node when the consumer is ESM.
+- **`bundler`** — Vite, Webpack 5, esbuild, Rspack.
+
+attw walks the `exports` map, traces every entry point, and flags any mode
+where types are missing, malformed, or describe a different shape than the
+runtime actually exports.
+
+### `publint`
+
+Validates `package.json` correctness against the npm spec. It catches things
+the spec says are wrong but the npm CLI doesn't enforce:
+
+- Missing files referenced by `exports`
+- Inconsistent `import`/`require` conditions
+- `.js` files described as ESM but interpreted as CJS (and vice versa)
+- Deprecated fields
+- Wrong extensions for the declared `"type"`
+
+Output is tiered — errors fail the check, warnings fail strict mode,
+suggestions are informational only.
+
+Both tools run against the same tarball `pnpm pack` produces, which is exactly
+what npm would publish.
+
+## When To Run It
+
+The check runs automatically in CI on every PR. Run it locally before pushing
+when:
+
+- You upgrade preconstruct or change preconstruct configuration
+- You edit a publishable package's `package.json` — especially `exports`,
+  `main`, `module`, `types`, or `type`
+- You add or rename a publishable entry point (e.g. a new preconstruct
+  entrypoint)
+- You bump a major dependency that touches the type graph
+- You change the build scripts in `scripts/`
+
+## Baseline (2026-05-20)
+
+Snapshot of the findings on `main` after the check was introduced. The cleanup
+sibling ([FEC-936
+mirror](https://commercetools.atlassian.net/browse/FEC-936)) will drive these
+to zero; until then `REPORT_ONLY` is true so the check does not gate merges.
+
+| Package                                         | Tool    | Finding                                                                                                                                                                 |
+| ----------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@commercetools-frontend/application-shell`     | attw    | `InternalResolutionError` on root entry and `/test-utils` subpath — bare relative imports in emitted `.d.ts` files fail `node16` ESM resolution. Both 4 modes affected. |
+| `@commercetools-frontend/browser-history`       | attw    | `FalseExportDefault` on root — `.d.ts` uses `export default` where the JS file uses `module.exports =`. All 4 modes.                                                    |
+| `@commercetools-frontend/cypress`               | attw    | `FalseExportDefault` on `/task` subpath. All 4 modes; root and `/add-commands` are clean.                                                                               |
+| `@commercetools-frontend/mc-html-template`      | attw    | `FalseExportDefault` on `/webpack-html-template` subpath. All 4 modes; root is clean.                                                                                   |
+| `@commercetools-frontend/mc-scripts`            | attw    | `FalseExportDefault` on `/webpack-loaders/i18n-message-compilation-loader` subpath. All 4 modes; six other entry points are clean.                                      |
+| `@commercetools-frontend/assets`                | publint | `pkg.module should be ESM, but the code is written in CJS` — `module: "index.js"` declared but the file is CJS.                                                         |
+| `@commercetools-frontend/babel-preset-mc-app`   | publint | Same root cause as `assets` — `module: "./index.js"` declared, file is CJS.                                                                                             |
+| `@commercetools-frontend/jest-preset-mc-app`    | publint | Same root cause — `module: "./jest-preset.js"` declared, file is CJS.                                                                                                   |
+| `@commercetools-frontend/jest-stylelint-runner` | publint | Same root cause — `module: "index.js"` declared, file is CJS.                                                                                                           |
+
+**Total: 9 findings across 7 packages.** Two failure modes account for all of
+them:
+
+- **attw `FalseExportDefault`** on subpath entries with `module.exports =`-style
+  JS but `export default`-style `.d.ts` (`browser-history`, `cypress/task`,
+  `mc-html-template/webpack-html-template`,
+  `mc-scripts/webpack-loaders/i18n-message-compilation-loader`).
+- **publint `pkg.module should be ESM`** on the four preconstruct-excluded
+  packages that ship plain CJS but declare a `module` field
+  (`assets`, `babel-preset-mc-app`, `jest-preset-mc-app`,
+  `jest-stylelint-runner`).
+
+`application-shell` is the one structural outlier — `InternalResolutionError`
+indicates bare relative imports in emitted `.d.ts` that fail Node16 ESM
+resolution; the precedent in Nimbus needed a relative-import rewriter in
+postbuild scripts to address the same class of issue.
+
+## CI Integration
+
+The check runs in the `lint_and_test` job
+(`.github/workflows/main.yml`) immediately after the typecheck steps:
+
+```yaml
+- name: Check package shape
+  run: pnpm check:package-shape
+```
+
+No additional services or secrets — just `pnpm pack`, `attw`, and `publint`.
+
+## Tooling Notes
+
+### fflate pinned to 0.8.2
+
+`@arethetypeswrong/core@0.18.2` uses `fflate`'s streaming `Gunzip` API to
+extract the packed tarball. `fflate@0.8.3` changed the Gunzip callback timing
+("Support sync flushes" in the 0.8.3 release notes), which causes attw to
+throw `Cannot read properties of undefined (reading 'filename')` on every
+input. We pin `fflate` to `0.8.2` via a `pnpm.overrides` entry. The override
+only affects the attw chain — nothing else in the repo depends on `fflate`.
+Revisit the pin once attw releases a version compatible with `fflate@0.8.3`.
+
+## Common Scenarios
+
+### Your PR Surfaces New Package Shape Findings
+
+While `REPORT_ONLY = true`, new findings won't fail CI — but they will appear
+in the job log under the "Check package shape" step.
+
+1. Look at the CI output. Each finding is annotated with the package and tool
+   that produced it.
+2. Compare against the baseline above — if it's listed, no action needed; if
+   it's new, your change introduced a regression.
+3. attw failures usually point to one of:
+   - A new subpath in `exports` that lacks a `types` condition.
+   - A `require.types` pointing at an `.d.ts` file that TypeScript will treat
+     as ESM (needs to be `.d.cts`).
+   - A bare relative import inside an emitted `.d.ts` (rejected by `node16`
+     ESM resolution).
+4. publint failures usually point to one of:
+   - A file referenced by `exports` that wasn't emitted to `dist/`.
+   - An `import` condition pointing at a `.cjs` file or vice versa.
+   - A `"type"` mismatch between root `package.json` and a nested directory's
+     marker `package.json`.
+5. Reproduce locally with `pnpm build && pnpm check:package-shape`.
+
+### You Need To Land Something Despite Known Findings
+
+`REPORT_ONLY` is already `true` during the baseline-cleanup phase, so this
+isn't a concern right now. Once the flag flips to `false`, the same escape
+hatch documented in Nimbus applies: flip `REPORT_ONLY` to `true` in the same
+PR or open a follow-up issue, and flip back as soon as the underlying issue is
+resolved.
+
+## Related Files
+
+- `scripts/check-package-shape.mjs` — The check script.
+- `.changeset/config.json` — Source of truth for the publishable package set
+  (the `fixed` group).
+- `.github/workflows/main.yml` — CI wiring (the `Check package shape` step in
+  the `lint_and_test` job).
+
+## References
+
+- Nimbus precedent:
+  [PR #1498](https://github.com/commercetools/nimbus/pull/1498) — the original
+  cross-repo implementation this is ported from.
+- [FEC-951](https://commercetools.atlassian.net/browse/FEC-951) — the ticket
+  that introduced this gate.
+- [FEC-936
+  mirror](https://commercetools.atlassian.net/browse/FEC-936) — the cleanup
+  sibling that drives the baseline to zero and flips `REPORT_ONLY` to `false`.

--- a/docs/package-shape-verification.md
+++ b/docs/package-shape-verification.md
@@ -100,51 +100,6 @@ when:
 - You bump a major dependency that touches the type graph
 - You change the build scripts in `scripts/`
 
-## Baseline (2026-05-20)
-
-Snapshot of the findings on `main` after the check was introduced. A follow-up
-cleanup will drive these to zero; until then `REPORT_ONLY` is true so the check
-does not gate merges.
-
-> **The baseline is a regression contract, not a punch list.** Listing a
-> finding here does not mean it must be fixed in this ticket — these are the
-> known-existing shape issues as of the date above, frozen so subsequent work
-> (catalog adoption, metadata normalization, dependency upgrades) can be
-> proven non-regressing. The expected outcome of a PR is **"no new findings"**,
-> not "all findings resolved." If your PR adds a row to this table, that is
-> the regression; if it leaves the existing rows unchanged, the baseline holds.
-> Findings get removed from this list only when an explicit cleanup ticket
-> resolves them.
-
-| Package                                         | Tool    | Finding                                                                                                                                                                 |
-| ----------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@commercetools-frontend/application-shell`     | attw    | `InternalResolutionError` on root entry and `/test-utils` subpath — bare relative imports in emitted `.d.ts` files fail `node16` ESM resolution. Both 4 modes affected. |
-| `@commercetools-frontend/browser-history`       | attw    | `FalseExportDefault` on root — `.d.ts` uses `export default` where the JS file uses `module.exports =`. All 4 modes.                                                    |
-| `@commercetools-frontend/cypress`               | attw    | `FalseExportDefault` on `/task` subpath. All 4 modes; root and `/add-commands` are clean.                                                                               |
-| `@commercetools-frontend/mc-html-template`      | attw    | `FalseExportDefault` on `/webpack-html-template` subpath. All 4 modes; root is clean.                                                                                   |
-| `@commercetools-frontend/mc-scripts`            | attw    | `FalseExportDefault` on `/webpack-loaders/i18n-message-compilation-loader` subpath. All 4 modes; six other entry points are clean.                                      |
-| `@commercetools-frontend/assets`                | publint | `pkg.module should be ESM, but the code is written in CJS` — `module: "index.js"` declared but the file is CJS.                                                         |
-| `@commercetools-frontend/babel-preset-mc-app`   | publint | Same root cause as `assets` — `module: "./index.js"` declared, file is CJS.                                                                                             |
-| `@commercetools-frontend/jest-preset-mc-app`    | publint | Same root cause — `module: "./jest-preset.js"` declared, file is CJS.                                                                                                   |
-| `@commercetools-frontend/jest-stylelint-runner` | publint | Same root cause — `module: "index.js"` declared, file is CJS.                                                                                                           |
-
-**Total: 9 findings across 7 packages.** Two failure modes account for all of
-them:
-
-- **attw `FalseExportDefault`** on subpath entries with `module.exports =`-style
-  JS but `export default`-style `.d.ts` (`browser-history`, `cypress/task`,
-  `mc-html-template/webpack-html-template`,
-  `mc-scripts/webpack-loaders/i18n-message-compilation-loader`).
-- **publint `pkg.module should be ESM`** on the four preconstruct-excluded
-  packages that ship plain CJS but declare a `module` field
-  (`assets`, `babel-preset-mc-app`, `jest-preset-mc-app`,
-  `jest-stylelint-runner`).
-
-`application-shell` is the one structural outlier — `InternalResolutionError`
-indicates bare relative imports in emitted `.d.ts` that fail Node16 ESM
-resolution. Resolving it likely requires a relative-import rewriter in the
-postbuild step.
-
 ## CI Integration
 
 The check runs in the `lint_and_test` job
@@ -178,8 +133,10 @@ in the job log under the "Check package shape" step.
 
 1. Look at the CI output. Each finding is annotated with the package and tool
    that produced it.
-2. Compare against the baseline above — if it's listed, no action needed; if
-   it's new, your change introduced a regression.
+2. Compare against the same job on `main` to know whether your change
+   introduced the finding or it was already there. Easiest way: run
+   `pnpm check:package-shape` locally on `main`, then on your branch, and
+   diff the two outputs.
 3. attw failures usually point to one of:
    - A new subpath in `exports` that lacks a `types` condition.
    - A `require.types` pointing at an `.d.ts` file that TypeScript will treat

--- a/docs/package-shape-verification.md
+++ b/docs/package-shape-verification.md
@@ -107,6 +107,16 @@ sibling ([FEC-936
 mirror](https://commercetools.atlassian.net/browse/FEC-936)) will drive these
 to zero; until then `REPORT_ONLY` is true so the check does not gate merges.
 
+> **The baseline is a regression contract, not a punch list.** Listing a
+> finding here does not mean it must be fixed in this ticket — these are the
+> known-existing shape issues as of the date above, frozen so subsequent work
+> (catalog adoption, metadata normalization, dependency upgrades) can be
+> proven non-regressing. The expected outcome of a PR is **"no new findings"**,
+> not "all findings resolved." If your PR adds a row to this table, that is
+> the regression; if it leaves the existing rows unchanged, the baseline holds.
+> Findings get removed from this list only when an explicit cleanup ticket
+> resolves them.
+
 | Package                                         | Tool    | Finding                                                                                                                                                                 |
 | ----------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@commercetools-frontend/application-shell`     | attw    | `InternalResolutionError` on root entry and `/test-utils` subpath — bare relative imports in emitted `.d.ts` files fail `node16` ESM resolution. Both 4 modes affected. |

--- a/docs/package-shape-verification.md
+++ b/docs/package-shape-verification.md
@@ -37,11 +37,9 @@ target package:
    readable even when packages run in parallel.
 
 A `REPORT_ONLY` constant at the top of the script controls whether findings
-fail the check. While the baseline is being driven to zero (see [FEC-936
-mirror](https://commercetools.atlassian.net/browse/FEC-936) — the metadata
-normalization cleanup), `REPORT_ONLY = true`: CI surfaces findings but does not
-gate merges. Once the baseline reaches zero, the flag flips to `false` and the
-check starts blocking.
+fail the check. While the baseline is being driven to zero, `REPORT_ONLY = true`:
+CI surfaces findings but does not gate merges. Once the baseline reaches zero,
+the flag flips to `false` and the check starts blocking.
 
 ## What Gets Tracked
 
@@ -102,10 +100,9 @@ when:
 
 ## Baseline (2026-05-20)
 
-Snapshot of the findings on `main` after the check was introduced. The cleanup
-sibling ([FEC-936
-mirror](https://commercetools.atlassian.net/browse/FEC-936)) will drive these
-to zero; until then `REPORT_ONLY` is true so the check does not gate merges.
+Snapshot of the findings on `main` after the check was introduced. A follow-up
+cleanup will drive these to zero; until then `REPORT_ONLY` is true so the check
+does not gate merges.
 
 > **The baseline is a regression contract, not a punch list.** Listing a
 > finding here does not mean it must be fixed in this ticket — these are the
@@ -143,8 +140,8 @@ them:
 
 `application-shell` is the one structural outlier — `InternalResolutionError`
 indicates bare relative imports in emitted `.d.ts` that fail Node16 ESM
-resolution; the precedent in Nimbus needed a relative-import rewriter in
-postbuild scripts to address the same class of issue.
+resolution. Resolving it likely requires a relative-import rewriter in the
+postbuild step.
 
 ## CI Integration
 
@@ -197,9 +194,9 @@ in the job log under the "Check package shape" step.
 ### You Need To Land Something Despite Known Findings
 
 `REPORT_ONLY` is already `true` during the baseline-cleanup phase, so this
-isn't a concern right now. Once the flag flips to `false`, the same escape
-hatch documented in Nimbus applies: flip `REPORT_ONLY` to `true` in the same
-PR or open a follow-up issue, and flip back as soon as the underlying issue is
+isn't a concern right now. Once the flag flips to `false`, the escape hatch is
+to flip `REPORT_ONLY` back to `true` in the same PR (or open a follow-up
+issue) and flip it back to `false` as soon as the underlying issue is
 resolved.
 
 ## Related Files
@@ -212,11 +209,5 @@ resolved.
 
 ## References
 
-- Nimbus precedent:
-  [PR #1498](https://github.com/commercetools/nimbus/pull/1498) — the original
-  cross-repo implementation this is ported from.
 - [FEC-951](https://commercetools.atlassian.net/browse/FEC-951) — the ticket
   that introduced this gate.
-- [FEC-936
-  mirror](https://commercetools.atlassian.net/browse/FEC-936) — the cleanup
-  sibling that drives the baseline to zero and flips `REPORT_ONLY` to `false`.

--- a/docs/package-shape-verification.md
+++ b/docs/package-shape-verification.md
@@ -204,8 +204,8 @@ resolved.
 ## Related Files
 
 - `scripts/check-package-shape.mjs` — The check script.
-- `.changeset/config.json` — Source of truth for the publishable package set
-  (the `fixed` group).
+- Each workspace's `package.json` — `"private": true` excludes a workspace from
+  the gate; the script picks up this field directly via `pnpm m ls`.
 - `.github/workflows/main.yml` — CI wiring (the `Check package shape` step in
   the `lint_and_test` job).
 

--- a/docs/package-shape-verification.md
+++ b/docs/package-shape-verification.md
@@ -43,14 +43,16 @@ the flag flips to `false` and the check starts blocking.
 
 ## What Gets Tracked
 
-The check mirrors the `fixed` group in `.changeset/config.json` — every package
-the changeset bot ships in a release. That is the 29 publishable workspaces
-under `@commercetools-frontend/*` and `@commercetools-backend/*`. Private
+The list of tracked packages is derived at runtime from `pnpm m ls`: every
+workspace whose `package.json` is _not_ marked `"private": true`. That matches
+the set the changeset bot ships in a release — today, 29 workspaces under
+`@commercetools-frontend/*` and `@commercetools-backend/*`. Internal
 workspaces (`@commercetools-applications/*`, `@commercetools-local/*`,
-`@commercetools-website/*`) are excluded because they are not published.
+`@commercetools-website/*`) are excluded because they all carry
+`"private": true`.
 
-To add or remove a tracked package, edit the `PACKAGES` array at the top of
-`scripts/check-package-shape.mjs`.
+To add or remove a tracked package, flip `"private"` in the workspace's
+`package.json` — the script picks the change up automatically.
 
 ## The Tools
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "template-custom-view-starter-typescript:start:prod:local": "pnpm --filter @commercetools-applications/merchant-center-custom-view-template-starter-typescript run start:prod:local",
     "build": "./scripts/build_packages.sh",
     "build:watch": "pnpm build --watch",
+    "check:package-shape": "node scripts/check-package-shape.mjs",
     "vercel-build": "echo \"Nothing to do, the build and deployment is managed in GH actions.\"",
     "labels:sync": "github-labels sync",
     "generate-types:mc": "graphql-codegen -r dotenv/config --config codegen.mc.yml",
@@ -81,6 +82,7 @@
     ]
   },
   "dependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@babel/cli": "^7.22.15",
     "@babel/core": "^7.22.17",
     "@changesets/changelog-github": "0.5.1",
@@ -155,6 +157,7 @@
     "postcss": "8.5.6",
     "postcss-load-config": "3.1.4",
     "prettier": "2.8.8",
+    "publint": "^0.3.21",
     "puppeteer": "20.9.0",
     "qss": "2.0.3",
     "react": "19.0.0",
@@ -205,6 +208,7 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "@remix-run/router": ">=1.23.2",
       "@xmldom/xmldom": ">=0.8.13",
+      "fflate": "0.8.2",
       "immutable": ">=3.8.3",
       "lodash-es": ">=4.17.21",
       "minimatch@^3": "^3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   '@remix-run/router': '>=1.23.2'
   '@xmldom/xmldom': '>=0.8.13'
+  fflate: 0.8.2
   immutable: '>=3.8.3'
   lodash-es: '>=4.17.21'
   minimatch@^3: ^3.1.4
@@ -54,6 +55,9 @@ importers:
 
   .:
     dependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.2
+        version: 0.18.2
       '@babel/cli':
         specifier: ^7.22.15
         version: 7.28.3(@babel/core@7.29.0)
@@ -276,6 +280,9 @@ importers:
       prettier:
         specifier: 2.8.8
         version: 2.8.8
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
       puppeteer:
         specifier: 20.9.0
         version: 20.9.0(typescript@5.9.2)
@@ -3517,6 +3524,9 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
@@ -3548,6 +3558,15 @@ packages:
   '@ardatan/sync-fetch@0.0.1':
     resolution: {integrity: sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==}
     engines: {node: '>=14'}
+
+  '@arethetypeswrong/cli@0.18.2':
+    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.18.2':
+    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+    engines: {node: '>=20'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -4274,6 +4293,9 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
+
   '@changesets/apply-release-plan@7.0.13':
     resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
 
@@ -4337,6 +4359,10 @@ packages:
 
   '@colordx/core@5.4.3':
     resolution: {integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -6181,6 +6207,9 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
+
   '@manypkg/cli@0.25.0':
     resolution: {integrity: sha512-qohYlbfx4RdQX6OqRR0yW7duYzSxgzB/gfHuJA+RDOrbNXhLh/3KQxcH9FxyRqr69OP+CjuEeWZVRfLhfJjqfw==}
     engines: {node: '>=20.0.0'}
@@ -6483,6 +6512,10 @@ packages:
 
   '@preconstruct/hook@0.4.0':
     resolution: {integrity: sha512-a7mrlPTM3tAFJyz43qb4pPVpUx8j8TzZBFsNFqcKcE/sEakNXRlQAuCT4RGZRf9dQiiUnBahzSIWawU4rENl+Q==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@puppeteer/browsers@1.4.6':
     resolution: {integrity: sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==}
@@ -6954,6 +6987,10 @@ packages:
   '@sindresorhus/is@0.14.0':
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -8033,6 +8070,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -8743,12 +8783,21 @@ packages:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
   cli-table3@0.6.1:
     resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
+    engines: {node: 10.* || >= 12.*}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
   cli-truncate@2.1.0:
@@ -8764,6 +8813,9 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -8850,6 +8902,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -9693,6 +9749,9 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
@@ -10344,6 +10403,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -10943,6 +11005,9 @@ packages:
 
   headers-polyfill@3.3.0:
     resolution: {integrity: sha512-5e57etwBpNcDc0b6KCVWEh/Ro063OxPvzVimUdM0/tsYM/T7Hfy3kknIGj78SFTOhNd8AZY41U8mOHoO4LzmIQ==}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   history-query-enhancer@1.0.4:
     resolution: {integrity: sha512-zs3zt64jspt9RGS5hLarIkeC9/omIkMjU4KkC2windSqD04KGQY84sDZWfnFS5qeJ07Ig8Y1t9jjBffQ9ZHdpw==}
@@ -12387,6 +12452,17 @@ packages:
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -12685,6 +12761,9 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -12735,6 +12814,10 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
+
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
 
   node-fetch@2.6.9:
     resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
@@ -13071,6 +13154,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -13109,6 +13195,15 @@ packages:
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -13640,6 +13735,11 @@ packages:
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -13670,7 +13770,7 @@ packages:
   puppeteer@20.9.0:
     resolution: {integrity: sha512-kAglT4VZ9fWEGg3oLc4/de+JcONuEJhlh3J6f5R1TLkrY/EHHIHxWXDOzXvaxQCtedmyVXBwg8M+P8YCO/wZjw==}
     engines: {node: '>=16.3.0'}
-    deprecated: < 24.15.0 is no longer supported
+    deprecated: < 22.8.2 is no longer supported
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
@@ -14469,6 +14569,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   slash@2.0.0:
     resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
     engines: {node: '>=6'}
@@ -14834,6 +14938,10 @@ packages:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -14973,6 +15081,13 @@ packages:
 
   thenby@1.3.4:
     resolution: {integrity: sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thingies@2.5.0:
     resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
@@ -15303,6 +15418,11 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -15345,6 +15465,10 @@ packages:
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
+    engines: {node: '>=4'}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -15592,6 +15716,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
@@ -16004,6 +16132,10 @@ packages:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
 
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
   yargs@17.7.1:
     resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
     engines: {node: '>=12'}
@@ -16042,6 +16174,8 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@andrewbranch/untar.js@1.0.3': {}
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     dependencies:
@@ -16101,6 +16235,27 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@arethetypeswrong/cli@0.18.2':
+    dependencies:
+      '@arethetypeswrong/core': 0.18.2
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.7.2
+
+  '@arethetypeswrong/core@0.18.2':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.2.3
+      fflate: 0.8.2
+      lru-cache: 11.2.5
+      semver: 7.7.2
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -17021,6 +17176,8 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@braidai/lang@1.1.2': {}
+
   '@changesets/apply-release-plan@7.0.13':
     dependencies:
       '@changesets/config': 3.1.1
@@ -17179,6 +17336,9 @@ snapshots:
       prettier: 2.8.8
 
   '@colordx/core@5.4.3': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@colors/colors@1.6.0': {}
 
@@ -20774,6 +20934,10 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@manypkg/cli@0.25.0':
     dependencies:
       '@manypkg/get-packages': 3.1.0
@@ -21308,6 +21472,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@publint/pack@0.1.4': {}
+
   '@puppeteer/browsers@1.4.6(typescript@5.9.2)':
     dependencies:
       debug: 4.3.4
@@ -21732,6 +21898,8 @@ snapshots:
   '@sinclair/typebox@0.34.47': {}
 
   '@sindresorhus/is@0.14.0': {}
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@sinonjs/commons@3.0.1':
     dependencies:
@@ -23004,6 +23172,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -23883,6 +24053,15 @@ snapshots:
     dependencies:
       restore-cursor: 3.1.0
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
   cli-spinners@2.9.2: {}
 
   cli-table3@0.6.1:
@@ -23890,6 +24069,12 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       colors: 1.4.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   cli-truncate@2.1.0:
     dependencies:
@@ -23905,6 +24090,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -23976,6 +24167,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@11.1.0: {}
 
@@ -24840,6 +25033,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  emojilib@2.4.0: {}
+
   emojis-list@3.0.0: {}
 
   enabled@2.0.0: {}
@@ -25658,6 +25853,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.2: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -26392,6 +26589,8 @@ snapshots:
   headers-polyfill@3.2.5: {}
 
   headers-polyfill@3.3.0: {}
+
+  highlight.js@10.7.3: {}
 
   history-query-enhancer@1.0.4(history@4.10.1):
     dependencies:
@@ -28305,6 +28504,19 @@ snapshots:
 
   map-stream@0.1.0: {}
 
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.2.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@9.1.6: {}
+
   math-intrinsics@1.1.0: {}
 
   mathml-tag-names@2.1.3: {}
@@ -28746,6 +28958,12 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -28782,6 +29000,13 @@ snapshots:
       minimatch: 3.1.5
 
   node-domexception@1.0.0: {}
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
 
   node-fetch@2.6.9:
     dependencies:
@@ -29190,6 +29415,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  package-manager-detector@1.6.0: {}
+
   pako@2.1.0: {}
 
   param-case@3.0.4:
@@ -29231,6 +29458,14 @@ snapshots:
   parse-ms@2.1.0: {}
 
   parse-passwd@1.0.0: {}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -29722,6 +29957,13 @@ snapshots:
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   pump@3.0.3:
     dependencies:
@@ -30740,6 +30982,10 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
   slash@2.0.0: {}
 
   slash@3.0.0: {}
@@ -31204,6 +31450,11 @@ snapshots:
       has-flag: 4.0.0
       supports-color: 7.2.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
@@ -31372,6 +31623,14 @@ snapshots:
   text-table@0.2.0: {}
 
   thenby@1.3.4: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
@@ -31710,6 +31969,8 @@ snapshots:
 
   typescript@4.9.5: {}
 
+  typescript@5.6.1-rc: {}
+
   typescript@5.9.2: {}
 
   ua-parser-js@1.0.41: {}
@@ -31739,6 +32000,8 @@ snapshots:
   unfetch@4.2.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
     dependencies:
@@ -32025,6 +32288,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@5.0.1: {}
 
   validate-npm-package-name@6.0.2: {}
 
@@ -32534,6 +32799,16 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.1:
     dependencies:

--- a/scripts/check-package-shape.mjs
+++ b/scripts/check-package-shape.mjs
@@ -23,7 +23,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,129 +35,20 @@ const ROOT = join(__dirname, '..');
 // reaches zero so this gate starts blocking merges.
 const REPORT_ONLY = true;
 
-// Mirror of the publishable workspaces in the Changesets `fixed` group
-// (`.changeset/config.json`) — every `@commercetools-frontend/*` and
-// `@commercetools-backend/*` package the changeset bot ships. Private
-// workspaces (`@commercetools-applications/*`, `@commercetools-local/*`,
-// `@commercetools-website/*`) are excluded by design — they are not published.
-const PACKAGES = [
-  {
-    name: '@commercetools-frontend/actions-global',
-    dir: join(ROOT, 'packages/actions-global'),
-  },
-  {
-    name: '@commercetools-frontend/application-components',
-    dir: join(ROOT, 'packages/application-components'),
-  },
-  {
-    name: '@commercetools-frontend/application-config',
-    dir: join(ROOT, 'packages/application-config'),
-  },
-  {
-    name: '@commercetools-frontend/application-shell',
-    dir: join(ROOT, 'packages/application-shell'),
-  },
-  {
-    name: '@commercetools-frontend/application-shell-connectors',
-    dir: join(ROOT, 'packages/application-shell-connectors'),
-  },
-  {
-    name: '@commercetools-frontend/assets',
-    dir: join(ROOT, 'packages/assets'),
-  },
-  {
-    name: '@commercetools-frontend/babel-preset-mc-app',
-    dir: join(ROOT, 'packages/babel-preset-mc-app'),
-  },
-  {
-    name: '@commercetools-frontend/browser-history',
-    dir: join(ROOT, 'packages/browser-history'),
-  },
-  {
-    name: '@commercetools-frontend/codemod',
-    dir: join(ROOT, 'packages/codemod'),
-  },
-  {
-    name: '@commercetools-frontend/constants',
-    dir: join(ROOT, 'packages/constants'),
-  },
-  {
-    name: '@commercetools-frontend/create-mc-app',
-    dir: join(ROOT, 'packages/create-mc-app'),
-  },
-  {
-    name: '@commercetools-frontend/cypress',
-    dir: join(ROOT, 'packages/cypress'),
-  },
-  {
-    name: '@commercetools-frontend/eslint-config-mc-app',
-    dir: join(ROOT, 'packages/eslint-config-mc-app'),
-  },
-  {
-    name: '@commercetools-frontend/i18n',
-    dir: join(ROOT, 'packages/i18n'),
-  },
-  {
-    name: '@commercetools-frontend/jest-preset-mc-app',
-    dir: join(ROOT, 'packages/jest-preset-mc-app'),
-  },
-  {
-    name: '@commercetools-frontend/jest-stylelint-runner',
-    dir: join(ROOT, 'packages/jest-stylelint-runner'),
-  },
-  {
-    name: '@commercetools-frontend/l10n',
-    dir: join(ROOT, 'packages/l10n'),
-  },
-  {
-    name: '@commercetools-frontend/mc-dev-authentication',
-    dir: join(ROOT, 'packages/mc-dev-authentication'),
-  },
-  {
-    name: '@commercetools-frontend/mc-html-template',
-    dir: join(ROOT, 'packages/mc-html-template'),
-  },
-  {
-    name: '@commercetools-frontend/mc-scripts',
-    dir: join(ROOT, 'packages/mc-scripts'),
-  },
-  {
-    name: '@commercetools-frontend/notifications',
-    dir: join(ROOT, 'packages/notifications'),
-  },
-  {
-    name: '@commercetools-frontend/permissions',
-    dir: join(ROOT, 'packages/permissions'),
-  },
-  {
-    name: '@commercetools-frontend/react-notifications',
-    dir: join(ROOT, 'packages/react-notifications'),
-  },
-  {
-    name: '@commercetools-frontend/sdk',
-    dir: join(ROOT, 'packages/sdk'),
-  },
-  {
-    name: '@commercetools-frontend/sentry',
-    dir: join(ROOT, 'packages/sentry'),
-  },
-  {
-    name: '@commercetools-frontend/url-utils',
-    dir: join(ROOT, 'packages/url-utils'),
-  },
-  {
-    name: '@commercetools-backend/eslint-config-node',
-    dir: join(ROOT, 'packages-backend/eslint-config-node'),
-  },
-  {
-    name: '@commercetools-backend/express',
-    dir: join(ROOT, 'packages-backend/express'),
-  },
-  {
-    name: '@commercetools-backend/loggers',
-    dir: join(ROOT, 'packages-backend/loggers'),
-  },
-];
+async function discoverPackages() {
+  const { code, stdout, stderr } = await runCommand(
+    'pnpm',
+    ['m', 'ls', '--json', '--depth', '-1'],
+    { cwd: ROOT }
+  );
+  if (code !== 0) {
+    throw new Error(`pnpm m ls exited ${code}\n${stderr}`);
+  }
+  return JSON.parse(stdout)
+    .filter((w) => w.private !== true)
+    .map((w) => ({ name: w.name, dir: w.path }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
 
 const DIM = '\x1b[2m';
 const BOLD = '\x1b[1m';
@@ -225,11 +116,6 @@ async function checkPackage(pkg, workDir) {
 
   log(header(pkg.name));
 
-  if (!existsSync(pkg.dir)) {
-    log(`${YELLOW}⚠ Skipping — ${pkg.dir} not found${RESET}\n`);
-    return { buffer, failures };
-  }
-
   let tarball;
   try {
     tarball = await packTarball(pkg, workDir);
@@ -241,19 +127,8 @@ async function checkPackage(pkg, workDir) {
     return { buffer, failures };
   }
 
-  // Wrap each tool run so a spawn failure (binary missing from PATH, etc.)
-  // doesn't reject out of Promise.all and bypass the structured summary.
-  const safeRun = async (label, bin) => {
-    try {
-      return await runTool(label, bin, [tarball], log);
-    } catch (err) {
-      log(`${RED}✗ ${label} failed to run: ${err.message}${RESET}\n`);
-      return false;
-    }
-  };
-
-  const attwOk = await safeRun('attw', 'attw');
-  const publintOk = await safeRun('publint', 'publint');
+  const attwOk = await runTool('attw', 'attw', [tarball], log);
+  const publintOk = await runTool('publint', 'publint', [tarball], log);
 
   if (!attwOk) failures.push({ pkg: pkg.name, tool: 'attw' });
   if (!publintOk) failures.push({ pkg: pkg.name, tool: 'publint' });
@@ -262,12 +137,16 @@ async function checkPackage(pkg, workDir) {
 }
 
 async function main() {
+  const packages = await discoverPackages();
+  process.stdout.write(
+    `${DIM}Discovered ${packages.length} publishable workspace(s).${RESET}\n`
+  );
   const workDir = mkdtempSync(join(tmpdir(), 'app-kit-pkg-shape-'));
   const failures = [];
 
   try {
     const results = await Promise.all(
-      PACKAGES.map((pkg) => checkPackage(pkg, workDir))
+      packages.map((pkg) => checkPackage(pkg, workDir))
     );
     for (const { buffer, failures: pkgFailures } of results) {
       for (const chunk of buffer) process.stdout.write(chunk);

--- a/scripts/check-package-shape.mjs
+++ b/scripts/check-package-shape.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+/**
+ * Package shape check for the Merchant Center Application Kit.
+ *
+ * For each publishable package: runs `pnpm pack` to produce a tarball that
+ * matches what npm would publish, then runs two linters against it:
+ *
+ *   - @arethetypeswrong/cli (attw): validates types resolve correctly across
+ *     module-resolution modes (node10, node16, bundler) — catches `exports`
+ *     map mistakes and ESM/CJS interop foot-guns.
+ *   - publint: validates package.json correctness against the npm spec.
+ *
+ * Packages are checked in parallel; per-package output is buffered and printed
+ * in declared order after all finish so the log stays readable. While
+ * REPORT_ONLY is true the script always exits 0 — findings are surfaced but do
+ * not gate merges. Flip it to false once the baseline reaches zero findings.
+ *
+ * Usage:
+ *   node scripts/check-package-shape.mjs
+ *
+ * Requires the target packages to be built first (`pnpm build`).
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// Surface findings without failing CI. Flip to `false` in the follow-up that
+// drives the baseline to zero (mirror of FEC-936) so this gate starts blocking
+// merges.
+const REPORT_ONLY = true;
+
+// Mirror of the publishable workspaces in the Changesets `fixed` group
+// (`.changeset/config.json`) — every `@commercetools-frontend/*` and
+// `@commercetools-backend/*` package the changeset bot ships. Private
+// workspaces (`@commercetools-applications/*`, `@commercetools-local/*`,
+// `@commercetools-website/*`) are excluded by design — they are not published.
+const PACKAGES = [
+  {
+    name: '@commercetools-frontend/actions-global',
+    dir: join(ROOT, 'packages/actions-global'),
+  },
+  {
+    name: '@commercetools-frontend/application-components',
+    dir: join(ROOT, 'packages/application-components'),
+  },
+  {
+    name: '@commercetools-frontend/application-config',
+    dir: join(ROOT, 'packages/application-config'),
+  },
+  {
+    name: '@commercetools-frontend/application-shell',
+    dir: join(ROOT, 'packages/application-shell'),
+  },
+  {
+    name: '@commercetools-frontend/application-shell-connectors',
+    dir: join(ROOT, 'packages/application-shell-connectors'),
+  },
+  {
+    name: '@commercetools-frontend/assets',
+    dir: join(ROOT, 'packages/assets'),
+  },
+  {
+    name: '@commercetools-frontend/babel-preset-mc-app',
+    dir: join(ROOT, 'packages/babel-preset-mc-app'),
+  },
+  {
+    name: '@commercetools-frontend/browser-history',
+    dir: join(ROOT, 'packages/browser-history'),
+  },
+  {
+    name: '@commercetools-frontend/codemod',
+    dir: join(ROOT, 'packages/codemod'),
+  },
+  {
+    name: '@commercetools-frontend/constants',
+    dir: join(ROOT, 'packages/constants'),
+  },
+  {
+    name: '@commercetools-frontend/create-mc-app',
+    dir: join(ROOT, 'packages/create-mc-app'),
+  },
+  {
+    name: '@commercetools-frontend/cypress',
+    dir: join(ROOT, 'packages/cypress'),
+  },
+  {
+    name: '@commercetools-frontend/eslint-config-mc-app',
+    dir: join(ROOT, 'packages/eslint-config-mc-app'),
+  },
+  {
+    name: '@commercetools-frontend/i18n',
+    dir: join(ROOT, 'packages/i18n'),
+  },
+  {
+    name: '@commercetools-frontend/jest-preset-mc-app',
+    dir: join(ROOT, 'packages/jest-preset-mc-app'),
+  },
+  {
+    name: '@commercetools-frontend/jest-stylelint-runner',
+    dir: join(ROOT, 'packages/jest-stylelint-runner'),
+  },
+  {
+    name: '@commercetools-frontend/l10n',
+    dir: join(ROOT, 'packages/l10n'),
+  },
+  {
+    name: '@commercetools-frontend/mc-dev-authentication',
+    dir: join(ROOT, 'packages/mc-dev-authentication'),
+  },
+  {
+    name: '@commercetools-frontend/mc-html-template',
+    dir: join(ROOT, 'packages/mc-html-template'),
+  },
+  {
+    name: '@commercetools-frontend/mc-scripts',
+    dir: join(ROOT, 'packages/mc-scripts'),
+  },
+  {
+    name: '@commercetools-frontend/notifications',
+    dir: join(ROOT, 'packages/notifications'),
+  },
+  {
+    name: '@commercetools-frontend/permissions',
+    dir: join(ROOT, 'packages/permissions'),
+  },
+  {
+    name: '@commercetools-frontend/react-notifications',
+    dir: join(ROOT, 'packages/react-notifications'),
+  },
+  {
+    name: '@commercetools-frontend/sdk',
+    dir: join(ROOT, 'packages/sdk'),
+  },
+  {
+    name: '@commercetools-frontend/sentry',
+    dir: join(ROOT, 'packages/sentry'),
+  },
+  {
+    name: '@commercetools-frontend/url-utils',
+    dir: join(ROOT, 'packages/url-utils'),
+  },
+  {
+    name: '@commercetools-backend/eslint-config-node',
+    dir: join(ROOT, 'packages-backend/eslint-config-node'),
+  },
+  {
+    name: '@commercetools-backend/express',
+    dir: join(ROOT, 'packages-backend/express'),
+  },
+  {
+    name: '@commercetools-backend/loggers',
+    dir: join(ROOT, 'packages-backend/loggers'),
+  },
+];
+
+const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+const RESET = '\x1b[0m';
+
+function header(text) {
+  const bar = '─'.repeat(Math.max(0, 72 - text.length - 2));
+  return `\n${BOLD}${CYAN}${text}${RESET} ${DIM}${bar}${RESET}\n`;
+}
+
+function runCommand(cmd, args, { cwd }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk.toString()));
+    child.stderr.on('data', (chunk) => (stderr += chunk.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function packTarball(pkg, destDir) {
+  const { code, stdout, stderr } = await runCommand(
+    'pnpm',
+    ['pack', '--pack-destination', destDir, '--json'],
+    { cwd: pkg.dir }
+  );
+  if (code !== 0) {
+    throw new Error(`pnpm pack exited ${code}\n${stderr}`);
+  }
+  // pnpm pack --json's `filename` is an absolute path to the tarball.
+  return JSON.parse(stdout).filename;
+}
+
+async function runTool(label, bin, args, log) {
+  log(`${DIM}$ ${bin} ${args.join(' ')}${RESET}\n`);
+  const { code, stdout, stderr } = await runCommand(
+    'pnpm',
+    ['exec', bin, ...args],
+    { cwd: ROOT }
+  );
+  if (stdout) log(stdout);
+  if (stderr) log(stderr);
+  const passed = code === 0;
+  log(
+    passed
+      ? `${GREEN}✓ ${label} passed${RESET}\n`
+      : `${YELLOW}⚠ ${label} reported findings (exit ${code})${RESET}\n`
+  );
+  return passed;
+}
+
+async function checkPackage(pkg, workDir) {
+  const buffer = [];
+  const log = (text) => buffer.push(text);
+  const failures = [];
+
+  log(header(pkg.name));
+
+  if (!existsSync(pkg.dir)) {
+    log(`${YELLOW}⚠ Skipping — ${pkg.dir} not found${RESET}\n`);
+    return { buffer, failures };
+  }
+
+  let tarball;
+  try {
+    tarball = await packTarball(pkg, workDir);
+    log(`${DIM}packed: ${tarball}${RESET}\n\n`);
+  } catch (err) {
+    log(`${RED}✗ Failed to pack ${pkg.name}${RESET}\n`);
+    log(`${err.message}\n`);
+    failures.push({ pkg: pkg.name, tool: 'pack' });
+    return { buffer, failures };
+  }
+
+  // Wrap each tool run so a spawn failure (binary missing from PATH, etc.)
+  // doesn't reject out of Promise.all and bypass the structured summary.
+  const safeRun = async (label, bin) => {
+    try {
+      return await runTool(label, bin, [tarball], log);
+    } catch (err) {
+      log(`${RED}✗ ${label} failed to run: ${err.message}${RESET}\n`);
+      return false;
+    }
+  };
+
+  const attwOk = await safeRun('attw', 'attw');
+  const publintOk = await safeRun('publint', 'publint');
+
+  if (!attwOk) failures.push({ pkg: pkg.name, tool: 'attw' });
+  if (!publintOk) failures.push({ pkg: pkg.name, tool: 'publint' });
+
+  return { buffer, failures };
+}
+
+async function main() {
+  const workDir = mkdtempSync(join(tmpdir(), 'app-kit-pkg-shape-'));
+  const failures = [];
+
+  try {
+    const results = await Promise.all(
+      PACKAGES.map((pkg) => checkPackage(pkg, workDir))
+    );
+    for (const { buffer, failures: pkgFailures } of results) {
+      for (const chunk of buffer) process.stdout.write(chunk);
+      failures.push(...pkgFailures);
+    }
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+
+  process.stdout.write(header('Summary'));
+  if (failures.length === 0) {
+    console.log(`${GREEN}All packages passed both checks.${RESET}`);
+    process.exit(0);
+  }
+
+  console.log(`${YELLOW}Findings:${RESET}`);
+  for (const f of failures) {
+    console.log(`  - ${f.pkg}: ${f.tool}`);
+  }
+
+  if (REPORT_ONLY) {
+    console.log(
+      `\n${DIM}REPORT_ONLY mode: exiting 0 despite ${failures.length} finding(s). Flip REPORT_ONLY to false to fail CI on findings.${RESET}`
+    );
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-package-shape.mjs
+++ b/scripts/check-package-shape.mjs
@@ -24,7 +24,7 @@
 
 import { spawn } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { availableParallelism, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -138,15 +138,24 @@ async function checkPackage(pkg, workDir) {
 
 async function main() {
   const packages = await discoverPackages();
+  const concurrency = Math.min(packages.length, availableParallelism());
   process.stdout.write(
-    `${DIM}Discovered ${packages.length} publishable workspace(s).${RESET}\n`
+    `${DIM}Discovered ${packages.length} publishable workspace(s); checking up to ${concurrency} in parallel.${RESET}\n`
   );
   const workDir = mkdtempSync(join(tmpdir(), 'app-kit-pkg-shape-'));
   const failures = [];
 
   try {
-    const results = await Promise.all(
-      packages.map((pkg) => checkPackage(pkg, workDir))
+    const results = new Array(packages.length);
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        while (true) {
+          const i = next++;
+          if (i >= packages.length) return;
+          results[i] = await checkPackage(packages[i], workDir);
+        }
+      })
     );
     for (const { buffer, failures: pkgFailures } of results) {
       for (const chunk of buffer) process.stdout.write(chunk);

--- a/scripts/check-package-shape.mjs
+++ b/scripts/check-package-shape.mjs
@@ -31,9 +31,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = join(__dirname, '..');
 
-// Surface findings without failing CI. Flip to `false` in the follow-up that
-// drives the baseline to zero (mirror of FEC-936) so this gate starts blocking
-// merges.
+// Surface findings without failing CI. Flip to `false` once the baseline
+// reaches zero so this gate starts blocking merges.
 const REPORT_ONLY = true;
 
 // Mirror of the publishable workspaces in the Changesets `fixed` group


### PR DESCRIPTION
## Summary

Adds a CI gate that packs each publishable `@commercetools-frontend/*` and `@commercetools-backend/*` workspace with `pnpm pack` and runs `publint` + `@arethetypeswrong/cli` (attw) against the tarball. Findings are reported but **do not gate merges** (`REPORT_ONLY = true`) — the flip to blocking happens in the metadata cleanup sibling ([FEC-936 mirror](https://commercetools.atlassian.net/browse/FEC-936)) once the baseline reaches zero.

Ported from the Nimbus precedent ([nimbus#1498](https://github.com/commercetools/nimbus/pull/1498)).

Closes [FEC-951](https://commercetools.atlassian.net/browse/FEC-951).

## The baseline is a regression contract, not a punch list

**This PR does not fix any of the listed findings — that's not its job.** It freezes today's shape issues so the subsequent catalog adoption and metadata normalization work can be proven non-regressing. The expected outcome of a future PR is **"no new findings"**, not "all findings resolved." If a PR adds a row to the table below, that is the regression; leaving the existing rows unchanged means the baseline still holds. Findings get removed only when an explicit cleanup ticket resolves them.

## Baseline: 9 findings across 7 packages

| Package                                                                                         | Tool    | Finding                                                                                                                 |
| ----------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
| `@commercetools-frontend/application-shell`                                                     | attw    | `InternalResolutionError` on root + `/test-utils` (bare relative imports in emitted `.d.ts` fail node16 ESM resolution) |
| `@commercetools-frontend/browser-history`                                                       | attw    | `FalseExportDefault` on root                                                                                            |
| `@commercetools-frontend/cypress`                                                               | attw    | `FalseExportDefault` on `/task` subpath                                                                                 |
| `@commercetools-frontend/mc-html-template`                                                      | attw    | `FalseExportDefault` on `/webpack-html-template` subpath                                                                |
| `@commercetools-frontend/mc-scripts`                                                            | attw    | `FalseExportDefault` on `/webpack-loaders/i18n-message-compilation-loader` subpath                                      |
| `@commercetools-frontend/{assets,babel-preset-mc-app,jest-preset-mc-app,jest-stylelint-runner}` | publint | `pkg.module should be ESM, but the code is written in CJS` (4 preconstruct-excluded CJS packages with a `module` field) |

Two failure classes account for all 9 findings: attw `FalseExportDefault` on subpath exports, and publint declaring `module` for CJS code. `application-shell` is the structural outlier (relative-import rewriting needed, mirroring the Nimbus precedent).

## Heads-up: `fflate` pinned to 0.8.2

`attw@0.18.2` crashes on every tarball when its transitive dependency `fflate` resolves to `0.8.3` (a behavior change in `fflate`'s streaming API broke attw's tarball extraction). This PR adds a `pnpm.overrides` entry pinning `fflate` to `0.8.2`. The override is scoped to the attw dependency chain — nothing else in the repo uses `fflate` — so the blast radius is just this check. Drop the pin once attw ships a fix.

## What changed

- `scripts/check-package-shape.mjs` — new, ported from `maintained/nimbus/scripts/check-package-shape.mjs`. The package list is derived at runtime from `pnpm m ls` and filtered by `"private" !== true` — today, the 29 publishable workspaces under `@commercetools-frontend/*` and `@commercetools-backend/*`. Per-package work runs through a small worker pool sized by `os.availableParallelism()` (≈4 on standard GHA runners) so we don't spawn 29 simultaneous `pnpm pack` + attw + publint chains.
- `package.json` — adds `@arethetypeswrong/cli@^0.18.2` + `publint@^0.3.21` and the `check:package-shape` script. Adds `pnpm.overrides.fflate = "0.8.2"`.
- `.github/workflows/main.yml` — adds a `Check package shape` step in `lint_and_test` after typecheck. Sequential step (reuses the existing install+build), not a parallel job — matches the Nimbus precedent.
- `docs/package-shape-verification.md` — new, full overview + REPORT_ONLY toggle docs.

No changeset: this PR adds zero published-package source changes — no version bump or CHANGELOG entry is warranted.

## Test plan

- [ ] CI's new "Check package shape" step runs successfully and prints the 9 baseline findings.
- [ ] Job is non-blocking (exits 0 in REPORT_ONLY mode).
- [ ] Local repro: `pnpm install && pnpm build && pnpm check:package-shape` reproduces the same findings.

[FEC-951]: https://commercetools.atlassian.net/browse/FEC-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
