### PR TITLE
Fix/nimbus button secondary variant

### DIFF
--- a/.changeset/save-toolbar-portal-target.md
+++ b/.changeset/save-toolbar-portal-target.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/constants': minor
+'@commercetools-frontend/application-shell': minor
+---
+
+Add a portal target (`mc-main-container-portal`) inside `MainContainer` so that fixed-position components like `SaveToolbar` can portal into the MC content area and automatically constrain their width to the main pane, excluding the agent side panel.

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -18,7 +18,11 @@ import {
   selectUserLanguageFromStorage,
   type TApplicationContext,
 } from '@commercetools-frontend/application-shell-connectors';
-import { DOMAINS, LOGOUT_REASONS } from '@commercetools-frontend/constants';
+import {
+  DOMAINS,
+  LOGOUT_REASONS,
+  MC_MAIN_CONTAINER_PORTAL_ID,
+} from '@commercetools-frontend/constants';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';
@@ -428,6 +432,15 @@ export const ApplicationShellAuthenticated = (
                                 </Route>
                               </Switch>
                             </div>
+                            <div
+                              id={MC_MAIN_CONTAINER_PORTAL_ID}
+                              css={css`
+                                position: sticky;
+                                bottom: 0;
+                                z-index: 9999;
+                                pointer-events: none;
+                              `}
+                            />
                           </MainContainer>
                         )}
                       </div>

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -42,6 +42,7 @@ export const PERMISSION_GROUP_NAME_REGEX =
 // DOM elements
 export const PORTALS_CONTAINER_ID = 'portals-container';
 export const PORTALS_CONTAINER_INDENTATION_SIZE = '48px';
+export const MC_MAIN_CONTAINER_PORTAL_ID = 'mc-main-container-portal';
 
 // Links
 export const SUPPORT_PORTAL_URL = 'https://support.commercetools.com';

--- a/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
+++ b/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
@@ -1,17 +1,32 @@
-import { type ReactNode, useState, useEffect } from 'react';
 import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+} from 'react';
+import {
+  Box,
+  Button,
+  Flex,
   NimbusProvider,
-  Splitter,
   Region,
+  Splitter,
   useRegion,
 } from '@commercetools/nimbus';
+import { createPortal } from 'react-dom';
 import {
   REGIONS,
   type TApplicationShellSplitterValue,
 } from '@commercetools-frontend/application-shell';
+import { MC_MAIN_CONTAINER_PORTAL_ID } from '@commercetools-frontend/constants';
 import { Suite, Spec } from '../../test-utils';
 
 export const routePath = '/shell-splitter';
