### PR TITLE
fix(deps): switch pnpm catalogMode from strict to prefer

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,10 +7,16 @@ packages:
   - visual-testing-app
   - website-components-playground
 
-# Reject `pnpm add foo` when foo is not in a catalog — moves the gate that
-# scripts/check-workspace-constraints.js enforces in CI down to the local
-# command, giving developers earlier feedback. Requires pnpm ≥ 10.12.1.
-catalogMode: strict
+# `prefer`, not `strict`: pnpm's strict mode requires the requested version to be
+# string-identical to the catalog specifier, even when the catalog entry is a range
+# (e.g. `^7.22.17`) that the requested version already satisfies. That breaks
+# Renovate's artifact-update flow — `pnpm update <pkg>@<version> --recursive
+# --lockfile-only` against any range-pinned catalog entry always fails with
+# ERR_PNPM_CATALOG_VERSION_MISMATCH, even for in-range versions. Confirmed as
+# intentional pnpm behavior, not a bug: https://github.com/pnpm/pnpm/pull/11706.
+# `prefer` warns on drift instead of hard-failing; scripts/check-workspace-constraints.js
+# still enforces "must be in a catalog" in CI, so that guarantee is unaffected.
+catalogMode: prefer
 
 # Skip interactive TTY prompt when pnpm needs to purge node_modules on a
 # version/store change. Safe in local dev — CI already bypasses this via CI=true.


### PR DESCRIPTION
## Problem

Renovate's pnpm artifact updater runs `pnpm update <pkg>@<version> --recursive --lockfile-only` to force a lockfile resolution bump for catalog-referenced dependencies. Under `catalogMode: strict`, pnpm's strict-mode check requires the requested version to be **string-identical** to the catalog specifier — even when the catalog entry is a range (e.g. `^7.22.17`) that the requested version already satisfies (`semver.valid()` rejects ranges, so the equality check can never pass).

This currently blocks #4047 (`@babel/core`), #4049 (`vite`), and #4050 (`yaml`) — all range-pinned catalog entries — with:
```
[ERR_PNPM_CATALOG_VERSION_MISMATCH] Wanted dependency outside the version range defined in catalog
```
Retrying/rebasing those PRs re-runs the identical command against the identical config and fails identically — this isn't transient.

## Root cause confirmed upstream

Filed and closed as [pnpm/pnpm#11570](https://github.com/pnpm/pnpm/issues/11570), fixed by [pnpm/pnpm#11706](https://github.com/pnpm/pnpm/pull/11706). Per that PR's own description, this is intentional behavior, not something pnpm plans to change further:

> This turns a crash into pnpm's normal catalog-mismatch handling; it does **not** make a strict-mode update succeed when the catalog is a range.

So the fix has to live in our own `pnpm-workspace.yaml`, not upstream.

## Fix

Switch `catalogMode` from `strict` to `prefer`. `prefer` warns on catalog drift instead of hard-failing on version mismatch, which unblocks Renovate's targeted-update path. It does **not** relax the "every catalog-listed dep must be consumed via its catalog reference" rule — that's separately enforced in CI by `scripts/check-workspace-constraints.js`, which is unaffected by this change.

Nothing published changes as a result of this: `catalogMode` only governs local `pnpm add`/`pnpm update` enforcement, not what pnpm writes into published packages' `dependencies` at `pnpm publish` time.

## Verification

Confirmed locally with pnpm 11.14.0 (the version pinned in `packageManager`):
- Before: `pnpm update '@babel/core@7.29.6' --recursive --lockfile-only` → `ERR_PNPM_CATALOG_VERSION_MISMATCH`
- After (this change): same command → succeeds (exit 0)
- `pnpm install --lockfile-only` still passes cleanly with no unintended lockfile drift