### PR TITLE
chore: harden supply chain for pnpm v11

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -7,12 +7,12 @@ runs:
 
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4.1.0
+      uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
       with:
         run_install: false
 
     - name: Setup Node (uses version in .nvmrc)
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version-file: '.nvmrc'
         cache: pnpm

--- a/.github/actions/test-template-action/action.yml
+++ b/.github/actions/test-template-action/action.yml
@@ -84,7 +84,7 @@ runs:
       # restore / cache the binary ourselves on Linux
       # see https://github.com/actions/cache
       id: cache-cypress
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ~/.cache/Cypress
         key: ${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           any-of-labels: '⌛ Status: Awaiting for feedback'
           start-date: '2022-05-01 00:00:00.000'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # We need to fetch the full history to get the correct coverage data.
           fetch-depth: 2
@@ -60,7 +60,7 @@ jobs:
           RTL_ASYNC_UTIL_TIMEOUT: 5000
 
       - name: Upload Jest coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/jest/lcov.info
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Test Custom Application javascript starter template
         uses: ./.github/actions/test-template-action
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Test Custom Application typescript starter template
         uses: ./.github/actions/test-template-action
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Test Custom View javascript starter template
         uses: ./.github/actions/test-template-action
@@ -238,7 +238,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
@@ -264,7 +264,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Test Custom View typescript starter template
         uses: ./.github/actions/test-template-action
@@ -290,7 +290,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Installing dependencies and building packages
         uses: ./.github/actions/ci
@@ -316,7 +316,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # We need to fetch the full history to get the correct coverage data.
           fetch-depth: 2
@@ -340,7 +340,7 @@ jobs:
         # restore / cache the binary ourselves on Linux
         # see https://github.com/actions/cache
         id: cache-cypress
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
@@ -374,7 +374,7 @@ jobs:
           mv ./coverage/lcov-report ./coverage/cypress/lcov-report
 
       - name: Upload Cypress coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/cypress/lcov.info

--- a/.github/workflows/merge-blocking-labels.yml
+++ b/.github/workflows/merge-blocking-labels.yml
@@ -20,7 +20,7 @@ jobs:
     name: Prevent merge with blocking labels
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://agilepathway/pull-request-label-checker:latest
+      - uses: docker://agilepathway/pull-request-label-checker@sha256:65e57fd98ba3ab6ca4fcbc5a0aef288dd984ee4ab988f124d83424d19b55b801 # latest as of 2026-07-22
         with:
           none_of: '👁 👨‍🎨 Status: UI/UX Review,🖐 🖐 Status: On Hold,🛑 Status: blocked,🚧 Status: WIP'
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playground-deployment-preview.yml
+++ b/.github/workflows/playground-deployment-preview.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install and build
         run: |

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -17,24 +17,24 @@ jobs:
       # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@0af3325639c0a60612b2eeaf010f0f88e468e800 # v2.1.0
         with:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
       - name: Get branch of PR
-        uses: xt0rted/pull-request-comment-branch@v3
+        uses: xt0rted/pull-request-comment-branch@e8b8daa837e8ea7331c0003c9c316a64c6d8b0b1 # v3
         id: comment-branch
 
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
           token: ${{ steps.generate_github_token.outputs.token }}
 
       # Ensure we are using valid node version for npm trusted publishing AFTER checkout
       # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
@@ -53,7 +53,7 @@ jobs:
       # This must run AFTER the CI action to override the Node setup with registry config
       # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - name: Setup npm registry for publishing
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,13 +18,13 @@ jobs:
       # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@0af3325639c0a60612b2eeaf010f0f88e468e800 # v2.1.0
         with:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Pass a personal access token (using our `ct-changesets` app) to be able to trigger other workflows
 
@@ -34,7 +34,7 @@ jobs:
 
       # Ensure we are using valid node version for npm trusted publising AFTER checkout
       # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
@@ -53,7 +53,7 @@ jobs:
       # This must run AFTER the CI action to override the Node setup with registry config
       # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - name: Setup npm registry for publishing
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
@@ -67,7 +67,7 @@ jobs:
 
       - name: Creating release pull request or publishing release to npm registry
         id: changesets
-        uses: changesets/action@v1.7.0
+        uses: changesets/action@e87c8ed249971350e47fab7515075f44eb134e5b # v1.7.0
         with:
           publish: pnpm changeset publish
           version: pnpm changeset:version-and-format

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
   "engines": {
     "node": ">=22",
     "npm": ">=6",
-    "pnpm": ">=10"
+    "pnpm": ">=11"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@11.15.1+sha512.gTULB+U8lTigLx8jA7QpD6LXvgTlbiqXDEzEtBfcdh3hlu2r1J1Vx9yVgNuBAHxEFD5OPX5GKzAA0jwlUSLQZQ=="
 }

--- a/package.json
+++ b/package.json
@@ -182,5 +182,5 @@
     "npm": ">=6",
     "pnpm": ">=11"
   },
-  "packageManager": "pnpm@11.15.1+sha512.gTULB+U8lTigLx8jA7QpD6LXvgTlbiqXDEzEtBfcdh3hlu2r1J1Vx9yVgNuBAHxEFD5OPX5GKzAA0jwlUSLQZQ=="
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85"
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -79,7 +79,7 @@
     "ts-node": "catalog:build",
     "typescript": "catalog:build"
   },
-  "packageManager": "pnpm@11.15.1",
+  "packageManager": "pnpm@11.14.0",
   "engines": {
     "node": ">=22",
     "pnpm": ">=11"

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "catalog:build",
-    "@commercetools-docs/ui-kit": "catalog:",
+    "@commercetools-docs/ui-kit": "catalog:apps",
     "@commercetools-frontend/actions-global": "workspace:^",
     "@commercetools-frontend/application-components": "workspace:^",
     "@commercetools-frontend/application-shell": "workspace:^",
@@ -51,16 +51,16 @@
     "@flopflip/react-broadcast": "catalog:flopflip",
     "apollo-link-rest": "catalog:apollo",
     "graphql": "catalog:apollo",
-    "graphql-anywhere": "catalog:",
+    "graphql-anywhere": "catalog:apps",
     "moment": "catalog:",
     "moment-timezone": "catalog:",
     "prop-types": "catalog:react",
-    "qs": "catalog:",
+    "qs": "catalog:apps",
     "react": "catalog:react",
     "react-dom": "catalog:react",
     "react-intl": "catalog:react",
     "react-router-dom": "catalog:react",
-    "vercel": "catalog:"
+    "vercel": "catalog:apps"
   },
   "devDependencies": {
     "@commercetools-backend/express": "workspace:^",
@@ -71,17 +71,17 @@
     "@types/jest": "catalog:test",
     "@types/node": "catalog:",
     "@types/testing-library__jest-dom": "catalog:test",
-    "@vercel/node": "catalog:",
-    "dotenv-flow": "catalog:",
+    "@vercel/node": "catalog:apps",
+    "dotenv-flow": "catalog:apps",
     "express": "catalog:",
     "jest": "catalog:test",
     "msw": "catalog:test",
     "ts-node": "catalog:build",
     "typescript": "catalog:build"
   },
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@11.15.1",
   "engines": {
     "node": ">=22",
-    "pnpm": ">=8"
+    "pnpm": ">=11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,25 @@ catalogs:
     graphql-tag:
       specifier: ^2.12.6
       version: 2.12.6
+  apps:
+    '@commercetools-docs/ui-kit':
+      specifier: 24.11.0
+      version: 24.11.0
+    '@vercel/node':
+      specifier: 5.5.5
+      version: 5.5.5
+    dotenv-flow:
+      specifier: 4.1.0
+      version: 4.1.0
+    graphql-anywhere:
+      specifier: 4.2.8
+      version: 4.2.8
+    qs:
+      specifier: 6.14.0
+      version: 6.14.0
+    vercel:
+      specifier: 24.2.5
+      version: 24.2.5
   build:
     '@babel/cli':
       specifier: ^7.22.15
@@ -254,9 +273,6 @@ catalogs:
     '@commercetools-community-kit/i18n':
       specifier: ^0.3.0
       version: 0.3.0
-    '@commercetools-docs/ui-kit':
-      specifier: 24.11.0
-      version: 24.11.0
     '@commercetools/api-request-builder':
       specifier: 6.0.0
       version: 6.0.0
@@ -374,9 +390,6 @@ catalogs:
     '@types/webpack-bundle-analyzer':
       specifier: ^4.6.0
       version: 4.7.0
-    '@vercel/node':
-      specifier: ^5.0.0
-      version: 5.5.5
     ajv:
       specifier: 8.18.0
       version: 8.18.0
@@ -428,9 +441,6 @@ catalogs:
     dotenv:
       specifier: 16.6.1
       version: 16.6.1
-    dotenv-flow:
-      specifier: ^4.0.0
-      version: 4.1.0
     execa:
       specifier: 5.1.1
       version: 5.1.1
@@ -458,9 +468,6 @@ catalogs:
     glob:
       specifier: ^10.5.0
       version: 10.5.0
-    graphql-anywhere:
-      specifier: ^4.2.8
-      version: 4.2.8
     graphql-request:
       specifier: 5.2.0
       version: 5.2.0
@@ -518,9 +525,6 @@ catalogs:
     puppeteer:
       specifier: 20.9.0
       version: 20.9.0
-    qs:
-      specifier: ^6.11.2
-      version: 6.14.1
     qss:
       specifier: 2.0.3
       version: 2.0.3
@@ -569,9 +573,6 @@ catalogs:
     uuid:
       specifier: 14.0.0
       version: 14.0.0
-    vercel:
-      specifier: 24.2.5
-      version: 24.2.5
     wait-for-observables:
       specifier: 1.0.3
       version: 1.0.3
@@ -1089,10 +1090,10 @@ importers:
         version: 0.18.2
       '@babel/cli':
         specifier: catalog:build
-        version: 7.28.3(@babel/core@7.29.0)
+        version: 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@changesets/changelog-github':
         specifier: catalog:repo
         version: 0.5.1
@@ -1125,10 +1126,10 @@ importers:
         version: link:packages/mc-scripts
       '@commercetools-uikit/design-system':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.11)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/github-labels':
         specifier: catalog:repo
         version: 1.1.0(@octokit/core@7.0.6)
@@ -1140,7 +1141,7 @@ importers:
         version: 17.8.1
       '@cypress/code-coverage':
         specifier: catalog:test
-        version: 3.14.7(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))))(cypress@14.5.4)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 3.14.7(@babel/core@7.29.0(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       '@faker-js/faker':
         specifier: catalog:test
         version: 8.4.1
@@ -1152,22 +1153,22 @@ importers:
         version: 3.2.3(graphql@16.11.0)
       '@graphql-codegen/cli':
         specifier: 'catalog:'
-        version: 2.16.5(@babel/core@7.29.0)(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.9.2)
+        version: 2.16.5(@babel/core@7.29.0(supports-color@8.1.1))(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(enquirer@2.4.1)(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@graphql-codegen/introspection':
         specifier: 'catalog:'
-        version: 2.2.3(graphql@16.11.0)
+        version: 2.2.3(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-codegen/typescript':
         specifier: 'catalog:'
-        version: 2.8.8(graphql@16.11.0)
+        version: 2.8.8(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-codegen/typescript-graphql-files-modules':
         specifier: 'catalog:'
         version: 2.2.1(graphql@16.11.0)
       '@graphql-codegen/typescript-operations':
         specifier: 'catalog:'
-        version: 2.5.13(graphql@16.11.0)
+        version: 2.5.13(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-eslint/eslint-plugin':
         specifier: catalog:lint
-        version: 4.4.0(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)
+        version: 4.4.0(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@manypkg/cli':
         specifier: catalog:repo
         version: 0.25.0
@@ -1179,28 +1180,28 @@ importers:
         version: 1.1.3
       '@percy/cli':
         specifier: catalog:test
-        version: 1.31.1(typescript@5.9.2)
+        version: 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
       '@percy/core':
         specifier: catalog:test
-        version: 1.31.1(typescript@5.9.2)
+        version: 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
       '@percy/cypress':
         specifier: catalog:test
         version: 3.1.6(cypress@14.5.4)
       '@percy/puppeteer':
         specifier: catalog:test
-        version: 2.0.2(puppeteer@20.9.0(typescript@5.9.2))
+        version: 2.0.2(puppeteer@20.9.0(supports-color@8.1.1)(typescript@5.9.2))(supports-color@8.1.1)
       '@preconstruct/cli':
         specifier: catalog:build
-        version: 2.8.12
+        version: 2.8.12(supports-color@8.1.1)
       '@svgr/cli':
         specifier: catalog:build
-        version: 6.5.1
+        version: 6.5.1(supports-color@8.1.1)
       '@svgr/plugin-jsx':
         specifier: catalog:build
-        version: 6.5.1(@svgr/core@6.5.1)
+        version: 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))(supports-color@8.1.1)
       '@svgr/plugin-svgo':
         specifier: catalog:build
-        version: 6.5.1(@svgr/core@6.5.1)
+        version: 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))
       '@testing-library/cypress':
         specifier: catalog:test
         version: 10.1.0(cypress@14.5.4)
@@ -1239,13 +1240,13 @@ importers:
         version: 2.8.1(graphql-tag@2.12.6(graphql@16.11.0))(graphql@16.11.0)
       babel-plugin-istanbul:
         specifier: catalog:build
-        version: 7.0.1
+        version: 7.0.1(supports-color@8.1.1)
       babel-plugin-transform-rename-import:
         specifier: catalog:build
         version: 2.3.0
       babel-plugin-typescript-to-proptypes:
         specifier: catalog:build
-        version: 2.1.0(@babel/core@7.29.0)(typescript@5.9.2)
+        version: 2.1.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1257,7 +1258,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-formatter-pretty:
         specifier: catalog:lint
         version: 4.1.0
@@ -1272,22 +1273,22 @@ importers:
         version: 7.0.4
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-each:
         specifier: catalog:test
         version: 30.2.0
       jest-environment-puppeteer:
         specifier: catalog:test
-        version: 8.0.6(typescript@5.9.2)
+        version: 8.0.6(debug@4.4.1(supports-color@8.1.1))(typescript@5.9.2)
       jest-preview:
         specifier: catalog:test
-        version: 0.3.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+        version: 0.3.2(postcss@8.5.6)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-puppeteer:
         specifier: catalog:test
-        version: 8.0.6(puppeteer@20.9.0(typescript@5.9.2))(typescript@5.9.2)
+        version: 8.0.6(debug@4.4.1(supports-color@8.1.1))(puppeteer@20.9.0(supports-color@8.1.1)(typescript@5.9.2))(typescript@5.9.2)
       jest-runner-eslint:
         specifier: catalog:test
-        version: 2.3.0(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))
+        version: 2.3.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))
       jest-runner-executor:
         specifier: catalog:test
         version: 1.0.0
@@ -1296,7 +1297,7 @@ importers:
         version: 0.6.0
       jest-watch-typeahead:
         specifier: catalog:test
-        version: 3.0.1(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))
+        version: 3.0.1(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))
       lint-staged:
         specifier: catalog:lint
         version: 11.2.6
@@ -1314,7 +1315,7 @@ importers:
         version: 0.3.21
       puppeteer:
         specifier: 'catalog:'
-        version: 20.9.0(typescript@5.9.2)
+        version: 20.9.0(supports-color@8.1.1)(typescript@5.9.2)
       qss:
         specifier: 'catalog:'
         version: 2.0.3
@@ -1335,22 +1336,22 @@ importers:
         version: 0.10.0
       start-server-and-test:
         specifier: catalog:test
-        version: 2.0.13
+        version: 2.0.13(supports-color@8.1.1)
       stylelint:
         specifier: catalog:lint
-        version: 14.16.1
+        version: 14.16.1(supports-color@8.1.1)
       stylelint-config-prettier:
         specifier: catalog:lint
-        version: 9.0.5(stylelint@14.16.1)
+        version: 9.0.5(stylelint@14.16.1(supports-color@8.1.1))
       stylelint-config-standard:
         specifier: catalog:lint
-        version: 26.0.0(stylelint@14.16.1)
+        version: 26.0.0(stylelint@14.16.1(supports-color@8.1.1))
       stylelint-order:
         specifier: catalog:lint
-        version: 5.0.0(stylelint@14.16.1)
+        version: 5.0.0(stylelint@14.16.1(supports-color@8.1.1))
       stylelint-value-no-unknown-custom-properties:
         specifier: catalog:lint
-        version: 4.0.0(stylelint@14.16.1)
+        version: 4.0.0(stylelint@14.16.1(supports-color@8.1.1))
       ts-node:
         specifier: catalog:build
         version: 10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)
