### PR TITLE
chore(renovate): hold pnpm at 11.14.0 until deploy --legacy regression is fixed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,11 @@
     {
       "matchPackageNames": ["nwsapi"],
       "allowedVersions": "<=2.2.7"
+    },
+    {
+      "description": "pnpm is pinned to 11.14.0 via packageManager. This is a proactive/precautionary hold: pnpm 11.19.0 through at least the current latest 11.20.0 has a regression (pnpm/pnpm#13618) where a workspace dependency with peerDependencies is left as a symlink escaping the deploy directory instead of being packed in when running `pnpm deploy --legacy`, which would break a Docker `COPY` of the deploy output with a dangling symlink. We have not confirmed this repo uses `pnpm deploy --legacy` in any Docker build today, so this rule is precautionary rather than a fix for a known break. The fix (pnpm/pnpm#13755) has merged upstream but has not shipped in a published pnpm release yet. Hold here until a release containing that fix is out, then remove this rule.",
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
     }
   ],
   "rebaseWhen": "never"


### PR DESCRIPTION
## Summary

Adds a precautionary Renovate rule that holds `pnpm` updates in this repo, mirroring the guard already in place on `commercetools/nimbus`.

This repo is already pinned to `pnpm@11.14.0` via the `packageManager` field in `package.json`, so no version-bump work is needed here. This PR only stops Renovate from proposing a bump past that pin until an upstream fix has shipped.

## Why

[pnpm/pnpm#13618](https://github.com/pnpm/pnpm/issues/13618) is a regression, first appearing in pnpm 11.19.0 and still present in the current published latest (11.20.0), where a workspace dependency with `peerDependencies` is left as a symlink escaping the deploy directory instead of being packed in when running `pnpm deploy --legacy`. In a typical Docker `COPY ./deploy .` flow, that leaves a dangling symlink that crashes the app at runtime.

The fix, [pnpm/pnpm#13755](https://github.com/pnpm/pnpm/pull/13755), merged upstream on 2026-08-10 but has not shipped in a published pnpm release yet.

I searched this repo for `pnpm deploy --legacy` usage in Dockerfiles and package.json scripts and did not find any, so this rule is precautionary rather than a fix for a confirmed break in this repo's build. It guards against a future Renovate bump landing on a broken pnpm version before we've had a chance to verify it against our own build steps.

## Change

Added to `.github/renovate.json`:

```json
{
  "description": "pnpm is pinned to 11.14.0 via packageManager. This is a proactive/precautionary hold: pnpm 11.19.0 through at least the current latest 11.20.0 has a regression (pnpm/pnpm#13618) where a workspace dependency with peerDependencies is left as a symlink escaping the deploy directory instead of being packed in when running `pnpm deploy --legacy`, which would break a Docker `COPY` of the deploy output with a dangling symlink. We have not confirmed this repo uses `pnpm deploy --legacy` in any Docker build today, so this rule is precautionary rather than a fix for a known break. The fix (pnpm/pnpm#13755) has merged upstream but has not shipped in a published pnpm release yet. Hold here until a release containing that fix is out, then remove this rule.",
  "matchPackageNames": ["pnpm"],
  "enabled": false
}
```

## Validation

- `jq . .github/renovate.json` passes.
- `npx --yes -p renovate renovate-config-validator .github/renovate.json` reports: `Config validated successfully against 1 file(s)`.

## Follow-up

Once a pnpm release containing pnpm/pnpm#13755 ships, remove this rule (and reconsider the `packageManager` pin at that point, out of scope for this PR).
