### PR TITLE
fix(mc-scripts): keep Nimbus optional when it is not installed (#4030)

### DIFF
--- a/.changeset/nimbus-optional-build-fallback.md
+++ b/.changeset/nimbus-optional-build-fallback.md
@@ -1,0 +1,17 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix Custom Application builds failing with
+`Module not found: Can't resolve '@commercetools/nimbus'` when
+`@commercetools/nimbus` is not installed (e.g. a fresh
+`create-mc-app --template=starter-typescript` project).
+
+`@commercetools/nimbus` is an optional dependency of the application shell.
+Previously the build only stayed unaffected when the app already had Nimbus
+installed, because the stubbing plugin was loaded from Nimbus itself and could
+not run when Nimbus was absent. `mc-scripts` now ships its own build-time
+fallback that stubs Nimbus imports when the package is not installed, and the
+shell splitter degrades to a passthrough at runtime when Nimbus is absent — so
+Nimbus stays genuinely optional for both webpack and Vite builds.

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter-wrapper.spec.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter-wrapper.spec.tsx
@@ -24,5 +24,46 @@ describe('ApplicationShellSplitterWrapper', () => {
       expect(source).toContain('.catch(');
       expect(source).toContain('children');
     });
+
+    it('source gates the splitter on `hasNimbus`, falling back to passthrough', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const source = fs.readFileSync(
+        path.join(__dirname, 'application-shell-splitter.async.tsx'),
+        'utf8'
+      );
+
+      expect(source).toContain('hasNimbus');
+      expect(source).toContain('Passthrough');
+    });
+  });
+
+  describe('hasNimbus availability flag', () => {
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    it('is true when @commercetools/nimbus resolves', () => {
+      jest.isolateModules(() => {
+        jest.doMock('@commercetools/nimbus', () => ({
+          NimbusProvider: () => null,
+          Splitter: { Root: () => null },
+          Region: () => null,
+          useResponsiveSplitterSizes: () => ({ rootProps: {} }),
+        }));
+        const { hasNimbus } = require('./application-shell-splitter');
+        expect(hasNimbus).toBe(true);
+      });
+    });
+
+    it('is false when @commercetools/nimbus is stubbed to an empty module', () => {
+      jest.isolateModules(() => {
+        // Mirrors what the mc-scripts bundler fallback produces when Nimbus is
+        // not installed: an empty module, so every named import is `undefined`.
+        jest.doMock('@commercetools/nimbus', () => ({}));
+        const { hasNimbus } = require('./application-shell-splitter');
+        expect(hasNimbus).toBe(false);
+      });
+    });
   });
 });

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.async.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.async.tsx
@@ -1,12 +1,21 @@
 import { type ReactNode, lazy, Suspense } from 'react';
 import { useHistory } from 'react-router-dom';
 
