### PR TITLE
fix(application-shell): support long-lived flags in user settings menu

### DIFF
--- a/.changeset/user-settings-menu-long-lived-flags.md
+++ b/.changeset/user-settings-menu-long-lived-flags.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Fix user-settings menu items gated by long-lived feature flags
+(`{ value: boolean, reason?: string }`) never rendering. The
+`OptionalFeatureToggle` component now uses `useFlagVariation` instead of
+flopflip's `ToggleFeature`, matching the pattern already used by the
+navbar's `RestrictedMenuItem`.

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -157,6 +157,88 @@ describe('rendering', () => {
       });
     });
   });
+  describe('when a menu item has a boolean feature toggle set to true', () => {
+    it('should render the menu item', async () => {
+      const props = createTestProps();
+      renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
+        flags: { myBooleanFlag: true },
+        environment: {
+          __DEVELOPMENT__: {
+            // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.
+            accountLinks: [
+              createTestMenuConfig('flagged-item', {
+                featureToggle: 'myBooleanFlag',
+              }),
+            ],
+          },
+        },
+        disableAutomaticEntryPointRoutes: true,
+      });
+      const dropdownMenu = await screen.findByRole('button', {
+        name: /open user settings menu/i,
+      });
+      fireEvent.click(dropdownMenu);
+
+      expect(await screen.findByText('Flagged-item')).toBeInTheDocument();
+    });
+  });
+  describe('when a menu item has a long-lived feature toggle with value true', () => {
+    it('should render the menu item', async () => {
+      const props = createTestProps();
+      renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
+        flags: { myLongLivedFlag: { value: true, reason: 'on' } },
+        environment: {
+          __DEVELOPMENT__: {
+            // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.
+            accountLinks: [
+              createTestMenuConfig('long-lived-item', {
+                featureToggle: 'myLongLivedFlag',
+              }),
+            ],
+          },
+        },
+        disableAutomaticEntryPointRoutes: true,
+      });
+      const dropdownMenu = await screen.findByRole('button', {
+        name: /open user settings menu/i,
+      });
+      fireEvent.click(dropdownMenu);
+
+      expect(await screen.findByText('Long-lived-item')).toBeInTheDocument();
+    });
+  });
+  describe('when a menu item has a feature toggle set to false', () => {
+    it('should not render the menu item', async () => {
+      const props = createTestProps();
+      renderApp(<UserSettingsMenu {...props} />, {
+        disableRoutePermissionCheck: true,
+        flags: { myDisabledFlag: false },
+        environment: {
+          __DEVELOPMENT__: {
+            // @ts-expect-error: the `accountLinks` is not explicitly typed as it's only used by the account app.
+            accountLinks: [
+              createTestMenuConfig('disabled-item', {
+                featureToggle: 'myDisabledFlag',
+              }),
+            ],
+          },
+        },
+        disableAutomaticEntryPointRoutes: true,
+      });
+      const dropdownMenu = await screen.findByRole('button', {
+        name: /open user settings menu/i,
+      });
+      fireEvent.click(dropdownMenu);
+      // Wait for the menu to be open
+      await screen.findByRole('button', {
+        name: /close user settings menu/i,
+      });
+
+      expect(screen.queryByText('Disabled-item')).not.toBeInTheDocument();
+    });
+  });
   describe('when clicking on the Privacy link', () => {
     it('should close the user menu', async () => {
       const props = createTestProps();

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.tsx
@@ -1,7 +1,8 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { ToggleFeature } from '@flopflip/react-broadcast';
+import { useFlagVariation } from '@flopflip/react-broadcast';
+import type { TFlagVariation } from '@flopflip/types';
 import Downshift, {
   type ControllerStateAndHelpers,
   type DownshiftProps,
@@ -96,11 +97,25 @@ const stateReducer: DownshiftProps<{}>['stateReducer'] = (state, changes) => {
   }
 };
 
+type TLongLivedFlag = {
+  value: boolean;
+  reason?: string;
+};
+
+function isLongLivedFlag(
+  flag: TFlagVariation | TLongLivedFlag
+): flag is TLongLivedFlag {
+  return typeof (flag as TLongLivedFlag)?.value === 'boolean';
+}
+
 const OptionalFeatureToggle = (props: OptionalFeatureToggleProps) => {
+  const flagVariation = useFlagVariation(props.featureToggle);
+
   if (props.featureToggle) {
-    return (
-      <ToggleFeature flag={props.featureToggle}>{props.children}</ToggleFeature>
-    );
+    if (flagVariation === true) return <>{props.children}</>;
+    if (isLongLivedFlag(flagVariation) && flagVariation.value === true)
+      return <>{props.children}</>;
+    return null;
   }
   return <>{props.children}</>;
 };


### PR DESCRIPTION
## Summary
- Replaced flopflip's `ToggleFeature` component with the `useFlagVariation` hook in `OptionalFeatureToggle`, matching the pattern already used by the navbar's `RestrictedMenuItem`.
- The user-settings dropdown now correctly handles long-lived flags (`{ value: boolean, reason?: string }`) in addition to simple boolean flags.
- Added tests for boolean-true, long-lived-true, and false feature toggle scenarios.

## Test plan
- [x] Existing tests pass
- [x] New test: menu item with boolean `true` toggle renders
- [x] New test: menu item with long-lived `{ value: true }` toggle renders
- [x] New test: menu item with `false` toggle does not render
- [x] TypeScript compiles cleanly
- [x] ESLint passes