@@ -1371,7 +1372,7 @@ importers:
         version: 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -1419,64 +1420,64 @@ importers:
         version: link:../../packages/permissions
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/data-table':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/grid':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/loading-spinner':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/notifications':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/pagination':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/select-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.17)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/sync-actions':
         specifier: 'catalog:'
         version: 5.19.2
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@formatjs/cli':
         specifier: catalog:formatjs
         version: 6.7.2
@@ -1515,7 +1516,7 @@ importers:
         version: 5.14.9
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-formatter-pretty:
         specifier: catalog:lint
         version: 4.1.0
@@ -1530,13 +1531,13 @@ importers:
         version: 2.12.6(graphql@16.11.0)
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       omit-empty-es:
         specifier: 'catalog:'
         version: 1.2.0
@@ -1567,7 +1568,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: catalog:lint
-        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)
+        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
 
   application-templates/starter-typescript:
     dependencies:
@@ -1576,7 +1577,7 @@ importers:
         version: 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -1627,64 +1628,64 @@ importers:
         version: link:../../packages/permissions
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/data-table':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/grid':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/loading-spinner':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/notifications':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/pagination':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/select-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.17)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/sync-actions':
         specifier: 'catalog:'
         version: 5.19.2
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@formatjs/cli':
         specifier: catalog:formatjs
         version: 6.7.2
@@ -1723,7 +1724,7 @@ importers:
         version: 5.14.9
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-formatter-pretty:
         specifier: catalog:lint
         version: 4.1.0
@@ -1738,13 +1739,13 @@ importers:
         version: 2.12.6(graphql@16.11.0)
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       omit-empty-es:
         specifier: 'catalog:'
         version: 1.2.0
@@ -1775,7 +1776,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: catalog:lint
-        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)
+        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
 
   custom-views-templates/starter:
     dependencies:
@@ -1784,7 +1785,7 @@ importers:
         version: 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -1832,64 +1833,64 @@ importers:
         version: link:../../packages/permissions
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/data-table':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/grid':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/loading-spinner':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/notifications':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/pagination':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/select-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.17)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/sync-actions':
         specifier: 'catalog:'
         version: 5.19.2
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@formatjs/cli':
         specifier: catalog:formatjs
         version: 6.7.2
@@ -1928,7 +1929,7 @@ importers:
         version: 5.14.9
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-formatter-pretty:
         specifier: catalog:lint
         version: 4.1.0
@@ -1943,13 +1944,13 @@ importers:
         version: 2.12.6(graphql@16.11.0)
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       omit-empty-es:
         specifier: 'catalog:'
         version: 1.2.0
@@ -1980,7 +1981,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: catalog:lint
-        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)
+        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
 
   custom-views-templates/starter-typescript:
     dependencies:
@@ -1989,7 +1990,7 @@ importers:
         version: 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2040,64 +2041,64 @@ importers:
         version: link:../../packages/permissions
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/data-table':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/grid':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/loading-spinner':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/notifications':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/pagination':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/select-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.17)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/sync-actions':
         specifier: 'catalog:'
         version: 5.19.2
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@formatjs/cli':
         specifier: catalog:formatjs
         version: 6.7.2
@@ -2136,7 +2137,7 @@ importers:
         version: 5.14.9
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-formatter-pretty:
         specifier: catalog:lint
         version: 4.1.0
@@ -2151,13 +2152,13 @@ importers:
         version: 2.12.6(graphql@16.11.0)
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       omit-empty-es:
         specifier: 'catalog:'
         version: 1.2.0
@@ -2188,46 +2189,46 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: catalog:lint
-        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)
+        version: 4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
 
   packages-backend/eslint-config-node:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: catalog:lint
-        version: 7.28.5(@babel/core@7.29.0)(eslint@9.39.2(jiti@2.6.1))
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       '@babel/preset-env':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
-        version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.0.0
-        version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       eslint-config-prettier:
         specifier: catalog:lint
-        version: 8.10.2(eslint@9.39.2(jiti@2.6.1))
+        version: 8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-import-resolver-typescript:
         specifier: catalog:lint
-        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-import:
         specifier: catalog:lint
-        version: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jest:
         specifier: catalog:lint
-        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(supports-color@8.1.1)(typescript@5.9.2)
       eslint-plugin-n:
         specifier: catalog:lint
-        version: 17.23.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 17.23.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(typescript@5.9.2)
       eslint-plugin-prettier:
         specifier: catalog:lint
-        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@2.8.8)
+        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@2.8.8)
       globals:
         specifier: catalog:lint
         version: 15.15.0
@@ -2243,7 +2244,7 @@ importers:
         version: 22.0.2
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
 
   packages-backend/express:
     dependencies:
@@ -2261,7 +2262,7 @@ importers:
         version: 22.19.11
       express:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.0(supports-color@8.1.1)
       jose:
         specifier: 'catalog:'
         version: 5.10.0
@@ -2271,7 +2272,7 @@ importers:
         version: 22.0.2
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.11)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)
       typescript:
         specifier: catalog:build
         version: 5.9.2
@@ -2317,7 +2318,7 @@ importers:
         version: 4.17.25
       express:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.0(supports-color@8.1.1)
       typescript:
         specifier: catalog:build
         version: 5.9.2
@@ -2360,7 +2361,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -2405,61 +2406,61 @@ importers:
         version: link:../sentry
       '@commercetools-uikit/accessible-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/card':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/design-system':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/label':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/messages':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/primary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/secondary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/secondary-icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/stamp':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils':
         specifier: catalog:repo
         version: 20.4.0(react@19.0.0)
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@flopflip/react-broadcast':
         specifier: catalog:flopflip
         version: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
@@ -2523,10 +2524,10 @@ importers:
         version: 5.14.9
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -2544,10 +2545,10 @@ importers:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/register':
         specifier: catalog:build
-        version: 7.28.3(@babel/core@7.29.0)
+        version: 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/runtime':
         specifier: catalog:build
         version: 7.28.6
@@ -2580,7 +2581,7 @@ importers:
         version: 3.4.0
       jsdom:
         specifier: 'catalog:'
-        version: 21.1.2
+        version: 21.1.2(supports-color@8.1.1)
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -2653,55 +2654,55 @@ importers:
         version: link:../url-utils
       '@commercetools-uikit/accessible-hidden':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/avatar':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/card':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/design-system':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/loading-spinner':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/notifications':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/primary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/secondary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/select-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@flopflip/combine-adapters':
         specifier: catalog:flopflip
         version: 15.1.7(typescript@5.9.2)
@@ -2803,7 +2804,7 @@ importers:
         version: 1.0.3
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       redux-logger:
         specifier: catalog:react
         version: 3.0.6
@@ -2825,7 +2826,7 @@ importers:
         version: 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(typescript@5.9.2))(@commercetools/nimbus-tokens@3.1.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)
+        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2))(@commercetools/nimbus-tokens@3.2.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)
       '@testing-library/react':
         specifier: catalog:test
         version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2837,13 +2838,13 @@ importers:
         version: 5.14.9
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-mock:
         specifier: catalog:test
         version: 30.2.0
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -2888,7 +2889,7 @@ importers:
         version: 3.0.0
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.20
@@ -2940,13 +2941,13 @@ importers:
         version: 3.3.0
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-mock:
         specifier: catalog:test
         version: 30.2.0
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -2957,49 +2958,49 @@ importers:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/plugin-proposal-do-expressions':
         specifier: catalog:build
-        version: 7.28.3(@babel/core@7.29.0)
+        version: 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/plugin-proposal-export-default-from':
         specifier: catalog:build
-        version: 7.27.1(@babel/core@7.29.0)
+        version: 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/plugin-transform-class-properties':
         specifier: catalog:build
-        version: 7.27.1(@babel/core@7.29.0)
+        version: 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-destructuring':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-export-namespace-from':
         specifier: catalog:build
-        version: 7.27.1(@babel/core@7.29.0)
+        version: 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/plugin-transform-logical-assignment-operators':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/plugin-transform-object-rest-spread':
         specifier: catalog:build
-        version: 7.28.4(@babel/core@7.29.0)
+        version: 7.28.4(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-private-methods':
         specifier: catalog:build
-        version: 7.27.1(@babel/core@7.29.0)
+        version: 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-private-property-in-object':
         specifier: catalog:build
-        version: 7.27.1(@babel/core@7.29.0)
+        version: 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-regenerator':
         specifier: catalog:build
-        version: 7.28.4(@babel/core@7.29.0)
+        version: 7.28.4(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/plugin-transform-runtime':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-env':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-react':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime':
         specifier: catalog:build
         version: 7.28.6
@@ -3008,19 +3009,19 @@ importers:
         version: 7.29.0
       '@emotion/babel-plugin':
         specifier: catalog:build
-        version: 11.13.5
+        version: 11.13.5(supports-color@8.1.1)
       '@emotion/babel-preset-css-prop':
         specifier: catalog:build
-        version: 11.12.0(@babel/core@7.29.0)
+        version: 11.12.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-dev-expression:
         specifier: catalog:build
-        version: 0.2.3(@babel/core@7.29.0)
+        version: 0.2.3(@babel/core@7.29.0(supports-color@8.1.1))
       babel-plugin-formatjs:
         specifier: catalog:build
-        version: 10.5.41(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))
+        version: 10.5.41(supports-color@8.1.1)(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))
       babel-plugin-istanbul:
         specifier: ^7.0.0
-        version: 7.0.1
+        version: 7.0.1(supports-color@8.1.1)
       babel-plugin-macros:
         specifier: catalog:build
         version: 3.1.0
@@ -3059,10 +3060,10 @@ importers:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/preset-env':
         specifier: catalog:build
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       commander:
         specifier: 'catalog:'
         version: 13.1.0
@@ -3071,7 +3072,7 @@ importers:
         version: 10.5.0
       jscodeshift:
         specifier: 'catalog:'
-        version: 0.16.1(@babel/preset-env@7.28.5(@babel/core@7.29.0))
+        version: 0.16.1(@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       prettier:
         specifier: catalog:lint
         version: 2.8.8
@@ -3081,7 +3082,7 @@ importers:
         version: link:../application-components
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@tsconfig/node22':
         specifier: 'catalog:'
         version: 22.0.2
@@ -3112,13 +3113,13 @@ importers:
         version: 29.5.14
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
 
   packages/create-mc-app:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/runtime':
         specifier: catalog:build
         version: 7.28.6
@@ -3201,55 +3202,55 @@ importers:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: catalog:lint
-        version: 7.28.5(@babel/core@7.29.0)(eslint@9.39.2(jiti@2.6.1))
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       '@commercetools-frontend/babel-preset-mc-app':
         specifier: workspace:^
         version: link:../babel-preset-mc-app
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
-        version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.0.0
-        version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       confusing-browser-globals:
         specifier: catalog:lint
         version: 1.0.11
       eslint-config-prettier:
         specifier: catalog:lint
-        version: 8.10.2(eslint@9.39.2(jiti@2.6.1))
+        version: 8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-import-resolver-typescript:
         specifier: catalog:lint
-        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-cypress:
         specifier: catalog:lint
-        version: 2.15.2(eslint@9.39.2(jiti@2.6.1))
+        version: 2.15.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-plugin-import:
         specifier: catalog:lint
-        version: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jest:
         specifier: catalog:lint
-        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(supports-color@8.1.1)(typescript@5.9.2)
       eslint-plugin-jest-dom:
         specifier: catalog:lint
-        version: 4.0.3(eslint@9.39.2(jiti@2.6.1))
+        version: 4.0.3(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-plugin-jsx-a11y:
         specifier: catalog:lint
-        version: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+        version: 6.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-plugin-prettier:
         specifier: catalog:lint
-        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@2.8.8)
+        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@2.8.8)
       eslint-plugin-react:
         specifier: catalog:lint
-        version: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+        version: 7.37.5(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-plugin-react-hooks:
         specifier: catalog:lint
-        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
+        version: 5.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-plugin-testing-library:
         specifier: catalog:lint
-        version: 7.15.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 7.15.4(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       globals:
         specifier: catalog:lint
         version: 15.15.0
@@ -3262,7 +3263,7 @@ importers:
     devDependencies:
       eslint:
         specifier: catalog:lint
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
 
   packages/i18n:
     dependencies:
@@ -3283,7 +3284,7 @@ importers:
         version: 20.4.0
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@formatjs/icu-messageformat-parser':
         specifier: catalog:formatjs
         version: 2.11.2
@@ -3320,7 +3321,7 @@ importers:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@commercetools-frontend/babel-preset-mc-app':
         specifier: workspace:^
         version: link:../babel-preset-mc-app
@@ -3347,10 +3348,10 @@ importers:
         version: 6.9.1
       babel-jest:
         specifier: catalog:test
-        version: 30.2.0(@babel/core@7.29.0)
+        version: 30.2.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       babel-preset-jest:
         specifier: catalog:test
-        version: 30.2.0(@babel/core@7.29.0)
+        version: 30.2.0(@babel/core@7.29.0(supports-color@8.1.1))
       colors:
         specifier: catalog:test
         version: 1.4.0
@@ -3371,7 +3372,7 @@ importers:
         version: 1.2.5
       jest-environment-jsdom:
         specifier: catalog:test
-        version: 30.2.0
+        version: 30.2.0(supports-color@8.1.1)
       jest-localstorage-mock:
         specifier: catalog:test
         version: 2.4.26
@@ -3383,7 +3384,7 @@ importers:
         version: 0.6.0
       jest-watch-typeahead:
         specifier: catalog:test
-        version: 3.0.1(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))
+        version: 3.0.1(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))
       raf:
         specifier: catalog:test
         version: 3.4.1
@@ -3399,13 +3400,13 @@ importers:
         version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
 
   packages/jest-stylelint-runner:
     dependencies:
       create-jest-runner:
         specifier: 'catalog:'
-        version: 1.0.0(@jest/test-result@30.2.0)(jest-runner@30.2.0)
+        version: 1.0.0(@jest/test-result@30.2.0)(jest-runner@30.2.0(supports-color@8.1.1))
       postcss-load-config:
         specifier: 'catalog:'
         version: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
@@ -3415,7 +3416,7 @@ importers:
         version: 8.5.6
       stylelint:
         specifier: catalog:lint
-        version: 14.16.1
+        version: 14.16.1(supports-color@8.1.1)
 
   packages/l10n:
     dependencies:
@@ -3430,7 +3431,7 @@ importers:
         version: link:../sentry
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.20
@@ -3507,7 +3508,7 @@ importers:
         version: 3.4.38
       connect:
         specifier: 'catalog:'
-        version: 3.7.0
+        version: 3.7.0(supports-color@8.1.1)
 
   packages/mc-html-template:
     dependencies:
@@ -3541,19 +3542,19 @@ importers:
         version: 5.0.4
       html-webpack-plugin:
         specifier: catalog:build
-        version: 5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3))
+        version: 5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       webpack:
         specifier: catalog:build
-        version: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)
+        version: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   packages/mc-scripts:
     dependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/plugin-proposal-do-expressions':
         specifier: catalog:build
-        version: 7.28.3(@babel/core@7.29.0)
+        version: 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/runtime':
         specifier: catalog:build
         version: 7.28.6
@@ -3586,13 +3587,13 @@ importers:
         version: 3.0.0
       '@emotion/babel-plugin':
         specifier: catalog:build
-        version: 11.13.5
+        version: 11.13.5(supports-color@8.1.1)
       '@formatjs/cli-lib':
         specifier: catalog:formatjs
-        version: 6.6.6(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))
+        version: 6.6.6(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: catalog:build
-        version: 0.6.1(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 0.6.1(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       '@rollup/plugin-graphql':
         specifier: catalog:build
         version: 2.0.5(graphql@16.11.0)(rollup@4.60.3)
@@ -3601,13 +3602,13 @@ importers:
         version: 5.2.0(rollup@4.60.3)
       '@svgr/babel-preset':
         specifier: catalog:build
-        version: 6.5.1(@babel/core@7.29.0)
+        version: 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@svgr/core':
         specifier: catalog:build
-        version: 6.5.1
+        version: 6.5.1(supports-color@8.1.1)
       '@svgr/webpack':
         specifier: catalog:build
-        version: 6.5.1
+        version: 6.5.1(supports-color@8.1.1)
       '@types/prompts':
         specifier: 'catalog:'
         version: 2.4.9
@@ -3616,10 +3617,10 @@ importers:
         version: 2.6.4
       '@types/webpack-bundle-analyzer':
         specifier: 'catalog:'
-        version: 4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))
+        version: 4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
       '@vitejs/plugin-react':
         specifier: catalog:build
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
+        version: 4.7.0(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
       '@vitejs/plugin-react-swc':
         specifier: catalog:build
         version: 3.11.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
@@ -3628,10 +3629,10 @@ importers:
         version: 10.4.22(postcss@8.5.6)
       babel-loader:
         specifier: catalog:build
-        version: 8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       babel-plugin-formatjs:
         specifier: catalog:build
-        version: 10.5.41(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))
+        version: 10.5.41(supports-color@8.1.1)(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))
       babel-plugin-react-compiler:
         specifier: catalog:build
         version: 1.0.0