+const Passthrough = ({ children }: { children: ReactNode }) => <>{children}</>;
+
 const LazyApplicationShellSplitter = lazy(() =>
   import(
     './application-shell-splitter' /* webpackChunkName: "application-shell-splitter" */
-  ).catch(() => ({
-    default: ({ children }: { children: ReactNode }) => <>{children}</>,
-  }))
+  )
+    // When `@commercetools/nimbus` is not installed, the mc-scripts bundler
+    // fallback stubs it to an empty module so the build succeeds — but the
+    // splitter's Nimbus bindings are then `undefined`. `hasNimbus` reflects that;
+    // render a passthrough so no Nimbus code path is mounted.
+    .then((mod) =>
+      mod.hasNimbus ? { default: mod.default } : { default: Passthrough }
+    )
+    // Belt-and-suspenders: if the chunk fails to load outright, still degrade.
+    .catch(() => ({ default: Passthrough }))
 );
 
 type TApplicationShellSplitterWrapperProps = {

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
@@ -8,6 +8,17 @@ import {
 } from '@commercetools/nimbus';
 import { REGIONS } from '../../constants';
 
+/**
+ * Whether `@commercetools/nimbus` actually resolved at build time. When an app
+ * has not installed Nimbus, the mc-scripts bundler fallback stubs the import to
+ * an empty module, so the bindings above are `undefined`. The async wrapper
+ * reads this flag and renders a passthrough instead of mounting the splitter, so
+ * Nimbus hooks (e.g. `useResponsiveSplitterSizes`) are never called without
+ * Nimbus present. See nimbus `home-bundler-plugins.mdx` ("shared code is
+ * responsible for checking whether Nimbus is available before rendering").
+ */
+export const hasNimbus = typeof Splitter !== 'undefined';
+
 type TApplicationShellSplitterProps = {
   children: ReactNode;
   locale: string;

--- a/packages/mc-scripts/nimbus-stub.js
+++ b/packages/mc-scripts/nimbus-stub.js
@@ -1,0 +1,12 @@
+// Empty stub that the mc-scripts Nimbus fallback redirects `@commercetools/nimbus`
+// imports to when the package is NOT installed, so production/dev builds resolve.
+//
+// Empty CJS is load-bearing: named imports interop to `undefined` instead of
+// failing the build with a missing-export error. Consuming code must guard
+// against `undefined` before using anything from Nimbus — see the application-shell
+// splitter's `hasNimbus` flag, which renders a passthrough when Nimbus is absent.
+//
+// This mirrors `@commercetools/nimbus/plugins/stub`, but ships from mc-scripts so
+// it is resolvable even when `@commercetools/nimbus` (which owns that stub and the
+// bundler plugin that would redirect to it) is not installed at all.
+module.exports = {};

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -35,6 +35,7 @@
     "postcss",
     "webpack",
     "webpack-loaders",
+    "nimbus-stub.js",
     "package.json",
     "LICENSE",
     "README.md"

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -9,7 +9,7 @@ import { packageLocation as applicationStaticAssetsPath } from '@commercetools-f
 import { generateTemplate } from '@commercetools-frontend/mc-html-template';
 import paths from '../config/paths';
 import nonNullable from '../utils/non-nullable';
-import { tryLoadNimbusVitePlugin } from '../utils/try-load-nimbus-plugins';
+import { loadNimbusVitePlugin } from '../utils/try-load-nimbus-plugins';
 import pluginChunkCycleCheck from '../vite-plugins/vite-plugin-chunk-cycle-check';
 import pluginDynamicBaseAssetsGlobals from '../vite-plugins/vite-plugin-dynamic-base-assets-globals';
 import pluginI18nMessageCompilation from '../vite-plugins/vite-plugin-i18n-message-compilation';
@@ -91,7 +91,7 @@ async function run() {
       },
     },
     plugins: [
-      tryLoadNimbusVitePlugin({ cwd: paths.appRoot }),
+      loadNimbusVitePlugin({ cwd: paths.appRoot }),
       pluginSvgr(),
       pluginGraphql() as Plugin,
       pluginReact({

--- a/packages/mc-scripts/src/commands/start-vite.ts
+++ b/packages/mc-scripts/src/commands/start-vite.ts
@@ -10,7 +10,7 @@ import {
   processHeaders,
 } from '@commercetools-frontend/mc-html-template';
 import paths from '../config/paths';
-import { tryLoadNimbusVitePlugin } from '../utils/try-load-nimbus-plugins';
+import { loadNimbusVitePlugin } from '../utils/try-load-nimbus-plugins';
 import pluginMerchantCenterCustomization from '../vite-plugins/vite-plugin-merchant-center-customization';
 import pluginSvgr from '../vite-plugins/vite-plugin-svgr';
 
@@ -49,7 +49,7 @@ async function run() {
       headers: compiledHeaders,
     },
     plugins: [
-      tryLoadNimbusVitePlugin({ cwd: paths.appRoot }),
+      loadNimbusVitePlugin({ cwd: paths.appRoot }),
       pluginGraphql() as Plugin,
       pluginReact({
         jsxImportSource: '@emotion/react',

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
@@ -11,7 +11,7 @@ import type {
   TWebpackConfigToggleFlagsForDevelopment,
   TWebpackConfigOptions,
 } from '../types';
-import { tryLoadNimbusWebpackPlugin } from '../utils/try-load-nimbus-plugins';
+import { loadNimbusWebpackPlugin } from '../utils/try-load-nimbus-plugins';
 import LocalHtmlWebpackPlugin from '../webpack-plugins/local-html-webpack-plugin';
 import createPostcssConfig from './create-postcss-config';
 import hasJsxRuntime from './has-jsx-runtime';
@@ -162,7 +162,7 @@ function createWebpackConfigForDevelopment(
     },
 
     plugins: [
-      tryLoadNimbusWebpackPlugin({ cwd: paths.appRoot }),
+      loadNimbusWebpackPlugin({ cwd: paths.appRoot }),
       new WebpackBar(),
       // Allows to "assign" custom options to the `webpack` object.
       // At the moment, this is used to share some props with `postcss.config`.

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
@@ -12,7 +12,7 @@ import type {
   TWebpackConfigToggleFlagsForProduction,
   TWebpackConfigOptions,
 } from '../types';
-import { tryLoadNimbusWebpackPlugin } from '../utils/try-load-nimbus-plugins';
+import { loadNimbusWebpackPlugin } from '../utils/try-load-nimbus-plugins';
 import FinalStatsWriterPlugin from '../webpack-plugins/final-stats-writer-plugin';
 import createPostcssConfig from './create-postcss-config';
 import hasJsxRuntime from './has-jsx-runtime';
@@ -187,7 +187,7 @@ function createWebpackConfigForProduction(
     },
 
     plugins: [
-      tryLoadNimbusWebpackPlugin({ cwd: paths.appRoot }),
+      loadNimbusWebpackPlugin({ cwd: paths.appRoot }),
       // Allows to "assign" custom options to the `webpack` object.
       // At the moment, this is used to share some props with `postcss.config`.
       new webpack.LoaderOptionsPlugin({

--- a/packages/mc-scripts/src/utils/try-load-nimbus-plugins.spec.ts
+++ b/packages/mc-scripts/src/utils/try-load-nimbus-plugins.spec.ts
@@ -1,9 +1,22 @@
-describe('tryLoadNimbusWebpackPlugin', () => {
+function mockNimbusNotInstalled(entry: string) {
+  jest.mock(
+    entry,
+    () => {
+      const error = Object.assign(new Error('Cannot find module'), {
+        code: 'MODULE_NOT_FOUND',
+      });
+      throw error;
+    },
+    { virtual: true }
+  );
+}
+
+describe('loadNimbusWebpackPlugin', () => {
   beforeEach(() => {
     jest.resetModules();
   });
 
-  it('returns a plugin instance when @commercetools/nimbus is installed', () => {
+  it('returns nimbus plugin instance when @commercetools/nimbus is installed', () => {
     const MockPlugin = jest.fn();
     jest.mock(
       '@commercetools/nimbus/plugins/webpack',
@@ -13,14 +26,14 @@ describe('tryLoadNimbusWebpackPlugin', () => {
       { virtual: true }
     );
 
-    const { tryLoadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
-    const plugin = tryLoadNimbusWebpackPlugin();
+    const { loadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
+    const plugin = loadNimbusWebpackPlugin();
 
     expect(plugin).toBeInstanceOf(MockPlugin);
     expect(MockPlugin).toHaveBeenCalledWith(undefined);
   });
 
-  it('passes options through to the plugin constructor', () => {
+  it('passes options through to the nimbus plugin constructor', () => {
     const MockPlugin = jest.fn();
     jest.mock(
       '@commercetools/nimbus/plugins/webpack',
@@ -30,29 +43,58 @@ describe('tryLoadNimbusWebpackPlugin', () => {
       { virtual: true }
     );
 
-    const { tryLoadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
+    const { loadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
     const options = { cwd: '/app/root', UNSAFE_forceStub: true };
-    tryLoadNimbusWebpackPlugin(options);
+    loadNimbusWebpackPlugin(options);
 
     expect(MockPlugin).toHaveBeenCalledWith(options);
   });
 
-  it('returns null when @commercetools/nimbus is not installed', () => {
-    jest.mock(
-      '@commercetools/nimbus/plugins/webpack',
-      () => {
-        const error = Object.assign(new Error('Cannot find module'), {
-          code: 'MODULE_NOT_FOUND',
-        });
-        throw error;
-      },
-      { virtual: true }
-    );
+  describe('when @commercetools/nimbus is not installed', () => {
+    it('returns an mc-scripts fallback stub plugin (not null)', () => {
+      mockNimbusNotInstalled('@commercetools/nimbus/plugins/webpack');
 
-    const { tryLoadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
-    const plugin = tryLoadNimbusWebpackPlugin();
+      const { loadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
+      const plugin = loadNimbusWebpackPlugin();
 
-    expect(plugin).toBeNull();
+      expect(plugin).not.toBeNull();
+      expect(typeof plugin.apply).toBe('function');
+    });
+
+    it('redirects Nimbus runtime imports to the mc-scripts stub via NormalModuleReplacementPlugin', () => {
+      mockNimbusNotInstalled('@commercetools/nimbus/plugins/webpack');
+
+      const { loadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
+      const applyToCompiler = jest.fn();
+      const NormalModuleReplacementPlugin = jest
+        .fn()
+        .mockImplementation(() => ({ apply: applyToCompiler }));
+      const compiler = { webpack: { NormalModuleReplacementPlugin } };
+
+      loadNimbusWebpackPlugin().apply(compiler);
+
+      expect(NormalModuleReplacementPlugin).toHaveBeenCalledTimes(1);
+      const [regex, replacement] = NormalModuleReplacementPlugin.mock.calls[0];
+      expect(replacement).toBe(
+        '@commercetools-frontend/mc-scripts/nimbus-stub'
+      );
+      // matches nimbus + subpaths, excludes /plugins, ignores siblings
+      expect(regex.test('@commercetools/nimbus')).toBe(true);
+      expect(regex.test('@commercetools/nimbus/components/Button')).toBe(true);
+      expect(regex.test('@commercetools/nimbus/plugins/webpack')).toBe(false);
+      expect(regex.test('@commercetools/nimbus-icons')).toBe(false);
+      expect(regex.test('react')).toBe(false);
+      expect(applyToCompiler).toHaveBeenCalledWith(compiler);
+    });
+
+    it('throws a clear error on webpack 4 (no compiler.webpack)', () => {
+      mockNimbusNotInstalled('@commercetools/nimbus/plugins/webpack');
+
+      const { loadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
+      expect(() => loadNimbusWebpackPlugin().apply({})).toThrow(
+        'requires webpack 5+'
+      );
+    });
   });
 
   it('re-throws non-MODULE_NOT_FOUND errors', () => {
@@ -64,17 +106,17 @@ describe('tryLoadNimbusWebpackPlugin', () => {
       { virtual: true }
     );
 
-    const { tryLoadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
-    expect(() => tryLoadNimbusWebpackPlugin()).toThrow('Unexpected token');
+    const { loadNimbusWebpackPlugin } = require('./try-load-nimbus-plugins');
+    expect(() => loadNimbusWebpackPlugin()).toThrow('Unexpected token');
   });
 });
 
-describe('tryLoadNimbusVitePlugin', () => {
+describe('loadNimbusVitePlugin', () => {
   beforeEach(() => {
     jest.resetModules();
   });
 
-  it('returns a plugin when @commercetools/nimbus is installed', () => {
+  it('returns nimbus plugin when @commercetools/nimbus is installed', () => {
     const mockPlugin = { name: 'nimbus-optional-dependency' };
     jest.mock(
       '@commercetools/nimbus/plugins/vite',
@@ -84,13 +126,13 @@ describe('tryLoadNimbusVitePlugin', () => {
       { virtual: true }
     );
 
-    const { tryLoadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
-    const plugin = tryLoadNimbusVitePlugin();
+    const { loadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
+    const plugin = loadNimbusVitePlugin();
 
     expect(plugin).toBe(mockPlugin);
   });
 
-  it('passes options through to the plugin factory', () => {
+  it('passes options through to the nimbus plugin factory', () => {
     const mockFactory = jest.fn(() => ({
       name: 'nimbus-optional-dependency',
     }));
@@ -102,29 +144,46 @@ describe('tryLoadNimbusVitePlugin', () => {
       { virtual: true }
     );
 
-    const { tryLoadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
+    const { loadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
     const options = { cwd: '/app/root', UNSAFE_forceStub: true };
-    tryLoadNimbusVitePlugin(options);
+    loadNimbusVitePlugin(options);
 
     expect(mockFactory).toHaveBeenCalledWith(options);
   });
 
-  it('returns null when @commercetools/nimbus is not installed', () => {
-    jest.mock(
-      '@commercetools/nimbus/plugins/vite',
-      () => {
-        const error = Object.assign(new Error('Cannot find module'), {
-          code: 'MODULE_NOT_FOUND',
-        });
-        throw error;
-      },
-      { virtual: true }
-    );
+  describe('when @commercetools/nimbus is not installed', () => {
+    it('returns an mc-scripts fallback stub plugin (not null)', () => {
+      mockNimbusNotInstalled('@commercetools/nimbus/plugins/vite');
 
-    const { tryLoadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
-    const plugin = tryLoadNimbusVitePlugin();
+      const { loadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
+      const plugin = loadNimbusVitePlugin();
 
-    expect(plugin).toBeNull();
+      expect(plugin).not.toBeNull();
+      expect(plugin.enforce).toBe('pre');
+      expect(typeof plugin.resolveId).toBe('function');
+      expect(typeof plugin.load).toBe('function');
+    });
+
+    it('resolves Nimbus runtime imports to a virtual empty stub, leaving /plugins and siblings alone', () => {
+      mockNimbusNotInstalled('@commercetools/nimbus/plugins/vite');
+
+      const { loadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
+      const plugin = loadNimbusVitePlugin();
+
+      const stubId = plugin.resolveId('@commercetools/nimbus');
+      expect(stubId).toBeTruthy();
+      expect(plugin.resolveId('@commercetools/nimbus/components/Button')).toBe(
+        stubId
+      );
+      expect(
+        plugin.resolveId('@commercetools/nimbus/plugins/vite')
+      ).toBeUndefined();
+      expect(plugin.resolveId('@commercetools/nimbus-icons')).toBeUndefined();
+      expect(plugin.resolveId('react')).toBeUndefined();
+
+      expect(plugin.load(stubId)).toBe('module.exports = {};');
+      expect(plugin.load('some-other-id')).toBeUndefined();
+    });
   });
 
   it('re-throws non-MODULE_NOT_FOUND errors', () => {
@@ -136,7 +195,7 @@ describe('tryLoadNimbusVitePlugin', () => {
       { virtual: true }
     );
 
-    const { tryLoadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
-    expect(() => tryLoadNimbusVitePlugin()).toThrow('Unexpected token');
+    const { loadNimbusVitePlugin } = require('./try-load-nimbus-plugins');
+    expect(() => loadNimbusVitePlugin()).toThrow('Unexpected token');
   });
 });

--- a/packages/mc-scripts/src/utils/try-load-nimbus-plugins.spec.ts
+++ b/packages/mc-scripts/src/utils/try-load-nimbus-plugins.spec.ts
@@ -75,9 +75,10 @@ describe('loadNimbusWebpackPlugin', () => {
 
       expect(NormalModuleReplacementPlugin).toHaveBeenCalledTimes(1);
       const [regex, replacement] = NormalModuleReplacementPlugin.mock.calls[0];
-      expect(replacement).toBe(
-        '@commercetools-frontend/mc-scripts/nimbus-stub'
-      );
+      // Absolute path (not a bare specifier) so it resolves under pnpm's strict
+      // node_modules, where application-shell cannot see mc-scripts.
+      expect(require('path').isAbsolute(replacement)).toBe(true);
+      expect(replacement).toMatch(/[/\\]nimbus-stub\.js$/);
       // matches nimbus + subpaths, excludes /plugins, ignores siblings
       expect(regex.test('@commercetools/nimbus')).toBe(true);
       expect(regex.test('@commercetools/nimbus/components/Button')).toBe(true);

--- a/packages/mc-scripts/src/utils/try-load-nimbus-plugins.ts
+++ b/packages/mc-scripts/src/utils/try-load-nimbus-plugins.ts
@@ -1,7 +1,21 @@
+import type { Plugin } from 'vite';
+
 type NimbusPluginOptions = {
   cwd?: string;
   UNSAFE_forceStub?: boolean;
 };
+
+// Source of truth: `@commercetools/nimbus` `src/plugins/nimbus-runtime-re.ts`.
+// Matches `@commercetools/nimbus` and any subpath EXCEPT `/plugins` and
+// `/plugins/*`. Duplicated here (rather than imported) on purpose: these
+// fallbacks only run when `@commercetools/nimbus` is NOT installed, so none of
+// its modules — including the regex — can be `require`d at that point.
+const NIMBUS_RUNTIME_RE = /^@commercetools\/nimbus(?:$|\/(?!plugins(?:\/|$)))/;
+
+// Empty CJS stub shipped by mc-scripts (see `packages/mc-scripts/nimbus-stub.js`).
+// Bare specifier so webpack resolves it from the consumer app's build context —
+// mc-scripts is always installed there, even when `@commercetools/nimbus` is not.
+const NIMBUS_STUB_MODULE = '@commercetools-frontend/mc-scripts/nimbus-stub';
 
 function isModuleNotFound(error: unknown): boolean {
   return (
@@ -11,26 +25,84 @@ function isModuleNotFound(error: unknown): boolean {
   );
 }
 
-export function tryLoadNimbusWebpackPlugin(options?: NimbusPluginOptions) {
+/**
+ * webpack fallback used when `@commercetools/nimbus` — and therefore its own
+ * `@commercetools/nimbus/plugins/webpack` — is not installed. Redirects every
+ * Nimbus runtime import to the empty stub so the build resolves. Mirrors
+ * nimbus's `UNSAFE_NimbusOptionalDependencyPlugin`, but ships from mc-scripts so
+ * it works precisely in the case Nimbus is absent.
+ */
+class NimbusStubWebpackPlugin {
+  apply(compiler: {
+    webpack?: {
+      NormalModuleReplacementPlugin: new (
+        regex: RegExp,
+        replacement: string
+      ) => { apply: (compiler: unknown) => void };
+    };
+  }): void {
+    if (!compiler.webpack) {
+      throw new Error(
+        'NimbusStubWebpackPlugin requires webpack 5+. ' +
+          'compiler.webpack is undefined — are you using webpack 4 or older?'
+      );
+    }
+    const { NormalModuleReplacementPlugin } = compiler.webpack;
+    new NormalModuleReplacementPlugin(
+      NIMBUS_RUNTIME_RE,
+      NIMBUS_STUB_MODULE
+    ).apply(compiler);
+  }
+}
+
+/**
+ * Vite fallback, mirroring nimbus's `UNSAFE_nimbusOptionalDependency` stub path:
+ * resolve every Nimbus runtime import to a virtual empty CJS module so the build
+ * resolves when `@commercetools/nimbus` is not installed.
+ */
+function createNimbusStubVitePlugin(): Plugin {
+  // The `.cjs` extension makes named imports interop to `undefined` rather than
+  // failing with a missing-export error (same trick nimbus uses).
+  const STUB_ID = '\0mc-scripts-nimbus-stub.cjs';
+  return {
+    name: 'mc-scripts-nimbus-optional-dependency-fallback',
+    // Run before Vite's default resolver, which would otherwise follow
+    // workspace symlinks and resolve Nimbus even when the app has not installed it.
+    enforce: 'pre',
+    resolveId(source: string) {
+      if (NIMBUS_RUNTIME_RE.test(source)) return STUB_ID;
+      return undefined;
+    },
+    load(id: string) {
+      if (id === STUB_ID) return 'module.exports = {};';
+      return undefined;
+    },
+  };
+}
+
+export function loadNimbusWebpackPlugin(options?: NimbusPluginOptions) {
   try {
     const {
       UNSAFE_NimbusOptionalDependencyPlugin,
     } = require('@commercetools/nimbus/plugins/webpack');
     return new UNSAFE_NimbusOptionalDependencyPlugin(options);
   } catch (error) {
-    if (isModuleNotFound(error)) return null;
+    // Nimbus is not installed: its own plugin can't be loaded (it lives inside
+    // Nimbus), so mc-scripts stubs the imports itself. Any other error (e.g. a
+    // present-but-broken Nimbus) still surfaces.
+    if (isModuleNotFound(error)) return new NimbusStubWebpackPlugin();
     throw error;
   }
 }
 
-export function tryLoadNimbusVitePlugin(options?: NimbusPluginOptions) {
+export function loadNimbusVitePlugin(options?: NimbusPluginOptions) {
   try {
     const {
       UNSAFE_nimbusOptionalDependency,
     } = require('@commercetools/nimbus/plugins/vite');
     return UNSAFE_nimbusOptionalDependency(options);
   } catch (error) {
-    if (isModuleNotFound(error)) return null;
+    if (isModuleNotFound(error)) return createNimbusStubVitePlugin();
     throw error;
   }
 }

--- a/packages/mc-scripts/src/utils/try-load-nimbus-plugins.ts
+++ b/packages/mc-scripts/src/utils/try-load-nimbus-plugins.ts
@@ -13,9 +13,7 @@ type NimbusPluginOptions = {
 const NIMBUS_RUNTIME_RE = /^@commercetools\/nimbus(?:$|\/(?!plugins(?:\/|$)))/;
 
 // Empty CJS stub shipped by mc-scripts (see `packages/mc-scripts/nimbus-stub.js`).
-// Bare specifier so webpack resolves it from the consumer app's build context —
-// mc-scripts is always installed there, even when `@commercetools/nimbus` is not.
-const NIMBUS_STUB_MODULE = '@commercetools-frontend/mc-scripts/nimbus-stub';
+const NIMBUS_STUB_SUBPATH = '@commercetools-frontend/mc-scripts/nimbus-stub';
 
 function isModuleNotFound(error: unknown): boolean {
   return (
@@ -26,6 +24,19 @@ function isModuleNotFound(error: unknown): boolean {
 }
 
 /**
+ * Resolve the stub to an absolute path from the application root. mc-scripts is
+ * a (dev)dependency of the app being built, so it is resolvable there under any
+ * package-manager layout. Resolving to an absolute path — rather than handing
+ * webpack the bare specifier — is what makes this work under pnpm's strict
+ * `node_modules`: a bare specifier would be re-resolved from application-shell's
+ * context, which cannot see mc-scripts (it is not application-shell's
+ * dependency).
+ */
+function resolveNimbusStub(cwd: string = process.cwd()): string {
+  return require.resolve(NIMBUS_STUB_SUBPATH, { paths: [cwd] });
+}
+
+/**
  * webpack fallback used when `@commercetools/nimbus` — and therefore its own
  * `@commercetools/nimbus/plugins/webpack` — is not installed. Redirects every
  * Nimbus runtime import to the empty stub so the build resolves. Mirrors
@@ -33,6 +44,12 @@ function isModuleNotFound(error: unknown): boolean {
  * it works precisely in the case Nimbus is absent.
  */
 class NimbusStubWebpackPlugin {
+  private stubPath: string;
+
+  constructor(cwd?: string) {
+    this.stubPath = resolveNimbusStub(cwd);
+  }
+
   apply(compiler: {
     webpack?: {
       NormalModuleReplacementPlugin: new (
@@ -48,10 +65,9 @@ class NimbusStubWebpackPlugin {
       );
     }
     const { NormalModuleReplacementPlugin } = compiler.webpack;
-    new NormalModuleReplacementPlugin(
-      NIMBUS_RUNTIME_RE,
-      NIMBUS_STUB_MODULE
-    ).apply(compiler);
+    new NormalModuleReplacementPlugin(NIMBUS_RUNTIME_RE, this.stubPath).apply(
+      compiler
+    );
   }
 }
 
@@ -90,7 +106,8 @@ export function loadNimbusWebpackPlugin(options?: NimbusPluginOptions) {
     // Nimbus is not installed: its own plugin can't be loaded (it lives inside
     // Nimbus), so mc-scripts stubs the imports itself. Any other error (e.g. a
     // present-but-broken Nimbus) still surfaces.
-    if (isModuleNotFound(error)) return new NimbusStubWebpackPlugin();
+    if (isModuleNotFound(error))
+      return new NimbusStubWebpackPlugin(options?.cwd);
     throw error;
   }
 }


### PR DESCRIPTION
Fixes #4030.

## Problem

A fresh Custom Application (`npx create-mc-app@latest my-app --template=starter-typescript`) fails `yarn build` with:

```
Module not found: Error: Can't resolve '@commercetools/nimbus'
  in '…/node_modules/@commercetools-frontend/application-shell/dist'
```

Reproduced end-to-end on the released **27.7.0** (`mc-scripts@27.7.0` + `application-shell@27.7.0`, Nimbus not installed).

## Root cause

27.7.0 shipped Nimbus as an *optional* dependency of the shell (nimbus #1599 bundler plugins + #4024 mc-scripts wiring + #4025 shell splitter). The intended contract — *stub Nimbus imports so the build succeeds, guard against `undefined` at runtime* — was broken in two places:

1. **Build fails.** `mc-scripts` loaded the stubbing plugin via `require('@commercetools/nimbus/plugins/webpack')`. That plugin (and the stub it redirects to) live **inside Nimbus**, so it cannot load precisely when Nimbus is absent — the one case it exists for. The loader returned `null`, nothing stubbed the import, and webpack could not resolve the splitter's static `@commercetools/nimbus` import. (PR #4024's checklist item *"Verify mc-scripts builds succeed without Nimbus installed (external consumer)"* was left unchecked; in the monorepo Nimbus is a hoisted devDep so it silently worked there.)
2. **Runtime guard missing.** The splitter's async wrapper only `.catch`-ed import *rejection*. An empty stub imports *successfully*, so once (1) is fixed with an empty stub the splitter would still mount and crash on `useResponsiveSplitterSizes(undefined)`. FEC-1017's planned availability guard had been simplified away.

## Fix (both packages in this repo; Nimbus untouched)

- **`@commercetools-frontend/mc-scripts`** — ships its own empty `nimbus-stub.js`. When `@commercetools/nimbus` is not installed, `loadNimbus{Webpack,Vite}Plugin` registers an mc-scripts-owned fallback that redirects Nimbus runtime imports to that stub (`NormalModuleReplacementPlugin` for webpack, a virtual module for Vite), mirroring Nimbus's own plugins but resolvable when Nimbus is absent. When Nimbus **is** installed it defers to Nimbus's own no-op plugin — unchanged.
- **`@commercetools-frontend/application-shell`** — the splitter exposes a `hasNimbus` flag; the async wrapper renders a passthrough when it is `false`, so no Nimbus code path is mounted without Nimbus.

## Verification

- **965 unit tests pass**, including new coverage for the fallback (webpack/Vite regex + stub target) and the `hasNimbus` gate.
- Reproduced the reporter's failure end-to-end on stock **27.7.0** (byte-for-byte the same error), then verified the fix by mocking the `npx` flow against this branch's real `pnpm pack` tarballs (`pnpm pack` resolves `catalog:`/`workspace:` like the release pipeline; `nimbus-stub.js` is confirmed in the tarball `files`).

### Build matrix — fresh `starter-typescript` scaffold, real tarballs of this branch

**Nimbus _absent_ (the scenario in #4030) — the fix:**

| | npm | pnpm | yarn |
|---|---|---|---|
| **webpack** | ✅ | ✅ | ✅ |
| **vite** | ✅ | ✅ | ✅ |

All 6 build cleanly (`Compiled successfully`, exit 0). webpack redirects Nimbus imports to the empty `nimbus-stub.js`; Vite inlines an equivalent virtual module (confirmed the Vite bundler engaged and Rollup raised no `@commercetools/nimbus` resolution error). The emitted `app-shell.js` carries the `hasNimbus ? splitter : Passthrough` guard, so the splitter is never mounted without Nimbus.

The webpack fallback resolves the stub to an **absolute path** from the app root (where `mc-scripts` is a declared dependency) rather than a bare specifier — a bare specifier would be re-resolved from `application-shell`'s context, which cannot see `mc-scripts` under **pnpm's strict `node_modules`**. This is why pnpm is green.

**Nimbus _present_ (Nimbus 3.2.0 installed) — regression / opt-in path:**

| | npm | pnpm | yarn |
|---|---|---|---|
| **webpack** | ✅ | ✅ | ⚠️¹ |
| **vite** | ✅ | ✅ | ⚠️¹ |

npm & pnpm bundle real Nimbus (splitter chunk ~1.3 MB, stub not used) — the happy path is intact.

¹ The two yarn cells fail with `Can't resolve '@chakra-ui/react/styled-system'` (then `slate-dom`). This is **not introduced by this PR**: Nimbus 3.2.0 declares `@chakra-ui/react`, `slate*`, `nimbus-icons`, `nimbus-tokens` as **peerDependencies**; npm and pnpm auto-install/wire peers, **yarn classic does not**, so Nimbus can't resolve its own deps. When Nimbus is present my fallback is never constructed (mc-scripts returns Nimbus's own plugin), and the replacement regex only matches `@commercetools/nimbus` — it cannot affect Chakra/Slate resolution. **Follow-up (separate from #4030):** yarn-classic Custom App users who adopt Nimbus need Nimbus's peer graph installed — worth template guidance or a Nimbus-side note.

### What is not covered

- **dev/serve** builds (only production `build` was run) and package managers beyond npm/pnpm/yarn (e.g. Yarn Berry/PnP).
- The literal `npx create-mc-app@latest … && yarn build` — it resolves `^27.7.0` from the `latest` dist-tag, so it only picks up this fix once a release bumps `latest`.

### Reproduce it yourself before merge

Because `create-mc-app@latest` scaffolds a template pinned to `^27.7.0` and `yarn` resolves that from the `latest` dist-tag, the vanilla `npx create-mc-app@latest … && yarn build` won't pick up this fix until a release bumps `latest`. To exercise the fix now, override the two packages to a build of this branch:

```bash
# from this branch's checkout
pnpm --filter @commercetools-frontend/mc-scripts --filter @commercetools-frontend/application-shell exec pnpm pack --pack-destination /tmp/preview

# fresh app, Nimbus intentionally NOT installed
npx --yes @commercetools-frontend/create-mc-app@latest app \
  --template starter-typescript --entry-point-uri-path myapp \
  --initial-project-key my-project-key --yes --skip-install
cd app
# pin the two deps + resolutions (application-shell is also a transitive dep) to the tarballs, then:
yarn install && yarn build   # expect: Compiled successfully
```

Alternatively, comment `[preview_deployment]` on this PR to publish snapshot versions to npm, then install those (`@<preview-tag>`) into a fresh scaffold — same result, hosted on npm.

