### PR TITLE
fix(ci): pin npm to v11 to avoid npm@12 sigstore bug

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -39,9 +39,9 @@ jobs:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      # Ensure npm 11.5.1 or later is installed for OIDC support
+      # Ensure npm >=11.5.1 for OIDC support (npm@12 has a broken sigstore dependency)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Verify npm version
         run: npm --version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,9 +39,9 @@ jobs:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
 
-      # Ensure npm 11.5.1 or later is installed for OIDC support
+      # Ensure npm >=11.5.1 for OIDC support (npm@12 has a broken sigstore dependency)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Verify npm version
         run: npm --version


### PR DESCRIPTION
## Summary

- Pins `npm install -g npm@latest` to `npm install -g npm@11` in both release workflows
- npm@12.0.0 removed `sigstore` as a bundled dependency but `libnpmpublish` still requires it for provenance during publish, causing `MODULE_NOT_FOUND` errors for every package

## Other affected repos

The same fix is needed in:
- `commercetools/commercetools-sdk-typescript` — `.github/workflows/release.yml`
- `commercetools/nimbus` — `.github/workflows/release.yml` (2 occurrences)
- `commercetools/typescript-dev-utilities` — `.github/workflows/release.yml`

## Test plan

- [ ] CI passes
- [ ] Next release publish succeeds without `MODULE_NOT_FOUND: sigstore` errors