@@ -3649,10 +3650,10 @@ importers:
         version: 3.46.0
       css-loader:
         specifier: catalog:build
-        version: 6.11.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 6.11.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       css-minimizer-webpack-plugin:
         specifier: catalog:build
-        version: 8.0.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.27.7)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
@@ -3676,7 +3677,7 @@ importers:
         version: 2.12.6(graphql@16.11.0)
       html-webpack-plugin:
         specifier: catalog:build
-        version: 5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       json-loader:
         specifier: catalog:build
         version: 0.5.7
@@ -3688,13 +3689,13 @@ importers:
         version: 4.18.1
       mini-css-extract-plugin:
         specifier: catalog:build
-        version: 2.9.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 2.9.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       moment-locales-webpack-plugin:
         specifier: catalog:build
-        version: 1.2.0(moment@2.30.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 1.2.0(moment@2.30.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       node-fetch:
         specifier: 'catalog:'
         version: 2.7.0
@@ -3715,7 +3716,7 @@ importers:
         version: 14.1.0(postcss@8.5.6)
       postcss-loader:
         specifier: catalog:build
-        version: 6.2.1(postcss@8.5.6)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 6.2.1(postcss@8.5.6)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       postcss-reporter:
         specifier: catalog:build
         version: 7.1.0(postcss@8.5.6)
@@ -3730,7 +3731,7 @@ importers:
         version: 0.2.1
       react-dev-utils:
         specifier: catalog:build
-        version: 12.0.1(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 12.0.1(supports-color@8.1.1)(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       react-refresh:
         specifier: catalog:build
         version: 0.17.0
@@ -3748,16 +3749,16 @@ importers:
         version: 3.0.2
       style-loader:
         specifier: catalog:build
-        version: 3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       svg-url-loader:
         specifier: catalog:build
-        version: 7.1.1(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 7.1.1(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       terser-webpack-plugin:
         specifier: catalog:build
-        version: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       thread-loader:
         specifier: catalog:build
-        version: 3.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 3.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       url:
         specifier: 'catalog:'
         version: 0.11.4
@@ -3769,23 +3770,23 @@ importers:
         version: 0.23.0
       webpack:
         specifier: catalog:build
-        version: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+        version: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
       webpack-bundle-analyzer:
         specifier: catalog:build
         version: 4.10.2
       webpack-dev-server:
         specifier: catalog:build
-        version: 4.15.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       webpackbar:
         specifier: catalog:build
-        version: 5.0.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+        version: 5.0.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
     devDependencies:
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.17)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(typescript@5.9.2))(@commercetools/nimbus-tokens@3.1.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)
+        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2))(@commercetools/nimbus-tokens@3.2.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)
       '@tsconfig/node22':
         specifier: 'catalog:'
         version: 22.0.2
@@ -3797,7 +3798,7 @@ importers:
         version: 4.17.20
       '@types/moment-locales-webpack-plugin':
         specifier: 'catalog:'
-        version: 1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))
+        version: 1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
       '@types/node-fetch':
         specifier: 'catalog:'
         version: 2.6.13
@@ -3812,10 +3813,10 @@ importers:
         version: 4.51.0
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.17)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       puppeteer:
         specifier: 'catalog:'
-        version: 20.9.0(typescript@5.9.2)
+        version: 20.9.0(supports-color@8.1.1)(typescript@5.9.2)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -3849,7 +3850,7 @@ importers:
         version: link:../sentry
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.20
@@ -3880,7 +3881,7 @@ importers:
         version: 5.14.9
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-mock:
         specifier: catalog:test
         version: 30.2.0
@@ -3913,31 +3914,31 @@ importers:
         version: link:../sentry
       '@commercetools-uikit/design-system':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/secondary-icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils':
         specifier: catalog:repo
         version: 20.4.0(react@19.0.0)
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/history':
         specifier: catalog:react
         version: 4.7.11
@@ -3983,7 +3984,7 @@ importers:
         version: 5.14.9
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-mock:
         specifier: catalog:test
         version: 30.2.0
@@ -4062,7 +4063,7 @@ importers:
     devDependencies:
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@testing-library/react':
         specifier: catalog:test
         version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -4120,19 +4121,19 @@ importers:
     devDependencies:
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/jest':
         specifier: catalog:test
         version: 29.5.14
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       react:
         specifier: 19.0.0
         version: 19.0.0
       sentry-testkit:
         specifier: catalog:test
-        version: 6.2.2
+        version: 6.2.2(supports-color@8.1.1)
       wait-for-expect:
         specifier: catalog:test
         version: 3.0.2
@@ -4156,8 +4157,8 @@ importers:
         specifier: catalog:build
         version: 7.29.0
       '@commercetools-docs/ui-kit':
-        specifier: 'catalog:'
-        version: 24.11.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        specifier: catalog:apps
+        version: 24.11.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-frontend/actions-global':
         specifier: workspace:^
         version: link:../packages/actions-global
@@ -4193,78 +4194,78 @@ importers:
         version: link:../packages/sdk
       '@commercetools-uikit/card':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/checkbox-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/constraints':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/data-table':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/date-time-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/flat-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/grid':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks':
         specifier: catalog:repo
         version: 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/label':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/loading-spinner':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/notifications':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/pagination':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/primary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/secondary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(typescript@5.9.2))(@commercetools/nimbus-tokens@3.1.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)
+        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2))(@commercetools/nimbus-tokens@3.2.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/nimbus-icons':
         specifier: catalog:nimbus
-        version: 3.2.0(typescript@5.9.2)
+        version: 3.2.0(supports-color@8.1.1)(typescript@5.9.2)
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@flopflip/react-broadcast':
         specifier: catalog:flopflip
         version: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
       apollo-link-rest:
         specifier: catalog:apollo
-        version: 0.9.0(@apollo/client@3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(graphql@16.11.0)(qs@6.14.1)
+        version: 0.9.0(@apollo/client@3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(graphql@16.11.0)(qs@6.14.0)
       graphql:
         specifier: catalog:apollo
         version: 16.11.0
       graphql-anywhere:
-        specifier: 'catalog:'
+        specifier: catalog:apps
         version: 4.2.8(graphql@16.11.0)
       moment:
         specifier: 'catalog:'
@@ -4276,8 +4277,8 @@ importers:
         specifier: catalog:react
         version: 15.8.1
       qs:
-        specifier: 'catalog:'
-        version: 6.14.1
+        specifier: catalog:apps
+        version: 6.14.0
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -4291,8 +4292,8 @@ importers:
         specifier: catalog:react
         version: 5.3.4(react@19.0.0)
       vercel:
-        specifier: 'catalog:'
-        version: 24.2.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: catalog:apps
+        version: 24.2.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
     devDependencies:
       '@commercetools-backend/express':
         specifier: workspace:^
@@ -4305,7 +4306,7 @@ importers:
         version: link:../packages/mc-scripts
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
-        version: 13.12.0(@types/node@22.19.11)(typescript@5.9.2)
+        version: 13.12.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)
       '@formatjs/cli':
         specifier: catalog:formatjs
         version: 6.7.2
@@ -4319,20 +4320,20 @@ importers:
         specifier: catalog:test
         version: 5.14.9
       '@vercel/node':
-        specifier: 'catalog:'
-        version: 5.5.5(@swc/core@1.15.1(@swc/helpers@0.5.23))(rollup@4.60.3)
+        specifier: catalog:apps
+        version: 5.5.5(@swc/core@1.15.1(@swc/helpers@0.5.23))(rollup@4.60.3)(supports-color@8.1.1)
       dotenv-flow:
-        specifier: 'catalog:'
+        specifier: catalog:apps
         version: 4.1.0
       express:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.0(supports-color@8.1.1)
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       msw:
         specifier: catalog:test
-        version: 1.3.5(@types/node@22.19.11)(typescript@5.9.2)
+        version: 1.3.5(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)
       ts-node:
         specifier: catalog:build
         version: 10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)
@@ -4368,46 +4369,46 @@ importers:
         version: link:../packages/react-notifications
       '@commercetools-uikit/accessible-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/card':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/design-system':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/grid':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(typescript@5.9.2))(@commercetools/nimbus-tokens@3.1.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)
+        version: 3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2))(@commercetools/nimbus-tokens@3.2.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@flopflip/react-broadcast':
         specifier: catalog:flopflip
         version: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
@@ -4425,7 +4426,7 @@ importers:
         version: 5.3.3
       '@vitejs/plugin-react':
         specifier: catalog:build
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
+        version: 4.7.0(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
       formik:
         specifier: catalog:react
         version: 2.4.6(@types/react@19.2.4)(react@19.0.0)
@@ -4434,7 +4435,7 @@ importers:
         version: 16.11.0
       jest:
         specifier: catalog:test
-        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+        version: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-each:
         specifier: catalog:test
         version: 30.2.0
@@ -4479,43 +4480,43 @@ importers:
         version: link:../packages/l10n
       '@commercetools-uikit/design-system':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/icon-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/icons':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/link':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/multiline-text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/secondary-button':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/select-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/spacings':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/text-field':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/text-input':
         specifier: catalog:repo
-        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+        version: 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       formik:
         specifier: catalog:react
         version: 2.4.6(@types/react@19.2.4)(react@19.0.0)
@@ -4542,7 +4543,7 @@ importers:
         version: 5.3.4(react@19.0.0)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
     devDependencies:
       '@commercetools-frontend/application-config':
         specifier: workspace:^
@@ -4561,7 +4562,7 @@ importers:
         version: 5.3.3
       '@vitejs/plugin-react':
         specifier: catalog:build
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
+        version: 4.7.0(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))
       vite:
         specifier: catalog:build
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1)
@@ -5875,8 +5876,8 @@ packages:
   '@commercetools/nimbus-icons@3.2.0':
     resolution: {integrity: sha512-PIKVEJW8hef3mSDT4wCHssaCLZEdtkgA3AhQL4vUZO98+dAlRFi7O2gKjg284stOQ7++bfZg2dKaxaF5weUtbA==}
 
-  '@commercetools/nimbus-tokens@3.1.0':
-    resolution: {integrity: sha512-cp2McV/hRLdu2kKpd3/wKwHmBq0VilNE4IYnQMCMSQseFws/y8lFRYnH6tR2YnsVIIPbJxAY7UdYSUWM2IBTUg==}
+  '@commercetools/nimbus-tokens@3.2.0':
+    resolution: {integrity: sha512-C6awJdSDWeAQ7x/SkFm+rKe8Usm18T0nR8YZ4oS0bG+gWhzc88YWVvBQz5B/HgRYsM186D+m134vWibCOb8vRg==}
 
   '@commercetools/nimbus@3.2.0':
     resolution: {integrity: sha512-K3fGr4KMY965LafVEBq+IVQCGshFGYCc21wEez2V2gj1F5XsXV7RAO8dh3Egflp5v8QsK97SJw6ZZMyAaU3NIQ==}
@@ -6702,6 +6703,7 @@ packages:
 
   '@formatjs/intl-enumerator@1.4.6':
     resolution: {integrity: sha512-O2YMcE3SuBy4jL8r6YNq/8hvFrQ92QGLawdmzFbOi8D1r3VOfEMr8ifnOMp3zt8XemfTLrma+aF6yRCVeEbVLw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@formatjs/intl-getcanonicallocales@2.3.0':
     resolution: {integrity: sha512-BOXbLwqQ7nKua/l7tKqDLRN84WupDXFDhGJQMFvsMVA2dKuOdRaWTxWpL3cJ7qPkoNw11Jf+Xpj4OSPBBvW0eQ==}
@@ -7153,89 +7155,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -7695,48 +7713,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -7809,41 +7835,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -8369,66 +8403,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -8739,24 +8786,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.1':
     resolution: {integrity: sha512-fKzP9mRQGbhc5QhJPIsqKNNX/jyWrZgBxmo3Nz1SPaepfCUc7RFmtcJQI5q8xAun3XabXjh90wqcY/OVyg2+Kg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.1':
     resolution: {integrity: sha512-ZLjMi138uTJxb+1wzo4cB8mIbJbAsSLWRNeHc1g1pMvkERPWOGlem+LEYkkzaFzCNv1J8aKcL653Vtw8INHQeg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.1':
     resolution: {integrity: sha512-jvSI1IdsIYey5kOITzyajjofXOOySVitmLxb45OPUjoNojql4sDojvlW5zoHXXFePdA6qAX4Y6KbzAOV3T3ctA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.1':
     resolution: {integrity: sha512-X/FcDtNrDdY9r4FcXHt9QxUqC/2FbQdvZobCKHlHe8vTSKhUHOilWl5EBtkFVfsEs4D5/yAri9e3bJbwyBhhBw==}
@@ -9313,41 +9364,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -12664,7 +12723,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-base@0.3.0:
@@ -15766,7 +15825,7 @@ packages:
   puppeteer@20.9.0:
     resolution: {integrity: sha512-kAglT4VZ9fWEGg3oLc4/de+JcONuEJhlh3J6f5R1TLkrY/EHHIHxWXDOzXvaxQCtedmyVXBwg8M+P8YCO/wZjw==}
     engines: {node: '>=16.3.0'}
-    deprecated: < 22.8.2 is no longer supported
+    deprecated: < 24.15.0 is no longer supported
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
@@ -18325,15 +18384,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@ardatan/relay-compiler@12.0.0(graphql@16.11.0)':
+  '@ardatan/relay-compiler@12.0.0(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
       '@babel/runtime': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
-      babel-preset-fbjs: 3.4.0(@babel/core@7.29.0)
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       fb-watchman: 2.0.2
       fbjs: 3.0.5
@@ -18456,9 +18515,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@babel/cli@7.28.3(@babel/core@7.29.0)':
+  '@babel/cli@7.28.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jridgewell/trace-mapping': 0.3.31
       commander: 6.2.1
       convert-source-map: 2.0.0
@@ -18478,16 +18537,16 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -18498,11 +18557,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.5(@babel/core@7.29.0)(eslint@9.39.2(jiti@2.6.1))':
+  '@babel/eslint-parser@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -18526,29 +18585,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -18559,26 +18618,26 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
+  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18588,27 +18647,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.29.0
+      '@babel/helper-wrap-function': 7.28.3(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -18619,10 +18678,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helper-wrap-function@7.28.3':
+  '@babel/helper-wrap-function@7.28.3(supports-color@8.1.1)':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -18636,695 +18695,695 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-do-expressions@7.28.3(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-do-expressions@7.28.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@8.1.1))
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.46.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-flow@7.27.1(@babel/core@7.29.0)':
+  '@babel/preset-flow@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-react@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.28.3(@babel/core@7.29.0)':
+  '@babel/register@7.28.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -19343,7 +19402,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -19364,12 +19423,12 @@ snapshots:
 
   '@braidai/lang@1.1.2': {}
 
-  '@chakra-ui/cli@3.36.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)':
+  '@chakra-ui/cli@3.36.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.2
-      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
-      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@clack/prompts': 1.0.1
       '@pandacss/is-valid-prop': 1.11.1
       '@types/babel__core': 7.20.5
@@ -19383,7 +19442,7 @@ snapshots:
       dotenv: 17.4.2
       esbuild: 0.27.7
       globby: 16.1.1
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       look-it-up: 2.1.0
       node-fetch: 3.3.2
       package-manager-detector: 1.6.0
@@ -19396,11 +19455,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@ark-ui/react': 5.37.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
       '@emotion/utils': 1.4.2
@@ -19589,26 +19648,26 @@ snapshots:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
 
-  '@commercetools-docs/ui-kit@24.11.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-docs/ui-kit@24.11.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/card': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/flat-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/icons': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/loading-spinner': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/primary-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/secondary-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/secondary-icon-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/tooltip': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/card': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/icons': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/loading-spinner': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/primary-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/secondary-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@react-hook/latest': 1.0.3(react@19.0.0)
       '@react-hook/resize-observer': 1.2.6(react@19.0.0)
       '@types/lodash.kebabcase': 4.1.9
@@ -19631,7 +19690,7 @@ snapshots:
       react-modal: 3.16.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       rehype-react: 7.2.0(@types/react@19.2.4)
       remark-frontmatter: 4.0.1
-      remark-parse: 10.0.2
+      remark-parse: 10.0.2(supports-color@8.1.1)
       remark-rehype: 10.1.0
       swr: 2.2.5(react@19.0.0)
       tiny-invariant: 1.3.3
@@ -19643,10 +19702,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-frontend/application-config@24.11.0(@types/node@22.19.11)(typescript@5.9.2)':
+  '@commercetools-frontend/application-config@24.11.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/register': 7.28.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/register': 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/constants': 24.11.0
@@ -19657,7 +19716,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       cosmiconfig-typescript-loader: 6.1.0(@types/node@22.19.11)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2)
       dompurify: 3.4.0
-      jsdom: 21.1.2
+      jsdom: 21.1.2(supports-color@8.1.1)
       lodash: 4.18.1
       omit-empty-es: 1.2.0
     transitivePeerDependencies:
@@ -19668,10 +19727,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@commercetools-frontend/application-config@24.11.0(@types/node@22.19.17)(typescript@5.9.2)':
+  '@commercetools-frontend/application-config@24.11.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/register': 7.28.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/register': 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/constants': 24.11.0
@@ -19682,7 +19741,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       cosmiconfig-typescript-loader: 6.1.0(@types/node@22.19.17)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2)
       dompurify: 3.4.0
-      jsdom: 21.1.2
+      jsdom: 21.1.2(supports-color@8.1.1)
       lodash: 4.18.1
       omit-empty-es: 1.2.0
     transitivePeerDependencies:
@@ -19698,14 +19757,14 @@ snapshots:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
 
-  '@commercetools-uikit/accessible-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/accessible-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/react-is': 17.0.7
       lodash: 4.18.1
       prop-types: 15.8.1
@@ -19716,14 +19775,14 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/accessible-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/accessible-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/react-is': 19.2.0
       lodash: 4.18.1
       react: 19.0.0
@@ -19733,48 +19792,48 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/accessible-hidden@20.4.0(@types/react@19.2.4)(react@19.0.0)':
+  '@commercetools-uikit/accessible-hidden@20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  '@commercetools-uikit/async-select-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/async-select-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/loading-spinner': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/loading-spinner': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
-      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/avatar@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/avatar@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -19791,42 +19850,42 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/calendar-utils@20.4.0(@types/react@19.2.4)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/calendar-utils@20.4.0(@types/react@19.2.4)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       moment: 2.30.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
-      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/card@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/card@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/react-router-dom': 5.3.3
       prop-types: 15.8.1
       react: 19.0.0
@@ -19836,15 +19895,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/card@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/card@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inset': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/react-router-dom': 5.3.3
       react: 19.0.0
       react-router-dom: 5.3.4(react@19.0.0)
@@ -19853,17 +19912,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/checkbox-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/checkbox-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -19872,14 +19931,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible-motion@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/collapsible-motion@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -19887,14 +19946,14 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/constraints@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/constraints@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       prop-types: 15.8.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -19902,48 +19961,48 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/constraints@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/constraints@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/data-table-manager@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/data-table-manager@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/accessible-hidden': 20.4.0(@types/react@19.2.4)(react@19.0.0)
-      '@commercetools-uikit/async-select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/card': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/collapsible-motion': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/dropdown-menu': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/grid': 20.4.0(@types/react@19.2.4)(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-hidden': 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/async-select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/card': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible-motion': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/dropdown-menu': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/grid': 20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/primary-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/radio-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/secondary-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/tag': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/primary-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/radio-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/secondary-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tag': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@hello-pangea/dnd': 18.0.1(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/debounce-promise': 3.1.9
       debounce-promise: 3.1.2
@@ -19957,19 +20016,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/data-table@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/data-table-manager': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/data-table-manager': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -19980,25 +20039,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-input@20.4.0(@types/react@19.2.4)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/date-time-input@20.4.0(@types/react@19.2.4)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/calendar-time-utils': 20.4.0(moment-timezone@0.6.0)(react@19.0.0)
-      '@commercetools-uikit/calendar-utils': 20.4.0(@types/react@19.2.4)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/calendar-utils': 20.4.0(@types/react@19.2.4)(moment@2.30.1)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       downshift: 9.0.10(react@19.0.0)
       moment: 2.30.1
       react: 19.0.0
@@ -20012,12 +20071,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/design-system@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))':
+  '@commercetools-uikit/design-system@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 19.9.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -20026,12 +20085,12 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/design-system@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/design-system@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -20039,20 +20098,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/dropdown-menu@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/dropdown-menu@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/secondary-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/secondary-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20062,13 +20121,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-errors@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/field-errors@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20077,22 +20136,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-label@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/field-label@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20101,13 +20160,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-warnings@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/field-warnings@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20116,17 +20175,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/flat-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/flat-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -20137,17 +20196,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/flat-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/flat-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20157,12 +20216,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/grid@20.4.0(@types/react@19.2.4)(react@19.0.0)':
+  '@commercetools-uikit/grid@20.4.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
@@ -20195,17 +20254,17 @@ snapshots:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
 
