### PR TITLE
feat(agents): clip content to the modal's box

### DIFF
--- a/.changeset/tired-bars-march.md
+++ b/.changeset/tired-bars-march.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-components': minor
+---
+
+clip modal content so when the container it is portaled into collapses, the top bar's back/close buttons cannot overflow

--- a/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
+++ b/packages/application-components/src/components/modal-pages/internals/modal-page.styles.ts
@@ -104,6 +104,7 @@ export const ModalContent = styled(Content, {
   box-shadow: 0px 0px 40px 0px rgba(0, 0, 0, 0.1);
   outline: 0;
   z-index: inherit;
+  overflow: hidden;
 
   &[data-state='open'] {
     animation: ${({ size }) => getContentShowAnimation(size)} 300ms ease


### PR DESCRIPTION
#### Summary

Clip content to the modal's box so that when the container it is portaled into collapses (e.g. a resizable side panel steals all the width), the top bar's back/close buttons — which are laid out at a fixed left offset — cannot overflow and paint over the rest of the app.

#### Screenshots

Before  (X icon on top left)
<img width="1055" height="869" alt="Intake Agent Beta" src="https://github.com/user-attachments/assets/b0872798-d5ab-46b6-bca9-ad43e75e965d" />

After (X icon not visible)
<img width="1140" height="871" alt="image" src="https://github.com/user-attachments/assets/28e37377-f829-45a8-a6d4-aef189a20666" />

