### PR TITLE
fix: use accurate prop

### DIFF
--- a/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
+++ b/visual-testing-app/src/components/shell-splitter/shell-splitter.visualroute.tsx
@@ -162,7 +162,7 @@ const FakeSaveToolbar = ({
       pointerEvents="auto"
       data-testid="fake-save-toolbar"
     >
-      <Button variant="secondary" onPress={onCancel}>
+      <Button variant="subtle" onPress={onCancel}>
         Cancel
       </Button>
       <Button variant="solid" onPress={onSave}>
@@ -186,7 +186,7 @@ const ToolbarDemo = () => {
     <>
       <MainContent>
         {!showToolbar && (
-          <Button variant="secondary" onPress={() => setShowToolbar(true)}>
+          <Button variant="subtle" onPress={() => setShowToolbar(true)}>
             Show toolbar
           </Button>
         )}


### PR DESCRIPTION
The "secondary" variant was removed from Nimbus Button; both usages in shell-splitter.visualroute.tsx are updated to "subtle" to unblock the typecheck CI failure