-  '@commercetools-uikit/icon-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/icon-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20215,14 +20274,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/icons@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/icons@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/dompurify': 2.4.0
       dompurify: 3.4.0
       prop-types: 15.8.1
@@ -20233,14 +20292,14 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/icons@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/icons@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/dompurify': 2.4.0
       dompurify: 3.4.0
       react: 19.0.0
@@ -20250,15 +20309,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/input-utils@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/input-utils@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
       react-textarea-autosize: 8.4.0(@types/react@19.2.4)(react@19.0.0)
@@ -20268,15 +20327,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/label@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)':
+  '@commercetools-uikit/label@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20284,16 +20343,16 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/link@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@types/history': 4.7.11
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
@@ -20305,15 +20364,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/loading-spinner@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/loading-spinner@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       prop-types: 15.8.1
       react: 19.0.0
       react-intl: 6.8.9(react@19.0.0)(typescript@5.9.2)
@@ -20323,15 +20382,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/loading-spinner@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/loading-spinner@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20340,20 +20399,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/localized-text-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/localized-text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/localized-text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20362,24 +20421,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/localized-text-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/localized-utils': 20.4.0(react@19.0.0)
-      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20397,14 +20456,14 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/messages@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/messages@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20413,20 +20472,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/multiline-text-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/multiline-text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/multiline-text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20435,23 +20494,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/multiline-text-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       downshift: 9.0.10(react@19.0.0)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20462,15 +20521,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/notifications@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)':
+  '@commercetools-uikit/notifications@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20478,16 +20537,16 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/number-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/number-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
@@ -20496,22 +20555,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/pagination@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/pagination@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
-      '@commercetools-uikit/number-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/number-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       formik: 2.4.6(@types/react@19.2.4)(react@19.0.0)
       lodash: 4.18.1
       react: 19.0.0
@@ -20522,17 +20581,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/primary-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -20543,17 +20602,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/primary-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20563,20 +20622,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/radio-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inset': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-is: 19.2.0
     transitivePeerDependencies:
@@ -20586,17 +20645,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/secondary-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -20607,17 +20666,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/secondary-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/secondary-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20627,17 +20686,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/secondary-icon-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/secondary-icon-button@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
-      '@commercetools-uikit/spacings': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -20648,17 +20707,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-icon-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/secondary-icon-button@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20668,20 +20727,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/select-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/select-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20690,58 +20749,58 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/select-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/select-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
-      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-utils@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/select-utils@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/checkbox-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/checkbox-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
-      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-select: 5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/spacings-inline@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-inline@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       prop-types: 15.8.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -20749,26 +20808,26 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inline@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-inline@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset-squish@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-inset-squish@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       prop-types: 15.8.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -20776,26 +20835,26 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset-squish@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-inset-squish@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-inset@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       prop-types: 15.8.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -20803,26 +20862,26 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-inset@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-stack@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-stack@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       prop-types: 15.8.1
       react: 19.0.0
     transitivePeerDependencies:
@@ -20830,56 +20889,56 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-stack@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings-stack@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inset-squish': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-stack': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset-squish': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/spacings@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inset': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inset-squish': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset-squish': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/stamp@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)':
+  '@commercetools-uikit/stamp@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
@@ -20887,19 +20946,19 @@ snapshots:
       - react-intl
       - supports-color
 
-  '@commercetools-uikit/tag@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/tag@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-router-dom@5.3.4(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
       react-router-dom: 5.3.4(react@19.0.0)
@@ -20909,21 +20968,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/text-field@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2)
-      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-label': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/field-warnings': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools-uikit/spacings-stack': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text-input': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
@@ -20932,16 +20991,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)':
+  '@commercetools-uikit/text-input@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(typescript@5.9.2)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       react: 19.0.0
     transitivePeerDependencies:
       - '@types/react'
@@ -20950,13 +21009,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)':
+  '@commercetools-uikit/text@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@6.8.9(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -20967,13 +21026,13 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/text@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)':
+  '@commercetools-uikit/text@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react-intl@7.1.14(react@19.0.0)(typescript@5.9.2))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-intl: 7.1.14(react@19.0.0)(typescript@5.9.2)
@@ -20983,16 +21042,16 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/tooltip@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/tooltip@19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))
+      '@commercetools-uikit/constraints': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 19.9.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/utils': 19.9.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -21003,16 +21062,16 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/tooltip@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@commercetools-uikit/tooltip@20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@commercetools-uikit/utils': 20.4.0(react@19.0.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.0.0
       react-is: 19.2.0
@@ -21038,11 +21097,11 @@ snapshots:
 
   '@commercetools/api-request-builder@6.0.0': {}
 
-  '@commercetools/composable-commerce-test-data@13.12.0(@types/node@22.19.11)(typescript@5.9.2)':
+  '@commercetools/composable-commerce-test-data@13.12.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.11)(typescript@5.9.2)
+      '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-frontend/constants': 24.11.0
       '@commercetools/platform-sdk': 8.18.0
       '@faker-js/faker': 9.9.0
@@ -21057,11 +21116,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@commercetools/composable-commerce-test-data@13.12.0(@types/node@22.19.17)(typescript@5.9.2)':
+  '@commercetools/composable-commerce-test-data@13.12.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
-      '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.17)(typescript@5.9.2)
+      '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2)
       '@commercetools-frontend/constants': 24.11.0
       '@commercetools/platform-sdk': 8.18.0
       '@faker-js/faker': 9.9.0
@@ -21093,22 +21152,22 @@ snapshots:
 
   '@commercetools/http-user-agent@3.0.0': {}
 
-  '@commercetools/nimbus-icons@3.2.0(typescript@5.9.2)':
+  '@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@material-design-icons/svg': 0.14.15
-      '@svgr/cli': 8.1.0(typescript@5.9.2)
+      '@svgr/cli': 8.1.0(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@commercetools/nimbus-tokens@3.1.0': {}
+  '@commercetools/nimbus-tokens@3.2.0': {}
 
-  '@commercetools/nimbus@3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(typescript@5.9.2))(@commercetools/nimbus-tokens@3.1.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)':
+  '@commercetools/nimbus@3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2))(@commercetools/nimbus-tokens@3.2.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@chakra-ui/cli': 3.36.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)
-      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools/nimbus-icons': 3.2.0(typescript@5.9.2)
-      '@commercetools/nimbus-tokens': 3.1.0
+      '@chakra-ui/cli': 3.36.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)
+      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools/nimbus-icons': 3.2.0(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools/nimbus-tokens': 3.2.0
       '@emotion/is-prop-valid': 1.4.0
       '@github-ui/storybook-addon-performance-panel': 1.1.4(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@internationalized/string': 3.2.9
@@ -21137,12 +21196,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools/nimbus@3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(typescript@5.9.2))(@commercetools/nimbus-tokens@3.1.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)':
+  '@commercetools/nimbus@3.2.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.2))(@commercetools/nimbus-tokens@3.2.0)(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@chakra-ui/cli': 3.36.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)
-      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@commercetools/nimbus-icons': 3.2.0(typescript@5.9.2)
-      '@commercetools/nimbus-tokens': 3.1.0
+      '@chakra-ui/cli': 3.36.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(supports-color@8.1.1)(typescript@5.9.2)
+      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@commercetools/nimbus-icons': 3.2.0(supports-color@8.1.1)(typescript@5.9.2)
+      '@commercetools/nimbus-tokens': 3.2.0
       '@emotion/is-prop-valid': 1.4.0
       '@github-ui/storybook-addon-performance-panel': 1.1.4(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@internationalized/string': 3.2.9
@@ -21343,22 +21402,22 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@cypress/code-coverage@3.14.7(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))))(cypress@14.5.4)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))':
+  '@cypress/code-coverage@3.14.7(@babel/core@7.29.0(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
-      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.0(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
+      babel-loader: 8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       chalk: 4.1.2
       cypress: 14.5.4
       dayjs: 1.11.13
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       execa: 4.1.0
       istanbul-lib-coverage: 3.2.2
       js-yaml: 3.14.2
-      nyc: 15.1.0
+      nyc: 15.1.0(supports-color@8.1.1)
       tinyglobby: 0.2.15
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -21383,16 +21442,16 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.0(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
-      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-loader: 8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       bluebird: 3.7.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       semver: 7.7.4
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -21466,14 +21525,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin-jsx-pragmatic@0.3.0(@babel/core@7.29.0)':
+  '@emotion/babel-plugin-jsx-pragmatic@0.3.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@emotion/babel-plugin@11.13.5':
+  '@emotion/babel-plugin@11.13.5(supports-color@8.1.1)':
     dependencies:
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -21487,13 +21546,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/babel-preset-css-prop@11.12.0(@babel/core@7.29.0)':
+  '@emotion/babel-preset-css-prop@11.12.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.28.6
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/babel-plugin-jsx-pragmatic': 0.3.0(@babel/core@7.29.0)
+      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
+      '@emotion/babel-plugin-jsx-pragmatic': 0.3.0(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -21519,10 +21578,10 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
@@ -21545,12 +21604,12 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0))(@types/react@19.2.4)(react@19.0.0)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
       '@emotion/utils': 1.4.2
@@ -21743,14 +21802,14 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.1(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -21766,7 +21825,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.3':
+  '@eslint/eslintrc@3.3.3(supports-color@8.1.1)':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -21927,11 +21986,11 @@ snapshots:
       launchdarkly-js-client-sdk: 3.9.0
       typescript: 5.9.2
 
-  '@formatjs/cli-lib@6.6.6(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))':
+  '@formatjs/cli-lib@6.6.6(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.4
       '@formatjs/icu-skeleton-parser': 1.8.8
-      '@formatjs/ts-transformer': 3.13.23(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))
+      '@formatjs/ts-transformer': 3.13.23(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))
       '@types/estree': 1.0.8
       '@types/fs-extra': 11.0.4
       '@types/json-stable-stringify': 1.2.0
@@ -22104,7 +22163,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@formatjs/ts-transformer@3.13.23(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))':
+  '@formatjs/ts-transformer@3.13.23(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.4
       '@types/json-stable-stringify': 1.2.0
@@ -22114,9 +22173,9 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.2
     optionalDependencies:
-      ts-jest: 29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2)
+      ts-jest: 29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2)
 
-  '@formatjs/ts-transformer@3.14.2(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))':
+  '@formatjs/ts-transformer@3.14.2(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.11.4
       '@types/node': 22.19.17
@@ -22125,7 +22184,18 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.2
     optionalDependencies:
-      ts-jest: 29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2)
+      ts-jest: 29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2)
+
+  '@formatjs/ts-transformer@3.14.2(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))':
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 2.11.4
+      '@types/node': 22.19.17
+      chalk: 4.1.2
+      json-stable-stringify: 1.3.0
+      tslib: 2.8.1
+      typescript: 5.9.2
+    optionalDependencies:
+      ts-jest: 29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2)
 
   '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
@@ -22147,7 +22217,7 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.4.1
 
