### PR TITLE
fix(workspace): add minimumReleaseAgeStrict + minimumReleaseAgeIgnore…

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "yaml": "catalog:"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=24",
     "npm": ">=6",
     "pnpm": ">=11"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,11 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@commercetools*'
 
+# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
+minimumReleaseAgeStrict: false
+# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
+minimumReleaseAgeIgnoreMissingTime: true
+
 # Explicit block — same v11-default-pinning rationale as minimumReleaseAge.
 blockExoticSubdeps: true
 


### PR DESCRIPTION
This pull request updates project configuration to improve compatibility and reliability for package management and Node.js version enforcement. The key changes include raising the minimum required Node.js version and adjusting `pnpm` workspace settings to better handle release age checks and missing metadata.

**Node.js Version Requirement:**
- Increased the minimum required Node.js version from 22 to 24 in the `engines` field of `package.json`, ensuring that the project uses a more recent and supported runtime.

**pnpm Workspace Configuration:**
- Set `minimumReleaseAgeStrict` to `false` in `pnpm-workspace.yaml` to restore `pnpm`'s soft fallback for package age checks, preventing CI/Vercel install failures.
- Enabled `minimumReleaseAgeIgnoreMissingTime` in `pnpm-workspace.yaml` to skip the age gate for packages missing publish time metadata, addressing issues like pnpm/pnpm#11616.
