### PR TITLE
Add main container portal target for save toolbar

### DIFF
--- a/.changeset/save-toolbar-portal-target.md
+++ b/.changeset/save-toolbar-portal-target.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/constants': minor
+'@commercetools-frontend/application-shell': minor
+---
+
+Add a portal target (`mc-main-container-portal`) inside `MainContainer` so that fixed-position components like `SaveToolbar` can portal into the MC content area and automatically constrain their width to the main pane, excluding the agent side panel.

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -18,7 +18,11 @@ import {
   selectUserLanguageFromStorage,
   type TApplicationContext,
 } from '@commercetools-frontend/application-shell-connectors';
-import { DOMAINS, LOGOUT_REASONS } from '@commercetools-frontend/constants';
+import {
+  DOMAINS,
+  LOGOUT_REASONS,
+  MC_MAIN_CONTAINER_PORTAL_ID,
+} from '@commercetools-frontend/constants';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';
@@ -428,6 +432,15 @@ export const ApplicationShellAuthenticated = (
                                 </Route>
                               </Switch>
                             </div>
+                            <div
+                              id={MC_MAIN_CONTAINER_PORTAL_ID}
+                              css={css`
+                                position: sticky;
+                                bottom: 0;
+                                z-index: 9999;
+                                pointer-events: none;
+                              `}
+                            />
                           </MainContainer>
                         )}
                       </div>

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -42,6 +42,7 @@ export const PERMISSION_GROUP_NAME_REGEX =
 // DOM elements
 export const PORTALS_CONTAINER_ID = 'portals-container';
 export const PORTALS_CONTAINER_INDENTATION_SIZE = '48px';
+export const MC_MAIN_CONTAINER_PORTAL_ID = 'mc-main-container-portal';
 
 // Links
 export const SUPPORT_PORTAL_URL = 'https://support.commercetools.com';

--- a/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
+++ b/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
@@ -1,17 +1,32 @@
-import { type ReactNode, useState, useEffect } from 'react';
 import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+} from 'react';
+import {
+  Box,
+  Button,
+  Flex,
   NimbusProvider,
-  Splitter,
   Region,
+  Splitter,
   useRegion,
 } from '@commercetools/nimbus';
+import { createPortal } from 'react-dom';
 import {
   REGIONS,
   type TApplicationShellSplitterValue,
 } from '@commercetools-frontend/application-shell';
+import { MC_MAIN_CONTAINER_PORTAL_ID } from '@commercetools-frontend/constants';
 import { Suite, Spec } from '../../test-utils';
 
 export const routePath = '/shell-splitter';