-  '@graphql-codegen/cli@2.16.5(@babel/core@7.29.0)(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.9.2)':
+  '@graphql-codegen/cli@2.16.5(@babel/core@7.29.0(supports-color@8.1.1))(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(enquirer@2.4.1)(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/template': 7.28.6
@@ -22155,13 +22225,13 @@ snapshots:
       '@graphql-codegen/core': 2.6.8(graphql@16.11.0)
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.11.0)
       '@graphql-tools/apollo-engine-loader': 7.3.26(graphql@16.11.0)
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.0)(graphql@16.11.0)
-      '@graphql-tools/git-loader': 7.3.0(@babel/core@7.29.0)(graphql@16.11.0)
-      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.29.0)(@types/node@22.19.11)(graphql@16.11.0)
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)
+      '@graphql-tools/git-loader': 7.3.0(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)
+      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.29.0(supports-color@8.1.1))(@types/node@22.19.11)(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/graphql-file-loader': 7.5.17(graphql@16.11.0)
       '@graphql-tools/json-file-loader': 7.4.18(graphql@16.11.0)
       '@graphql-tools/load': 7.8.14(graphql@16.11.0)
-      '@graphql-tools/prisma-loader': 7.2.72(@types/node@22.19.11)(graphql@16.11.0)
+      '@graphql-tools/prisma-loader': 7.2.72(@types/node@22.19.11)(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/url-loader': 7.17.18(@types/node@22.19.11)(graphql@16.11.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       '@whatwg-node/fetch': 0.6.9(@types/node@22.19.11)
@@ -22206,10 +22276,10 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.4.1
 
-  '@graphql-codegen/introspection@2.2.3(graphql@16.11.0)':
+  '@graphql-codegen/introspection@2.2.3(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.11.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.11.0)(supports-color@8.1.1)
       graphql: 16.11.0
       tslib: 2.4.1
     transitivePeerDependencies:
@@ -22249,11 +22319,11 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.4.1
 
-  '@graphql-codegen/typescript-operations@2.5.13(graphql@16.11.0)':
+  '@graphql-codegen/typescript-operations@2.5.13(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.11.0)
-      '@graphql-codegen/typescript': 2.8.8(graphql@16.11.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.11.0)
+      '@graphql-codegen/typescript': 2.8.8(graphql@16.11.0)(supports-color@8.1.1)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.11.0)(supports-color@8.1.1)
       auto-bind: 4.0.0
       graphql: 16.11.0
       tslib: 2.4.1
@@ -22261,11 +22331,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@graphql-codegen/typescript@2.8.8(graphql@16.11.0)':
+  '@graphql-codegen/typescript@2.8.8(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.11.0)
       '@graphql-codegen/schema-ast': 2.6.1(graphql@16.11.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 2.13.8(graphql@16.11.0)(supports-color@8.1.1)
       auto-bind: 4.0.0
       graphql: 16.11.0
       tslib: 2.4.1
@@ -22273,11 +22343,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@graphql-codegen/visitor-plugin-common@2.13.8(graphql@16.11.0)':
+  '@graphql-codegen/visitor-plugin-common@2.13.8(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.11.0)
       '@graphql-tools/optimize': 1.4.0(graphql@16.11.0)
-      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@16.11.0)
+      '@graphql-tools/relay-operation-optimizer': 6.5.18(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
@@ -22290,16 +22360,16 @@ snapshots:
       - encoding
       - supports-color
 
-  '@graphql-eslint/eslint-plugin@4.4.0(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)':
+  '@graphql-eslint/eslint-plugin@4.4.0(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@graphql-tools/code-file-loader': 8.1.26(graphql@16.11.0)
-      '@graphql-tools/graphql-tag-pluck': 8.3.25(graphql@16.11.0)
+      '@graphql-tools/code-file-loader': 8.1.26(graphql@16.11.0)(supports-color@8.1.1)
+      '@graphql-tools/graphql-tag-pluck': 8.3.25(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 10.10.3(graphql@16.11.0)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       fast-glob: 3.3.3
       graphql: 16.11.0
-      graphql-config: 5.1.5(@types/node@22.19.11)(graphql@16.11.0)(typescript@5.9.2)
+      graphql-config: 5.1.5(@types/node@22.19.11)(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
       graphql-depth-limit: 1.1.0(graphql@16.11.0)
       lodash.lowercase: 4.3.0
     transitivePeerDependencies:
@@ -22313,16 +22383,16 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@graphql-eslint/eslint-plugin@4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1))(graphql@16.11.0)(typescript@5.9.2)':
+  '@graphql-eslint/eslint-plugin@4.4.0(@types/node@22.19.17)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@graphql-tools/code-file-loader': 8.1.26(graphql@16.11.0)
-      '@graphql-tools/graphql-tag-pluck': 8.3.25(graphql@16.11.0)
+      '@graphql-tools/code-file-loader': 8.1.26(graphql@16.11.0)(supports-color@8.1.1)
+      '@graphql-tools/graphql-tag-pluck': 8.3.25(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 10.10.3(graphql@16.11.0)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       fast-glob: 3.3.3
       graphql: 16.11.0
-      graphql-config: 5.1.5(@types/node@22.19.17)(graphql@16.11.0)(typescript@5.9.2)
+      graphql-config: 5.1.5(@types/node@22.19.17)(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2)
       graphql-depth-limit: 1.1.0(graphql@16.11.0)
       lodash.lowercase: 4.3.0
     transitivePeerDependencies:
@@ -22364,9 +22434,9 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.8.1
 
-  '@graphql-tools/code-file-loader@7.3.23(@babel/core@7.29.0)(graphql@16.11.0)':
+  '@graphql-tools/code-file-loader@7.3.23(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.0)(graphql@16.11.0)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       globby: 11.1.0
       graphql: 16.11.0
@@ -22376,9 +22446,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@graphql-tools/code-file-loader@8.1.26(graphql@16.11.0)':
+  '@graphql-tools/code-file-loader@8.1.26(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.25(graphql@16.11.0)
+      '@graphql-tools/graphql-tag-pluck': 8.3.25(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 10.10.3(graphql@16.11.0)
       globby: 11.1.0
       graphql: 16.11.0
@@ -22541,9 +22611,9 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.8.1
 
-  '@graphql-tools/git-loader@7.3.0(@babel/core@7.29.0)(graphql@16.11.0)':
+  '@graphql-tools/git-loader@7.3.0(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.0)(graphql@16.11.0)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       graphql: 16.11.0
       is-glob: 4.0.3
@@ -22554,11 +22624,11 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@graphql-tools/github-loader@7.3.28(@babel/core@7.29.0)(@types/node@22.19.11)(graphql@16.11.0)':
+  '@graphql-tools/github-loader@7.3.28(@babel/core@7.29.0(supports-color@8.1.1))(@types/node@22.19.11)(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/executor-http': 0.1.10(@types/node@22.19.11)(graphql@16.11.0)
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.0)(graphql@16.11.0)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       '@whatwg-node/fetch': 0.8.8
       graphql: 16.11.0
@@ -22579,9 +22649,9 @@ snapshots:
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/graphql-file-loader@8.1.6(graphql@16.11.0)':
+  '@graphql-tools/graphql-file-loader@8.1.6(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@graphql-tools/import': 7.1.6(graphql@16.11.0)
+      '@graphql-tools/import': 7.1.6(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 10.10.3(graphql@16.11.0)
       globby: 11.1.0
       graphql: 16.11.0
@@ -22590,11 +22660,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.29.0)(graphql@16.11.0)':
+  '@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.29.0(supports-color@8.1.1))(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/parser': 7.29.2
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       graphql: 16.11.0
@@ -22603,12 +22673,12 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@graphql-tools/graphql-tag-pluck@8.3.25(graphql@16.11.0)':
+  '@graphql-tools/graphql-tag-pluck@8.3.25(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.2
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@graphql-tools/utils': 10.10.3(graphql@16.11.0)
       graphql: 16.11.0
@@ -22623,10 +22693,10 @@ snapshots:
       resolve-from: 5.0.0
       tslib: 2.8.1
 
-  '@graphql-tools/import@7.1.6(graphql@16.11.0)':
+  '@graphql-tools/import@7.1.6(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-tools/utils': 10.10.3(graphql@16.11.0)
-      '@theguild/federation-composition': 0.20.2(graphql@16.11.0)
+      '@theguild/federation-composition': 0.20.2(graphql@16.11.0)(supports-color@8.1.1)
       graphql: 16.11.0
       resolve-from: 5.0.0
       tslib: 2.8.1
@@ -22682,7 +22752,7 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.8.1
 
-  '@graphql-tools/prisma-loader@7.2.72(@types/node@22.19.11)(graphql@16.11.0)':
+  '@graphql-tools/prisma-loader@7.2.72(@types/node@22.19.11)(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       '@graphql-tools/url-loader': 7.17.18(@types/node@22.19.11)(graphql@16.11.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
@@ -22694,8 +22764,8 @@ snapshots:
       dotenv: 16.6.1
       graphql: 16.11.0
       graphql-request: 6.1.0(graphql@16.11.0)
-      http-proxy-agent: 6.1.1
-      https-proxy-agent: 6.2.1
+      http-proxy-agent: 6.1.1(supports-color@8.1.1)
+      https-proxy-agent: 6.2.1(supports-color@8.1.1)
       jose: 4.15.9
       js-yaml: 3.14.2
       json-stable-stringify: 1.3.0
@@ -22710,9 +22780,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.11.0)':
+  '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
-      '@ardatan/relay-compiler': 12.0.0(graphql@16.11.0)
+      '@ardatan/relay-compiler': 12.0.0(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
       graphql: 16.11.0
       tslib: 2.8.1
@@ -23033,13 +23103,13 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))':
+  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.2.0
+      '@jest/reporters': 30.2.0(supports-color@8.1.1)
       '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
+      '@jest/transform': 30.2.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
       '@types/node': 22.19.17
       ansi-escapes: 4.3.2
@@ -23048,51 +23118,15 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      jest-config: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
       jest-resolve: 30.2.0
-      jest-resolve-dependencies: 30.2.0
-      jest-runner: 30.2.0
-      jest-runtime: 30.2.0
-      jest-snapshot: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      jest-watcher: 30.2.0
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))':
-    dependencies:
-      '@jest/console': 30.2.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.2.0
-      '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      '@types/node': 22.19.17
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
-      jest-haste-map: 30.2.0
-      jest-message-util: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-resolve-dependencies: 30.2.0
-      jest-runner: 30.2.0
-      jest-runtime: 30.2.0
-      jest-snapshot: 30.2.0
+      jest-resolve-dependencies: 30.2.0(supports-color@8.1.1)
+      jest-runner: 30.2.0(supports-color@8.1.1)
+      jest-runtime: 30.2.0(supports-color@8.1.1)
+      jest-snapshot: 30.2.0(supports-color@8.1.1)
       jest-util: 30.2.0
       jest-validate: 30.2.0
       jest-watcher: 30.2.0
@@ -23107,7 +23141,7 @@ snapshots:
 
   '@jest/diff-sequences@30.0.1': {}
 
-  '@jest/environment-jsdom-abstract@30.2.0(jsdom@26.1.0)':
+  '@jest/environment-jsdom-abstract@30.2.0(jsdom@26.1.0(supports-color@8.1.1))':
     dependencies:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
@@ -23116,7 +23150,7 @@ snapshots:
       '@types/node': 22.19.17
       jest-mock: 30.2.0
       jest-util: 30.2.0
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
 
   '@jest/environment@29.7.0':
     dependencies:
@@ -23140,10 +23174,10 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@30.2.0':
+  '@jest/expect@30.2.0(supports-color@8.1.1)':
     dependencies:
       expect: 30.2.0
-      jest-snapshot: 30.2.0
+      jest-snapshot: 30.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23167,10 +23201,10 @@ snapshots:
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@30.2.0':
+  '@jest/globals@30.2.0(supports-color@8.1.1)':
     dependencies:
       '@jest/environment': 30.2.0
-      '@jest/expect': 30.2.0
+      '@jest/expect': 30.2.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
       jest-mock: 30.2.0
     transitivePeerDependencies:
@@ -23181,12 +23215,12 @@ snapshots:
       '@types/node': 22.19.17
       jest-regex-util: 30.0.1
 
-  '@jest/reporters@30.2.0':
+  '@jest/reporters@30.2.0(supports-color@8.1.1)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 30.2.0
       '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
+      '@jest/transform': 30.2.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.19.17
@@ -23196,9 +23230,9 @@ snapshots:
       glob: 10.5.0
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
       istanbul-reports: 3.2.0
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -23244,12 +23278,12 @@ snapshots:
       jest-haste-map: 30.2.0
       slash: 3.0.0
 
-  '@jest/transform@29.7.0':
+  '@jest/transform@29.7.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -23265,12 +23299,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@jest/transform@30.2.0':
+  '@jest/transform@30.2.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 7.0.1
+      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -23446,10 +23480,10 @@ snapshots:
     dependencies:
       unist-util-visit: 1.4.1
 
-  '@mapbox/node-pre-gyp@1.0.11':
+  '@mapbox/node-pre-gyp@1.0.11(supports-color@8.1.1)':
     dependencies:
       detect-libc: 2.1.2
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       make-dir: 3.1.0
       node-fetch: 2.7.0
       nopt: 5.0.0
@@ -23461,11 +23495,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mapbox/node-pre-gyp@2.0.0':
+  '@mapbox/node-pre-gyp@2.0.0(supports-color@8.1.1)':
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.7.4
@@ -23481,7 +23515,7 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 2.7.2
 
-  '@mswjs/interceptors@0.17.10':
+  '@mswjs/interceptors@0.17.10(supports-color@8.1.1)':
     dependencies:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.12
@@ -23807,29 +23841,29 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.8.1
 
-  '@percy/cli-app@1.31.1(typescript@5.9.2)':
+  '@percy/cli-app@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
-      '@percy/cli-exec': 1.31.1(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-exec': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-build@1.31.1(typescript@5.9.2)':
+  '@percy/cli-build@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-command@1.31.1(typescript@5.9.2)':
+  '@percy/cli-command@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@percy/config': 1.31.1(typescript@5.9.2)
-      '@percy/core': 1.31.1(typescript@5.9.2)
+      '@percy/core': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
       '@percy/logger': 1.31.1
     transitivePeerDependencies:
       - bufferutil
@@ -23837,18 +23871,18 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli-config@1.31.1(typescript@5.9.2)':
+  '@percy/cli-config@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-exec@1.31.1(typescript@5.9.2)':
+  '@percy/cli-exec@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
       '@percy/logger': 1.31.1
       cross-spawn: 7.0.6
       which: 2.0.2
@@ -23858,9 +23892,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli-snapshot@1.31.1(typescript@5.9.2)':
+  '@percy/cli-snapshot@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
       yaml: 2.8.1
     transitivePeerDependencies:
       - bufferutil
@@ -23868,9 +23902,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli-upload@1.31.1(typescript@5.9.2)':
+  '@percy/cli-upload@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
@@ -23879,16 +23913,16 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli@1.31.1(typescript@5.9.2)':
+  '@percy/cli@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/cli-app': 1.31.1(typescript@5.9.2)
-      '@percy/cli-build': 1.31.1(typescript@5.9.2)
-      '@percy/cli-command': 1.31.1(typescript@5.9.2)
-      '@percy/cli-config': 1.31.1(typescript@5.9.2)
-      '@percy/cli-exec': 1.31.1(typescript@5.9.2)
-      '@percy/cli-snapshot': 1.31.1(typescript@5.9.2)
-      '@percy/cli-upload': 1.31.1(typescript@5.9.2)
-      '@percy/client': 1.31.1
+      '@percy/cli-app': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-build': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-command': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-config': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-exec': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-snapshot': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/cli-upload': 1.31.1(supports-color@8.1.1)(typescript@5.9.2)
+      '@percy/client': 1.31.1(supports-color@8.1.1)
       '@percy/logger': 1.31.1
     transitivePeerDependencies:
       - bufferutil
@@ -23896,11 +23930,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/client@1.31.1':
+  '@percy/client@1.31.1(supports-color@8.1.1)':
     dependencies:
       '@percy/env': 1.31.1
       '@percy/logger': 1.31.1
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
       pako: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -23914,9 +23948,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@percy/core@1.31.1(typescript@5.9.2)':
+  '@percy/core@1.31.1(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@percy/client': 1.31.1
+      '@percy/client': 1.31.1(supports-color@8.1.1)
       '@percy/config': 1.31.1(typescript@5.9.2)
       '@percy/dom': 1.31.1
       '@percy/logger': 1.31.1
@@ -23961,10 +23995,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@percy/puppeteer@2.0.2(puppeteer@20.9.0(typescript@5.9.2))':
+  '@percy/puppeteer@2.0.2(puppeteer@20.9.0(supports-color@8.1.1)(typescript@5.9.2))(supports-color@8.1.1)':
     dependencies:
-      '@percy/sdk-utils': 1.31.4
-      puppeteer: 20.9.0(typescript@5.9.2)
+      '@percy/sdk-utils': 1.31.4(supports-color@8.1.1)
+      puppeteer: 20.9.0(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -23972,9 +24006,9 @@ snapshots:
 
   '@percy/sdk-utils@1.31.1': {}
 
-  '@percy/sdk-utils@1.31.4':
+  '@percy/sdk-utils@1.31.4(supports-color@8.1.1)':
     dependencies:
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23990,7 +24024,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.6.1(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.6.1(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))':
     dependencies:
       anser: 2.3.2
       core-js-pure: 3.48.0
@@ -23999,10 +24033,10 @@ snapshots:
       react-refresh: 0.17.0
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 4.15.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      webpack-dev-server: 4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -24018,13 +24052,13 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@preconstruct/cli@2.8.12':
+  '@preconstruct/cli@2.8.12(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/runtime': 7.28.6
-      '@preconstruct/hook': 0.4.0
+      '@preconstruct/hook': 0.4.0(supports-color@8.1.1)
       '@rollup/plugin-alias': 3.1.9(rollup@2.80.0)
       '@rollup/plugin-commonjs': 15.1.0(rollup@2.80.0)
       '@rollup/plugin-json': 4.1.0(rollup@2.80.0)
@@ -24059,10 +24093,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@preconstruct/hook@0.4.0':
+  '@preconstruct/hook@0.4.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       pirates: 4.0.7
       source-map-support: 0.5.21
     transitivePeerDependencies:
@@ -24070,12 +24104,12 @@ snapshots:
 
   '@publint/pack@0.1.4': {}
 
-  '@puppeteer/browsers@1.4.6(typescript@5.9.2)':
+  '@puppeteer/browsers@1.4.6(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 2.0.1(supports-color@8.1.1)
       progress: 2.0.3
-      proxy-agent: 6.3.0
+      proxy-agent: 6.3.0(supports-color@8.1.1)
       tar-fs: 3.1.2
       unbzip2-stream: 1.4.3
       yargs: 17.7.1
@@ -24547,92 +24581,92 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-dynamic-title@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-em-dimensions@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-react-native-svg@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-svg-component@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-svg-component@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-preset@6.5.1(@babel/core@7.29.0)':
+  '@svgr/babel-preset@6.5.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 6.5.1(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.5.1(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 6.5.1(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 6.5.1(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 6.5.1(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 6.5.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-plugin-add-jsx-attribute': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-dynamic-title': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-em-dimensions': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-react-native-svg': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-svg-component': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@svgr/cli@6.5.1':
+  '@svgr/cli@6.5.1(supports-color@8.1.1)':
     dependencies:
-      '@svgr/core': 6.5.1
-      '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
-      '@svgr/plugin-prettier': 6.5.1(@svgr/core@6.5.1)
-      '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1)
+      '@svgr/core': 6.5.1(supports-color@8.1.1)
+      '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))(supports-color@8.1.1)
+      '@svgr/plugin-prettier': 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))
+      '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))
       camelcase: 6.3.0
       chalk: 4.1.2
       commander: 9.5.0