+
+let shellCounter = 0;
+
+const PortalIdContext = createContext<string>(MC_MAIN_CONTAINER_PORTAL_ID);
 
 type SplitterShellProps = {
   defaultOpen?: boolean;
@@ -23,6 +38,9 @@ const SplitterShell = ({
   children,
 }: SplitterShellProps) => {
   const [open, setOpen] = useState(defaultOpen);
+  const [portalId] = useState(
+    () => `${MC_MAIN_CONTAINER_PORTAL_ID}-${shellCounter++}`
+  );
 
   const controller = {
     isCollapsed: !open,
@@ -37,64 +55,158 @@ const SplitterShell = ({
       router={{ navigate: () => {} }}
       loadFonts={false}
     >
-      <Splitter.Root
-        orientation="horizontal"
-        defaultSize={30}
-        minSize={20}
-        maxSize={40}
-        collapsible
-        collapsedSize={0}
-        collapsed={!open}
-        onCollapsedChange={(c: boolean) => setOpen(!c)}
-      >
-        <Splitter.Main style={{ containerType: 'inline-size', minWidth: 0 }}>
-          {children}
-        </Splitter.Main>
-        <Splitter.Handle aria-label="Resize side panel" />
-        <Splitter.Aside>
-          <Region name={REGIONS.MC_RIGHT_PANEL} value={controller} />
-        </Splitter.Aside>
-      </Splitter.Root>
+      <PortalIdContext.Provider value={portalId}>
+        <Splitter.Root
+          orientation="horizontal"
+          defaultSize={30}
+          minSize={20}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          collapsed={!open}
+          onCollapsedChange={(c: boolean) => setOpen(!c)}
+          style={{ height: '100%' }}
+        >
+          <Splitter.Main style={{ containerType: 'inline-size', minWidth: 0 }}>
+            <Flex
+              direction="column"
+              height="100%"
+              position="relative"
+              overflow="auto"
+            >
+              <Box flexGrow={1}>{children}</Box>
+              <Box
+                id={portalId}
+                position="sticky"
+                bottom={0}
+                zIndex={9999}
+                pointerEvents="none"
+              />
+            </Flex>
+          </Splitter.Main>
+          <Splitter.Handle aria-label="Resize side panel" />
+          <Splitter.Aside>
+            <Region name={REGIONS.MC_RIGHT_PANEL} value={controller} />
+          </Splitter.Aside>
+        </Splitter.Root>
+      </PortalIdContext.Provider>
     </NimbusProvider>
   );
 };
 SplitterShell.displayName = 'SplitterShell';
 
-const AsideContent = () => {
+const AsideContent = ({ autoExpand = false }: { autoExpand?: boolean }) => {
   const { Region: Filler, value } = useRegion<TApplicationShellSplitterValue>(
     REGIONS.MC_RIGHT_PANEL
   );
 
   useEffect(() => {
-    value?.expand();
-  }, [value]);
+    if (autoExpand) {
+      value?.expand();
+    }
+  }, [value, autoExpand]);
 
   return (
     <Filler>
-      <div style={{ padding: 16, background: '#f5f5f5', height: '100%' }}>
-        <h3 style={{ margin: '0 0 8px' }}>Side Panel</h3>
-        <p style={{ margin: 0 }}>Region-portalled content in the aside pane.</p>
-      </div>
+      <Box padding={4} bg="warning.3" height="100%">
+        <Box as="h3" marginBottom={2}>
+          Side Panel
+        </Box>
+        <Box as="p">Region-portalled content in the aside pane.</Box>
+      </Box>
     </Filler>
   );
 };
 AsideContent.displayName = 'AsideContent';
 
-const MainContent = () => (
-  <div style={{ padding: 24 }}>
-    <h2 style={{ margin: '0 0 8px' }}>Main Content</h2>
-    <p style={{ margin: 0 }}>
+const MainContent = ({ children }: { children?: ReactNode }) => (
+  <Box padding={6} bg="positive.3" height="100%">
+    <Box as="h2" marginBottom={2}>
+      Main Content
+    </Box>
+    <Box as="p" marginBottom={4}>
       This is the main content area inside Splitter.Main.
-    </p>
-  </div>
+    </Box>
+    {children}
+  </Box>
 );
 MainContent.displayName = 'MainContent';
+
+const FakeSaveToolbar = ({
+  visible,
+  onCancel,
+  onSave,
+}: {
+  visible: boolean;
+  onCancel?: () => void;
+  onSave?: () => void;
+}) => {
+  const portalId = useContext(PortalIdContext);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setPortalTarget(document.getElementById(portalId));
+  }, [portalId]);
+
+  if (!visible) return null;
+
+  const toolbar = (
+    <Flex
+      justify="space-between"
+      align="center"
+      paddingX={4}
+      paddingY={3}
+      bg="info.4"
+      borderTopRadius="md"
+      width="100%"
+      pointerEvents="auto"
+      data-testid="fake-save-toolbar"
+    >
+      <Button variant="secondary" onPress={onCancel}>
+        Cancel
+      </Button>
+      <Button variant="solid" onPress={onSave}>
+        Save
+      </Button>
+    </Flex>
+  );
+
+  if (portalTarget) {
+    return createPortal(toolbar, portalTarget);
+  }
+
+  return null;
+};
+FakeSaveToolbar.displayName = 'FakeSaveToolbar';
+
+const ToolbarDemo = () => {
+  const [showToolbar, setShowToolbar] = useState(true);
+
+  return (
+    <>
+      <MainContent>
+        {!showToolbar && (
+          <Button variant="secondary" onPress={() => setShowToolbar(true)}>
+            Show toolbar
+          </Button>
+        )}
+      </MainContent>
+      <AsideContent />
+      <FakeSaveToolbar
+        visible={showToolbar}
+        onCancel={() => setShowToolbar(false)}
+        onSave={() => setShowToolbar(false)}
+      />
+    </>
+  );
+};
+ToolbarDemo.displayName = 'ToolbarDemo';
 
 export const Component = () => (
   <Suite>
     <Spec
       label="ShellSplitter - Aside collapsed (default)"
-      size="l"
+      size="m"
       omitPropsList
     >
       <SplitterShell>
@@ -103,22 +215,40 @@ export const Component = () => (
     </Spec>
     <Spec
       label="ShellSplitter - Aside expanded via Region"
-      size="l"
+      size="m"
       omitPropsList
     >
       <SplitterShell>
         <MainContent />
-        <AsideContent />
+        <AsideContent autoExpand />
       </SplitterShell>
     </Spec>
     <Spec
       label="ShellSplitter - Aside expanded (defaultOpen)"
-      size="l"
+      size="m"
       omitPropsList
     >
       <SplitterShell defaultOpen>
         <MainContent />
         <AsideContent />
+      </SplitterShell>
+    </Spec>
+    <Spec
+      label="ShellSplitter - Save toolbar portaled (aside collapsed, toggleable)"
+      size="m"
+      omitPropsList
+    >
+      <SplitterShell>
+        <ToolbarDemo />
+      </SplitterShell>
+    </Spec>
+    <Spec
+      label="ShellSplitter - Save toolbar portaled (aside expanded, toggleable)"
+      size="m"
+      omitPropsList
+    >
+      <SplitterShell defaultOpen>
+        <ToolbarDemo />
       </SplitterShell>
     </Spec>
   </Suite>

--- a/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
+++ b/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
@@ -162,7 +162,7 @@ const FakeSaveToolbar = ({
       pointerEvents="auto"
       data-testid="fake-save-toolbar"
     >
-      <Button variant="secondary" onPress={onCancel}>
+      <Button variant="subtle" onPress={onCancel}>
         Cancel
       </Button>
       <Button variant="solid" onPress={onSave}>
@@ -186,7 +186,7 @@ const ToolbarDemo = () => {
     <>
       <MainContent>
         {!showToolbar && (
-          <Button variant="secondary" onPress={() => setShowToolbar(true)}>
+          <Button variant="subtle" onPress={() => setShowToolbar(true)}>
             Show toolbar
           </Button>
         )}


### PR DESCRIPTION
The "secondary" variant was removed from Nimbus Button; both usages in shell-splitter.visualroute.tsx are updated to "subtle"  to unblock the typecheck CI failure.