+
+let shellCounter = 0;
+
+const PortalIdContext = createContext<string>(MC_MAIN_CONTAINER_PORTAL_ID);
 
 type SplitterShellProps = {
   defaultOpen?: boolean;
@@ -23,6 +38,9 @@ const SplitterShell = ({
   children,
 }: SplitterShellProps) => {
   const [open, setOpen] = useState(defaultOpen);
+  const [portalId] = useState(
+    () => `${MC_MAIN_CONTAINER_PORTAL_ID}-${shellCounter++}`
+  );
 
   const controller = {
     isCollapsed: !open,
@@ -37,64 +55,158 @@ const SplitterShell = ({
       router={{ navigate: () => {} }}
       loadFonts={false}
     >
-      <Splitter.Root
-        orientation="horizontal"
-        defaultSize={30}
-        minSize={20}
-        maxSize={40}
-        collapsible
-        collapsedSize={0}
-        collapsed={!open}
-        onCollapsedChange={(c: boolean) => setOpen(!c)}
-      >
-        <Splitter.Main style={{ containerType: 'inline-size', minWidth: 0 }}>
-          {children}
-        </Splitter.Main>
-        <Splitter.Handle aria-label="Resize side panel" />
-        <Splitter.Aside>
-          <Region name={REGIONS.MC_RIGHT_PANEL} value={controller} />
-        </Splitter.Aside>
-      </Splitter.Root>
+      <PortalIdContext.Provider value={portalId}>
+        <Splitter.Root
+          orientation="horizontal"
+          defaultSize={30}
+          minSize={20}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          collapsed={!open}
+          onCollapsedChange={(c: boolean) => setOpen(!c)}
+          style={{ height: '100%' }}
+        >
+          <Splitter.Main style={{ containerType: 'inline-size', minWidth: 0 }}>
+            <Flex
+              direction="column"
+              height="100%"
+              position="relative"
+              overflow="auto"
+            >
+              <Box flexGrow={1}>{children}</Box>
+              <Box
+                id={portalId}
+                position="sticky"
+                bottom={0}
+                zIndex={9999}
+                pointerEvents="none"
+              />
+            </Flex>
+          </Splitter.Main>
+          <Splitter.Handle aria-label="Resize side panel" />
+          <Splitter.Aside>
+            <Region name={REGIONS.MC_RIGHT_PANEL} value={controller} />
+          </Splitter.Aside>
+        </Splitter.Root>
+      </PortalIdContext.Provider>
     </NimbusProvider>
   );
 };
 SplitterShell.displayName = 'SplitterShell';
 
-const AsideContent = () => {
+const AsideContent = ({ autoExpand = false }: { autoExpand?: boolean }) => {
   const { Region: Filler, value } = useRegion<TApplicationShellSplitterValue>(
     REGIONS.MC_RIGHT_PANEL
   );
 
   useEffect(() => {
-    value?.expand();
-  }, [value]);
+    if (autoExpand) {
+      value?.expand();
+    }
+  }, [value, autoExpand]);
 
   return (
     <Filler>
-      <div style={{ padding: 16, background: '#f5f5f5', height: '100%' }}>
-        <h3 style={{ margin: '0 0 8px' }}>Side Panel</h3>
-        <p style={{ margin: 0 }}>Region-portalled content in the aside pane.</p>
-      </div>
+      <Box padding={4} bg="warning.3" height="100%">
+        <Box as="h3" marginBottom={2}>
+          Side Panel
+        </Box>
+        <Box as="p">Region-portalled content in the aside pane.</Box>
+      </Box>
     </Filler>
   );
 };
 AsideContent.displayName = 'AsideContent';
 
-const MainContent = () => (
-  <div style={{ padding: 24 }}>
-    <h2 style={{ margin: '0 0 8px' }}>Main Content</h2>
-    <p style={{ margin: 0 }}>
+const MainContent = ({ children }: { children?: ReactNode }) => (
+  <Box padding={6} bg="positive.3" height="100%">
+    <Box as="h2" marginBottom={2}>
+      Main Content
+    </Box>
+    <Box as="p" marginBottom={4}>
       This is the main content area inside Splitter.Main.
-    </p>
-  </div>
+    </Box>
+    {children}
+  </Box>
 );
 MainContent.displayName = 'MainContent';
+
+const FakeSaveToolbar = ({
+  visible,
+  onCancel,
+  onSave,
+}: {
+  visible: boolean;
+  onCancel?: () => void;
+  onSave?: () => void;
+}) => {
+  const portalId = useContext(PortalIdContext);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setPortalTarget(document.getElementById(portalId));
+  }, [portalId]);
+
+  if (!visible) return null;
+
+  const toolbar = (
+    <Flex
+      justify="space-between"
+      align="center"
+      paddingX={4}
+      paddingY={3}
+      bg="info.4"
+      borderTopRadius="md"
+      width="100%"
+      pointerEvents="auto"
+      data-testid="fake-save-toolbar"
+    >
+      <Button variant="secondary" onPress={onCancel}>
+        Cancel
+      </Button>
+      <Button variant="solid" onPress={onSave}>
+        Save
+      </Button>
+    </Flex>
+  );
+
+  if (portalTarget) {
+    return createPortal(toolbar, portalTarget);
+  }
+
+  return null;
+};
+FakeSaveToolbar.displayName = 'FakeSaveToolbar';
+
+const ToolbarDemo = () => {
+  const [showToolbar, setShowToolbar] = useState(true);
+
+  return (
+    <>
+      <MainContent>
+        {!showToolbar && (
+          <Button variant="secondary" onPress={() => setShowToolbar(true)}>
+            Show toolbar
+          </Button>
+        )}
+      </MainContent>
+      <AsideContent />
+      <FakeSaveToolbar
+        visible={showToolbar}
+        onCancel={() => setShowToolbar(false)}
+        onSave={() => setShowToolbar(false)}
+      />
+    </>
+  );
+};
+ToolbarDemo.displayName = 'ToolbarDemo';
 
 export const Component = () => (
   <Suite>
     <Spec
       label="ShellSplitter - Aside collapsed (default)"
-      size="l"
+      size="m"
       omitPropsList
     >
       <SplitterShell>
@@ -103,22 +215,40 @@ export const Component = () => (
     </Spec>
     <Spec
       label="ShellSplitter - Aside expanded via Region"
-      size="l"
+      size="m"
       omitPropsList
     >
       <SplitterShell>
         <MainContent />
-        <AsideContent />
+        <AsideContent autoExpand />
       </SplitterShell>
     </Spec>
     <Spec
       label="ShellSplitter - Aside expanded (defaultOpen)"
-      size="l"
+      size="m"
       omitPropsList
     >
       <SplitterShell defaultOpen>
         <MainContent />
         <AsideContent />
+      </SplitterShell>
+    </Spec>
+    <Spec
+      label="ShellSplitter - Save toolbar portaled (aside collapsed, toggleable)"
+      size="m"
+      omitPropsList
+    >
+      <SplitterShell>
+        <ToolbarDemo />
+      </SplitterShell>
+    </Spec>
+    <Spec
+      label="ShellSplitter - Save toolbar portaled (aside expanded, toggleable)"
+      size="m"
+      omitPropsList
+    >
+      <SplitterShell defaultOpen>
+        <ToolbarDemo />
       </SplitterShell>
     </Spec>
   </Suite>


### PR DESCRIPTION
## Why

When the agent side panel is open, fixed-position components like the SaveToolbar span the full viewport width, rendering underneath the panel. The current approach in [commerce-agents#570](https://github.com/commercetools/commerce-agents/pull/570) uses a CSS custom property (`--mc-right-panel-width`) published via a ResizeObserver, requiring cross-repo coordination between commerce-agents and mc-fe. Discussion on that PR converged on the idea that the application shell should provide a portal target instead, since it owns the splitter layout.

## Summary

- Add `MC_MAIN_CONTAINER_PORTAL_ID` constant to `@commercetools-frontend/constants`
- Add a portal target `<div>` inside `MainContainer` (last child, `position: sticky; bottom: 0; pointer-events: none`) so components can portal into the MC content area and automatically constrain their width to the main pane
- Add visual test specs demonstrating the portal-based toolbar in both collapsed and expanded splitter states

The consuming side (SaveToolbar using `createPortal`) is in the companion mc-fe PR.

> To see the splitter demo with the toolbar, you need to pull down this branch and run `pnpm visual-testing-app:start` locally, then navigate to `localhost:5173/shell-splitter`

## Test plan

- [x] Visual test specs render correctly at `/shell-splitter` (toolbar constrained to main pane when aside is open)
- [x] Existing splitter unit tests pass
- [x] No regressions in modal/dialog behavior (PortalsContainer unchanged)