@@ -24641,12 +24675,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/cli@8.1.0(typescript@5.9.2)':
+  '@svgr/cli@8.1.0(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
-      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2))(supports-color@8.1.1)
+      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2))(typescript@5.9.2)
       camelcase: 6.3.0
       chalk: 4.1.2
       commander: 9.5.0
@@ -24657,20 +24691,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@6.5.1':
+  '@svgr/core@6.5.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 6.5.1(@babel/core@7.29.0)
-      '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))(supports-color@8.1.1)
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/core@8.1.0(typescript@5.9.2)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.2)
       snake-case: 3.0.4
@@ -24688,64 +24722,64 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@6.5.1(@svgr/core@6.5.1)':
+  '@svgr/plugin-jsx@6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 6.5.1(@babel/core@7.29.0)
-      '@svgr/core': 6.5.1
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 6.5.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/core': 6.5.1(supports-color@8.1.1)
       '@svgr/hast-util-to-babel-ast': 6.5.1
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.2))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.2)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-prettier@6.5.1(@svgr/core@6.5.1)':
+  '@svgr/plugin-prettier@6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))':
     dependencies:
-      '@svgr/core': 6.5.1
+      '@svgr/core': 6.5.1(supports-color@8.1.1)
       deepmerge: 4.3.1
       prettier: 2.8.8
 
-  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(typescript@5.9.2))':
+  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2))':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.2)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.2)
       deepmerge: 4.3.1
       prettier: 2.8.8
 
-  '@svgr/plugin-svgo@6.5.1(@svgr/core@6.5.1)':
+  '@svgr/plugin-svgo@6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))':
     dependencies:
-      '@svgr/core': 6.5.1
+      '@svgr/core': 6.5.1(supports-color@8.1.1)
       cosmiconfig: 7.1.0
       deepmerge: 4.3.1
       svgo: 4.0.1
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.2)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.2)
       cosmiconfig: 8.3.6(typescript@5.9.2)
       deepmerge: 4.3.1
       svgo: 4.0.1
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@6.5.1':
+  '@svgr/webpack@6.5.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@svgr/core': 6.5.1
-      '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
-      '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/preset-env': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@svgr/core': 6.5.1(supports-color@8.1.1)
+      '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))(supports-color@8.1.1)
+      '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -24861,7 +24895,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@theguild/federation-composition@0.20.2(graphql@16.11.0)':
+  '@theguild/federation-composition@0.20.2(graphql@16.11.0)(supports-color@8.1.1)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -25108,11 +25142,11 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))':
+  '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
       tapable: 2.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -25192,7 +25226,7 @@ snapshots:
 
   '@types/react@19.2.4':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/redux-logger@3.0.13':
     dependencies:
