### PR TITLE
fix(supply-chain): adopt strict minimumReleaseAge posture

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "yaml": "catalog:"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=24",
     "npm": ">=6",
     "pnpm": ">=11"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,10 +54,10 @@ minimumReleaseAgeExclude:
   # Renovate security update: js-yaml@3.15.0 || 3.15.1
   - js-yaml@3.15.0 || 3.15.1
 
-# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
-minimumReleaseAgeStrict: false
-# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
-minimumReleaseAgeIgnoreMissingTime: true
+# Explicit minimumReleaseAge already makes pnpm hard-fail on a no-mature-match; true keeps that (no silent fall-back or auto-exclude).
+minimumReleaseAgeStrict: true
+# Deliberate tightening: enforce the gate even when registry metadata omits a publish time, so a time-less mirror can't waive the cooldown.
+minimumReleaseAgeIgnoreMissingTime: false
 
 # Explicit block — same v11-default-pinning rationale as minimumReleaseAge.
 blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,11 @@ minimumReleaseAgeExclude:
   # Renovate security update: js-yaml@3.15.0 || 3.15.1
   - js-yaml@3.15.0 || 3.15.1
 
+# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
+minimumReleaseAgeStrict: false
+# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
+minimumReleaseAgeIgnoreMissingTime: true
+
 # Explicit block — same v11-default-pinning rationale as minimumReleaseAge.
 blockExoticSubdeps: true
 


### PR DESCRIPTION
Flip the pnpm age-gate from the soft fall-back to the strict posture, aligning with nimbus (#1859):

  - minimumReleaseAgeStrict: false -> true — no silent fall-back (or auto-generated exclude) when no version satisfies a range within the 24h gate
  - minimumReleaseAgeIgnoreMissingTime: true -> false — enforce the gate even when a package's registry metadata omits a publish time

Refs: FEC-1199 (epic FEC-964 — Supply Chain Hardening)
