### PR TITLE
docs(deps): link the upstream pnpm catalogMode issue

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,13 +9,18 @@ packages:
 
 # `prefer`, not `strict`: pnpm's strict mode requires the requested version to be
 # string-identical to the catalog specifier, even when the catalog entry is a range
-# (e.g. `^7.22.17`) that the requested version already satisfies. That breaks
-# Renovate's artifact-update flow — `pnpm update <pkg>@<version> --recursive
+# (e.g. `^7.22.17`) that the requested version already satisfies. This breaks
+# Renovate's artifact-update flow, since `pnpm update <pkg>@<version> --recursive
 # --lockfile-only` against any range-pinned catalog entry always fails with
-# ERR_PNPM_CATALOG_VERSION_MISMATCH, even for in-range versions. Confirmed as
-# intentional pnpm behavior, not a bug: https://github.com/pnpm/pnpm/pull/11706.
-# `prefer` warns on drift instead of hard-failing; scripts/check-workspace-constraints.js
-# still enforces "must be in a catalog" in CI, so that guarantee is unaffected.
+# ERR_PNPM_CATALOG_VERSION_MISMATCH, even for in-range versions. pnpm/pnpm#11706
+# preserved this behavior deliberately rather than fixing it, so it is not
+# transient. `prefer` warns on drift instead of hard-failing; scripts/check-
+# workspace-constraints.js still enforces "must be in a catalog" in CI, so that
+# guarantee is unaffected.
+#
+# Filed upstream: https://github.com/pnpm/pnpm/issues/13715, proposing
+# `semver.satisfies` for a range catalog entry under strict mode. When that
+# lands and ships, revisit switching this back to `strict`.
 catalogMode: prefer
 
 # Skip interactive TTY prompt when pnpm needs to purge node_modules on a


### PR DESCRIPTION
Small follow-up to #4059 (already merged). Points the `catalogMode: prefer` comment at the upstream bug report filed to track this: pnpm/pnpm#13715, which proposes checking `semver.satisfies` instead of exact equality for a range catalog entry under strict mode.

When that issue is fixed and ships in a pnpm release, this repo can revisit switching `catalogMode` back to `strict`.

Verified `pnpm install` still passes cleanly with no lockfile drift.