@@ -25267,11 +25301,11 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))':
+  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
       tapable: 2.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -25299,15 +25333,15 @@ snapshots:
       '@types/node': 22.19.17
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.55.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.2)
@@ -25315,19 +25349,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.55.0(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.55.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.55.0(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.55.0(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.55.0
@@ -25345,13 +25379,13 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.55.0(supports-color@8.1.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -25359,9 +25393,9 @@ snapshots:
 
   '@typescript-eslint/types@8.55.0': {}
 
-  '@typescript-eslint/typescript-estree@8.55.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.55.0(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.55.0(typescript@5.9.2)
+      '@typescript-eslint/project-service': 8.55.0(supports-color@8.1.1)(typescript@5.9.2)
       '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
@@ -25374,13 +25408,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/typescript-estree': 8.55.0(supports-color@8.1.1)(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -25461,9 +25495,9 @@ snapshots:
 
   '@vercel/next@2.9.0': {}
 
-  '@vercel/nft@0.19.1':
+  '@vercel/nft@0.19.1(supports-color@8.1.1)':
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11
+      '@mapbox/node-pre-gyp': 1.0.11(supports-color@8.1.1)
       acorn: 8.15.0
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -25471,16 +25505,16 @@ snapshots:
       graceful-fs: 4.2.11
       micromatch: 4.0.8
       node-gyp-build: 4.8.4
-      node-pre-gyp: 0.13.0
+      node-pre-gyp: 0.13.0(supports-color@8.1.1)
       resolve-from: 5.0.0
       rollup-pluginutils: 2.8.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@vercel/nft@0.30.1(rollup@4.60.3)':
+  '@vercel/nft@0.30.1(rollup@4.60.3)(supports-color@8.1.1)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.0
+      '@mapbox/node-pre-gyp': 2.0.0(supports-color@8.1.1)
       '@rollup/pluginutils': 5.2.0(rollup@4.60.3)
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -25506,7 +25540,7 @@ snapshots:
       ts-node: 8.9.1(typescript@4.3.4)
       typescript: 4.3.4
 
-  '@vercel/node@5.5.5(@swc/core@1.15.1(@swc/helpers@0.5.23))(rollup@4.60.3)':
+  '@vercel/node@5.5.5(@swc/core@1.15.1(@swc/helpers@0.5.23))(rollup@4.60.3)(supports-color@8.1.1)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
@@ -25514,7 +25548,7 @@ snapshots:
       '@types/node': 22.19.17
       '@vercel/build-utils': 13.0.0
       '@vercel/error-utils': 2.0.3
-      '@vercel/nft': 0.30.1(rollup@4.60.3)
+      '@vercel/nft': 0.30.1(rollup@4.60.3)(supports-color@8.1.1)
       '@vercel/static-config': 3.1.2
       async-listen: 3.0.0
       cjs-module-lexer: 1.2.3
@@ -25539,19 +25573,19 @@ snapshots:
 
   '@vercel/python@2.3.4': {}
 
-  '@vercel/redwood@0.8.4':
+  '@vercel/redwood@0.8.4(supports-color@8.1.1)':
     dependencies:
-      '@vercel/nft': 0.19.1
+      '@vercel/nft': 0.19.1(supports-color@8.1.1)
       '@vercel/routing-utils': 1.13.3
       semver: 6.3.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@vercel/remix@0.0.2(@vercel/node@1.15.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@vercel/remix@0.0.2(@vercel/node@1.15.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)':
     dependencies:
       '@remix-run/vercel': 1.4.3(@vercel/node@1.15.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@vercel/nft': 0.19.1
+      '@vercel/nft': 0.19.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@vercel/node'
       - encoding
@@ -25585,11 +25619,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -26411,7 +26445,7 @@ snapshots:
 
   address@1.2.2: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -26512,11 +26546,11 @@ snapshots:
     dependencies:
       '@apollo/client': 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  apollo-link-rest@0.9.0(@apollo/client@3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(graphql@16.11.0)(qs@6.14.1):
+  apollo-link-rest@0.9.0(@apollo/client@3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(graphql@16.11.0)(qs@6.14.0):
     dependencies:
       '@apollo/client': 3.13.9(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       graphql: 16.11.0
-      qs: 6.14.1
+      qs: 6.14.0
 
   apollo-utilities@1.3.4(graphql@16.11.0):
     dependencies:
@@ -26722,9 +26756,9 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  axios@1.16.0(debug@4.4.1):
+  axios@1.16.0(debug@4.4.1(supports-color@8.1.1)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.1)
+      follow-redirects: 1.16.0(debug@4.4.1(supports-color@8.1.1))
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -26734,13 +26768,13 @@ snapshots:
 
   b4a@1.7.3: {}
 
-  babel-jest@29.7.0(@babel/core@7.29.0):
+  babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 29.7.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.29.0)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
+      babel-preset-jest: 29.6.3(@babel/core@7.29.0(supports-color@8.1.1))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -26748,41 +26782,58 @@ snapshots:
       - supports-color
     optional: true
 
-  babel-jest@30.2.0(@babel/core@7.29.0):
+  babel-jest@30.2.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.2.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@jest/transform': 30.2.0(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.2.0(@babel/core@7.29.0)
+      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
+      babel-preset-jest: 30.2.0(@babel/core@7.29.0(supports-color@8.1.1))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
-  babel-plugin-dev-expression@0.2.3(@babel/core@7.29.0):
+  babel-plugin-dev-expression@0.2.3(@babel/core@7.29.0(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  babel-plugin-formatjs@10.5.41(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2)):
+  babel-plugin-formatjs@10.5.41(supports-color@8.1.1)(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@formatjs/icu-messageformat-parser': 2.11.4
-      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2))
+      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))
+      '@types/babel__core': 7.20.5
+      '@types/babel__helper-plugin-utils': 7.10.3
+      '@types/babel__traverse': 7.28.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-jest
+
+  babel-plugin-formatjs@10.5.41(supports-color@8.1.1)(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2)):
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/types': 7.29.0
+      '@formatjs/icu-messageformat-parser': 2.11.4
+      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2))
       '@types/babel__core': 7.20.5
       '@types/babel__helper-plugin-utils': 7.10.3
       '@types/babel__traverse': 7.28.0
@@ -26796,23 +26847,23 @@ snapshots:
       graphql: 16.11.0
       graphql-tag: 2.12.6(graphql@16.11.0)
 
-  babel-plugin-istanbul@6.1.1:
+  babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
     dependencies:
       '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
       test-exclude: 7.0.2
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  babel-plugin-istanbul@7.0.1:
+  babel-plugin-istanbul@7.0.1(supports-color@8.1.1):
     dependencies:
       '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       test-exclude: 7.0.1
     transitivePeerDependencies:
       - supports-color
@@ -26835,27 +26886,27 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.46.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.0):
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26876,80 +26927,80 @@ snapshots:
 
   babel-plugin-transform-rename-import@2.3.0: {}
 
-  babel-plugin-typescript-to-proptypes@2.1.0(@babel/core@7.29.0)(typescript@5.9.2):
+  babel-plugin-typescript-to-proptypes@2.1.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
 
-  babel-preset-fbjs@3.4.0(@babel/core@7.29.0):
+  babel-preset-fbjs@3.4.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-jest@29.6.3(@babel/core@7.29.0):
+  babel-preset-jest@29.6.3(@babel/core@7.29.0(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0(supports-color@8.1.1))
     optional: true
 
-  babel-preset-jest@30.2.0(@babel/core@7.29.0):
+  babel-preset-jest@30.2.0(@babel/core@7.29.0(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       babel-plugin-jest-hoist: 30.2.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0(supports-color@8.1.1))
 
   bail@2.0.2: {}
 
@@ -27042,11 +27093,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@1.20.4:
+  body-parser@1.20.4(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -27540,11 +27591,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -27583,10 +27634,10 @@ snapshots:
 
   connect-history-api-fallback@2.0.0: {}
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
+      debug: 2.6.9(supports-color@8.1.1)
+      finalhandler: 1.1.2(supports-color@8.1.1)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -27750,14 +27801,14 @@ snapshots:
       jest-worker: 24.9.0
       throat: 4.1.0
 
-  create-jest-runner@1.0.0(@jest/test-result@30.2.0)(jest-runner@30.2.0):
+  create-jest-runner@1.0.0(@jest/test-result@30.2.0)(jest-runner@30.2.0(supports-color@8.1.1)):
     dependencies:
       chalk: 4.1.2
       jest-worker: 30.2.0
       p-limit: 3.1.0
     optionalDependencies:
       '@jest/test-result': 30.2.0
-      jest-runner: 30.2.0
+      jest-runner: 30.2.0(supports-color@8.1.1)
 
   create-require@1.1.1: {}
 
@@ -27811,7 +27862,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@6.11.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  css-loader@6.11.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.12)
       postcss: 8.5.12
@@ -27822,9 +27873,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
-  css-minimizer-webpack-plugin@8.0.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  css-minimizer-webpack-plugin@8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.27.7)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.7(postcss@8.5.12)
@@ -27832,7 +27883,11 @@ snapshots:
       postcss: 8.5.12
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
+    optionalDependencies:
+      clean-css: 5.3.3
+      csso: 5.0.5
+      esbuild: 0.27.7
 
   css-select@4.3.0:
     dependencies:
@@ -28049,9 +28104,11 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
   debug@3.2.7(supports-color@8.1.1):
     dependencies:
@@ -28059,17 +28116,23 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  debug@4.3.4:
+  debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.0:
+  debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.1:
+  debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -28210,10 +28273,10 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port-alt@1.1.6:
+  detect-port-alt@1.1.6(supports-color@8.1.1):
     dependencies:
       address: 1.2.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28719,14 +28782,14 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-compat-utils@0.5.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       semver: 7.7.4
 
-  eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
 
   eslint-formatter-pretty@4.1.0:
     dependencies:
@@ -28739,7 +28802,7 @@ snapshots:
       string-width: 4.2.3
       supports-hyperlinks: 2.3.0
 
-  eslint-import-resolver-node@0.3.9:
+  eslint-import-resolver-node@0.3.9(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.1
@@ -28747,45 +28810,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-cypress@2.15.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-cypress@2.15.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       globals: 13.24.0
 
-  eslint-plugin-es-x@7.8.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-es-x@7.8.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-compat-utils: 0.5.1(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
+      eslint-compat-utils: 0.5.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -28794,9 +28857,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -28808,31 +28871,31 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest-dom@4.0.3(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jest-dom@4.0.3(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 8.20.1
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       requireindex: 1.2.0
 
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2):
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      jest: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
+      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -28842,7 +28905,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -28851,12 +28914,12 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-n@17.23.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
+  eslint-plugin-n@17.23.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(typescript@5.9.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       enhanced-resolve: 5.19.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.2(jiti@2.6.1))
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       get-tsconfig: 4.13.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -28866,19 +28929,19 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-prettier@4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@2.8.8):
+  eslint-plugin-prettier@4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@2.8.8):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     optionalDependencies:
-      eslint-config-prettier: 8.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-config-prettier: 8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -28886,7 +28949,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -28900,11 +28963,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-testing-library@7.15.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
+  eslint-plugin-testing-library@7.15.4(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -28927,14 +28990,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
+      '@eslint/config-array': 0.21.1(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3
+      '@eslint/eslintrc': 3.3.3(supports-color@8.1.1)
       '@eslint/js': 9.39.2
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -29097,21 +29160,21 @@ snapshots:
       lodash: 4.18.1
       winston: 3.17.0
 
-  express@4.22.0:
+  express@4.22.0(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4
+      body-parser: 1.20.4(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -29123,8 +29186,8 @@ snapshots:
       qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.1
-      serve-static: 1.16.2
+      send: 0.19.1(supports-color@8.1.1)
+      serve-static: 1.16.2(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -29262,11 +29325,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  file-loader@6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   file-match@1.0.2:
     dependencies:
@@ -29290,9 +29353,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -29302,9 +29365,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@1.3.2:
+  finalhandler@1.3.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -29386,9 +29449,13 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.16.0(debug@4.4.1):
+  follow-redirects@1.16.0(debug@4.4.1(supports-color@8.1.1)):
     optionalDependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
+
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -29406,7 +29473,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -29421,7 +29488,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.2
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   form-data@3.0.4:
     dependencies:
@@ -29601,7 +29668,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5:
+  get-uri@6.0.5(supports-color@8.1.1):
     dependencies:
       basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
@@ -29821,9 +29888,9 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  graphql-config@5.1.5(@types/node@22.19.11)(graphql@16.11.0)(typescript@5.9.2):
+  graphql-config@5.1.5(@types/node@22.19.11)(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
-      '@graphql-tools/graphql-file-loader': 8.1.6(graphql@16.11.0)
+      '@graphql-tools/graphql-file-loader': 8.1.6(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/json-file-loader': 8.0.24(graphql@16.11.0)
       '@graphql-tools/load': 8.1.6(graphql@16.11.0)
       '@graphql-tools/merge': 9.1.5(graphql@16.11.0)
@@ -29845,9 +29912,9 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  graphql-config@5.1.5(@types/node@22.19.17)(graphql@16.11.0)(typescript@5.9.2):
+  graphql-config@5.1.5(@types/node@22.19.17)(graphql@16.11.0)(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
-      '@graphql-tools/graphql-file-loader': 8.1.6(graphql@16.11.0)
+      '@graphql-tools/graphql-file-loader': 8.1.6(graphql@16.11.0)(supports-color@8.1.1)
       '@graphql-tools/json-file-loader': 8.0.24(graphql@16.11.0)
       '@graphql-tools/load': 8.1.6(graphql@16.11.0)
       '@graphql-tools/merge': 9.1.5(graphql@16.11.0)
@@ -30046,7 +30113,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)):
+  html-webpack-plugin@5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -30054,17 +30121,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)
-
-  html-webpack-plugin@5.6.3(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-    optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -30102,32 +30159,32 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@6.1.1:
+  http-proxy-agent@6.1.1(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -30136,10 +30193,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.1)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -30150,21 +30207,21 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@6.2.1:
+  https-proxy-agent@6.2.1(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -30644,18 +30701,18 @@ snapshots:
     dependencies:
       append-transform: 2.0.0
 
-  istanbul-lib-instrument@4.0.3:
+  istanbul-lib-instrument@4.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@5.2.1:
+  istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -30664,9 +30721,9 @@ snapshots:
       - supports-color
     optional: true
 
-  istanbul-lib-instrument@6.0.3:
+  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -30689,7 +30746,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1:
+  istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
@@ -30697,7 +30754,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       debug: 4.4.3(supports-color@8.1.1)
@@ -30742,10 +30799,10 @@ snapshots:
       jest-util: 30.2.0
       p-limit: 3.1.0
 
-  jest-circus@30.2.0(babel-plugin-macros@3.1.0):
+  jest-circus@30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.2.0
-      '@jest/expect': 30.2.0
+      '@jest/expect': 30.2.0(supports-color@8.1.1)
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       '@types/node': 22.19.17
@@ -30756,8 +30813,8 @@ snapshots:
       jest-each: 30.2.0
       jest-matcher-utils: 30.2.0
       jest-message-util: 30.2.0
-      jest-runtime: 30.2.0
-      jest-snapshot: 30.2.0
+      jest-runtime: 30.2.0(supports-color@8.1.1)
+      jest-snapshot: 30.2.0(supports-color@8.1.1)
       jest-util: 30.2.0
       p-limit: 3.1.0
       pretty-format: 30.2.0
@@ -30768,15 +30825,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
+  jest-cli@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      jest-config: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -30787,15 +30844,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)):
+  jest-cli@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      jest-config: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -30806,25 +30863,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
+  jest-config@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.0.1
       '@jest/test-sequencer': 30.2.0
       '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.0)
+      babel-jest: 30.2.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 4.3.1
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)
+      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
       jest-docblock: 30.2.0
       jest-environment-node: 30.2.0
       jest-regex-util: 30.0.1
       jest-resolve: 30.2.0
-      jest-runner: 30.2.0
+      jest-runner: 30.2.0(supports-color@8.1.1)
       jest-util: 30.2.0
       jest-validate: 30.2.0
       micromatch: 4.0.8
@@ -30839,25 +30896,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
+  jest-config@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.0.1
       '@jest/test-sequencer': 30.2.0
       '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.0)
+      babel-jest: 30.2.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 4.3.1
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)
+      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
       jest-docblock: 30.2.0
       jest-environment-node: 30.2.0
       jest-regex-util: 30.0.1
       jest-resolve: 30.2.0
-      jest-runner: 30.2.0
+      jest-runner: 30.2.0(supports-color@8.1.1)
       jest-util: 30.2.0
       jest-validate: 30.2.0
       micromatch: 4.0.8
@@ -30872,40 +30929,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-runner: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.17
-      ts-node: 10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-dev-server@8.0.5:
+  jest-dev-server@8.0.5(debug@4.4.1(supports-color@8.1.1)):
     dependencies:
       chalk: 4.1.2
       cwd: 0.10.0
@@ -30913,7 +30937,7 @@ snapshots:
       prompts: 2.4.2
       spawnd: 8.0.5
       tree-kill: 1.2.2
-      wait-on: 7.2.0
+      wait-on: 7.2.0(debug@4.4.1(supports-color@8.1.1))
     transitivePeerDependencies:
       - debug
 
@@ -30943,13 +30967,13 @@ snapshots:
       jest-util: 30.2.0
       pretty-format: 30.2.0
 
-  jest-environment-jsdom@30.2.0:
+  jest-environment-jsdom@30.2.0(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.2.0
-      '@jest/environment-jsdom-abstract': 30.2.0(jsdom@26.1.0)
+      '@jest/environment-jsdom-abstract': 30.2.0(jsdom@26.1.0(supports-color@8.1.1))
       '@types/jsdom': 21.1.7
       '@types/node': 22.19.17
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -30974,12 +30998,12 @@ snapshots:
       jest-util: 30.2.0
       jest-validate: 30.2.0
 
-  jest-environment-puppeteer@8.0.6(typescript@5.9.2):
+  jest-environment-puppeteer@8.0.6(debug@4.4.1(supports-color@8.1.1))(typescript@5.9.2):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.9.2)
       deepmerge: 4.3.1
-      jest-dev-server: 8.0.5
+      jest-dev-server: 8.0.5(debug@4.4.1(supports-color@8.1.1))
       jest-environment-node: 29.7.0
     transitivePeerDependencies:
       - debug
@@ -31080,14 +31104,14 @@ snapshots:
     optionalDependencies:
       jest-resolve: 30.2.0
 
-  jest-preview@0.3.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
+  jest-preview@0.3.2(postcss@8.5.6)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@svgr/core': 6.5.1
+      '@svgr/core': 6.5.1(supports-color@8.1.1)
       camelcase: 6.3.0
       chalk: 4.1.2
       chokidar: 3.6.0
       commander: 9.5.0
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@8.1.1)
       find-node-modules: 2.1.3
       open: 8.4.2
       postcss-import: 14.1.0(postcss@8.5.6)
@@ -31104,11 +31128,11 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-puppeteer@8.0.6(puppeteer@20.9.0(typescript@5.9.2))(typescript@5.9.2):
+  jest-puppeteer@8.0.6(debug@4.4.1(supports-color@8.1.1))(puppeteer@20.9.0(supports-color@8.1.1)(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
       expect-puppeteer: 8.0.5
-      jest-environment-puppeteer: 8.0.6(typescript@5.9.2)
-      puppeteer: 20.9.0(typescript@5.9.2)
+      jest-environment-puppeteer: 8.0.6(debug@4.4.1(supports-color@8.1.1))(typescript@5.9.2)
+      puppeteer: 20.9.0(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - debug
       - typescript
@@ -31118,10 +31142,10 @@ snapshots:
 
   jest-regex-util@30.0.1: {}
 
-  jest-resolve-dependencies@30.2.0:
+  jest-resolve-dependencies@30.2.0(supports-color@8.1.1):
     dependencies:
       jest-regex-util: 30.0.1
-      jest-snapshot: 30.2.0
+      jest-snapshot: 30.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31136,14 +31160,14 @@ snapshots:
       slash: 3.0.0
       unrs-resolver: 1.11.1
 
-  jest-runner-eslint@2.3.0(eslint@9.39.2(jiti@2.6.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))):
+  jest-runner-eslint@2.3.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 7.1.0
       create-jest-runner: 0.11.2
       dot-prop: 6.0.1
-      eslint: 9.39.2(jiti@2.6.1)
-      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
+      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@jest/test-result'
       - jest-runner
@@ -31154,12 +31178,12 @@ snapshots:
       create-jest-runner: 0.5.3
       lodash.kebabcase: 4.1.1
 
-  jest-runner@30.2.0:
+  jest-runner@30.2.0(supports-color@8.1.1):
     dependencies:
       '@jest/console': 30.2.0
       '@jest/environment': 30.2.0
       '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
+      '@jest/transform': 30.2.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
       '@types/node': 22.19.17
       chalk: 4.1.2
@@ -31172,7 +31196,7 @@ snapshots:
       jest-leak-detector: 30.2.0
       jest-message-util: 30.2.0
       jest-resolve: 30.2.0
-      jest-runtime: 30.2.0
+      jest-runtime: 30.2.0(supports-color@8.1.1)
       jest-util: 30.2.0
       jest-watcher: 30.2.0
       jest-worker: 30.2.0
@@ -31181,14 +31205,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.2.0:
+  jest-runtime@30.2.0(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
-      '@jest/globals': 30.2.0
+      '@jest/globals': 30.2.0(supports-color@8.1.1)
       '@jest/source-map': 30.0.1
       '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
+      '@jest/transform': 30.2.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
       '@types/node': 22.19.17
       chalk: 4.1.2
@@ -31201,7 +31225,7 @@ snapshots:
       jest-mock: 30.2.0
       jest-regex-util: 30.0.1
       jest-resolve: 30.2.0
-      jest-snapshot: 30.2.0
+      jest-snapshot: 30.2.0(supports-color@8.1.1)
       jest-util: 30.2.0
       slash: 3.0.0
       strip-bom: 4.0.0
@@ -31213,19 +31237,19 @@ snapshots:
       chalk: 4.1.2
       jest-util: 26.6.2
 
-  jest-snapshot@30.2.0:
+  jest-snapshot@30.2.0(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
       '@jest/expect-utils': 30.2.0
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.2.0
-      '@jest/transform': 30.2.0
+      '@jest/transform': 30.2.0(supports-color@8.1.1)
       '@jest/types': 30.2.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0(supports-color@8.1.1))
       chalk: 4.1.2
       expect: 30.2.0
       graceful-fs: 4.2.11
@@ -31275,22 +31299,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.2.0
 
-  jest-watch-typeahead@3.0.1(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))):
+  jest-watch-typeahead@3.0.1(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))):
     dependencies:
       ansi-escapes: 7.2.0
       chalk: 5.6.2
-      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
-      jest-regex-util: 30.0.1
-      jest-watcher: 30.2.0
-      slash: 5.1.0
-      string-length: 6.0.0
-      strip-ansi: 7.1.2
-
-  jest-watch-typeahead@3.0.1(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))):
-    dependencies:
-      ansi-escapes: 7.2.0
-      chalk: 5.6.2
-      jest: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-regex-util: 30.0.1
       jest-watcher: 30.2.0
       slash: 5.1.0
@@ -31347,12 +31360,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
+  jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      jest-cli: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -31360,12 +31373,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)):
+  jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      jest-cli: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -31404,18 +31417,18 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jscodeshift@0.16.1(@babel/preset-env@7.28.5(@babel/core@7.29.0)):
+  jscodeshift@0.16.1(@babel/preset-env@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.2
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-flow': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/register': 7.28.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-flow': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/register': 7.28.3(@babel/core@7.29.0(supports-color@8.1.1))
       chalk: 4.1.2
       flow-parser: 0.291.0
       graceful-fs: 4.2.11
@@ -31426,11 +31439,11 @@ snapshots:
       temp: 0.9.4
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  jsdom@21.1.2:
+  jsdom@21.1.2(supports-color@8.1.1):
     dependencies:
       abab: 2.0.6
       acorn: 8.15.0
@@ -31442,8 +31455,8 @@ snapshots:
       escodegen: 2.1.0
       form-data: 4.0.5
       html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.22
       parse5: 7.3.0
@@ -31463,14 +31476,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.22
       parse5: 7.3.0
@@ -31927,13 +31940,13 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-visit: 4.1.2
 
-  mdast-util-from-markdown@1.3.1:
+  mdast-util-from-markdown@1.3.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.11
       decode-named-character-reference: 1.2.0
       mdast-util-to-string: 3.2.0
-      micromark: 3.2.0
+      micromark: 3.2.0(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 1.1.0
       micromark-util-decode-string: 1.1.0
       micromark-util-normalize-identifier: 1.1.0
@@ -32176,7 +32189,7 @@ snapshots:
 
   micromark-util-types@1.1.0: {}
 
-  micromark@3.2.0:
+  micromark@3.2.0(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@8.1.1)
@@ -32221,11 +32234,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   minimalistic-assert@1.0.1: {}
 
@@ -32273,11 +32286,11 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  moment-locales-webpack-plugin@1.2.0(moment@2.30.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  moment-locales-webpack-plugin@1.2.0(moment@2.30.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       lodash.difference: 4.5.0
       moment: 2.30.1
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   moment-timezone@0.6.0:
     dependencies:
@@ -32295,10 +32308,10 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@1.3.5(@types/node@22.19.11)(typescript@5.9.2):
+  msw@1.3.5(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
       '@mswjs/cookies': 0.2.2
-      '@mswjs/interceptors': 0.17.10
+      '@mswjs/interceptors': 0.17.10(supports-color@8.1.1)
       '@open-draft/until': 1.0.3
       '@types/cookie': 0.4.1
       '@types/js-levenshtein': 1.1.3
@@ -32323,10 +32336,10 @@ snapshots:
       - encoding
       - supports-color
 
-  msw@1.3.5(@types/node@22.19.17)(typescript@5.9.2):
+  msw@1.3.5(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
       '@mswjs/cookies': 0.2.2
-      '@mswjs/interceptors': 0.17.10
+      '@mswjs/interceptors': 0.17.10(supports-color@8.1.1)
       '@open-draft/until': 1.0.3
       '@types/cookie': 0.4.1
       '@types/js-levenshtein': 1.1.3
@@ -32385,7 +32398,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  needle@2.9.1:
+  needle@2.9.1(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
       iconv-lite: 0.4.24
@@ -32448,11 +32461,11 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pre-gyp@0.13.0:
+  node-pre-gyp@0.13.0(supports-color@8.1.1):
     dependencies:
       detect-libc: 1.0.3
       mkdirp: 0.5.6
-      needle: 2.9.1
+      needle: 2.9.1(supports-color@8.1.1)
       nopt: 4.0.3
       npm-packlist: 1.4.8
       npmlog: 4.1.2
@@ -32557,7 +32570,7 @@ snapshots:
 
   nwsapi@2.2.22: {}
 
-  nyc@15.1.0:
+  nyc@15.1.0(supports-color@8.1.1):
     dependencies:
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
@@ -32571,10 +32584,10 @@ snapshots:
       glob: 7.2.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-hook: 3.0.0
-      istanbul-lib-instrument: 4.0.3
+      istanbul-lib-instrument: 4.0.3(supports-color@8.1.1)
       istanbul-lib-processinfo: 2.0.3
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
       istanbul-reports: 3.2.0
       make-dir: 3.1.0
       node-preload: 0.2.1
@@ -32837,16 +32850,16 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0:
+  pac-proxy-agent@7.2.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      get-uri: 6.0.5(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -33122,13 +33135,13 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)
 
-  postcss-loader@6.2.1(postcss@8.5.6)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  postcss-loader@6.2.1(postcss@8.5.6)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.5.6
       semver: 7.7.4
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -33392,16 +33405,16 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.3.0:
+  proxy-agent@6.3.0(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
       proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -33449,12 +33462,12 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
-  puppeteer-core@20.9.0(typescript@5.9.2):
+  puppeteer-core@20.9.0(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
-      '@puppeteer/browsers': 1.4.6(typescript@5.9.2)
+      '@puppeteer/browsers': 1.4.6(supports-color@8.1.1)(typescript@5.9.2)
       chromium-bidi: 0.4.16(devtools-protocol@0.0.1147663)
       cross-fetch: 4.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       devtools-protocol: 0.0.1147663
       ws: 8.13.0
     optionalDependencies:
@@ -33468,11 +33481,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@20.9.0(typescript@5.9.2):
+  puppeteer@20.9.0(supports-color@8.1.1)(typescript@5.9.2):
     dependencies:
-      '@puppeteer/browsers': 1.4.6(typescript@5.9.2)
+      '@puppeteer/browsers': 1.4.6(supports-color@8.1.1)(typescript@5.9.2)
       cosmiconfig: 8.2.0
-      puppeteer-core: 20.9.0(typescript@5.9.2)
+      puppeteer-core: 20.9.0(supports-color@8.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -33564,18 +33577,18 @@ snapshots:
       react-stately: 3.47.0(react@19.0.0)
       use-sync-external-store: 1.6.0(react@19.0.0)
 
-  react-dev-utils@12.0.1(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  react-dev-utils@12.0.1(supports-color@8.1.1)(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       address: 1.2.2
       browserslist: 4.28.1
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      detect-port-alt: 1.1.6
+      detect-port-alt: 1.1.6(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -33590,7 +33603,7 @@ snapshots:
       shell-quote: 1.8.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -33739,11 +33752,11 @@ snapshots:
       '@remix-run/router': 1.23.2
       react: 19.0.0
 
-  react-select@5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-select@5.10.2(@types/react@19.2.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1):
     dependencies:
       '@babel/runtime': 7.28.6
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.0.0)(supports-color@8.1.1)
       '@floating-ui/dom': 1.7.4
       '@types/react-transition-group': 4.4.12(@types/react@19.2.4)
       memoize-one: 6.0.0
@@ -33996,10 +34009,10 @@ snapshots:
       micromark-extension-frontmatter: 1.1.1
       unified: 10.1.2
 
-  remark-parse@10.0.2:
+  remark-parse@10.0.2(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 3.0.15
-      mdast-util-from-markdown: 1.3.1
+      mdast-util-from-markdown: 1.3.1(supports-color@8.1.1)
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
@@ -34294,9 +34307,9 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@0.19.0:
+  send@0.19.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -34312,9 +34325,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@0.19.1:
+  send@0.19.1(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -34336,10 +34349,10 @@ snapshots:
       tslib: 2.8.1
       upper-case-first: 2.0.2
 
-  sentry-testkit@6.2.2:
+  sentry-testkit@6.2.2(supports-color@8.1.1):
     dependencies:
-      body-parser: 1.20.4
-      express: 4.22.0
+      body-parser: 1.20.4(supports-color@8.1.1)
+      express: 4.22.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34350,11 +34363,11 @@ snapshots:
 
   serialize-javascript@7.0.5: {}
 
-  serve-index@1.9.1:
+  serve-index@1.9.1(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       escape-html: 1.0.3
       http-errors: 1.6.3
       mime-types: 2.1.35
@@ -34362,12 +34375,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2:
+  serve-static@1.16.2(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34584,7 +34597,7 @@ snapshots:
       uuid: 8.3.2
       websocket-driver: 0.7.4
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -34654,7 +34667,7 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       detect-node: 2.1.0
@@ -34665,13 +34678,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34726,16 +34739,16 @@ snapshots:
       stack-generator: 2.0.10
       stacktrace-gps: 3.1.2
 
-  start-server-and-test@2.0.13:
+  start-server-and-test@2.0.13(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
       bluebird: 3.7.2
       check-more-types: 2.24.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
-      wait-on: 8.0.4(debug@4.4.1)
+      wait-on: 8.0.4(debug@4.4.1(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -34966,9 +34979,9 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  style-loader@3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  style-loader@3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   style-search@0.1.0: {}
 
@@ -34982,32 +34995,32 @@ snapshots:
       postcss: 8.5.12
       postcss-selector-parser: 7.1.1
 
-  stylelint-config-prettier@9.0.5(stylelint@14.16.1):
+  stylelint-config-prettier@9.0.5(stylelint@14.16.1(supports-color@8.1.1)):
     dependencies:
-      stylelint: 14.16.1
+      stylelint: 14.16.1(supports-color@8.1.1)
 
-  stylelint-config-recommended@8.0.0(stylelint@14.16.1):
+  stylelint-config-recommended@8.0.0(stylelint@14.16.1(supports-color@8.1.1)):
     dependencies:
-      stylelint: 14.16.1
+      stylelint: 14.16.1(supports-color@8.1.1)
 
-  stylelint-config-standard@26.0.0(stylelint@14.16.1):
+  stylelint-config-standard@26.0.0(stylelint@14.16.1(supports-color@8.1.1)):
     dependencies:
-      stylelint: 14.16.1
-      stylelint-config-recommended: 8.0.0(stylelint@14.16.1)
+      stylelint: 14.16.1(supports-color@8.1.1)
+      stylelint-config-recommended: 8.0.0(stylelint@14.16.1(supports-color@8.1.1))
 
-  stylelint-order@5.0.0(stylelint@14.16.1):
+  stylelint-order@5.0.0(stylelint@14.16.1(supports-color@8.1.1)):
     dependencies:
       postcss: 8.5.12
       postcss-sorting: 7.0.1(postcss@8.5.12)
-      stylelint: 14.16.1
+      stylelint: 14.16.1(supports-color@8.1.1)
 
-  stylelint-value-no-unknown-custom-properties@4.0.0(stylelint@14.16.1):
+  stylelint-value-no-unknown-custom-properties@4.0.0(stylelint@14.16.1(supports-color@8.1.1)):
     dependencies:
       postcss-value-parser: 4.2.0
       resolve: 1.22.11
-      stylelint: 14.16.1
+      stylelint: 14.16.1(supports-color@8.1.1)
 
-  stylelint@14.16.1:
+  stylelint@14.16.1(supports-color@8.1.1):
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.1.2)
       balanced-match: 2.0.0
@@ -35086,11 +35099,11 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svg-url-loader@7.1.1(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  svg-url-loader@7.1.1(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      file-loader: 6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       loader-utils: 2.0.4
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   svgo@4.0.1:
     dependencies:
@@ -35182,26 +35195,17 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)):
+  terser-webpack-plugin@5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     optionalDependencies:
       '@swc/core': 1.15.1(@swc/helpers@0.5.23)
+      esbuild: 0.27.7
       uglify-js: 3.19.3
-
-  terser-webpack-plugin@5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
-    optionalDependencies:
-      '@swc/core': 1.15.1(@swc/helpers@0.5.23)
 
   terser@5.46.0:
     dependencies:
@@ -35248,14 +35252,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  thread-loader@3.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  thread-loader@3.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.1
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   throat@4.1.0: {}
 
@@ -35394,12 +35398,12 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  ts-jest@29.2.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2)))(typescript@5.9.2):
+  ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.2))
+      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -35408,10 +35412,32 @@ snapshots:
       typescript: 5.9.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 29.7.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-jest: 29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      esbuild: 0.27.7
+    optional: true
+
+  ts-jest@29.2.6(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.27.7)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2)))(typescript@5.9.2):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.2))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      typescript: 5.9.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      esbuild: 0.27.7
     optional: true
 
   ts-log@2.2.7: {}
@@ -35934,15 +35960,15 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel@24.2.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  vercel@24.2.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1):
     dependencies:
       '@vercel/build-utils': 3.1.1
       '@vercel/go': 1.4.4
       '@vercel/next': 2.9.0
       '@vercel/node': 1.15.4
       '@vercel/python': 2.3.4
-      '@vercel/redwood': 0.8.4
-      '@vercel/remix': 0.0.2(@vercel/node@1.15.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@vercel/redwood': 0.8.4(supports-color@8.1.1)
+      '@vercel/remix': 0.0.2(@vercel/node@1.15.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(supports-color@8.1.1)
       '@vercel/ruby': 1.3.7
       '@vercel/static-build': 0.26.0
       update-notifier: 4.1.0
@@ -36001,9 +36027,9 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  wait-on@7.2.0:
+  wait-on@7.2.0(debug@4.4.1(supports-color@8.1.1)):
     dependencies:
-      axios: 1.16.0(debug@4.4.1)
+      axios: 1.16.0(debug@4.4.1(supports-color@8.1.1))
       joi: 17.13.3
       lodash: 4.18.1
       minimist: 1.2.8
@@ -36011,9 +36037,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  wait-on@8.0.4(debug@4.4.1):
+  wait-on@8.0.4(debug@4.4.1(supports-color@8.1.1)):
     dependencies:
-      axios: 1.16.0(debug@4.4.1)
+      axios: 1.16.0(debug@4.4.1(supports-color@8.1.1))
       joi: 17.13.3
       lodash: 4.18.1
       minimist: 1.2.8
@@ -36082,16 +36108,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@5.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  webpack-dev-middleware@5.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
-  webpack-dev-server@4.15.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -36104,13 +36130,13 @@ snapshots:
       bonjour-service: 1.3.0
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1
+      compression: 1.8.1(supports-color@8.1.1)
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.22.0
+      express: 4.22.0(supports-color@8.1.1)
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
       ipaddr.js: 2.2.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -36118,13 +36144,13 @@ snapshots:
       rimraf: 5.0.10
       schema-utils: 4.3.3
       selfsigned: 2.4.1
-      serve-index: 1.9.1
+      serve-index: 1.9.1(supports-color@8.1.1)
       sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      spdy: 4.0.2(supports-color@8.1.1)
+      webpack-dev-middleware: 5.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -36133,7 +36159,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)):
+  webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -36157,7 +36183,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23)))
+      terser-webpack-plugin: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3))
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -36165,45 +36191,13 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(uglify-js@3.19.3))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpackbar@5.0.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))):
+  webpackbar@5.0.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)):
     dependencies:
       chalk: 4.1.2
       consola: 2.15.3
       pretty-time: 1.1.0
       std-env: 3.10.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.27.7)(uglify-js@3.19.3)
 
   websocket-driver@0.7.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,32 @@ packages:
 # command, giving developers earlier feedback. Requires pnpm ≥ 10.12.1.
 catalogMode: strict
 
+# Skip interactive TTY prompt when pnpm needs to purge node_modules on a
+# version/store change. Safe in local dev — CI already bypasses this via CI=true.
+confirmModulesPurge: false
+
 # Drop catalog entries whose last consumer is removed. Idempotent in steady
 # state (every entry is in use today); guards against silent rot over time.
 cleanupUnusedCatalogs: true
+
+# Explicit allowlist of packages permitted to run lifecycle scripts (preinstall,
+# install, postinstall) during `pnpm install`. In pnpm v11, packages not listed
+# here are blocked by default (strictDepBuilds). Audit any new dep that carries
+# build scripts and add it here before merging.
+allowBuilds:
+  '@commercetools/nimbus': true
+  '@percy/core': true
+  '@swc/core': true
+  core-js: true
+  core-js-pure: true
+  cypress: true
+  esbuild: true
+  jest-preview: true
+  msw: true
+  puppeteer: true
+  sharp: true
+  unrs-resolver: true
+  vercel: true
 
 # Transitive-dep pins for Dependabot security advisories and known-good
 # baselines. Yarn-style `package@range` keys are preserved so a single
@@ -106,7 +129,6 @@ overrides:
 
 catalog:
   '@commercetools-community-kit/i18n': ^0.3.0
-  '@commercetools-docs/ui-kit': 24.11.0
   '@commercetools/api-request-builder': 6.0.0
   '@commercetools/composable-commerce-test-data': 13.12.0
   '@commercetools/http-user-agent': 3.0.0
@@ -149,7 +171,6 @@ catalog:
   '@types/triple-beam': 1.3.5
   '@types/webpack-bundle-analyzer': ^4.6.0
   '@types/webpack-env': ^1.18.8
-  '@vercel/node': ^5.0.0
   ajv: 8.18.0
   autoprefixer: ^10.4.15
   buffer: 6.0.3
@@ -168,7 +189,6 @@ catalog:
   deep-diff: 1.0.2
   dompurify: ^3.0.0
   dotenv: 16.6.1
-  dotenv-flow: ^4.0.0
   execa: 5.1.1
   express: ^4.21.2
   express-winston: 4.2.0
@@ -178,7 +198,6 @@ catalog:
   fs-extra: 10.1.0
   fuse.js: 6.6.2
   glob: ^10.5.0
-  graphql-anywhere: ^4.2.8
   graphql-request: 5.2.0
   history-query-enhancer: 1.0.4
   is-retina: 1.0.3
@@ -199,7 +218,6 @@ catalog:
   postcss-load-config: 3.1.4
   prompts: ^2.4.2
   puppeteer: 20.9.0
-  qs: ^6.11.2
   qss: 2.0.3
   querystring-es3: ^0.2.1
   replace: 1.2.2
@@ -216,12 +234,22 @@ catalog:
   unfetch: 4.2.0
   url: ^0.11.0
   uuid: 14.0.0
-  vercel: 24.2.5
   wait-for-observables: 1.0.3
   winston: 3.17.0
   yaml: ^2.6.1
 
 catalogs:
+  apps:
+    # Exact-pinned deps used exclusively by private/application packages
+    # (playground). Never reference these from published packages in packages/*
+    # or packages-backend/*; use catalog: (default) for shared deps instead.
+    '@commercetools-docs/ui-kit': 24.11.0
+    '@vercel/node': 5.5.5
+    dotenv-flow: 4.1.0
+    graphql-anywhere: 4.2.8
+    qs: 6.14.0
+    vercel: 24.2.5
+
   apollo:
     '@apollo/client': 3.13.9
     graphql: 16.11.0
@@ -555,9 +583,3 @@ catalogs:
   nimbus:
     '@commercetools/nimbus': 3.2.0
     '@commercetools/nimbus-icons': ^3.2.0
-    '@commercetools/nimbus-tokens': ^3.2.0
-    '@chakra-ui/react': ^3.36.0
-    slate: ^0.123.0
-    slate-history: ^0.115.0
-    slate-hyperscript: ^0.115.0
-    slate-react: ^0.123.0


### PR DESCRIPTION
## FEC-970: Supply Chain Hardening

Upgrades this repo to pnpm v11 and applies the full set of supply chain hardening measures called out in the FEC-964 epic.

### Changes

**pnpm v11**
- Bumped `packageManager` to `pnpm@11.14` (with SHA integrity) in root and `playground/package.json`
- Updated engine constraint from `>=10` to `>=11`
- Added `confirmModulesPurge: false` to `pnpm-workspace.yaml` so local installs don't require a TTY when pnpm needs to purge `node_modules` on a store/version change (CI is unaffected — it sets `CI=true` which already bypasses the prompt)

**`allowBuilds` allowlist**
pnpm v11 blocks all dependency lifecycle scripts by default unless explicitly permitted. Added an `allowBuilds` map to `pnpm-workspace.yaml` covering the 13 packages in this repo that run install-time scripts: `@commercetools/nimbus`, `@percy/core`, `@swc/core`, `core-js`, `core-js-pure`, `cypress`, `esbuild`, `jest-preview`, `msw`, `puppeteer`, `sharp`, `unrs-resolver`, `vercel`. Any new dep that carries build scripts must be audited and added here before merging.

**`catalog:apps` for private packages**
Added a new named catalog for deps that are exclusively consumed by private/application packages (i.e. never by any published `packages/*` or `packages-backend/*`). Migrated 6 entries out of the default `catalog:` into `catalog:apps` with exact-pinned versions: `@commercetools-docs/ui-kit`, `@vercel/node`, `dotenv-flow`, `graphql-anywhere`, `qs`, `vercel`. Updated `playground/package.json` to reference `catalog:apps` for each. The workspace constraints check enforces this separation going forward.

**GitHub Actions pinned to commit SHAs**
All external `uses:` references across workflows and composite actions are now pinned to commit SHAs with the version tag preserved as a comment. Actions pinned: `actions/checkout`, `actions/cache`, `actions/setup-node`, `actions/stale`, `codecov/codecov-action`, `pnpm/action-setup`, `tibdex/github-app-token`, `xt0rted/pull-request-comment-branch`, `changesets/action`, and the `agilepathway/pull-request-label-checker` Docker image. Local composite actions (`uses: ./.github/actions/*` and `uses: ./.github/workflows/*`) are tied to the checkout by definition and need no pinning.

### Testing

Ran the full locally-executable CI suite post-install and post-build — all clean:
- `pnpm check:workspace-constraints` ✅
- `pnpm check:package-shape` ✅
- `pnpm typecheck` + `typecheck:cypress` + `typecheck:starters` ✅
- `pnpm lint` (1072/1072) ✅
- `pnpm test:node` (66/66) ✅
- `pnpm test` — two pre-existing failures unrelated to these changes (haste map collision on `codemod/build/` after a local build; `EPERM` on `~/.commercetools/mc-credentials.json` in `mc-scripts` tests)
