### PR TITLE
chore(deps): Prettier v3 migration (pathfinder) — ESLint v10 blocked

### DIFF
--- a/.changeset/prettier-v3-migration.md
+++ b/.changeset/prettier-v3-migration.md
@@ -1,0 +1,54 @@
+---
+'@commercetools-frontend/eslint-config-mc-app': major
+'@commercetools-backend/eslint-config-node': major
+'@commercetools-frontend/l10n': patch
+'@commercetools-frontend/create-mc-app': patch
+---
+
+Upgrade Prettier from v2 to v3.
+
+## `@commercetools-frontend/eslint-config-mc-app` / `@commercetools-backend/eslint-config-node` (major)
+
+Both shared ESLint configs now bundle `prettier@^3.9.6` and
+`eslint-plugin-prettier@^5.5.6` (up from `prettier@2.8.8` and
+`eslint-plugin-prettier@^4.2.1`). `eslint-plugin-prettier@5` only supports
+`prettier@>=3.0.0`, so consumers of these configs must upgrade their own
+`prettier` dependency to v3 as well.
+
+**Consumer migration steps:**
+
+1. Upgrade your own `prettier` dependency to `^3.0.0` (and `eslint-plugin-prettier`
+   to `^5.0.0` if you depend on it directly).
+2. If you call the `prettier` package's API directly (e.g. in build scripts or
+   codemods), note that Prettier v3's primary APIs are now **async-only**:
+   `format()`, `check()`, `resolveConfig()`, `resolveConfigFile()`, and
+   `getFileInfo()` all return Promises, and the `.sync()` variants
+   (`resolveConfig.sync()`, `resolveConfigFile.sync()`, `getFileInfo.sync()`)
+   have been removed. Use `@prettier/sync` if you need a synchronous shim.
+3. Prettier v3 is distributed as ESM (with a CJS-compatible entry point for
+   `require()`), and plugin loading moved from `require()` to `import()`.
+   This only matters if you register custom Prettier plugins.
+4. Re-run `prettier --write` (or your project's format script) across your
+   codebase after upgrading. Prettier v3's formatting engine changed several
+   long-standing output decisions independent of any config changes —
+   most visibly, indentation of nested ternaries and a new trailing comma
+   after the last generic type parameter — so expect a one-time reformat
+   diff even if your `.prettierrc` is unchanged.
+5. If your `.prettierrc` does **not** explicitly set `trailingComma`, note
+   that Prettier v3 changed the default from `"es5"` to `"all"`. This
+   repository's own `.prettierrc` (and the application/custom-view templates
+   it ships) already pin `trailingComma: "es5"` explicitly, so this default
+   change does not affect projects scaffolded from this repo, but it will
+   affect any downstream project that relied on the old default implicitly.
+
+No ESLint rule behavior changed as part of this migration — `eslint` itself
+stays on the current major version in this release. See the PR description
+for why the ESLint v10 half of this pathfinder was not shipped.
+
+## `@commercetools-frontend/l10n` / `@commercetools-frontend/create-mc-app` (patch)
+
+Internal build/CLI scripts that called `prettier.format()` /
+`prettier.resolveConfig.sync()` directly were updated to use Prettier v3's
+async API (`await prettier.format(...)`, `await prettier.resolveConfig(...)`).
+This is an internal implementation detail with no change to either package's
+public API or CLI behavior.

--- a/@types/commercetools__sdk-client/index.d.ts
+++ b/@types/commercetools__sdk-client/index.d.ts
@@ -2,14 +2,7 @@ declare module '@commercetools/sdk-client' {
   export type Json = { [key: string]: unknown };
   export type Headers = { [key: string]: string };
   export type MethodType =
-    | 'GET'
-    | 'POST'
-    | 'DELETE'
-    | 'HEAD'
-    | 'OPTIONS'
-    | 'PUT'
-    | 'PATCH'
-    | 'TRACE';
+    'GET' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'PUT' | 'PATCH' | 'TRACE';
   export type ClientRequest = {
     uri: string;
     method: MethodType;

--- a/application-templates/starter-typescript/src/components/channel-details/channel-details.spec.tsx
+++ b/application-templates/starter-typescript/src/components/channel-details/channel-details.spec.tsx
@@ -169,9 +169,8 @@ describe('rendering', () => {
     useMockServerHandlers([fetchChannelDetailsQueryHandler]);
     renderApp();
 
-    const keyInput: HTMLInputElement = await screen.findByLabelText(
-      /channel key/i
-    );
+    const keyInput: HTMLInputElement =
+      await screen.findByLabelText(/channel key/i);
     expect(keyInput.value).toBe(TEST_CHANNEL_KEY);
 
     screen.getByRole('combobox', { name: /channel roles/i });
@@ -186,9 +185,8 @@ describe('rendering', () => {
     });
     expect(resetButton).toBeDisabled();
 
-    const keyInput: HTMLInputElement = await screen.findByLabelText(
-      /channel key/i
-    );
+    const keyInput: HTMLInputElement =
+      await screen.findByLabelText(/channel key/i);
     expect(keyInput.value).toBe(TEST_CHANNEL_KEY);
 
     fireEvent.change(keyInput, {
@@ -241,9 +239,8 @@ describe('rendering', () => {
     ]);
     renderApp();
 
-    const keyInput: HTMLInputElement = await screen.findByLabelText(
-      /channel key/i
-    );
+    const keyInput: HTMLInputElement =
+      await screen.findByLabelText(/channel key/i);
 
     fireEvent.change(keyInput, {
       target: { value: TEST_CHANNEL_NEW_KEY },
@@ -265,9 +262,8 @@ describe('notifications', () => {
     ]);
     renderApp();
 
-    const keyInput: HTMLInputElement = await screen.findByLabelText(
-      /channel key/i
-    );
+    const keyInput: HTMLInputElement =
+      await screen.findByLabelText(/channel key/i);
     expect(keyInput.value).toBe(TEST_CHANNEL_KEY);
 
     fireEvent.change(keyInput, {

--- a/application-templates/starter/src/components/channel-details/index.js
+++ b/application-templates/starter/src/components/channel-details/index.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
-const ChannelDetails = lazy(() =>
-  import('./channel-details' /* webpackChunkName: "channel-details" */)
+const ChannelDetails = lazy(
+  () => import('./channel-details' /* webpackChunkName: "channel-details" */)
 );
 
 export default ChannelDetails;

--- a/application-templates/starter/src/components/channels/index.js
+++ b/application-templates/starter/src/components/channels/index.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
-const Channels = lazy(() =>
-  import('./channels' /* webpackChunkName: "channels" */)
+const Channels = lazy(
+  () => import('./channels' /* webpackChunkName: "channels" */)
 );
 
 export default Channels;

--- a/application-templates/starter/src/components/entry-point/entry-point.jsx
+++ b/application-templates/starter/src/components/entry-point/entry-point.jsx
@@ -8,8 +8,8 @@ import loadMessages from '../../load-messages';
 // Here we split up the main (app) bundle with the actual application business logic.
 // Splitting by route is usually recommended and you can potentially have a splitting
 // point for each route. More info at https://reactjs.org/docs/code-splitting.html
-const AsyncApplicationRoutes = lazy(() =>
-  import('../../routes' /* webpackChunkName: "routes" */)
+const AsyncApplicationRoutes = lazy(
+  () => import('../../routes' /* webpackChunkName: "routes" */)
 );
 
 // Ensure to setup the global error listener before any React component renders

--- a/application-templates/starter/src/components/welcome/index.js
+++ b/application-templates/starter/src/components/welcome/index.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
-const Welcome = lazy(() =>
-  import('./welcome' /* webpackChunkName: "welcome" */)
+const Welcome = lazy(
+  () => import('./welcome' /* webpackChunkName: "welcome" */)
 );
 
 export default Welcome;

--- a/custom-views-templates/starter/src/components/channels/index.js
+++ b/custom-views-templates/starter/src/components/channels/index.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
-const Channels = lazy(() =>
-  import('./channels' /* webpackChunkName: "channels" */)
+const Channels = lazy(
+  () => import('./channels' /* webpackChunkName: "channels" */)
 );
 
 export default Channels;

--- a/custom-views-templates/starter/src/components/entry-point/entry-point.jsx
+++ b/custom-views-templates/starter/src/components/entry-point/entry-point.jsx
@@ -8,8 +8,8 @@ import loadMessages from '../../load-messages';
 // Here we split up the main (app) bundle with the actual application business logic.
 // Splitting by route is usually recommended and you can potentially have a splitting
 // point for each route. More info at https://reactjs.org/docs/code-splitting.html
-const AsyncApplicationRoutes = lazy(() =>
-  import('../../routes' /* webpackChunkName: "routes" */)
+const AsyncApplicationRoutes = lazy(
+  () => import('../../routes' /* webpackChunkName: "routes" */)
 );
 
 // Ensure to setup the global error listener before any React component renders

--- a/packages-backend/express/src/auth.ts
+++ b/packages-backend/express/src/auth.ts
@@ -161,8 +161,8 @@ function createSessionAuthVerifier<Request extends TBaseRequest>(
 
     let issuer =
       options.inferIssuer && cloudIdentifierHeader
-        ? mapCloudIdentifierToIssuer<Request>(cloudIdentifierHeader) ??
-          configuredDefaultIssuer
+        ? (mapCloudIdentifierToIssuer<Request>(cloudIdentifierHeader) ??
+          configuredDefaultIssuer)
         : configuredDefaultIssuer;
 
     // Get the `Accept-version` header, forwarded by the `/proxy/forward-to` endpoint.
@@ -179,7 +179,7 @@ function createSessionAuthVerifier<Request extends TBaseRequest>(
 
     const requestUrlPath = options.getRequestUrl
       ? options.getRequestUrl(request)
-      : request.originalUrl ?? request.url;
+      : (request.originalUrl ?? request.url);
 
     if (!requestUrlPath || !requestUrlPath.startsWith('/')) {
       throw new Error(

--- a/packages/actions-global/src/actions/show-notification.ts
+++ b/packages/actions-global/src/actions/show-notification.ts
@@ -11,7 +11,7 @@ import { addNotification } from '@commercetools-frontend/notifications';
 import type { TShowNotification } from '../types';
 
 export default function showNotification<
-  Notification extends TShowNotification
+  Notification extends TShowNotification,
 >(notification: Notification, meta: TNotificationMetaOptions = {}) {
   if (process.env.NODE_ENV !== 'production')
     if (notification.domain) {

--- a/packages/actions-global/src/hooks/use-show-notification.ts
+++ b/packages/actions-global/src/hooks/use-show-notification.ts
@@ -25,7 +25,7 @@ type TNotificationHook<Notification extends TShowNotification> = (
  * });
  */
 function useShowNotification<
-  Notification extends TShowNotification
+  Notification extends TShowNotification,
 >(): TNotificationHook<Notification>;
 /**
  * Dispatch a notification.

--- a/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/custom-views-selector.tsx
@@ -36,7 +36,9 @@ type TWrapperProps = {
 const Wrapper = styled.div<TWrapperProps>`
   height: ${(props) => (props.shouldRender ? COMPONENT_HEIGHT : '0')};
   overflow: hidden;
-  transition: margin 0.3s ease-in-out, height 0.3s ease-in-out;
+  transition:
+    margin 0.3s ease-in-out,
+    height 0.3s ease-in-out;
   margin: ${(props) => (props.shouldRender ? props.margin : '0')};
 `;
 

--- a/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
+++ b/packages/application-components/src/components/custom-views/custom-views-selector/types.ts
@@ -5,8 +5,7 @@ export type TCustomViewLocatorCodeLocationDescriptor = {
   search?: string;
 };
 export type TCustomViewLocatorCode =
-  | string
-  | TCustomViewLocatorCodeLocationDescriptor;
+  string | TCustomViewLocatorCodeLocationDescriptor;
 
 export type TCustomViewSelectorProps = {
   onCustomViewsResolved?: (customViews: CustomViewData[]) => void;

--- a/packages/application-components/src/components/dialogs/internals/dialog.styles.ts
+++ b/packages/application-components/src/components/dialogs/internals/dialog.styles.ts
@@ -79,12 +79,14 @@ export const getModalContentStyles = (props: StyleProps): SerializedStyles => {
     outline: none;
     position: relative;
     pointer-events: none;
-    z-index: ${typeof props.zIndex === 'number'
-      ? // Use `!important` to overwrite the default value assigned by the Stacking Layer System.
-        // We're assigning value 1 unit higher than the overlay to ensure the content is on top.
-        // It's safe to do that since the modal is topmost in the stacking layer.
-        `${props.zIndex + 1} !important`
-      : 'auto'};
+    z-index: ${
+      typeof props.zIndex === 'number'
+        ? // Use `!important` to overwrite the default value assigned by the Stacking Layer System.
+          // We're assigning value 1 unit higher than the overlay to ensure the content is on top.
+          // It's safe to do that since the modal is topmost in the stacking layer.
+          `${props.zIndex + 1} !important`
+        : 'auto'
+    };
 
     ${gridStyle};
   `;

--- a/packages/application-config/src/formatters.ts
+++ b/packages/application-config/src/formatters.ts
@@ -3,7 +3,7 @@ import { CUSTOM_VIEW_HOST_ENTRY_POINT_URI_PATH } from '@commercetools-frontend/c
 import type { CamelCase } from './types';
 
 type TImplicitCustomApplicationResourceAccesses<
-  PermissionGroupName extends string = ''
+  PermissionGroupName extends string = '',
 > = Record<
   | `view`
   | `manage`
@@ -13,11 +13,11 @@ type TImplicitCustomApplicationResourceAccesses<
 >;
 
 type TImplicitCustomViewResourceAccesses<
-  PermissionGroupName extends string = ''
+  PermissionGroupName extends string = '',
 > = TImplicitCustomApplicationResourceAccesses<PermissionGroupName>;
 
 type TImplicitCustomApplicationPermissionKeys<
-  PermissionGroupName extends string = ''
+  PermissionGroupName extends string = '',
 > = Record<
   | `View`
   | `Manage`
@@ -82,13 +82,13 @@ function entryPointUriPathToResourceAccesses(
   entryPointUriPath: string
 ): TImplicitCustomApplicationResourceAccesses<''>;
 function entryPointUriPathToResourceAccesses<
-  PermissionGroupName extends string
+  PermissionGroupName extends string,
 >(
   entryPointUriPath: string,
   permissionGroupNames: PermissionGroupName[]
 ): TImplicitCustomApplicationResourceAccesses<PermissionGroupName>;
 function entryPointUriPathToResourceAccesses<
-  PermissionGroupName extends string
+  PermissionGroupName extends string,
 >(
   entryPointUriPath: string,
   permissionGroupNames?: PermissionGroupName[]

--- a/packages/application-config/src/load-config.ts
+++ b/packages/application-config/src/load-config.ts
@@ -103,9 +103,8 @@ const loadConfig = async (
     'custom-application-config'
   );
   const customViewExplorer = await createExplorerFor('custom-view-config');
-  const customApplicationConfigFile = await customApplicationExplorer.search(
-    applicationPath
-  );
+  const customApplicationConfigFile =
+    await customApplicationExplorer.search(applicationPath);
   const customViewConfigFile = await customViewExplorer.search(applicationPath);
   if (
     (!customApplicationConfigFile || !customApplicationConfigFile.config) &&

--- a/packages/application-config/src/transformers.ts
+++ b/packages/application-config/src/transformers.ts
@@ -44,15 +44,18 @@ const getPermissions = (
 ) => {
   const additionalResourceAccessKeyToOauthScopeMap = (
     appConfig.additionalOAuthScopes || []
-  ).reduce((previousOauthScope, { name, view, manage }) => {
-    const formattedResourceKey =
-      formatEntryPointUriPathToResourceAccessKey(name);
-    return {
-      ...previousOauthScope,
-      [`view${formattedResourceKey}`]: view,
-      [`manage${formattedResourceKey}`]: manage,
-    };
-  }, {} as Record<string, string[]>);
+  ).reduce(
+    (previousOauthScope, { name, view, manage }) => {
+      const formattedResourceKey =
+        formatEntryPointUriPathToResourceAccessKey(name);
+      return {
+        ...previousOauthScope,
+        [`view${formattedResourceKey}`]: view,
+        [`manage${formattedResourceKey}`]: manage,
+      };
+    },
+    {} as Record<string, string[]>
+  );
 
   const additionalPermissionNames =
     appConfig.additionalOAuthScopes?.map(({ name }) => name) || [];

--- a/packages/application-config/src/types.ts
+++ b/packages/application-config/src/types.ts
@@ -62,7 +62,7 @@ export type CustomViewData = {
 
 // The object result after processing the config file
 export type ApplicationRuntimeConfig<
-  AdditionalEnvironmentProperties extends {} = {}
+  AdditionalEnvironmentProperties extends {} = {},
 > = {
   data: CustomApplicationData | CustomViewData;
   env: AdditionalEnvironmentProperties & ApplicationWindow['app'];
@@ -93,12 +93,12 @@ array = split(items, ',');
 */
 export type Split<
   S extends string,
-  Delimiter extends string
+  Delimiter extends string,
 > = S extends `${infer Head}${Delimiter}${infer Tail}`
   ? [Head, ...Split<Tail, Delimiter>]
   : S extends Delimiter
-  ? []
-  : [S];
+    ? []
+    : [S];
 
 /**
 Step by step takes the first item in an array literal, formats it and adds it to a string literal, and then recursively appends the remainder.
@@ -108,18 +108,18 @@ source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c9
 */
 type InnerCamelCaseStringArray<
   Parts extends readonly unknown[],
-  PreviousPart
+  PreviousPart,
 > = Parts extends [`${infer FirstPart}`, ...infer RemainingParts]
   ? FirstPart extends undefined
     ? ''
     : FirstPart extends ''
-    ? InnerCamelCaseStringArray<RemainingParts, PreviousPart>
-    : `${PreviousPart extends ''
-        ? FirstPart
-        : Capitalize<FirstPart>}${InnerCamelCaseStringArray<
-        RemainingParts,
-        FirstPart
-      >}`
+      ? InnerCamelCaseStringArray<RemainingParts, PreviousPart>
+      : `${PreviousPart extends ''
+          ? FirstPart
+          : Capitalize<FirstPart>}${InnerCamelCaseStringArray<
+          RemainingParts,
+          FirstPart
+        >}`
   : '';
 
 /**
@@ -130,7 +130,7 @@ source: https://github.com/sindresorhus/type-fest/blob/fedbc441a314c1f9f5f6225c9
 */
 type CamelCaseStringArray<Parts extends readonly string[]> = Parts extends [
   `${infer FirstPart}`,
-  ...infer RemainingParts
+  ...infer RemainingParts,
 ]
   ? Uncapitalize<`${FirstPart}${InnerCamelCaseStringArray<
       RemainingParts,

--- a/packages/application-shell-connectors/src/apollo-links/header-link.ts
+++ b/packages/application-shell-connectors/src/apollo-links/header-link.ts
@@ -46,7 +46,7 @@ const getUserAgent = () => {
       // version: apolloVersion,
       libraryName: [
         typeof window !== 'undefined'
-          ? window.app?.applicationName ?? 'unknown-application-name'
+          ? (window.app?.applicationName ?? 'unknown-application-name')
           : undefined,
         'application-shell',
       ]

--- a/packages/application-shell-connectors/src/apollo-links/utils.ts
+++ b/packages/application-shell-connectors/src/apollo-links/utils.ts
@@ -37,17 +37,16 @@ const getDoesGraphQLTargetSupportTokenRetry = (
   const graphQLTarget = (context.headers?.[
     SUPPORTED_HEADERS.X_GRAPHQL_TARGET
   ] || context.headers?.[SUPPORTED_HEADERS.X_GRAPHQL_TARGET.toLowerCase()]) as
-    | TTokenRetryGraphQlTarget
-    | undefined;
+    TTokenRetryGraphQlTarget | undefined;
 
   return Boolean(
     graphQLTarget &&
-      [
-        GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
-        GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
-        GRAPHQL_TARGETS.SETTINGS_SERVICE,
-        GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
-      ].includes(graphQLTarget)
+    [
+      GRAPHQL_TARGETS.COMMERCETOOLS_PLATFORM,
+      GRAPHQL_TARGETS.ADMINISTRATION_SERVICE,
+      GRAPHQL_TARGETS.SETTINGS_SERVICE,
+      GRAPHQL_TARGETS.MERCHANT_CENTER_BACKEND,
+    ].includes(graphQLTarget)
   );
 };
 

--- a/packages/application-shell-connectors/src/components/application-context/application-context.tsx
+++ b/packages/application-shell-connectors/src/components/application-context/application-context.tsx
@@ -121,7 +121,7 @@ export const mapUserToApplicationContextUser = (user?: TFetchedUser) => {
 
 // Adjust certain fields which depend e.g. on the origin
 export const mapEnvironmentToApplicationContextEnvironment = <
-  AdditionalEnvironmentProperties extends {}
+  AdditionalEnvironmentProperties extends {},
 >(
   environment: AdditionalEnvironmentProperties & TApplicationContextEnvironment,
   origin?: string
@@ -236,7 +236,7 @@ function withApplicationContext<
   AdditionalEnvironmentProperties extends {},
   MappedProps extends {} = {
     applicationContext?: TApplicationContext<AdditionalEnvironmentProperties>;
-  }
+  },
 >(
   mapApplicationContextToProps?: (
     context: TApplicationContext<AdditionalEnvironmentProperties>
@@ -266,11 +266,11 @@ function withApplicationContext<
 // Use function overloading to declare two possible signatures with two
 // distict return types, based on the selector function argument.
 function useApplicationContextHook<
-  AdditionalEnvironmentProperties extends {} = {}
+  AdditionalEnvironmentProperties extends {} = {},
 >(): TApplicationContext<AdditionalEnvironmentProperties>;
 function useApplicationContextHook<
   SelectedContext,
-  AdditionalEnvironmentProperties extends {} = {}
+  AdditionalEnvironmentProperties extends {} = {},
 >(
   selector: (
     context: TApplicationContext<AdditionalEnvironmentProperties>
@@ -281,7 +281,7 @@ function useApplicationContextHook<
 // based on the function arguments.
 function useApplicationContextHook<
   SelectedContext,
-  AdditionalEnvironmentProperties extends {} = {}
+  AdditionalEnvironmentProperties extends {} = {},
 >(
   selector?: (
     context: TApplicationContext<AdditionalEnvironmentProperties>

--- a/packages/application-shell-connectors/src/hooks/apollo-hooks/apollo-hooks.ts
+++ b/packages/application-shell-connectors/src/hooks/apollo-hooks/apollo-hooks.ts
@@ -13,20 +13,20 @@ import type { TApolloContext } from '../../utils/apollo-context';
 
 type TQueryOptionsWithContext<
   TData = unknown,
-  TVariables extends OperationVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables,
 > = QueryHookOptions<TData, TVariables> & {
   context: TApolloContext;
 };
 type TMutationOptionsWithContext<
   TData = unknown,
-  TVariables = OperationVariables
+  TVariables = OperationVariables,
 > = MutationHookOptions<TData, TVariables, TApolloContext> & {
   context: TApolloContext;
 };
 
 function useMcQuery<
   TData = unknown,
-  TVariables extends OperationVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: TQueryOptionsWithContext<TData, TVariables>
@@ -36,7 +36,7 @@ function useMcQuery<
 
 function useMcLazyQuery<
   TData = unknown,
-  TVariables extends OperationVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: TQueryOptionsWithContext<TData, TVariables>
@@ -46,7 +46,7 @@ function useMcLazyQuery<
 
 function useMcMutation<
   TData = unknown,
-  TVariables extends OperationVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables,
 >(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: TMutationOptionsWithContext<TData, TVariables>

--- a/packages/application-shell-connectors/src/utils/apollo-client-runtime-cache.ts
+++ b/packages/application-shell-connectors/src/utils/apollo-client-runtime-cache.ts
@@ -10,7 +10,6 @@ const setCachedApolloClient = (
   cachedApolloClient = apolloClient;
 };
 const getCachedApolloClient = ():
-  | ApolloClient<NormalizedCacheObject>
-  | undefined => cachedApolloClient;
+  ApolloClient<NormalizedCacheObject> | undefined => cachedApolloClient;
 
 export { setCachedApolloClient, getCachedApolloClient };

--- a/packages/application-shell-connectors/src/utils/http-client.ts
+++ b/packages/application-shell-connectors/src/utils/http-client.ts
@@ -21,8 +21,7 @@ declare let window: ApplicationWindow;
 export type THeaders = Record<string, string>;
 
 export type TForwardToAudiencePolicy =
-  | 'forward-url-full-path'
-  | 'forward-url-origin';
+  'forward-url-full-path' | 'forward-url-origin';
 
 export type TForwardToExchangeTokenClaim = 'permissions';
 
@@ -140,7 +139,7 @@ const getUserAgent = () => {
       name: 'unknown-http-client',
       libraryName:
         typeof window !== 'undefined'
-          ? window.app?.applicationName ?? 'unknown-application-name'
+          ? (window.app?.applicationName ?? 'unknown-application-name')
           : undefined,
     });
   }

--- a/packages/application-shell/src/components/navbar/menu-items.tsx
+++ b/packages/application-shell/src/components/navbar/menu-items.tsx
@@ -248,11 +248,9 @@ type MenuItemProps = {
   isMenuOpen: boolean;
   onClick: MouseEventHandler<HTMLElement>;
   onMouseEnter?:
-    | MouseEventHandler<HTMLElement>
-    | FocusEventHandler<HTMLElement>;
+    MouseEventHandler<HTMLElement> | FocusEventHandler<HTMLElement>;
   onMouseLeave?:
-    | MouseEventHandler<HTMLElement>
-    | FocusEventHandler<HTMLElement>;
+    MouseEventHandler<HTMLElement> | FocusEventHandler<HTMLElement>;
   children: ReactNode;
   identifier?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLLIElement>) => void;

--- a/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
+++ b/packages/application-shell/src/components/user-settings-menu/user-settings-menu.spec.js
@@ -57,9 +57,8 @@ describe('rendering', () => {
       });
 
       // Make sure Downshift combobox is correctly labelled (a11y)
-      const dropdownCombobox = await screen.findByLabelText(
-        /^user settings menu$/i
-      );
+      const dropdownCombobox =
+        await screen.findByLabelText(/^user settings menu$/i);
       expect(dropdownCombobox).toHaveAttribute('role', 'combobox');
 
       const dropdownMenu = await screen.findByRole('button', {

--- a/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
+++ b/packages/application-shell/src/hooks/use-applications-menu/use-applications-menu.ts
@@ -21,8 +21,8 @@ export type MenuKey = 'appBar' | 'navBarGroups';
 export type MenuLoaderResult<Key extends MenuKey> = Key extends 'appBar'
   ? TFetchApplicationsMenuQuery['applicationsMenu']['appBar']
   : Key extends 'navBarGroups'
-  ? TFetchApplicationsMenuQuery['applicationsMenu']['navBarGroups']
-  : never;
+    ? TFetchApplicationsMenuQuery['applicationsMenu']['navBarGroups']
+    : never;
 export type Config = {
   environment: TApplicationContext<{}>['environment'];
 };

--- a/packages/application-shell/src/test-utils/test-utils.tsx
+++ b/packages/application-shell/src/test-utils/test-utils.tsx
@@ -295,7 +295,7 @@ type TApplicationProvidersProps = {
 };
 
 function createApplicationProviders<
-  AdditionalEnvironmentProperties extends {} = {}
+  AdditionalEnvironmentProperties extends {} = {},
 >({
   // application
   disableAutomaticEntryPointRoutes = false,
@@ -435,7 +435,7 @@ function renderApp<AdditionalEnvironmentProperties extends {} = {}>(
 
 export type TRenderAppWithReduxOptions<
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 > = {
   store: ReturnType<typeof createReduxStore>;
   storeState: StoreState;
@@ -444,7 +444,7 @@ export type TRenderAppWithReduxOptions<
 } & TRenderAppOptions<AdditionalEnvironmentProperties>;
 type TRenderAppWithReduxResult<
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 > = TRenderAppResult<AdditionalEnvironmentProperties> &
   Pick<
     TRenderAppWithReduxOptions<AdditionalEnvironmentProperties, StoreState>,
@@ -453,7 +453,7 @@ type TRenderAppWithReduxResult<
 
 function createReduxProviders<
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 >({
   // The store option is kept around to keep the API open as not all use-cases
   // are known yet. Meanwhile storeState and sdkMocks provide convenient ways
@@ -547,7 +547,7 @@ function createReduxProviders<
 // Use this function only when your test actually needs Redux
 function renderAppWithRedux<
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 >(
   ui: ReactElement,
   options: Partial<
@@ -578,7 +578,7 @@ function renderAppWithRedux<
 export type TRenderHookOptions<
   RenderedHookProps,
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 > = TRenderAppWithReduxOptions<AdditionalEnvironmentProperties, StoreState> &
   rtl.RenderHookOptions<RenderedHookProps>;
 
@@ -586,7 +586,7 @@ export type TRenderHookResult<
   RenderHookCallbackProps,
   RenderHookCallbackValue,
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 > = Omit<
   rtl.RenderHookResult<RenderHookCallbackProps, RenderHookCallbackValue>,
   'rerender' | 'result'
@@ -604,7 +604,7 @@ function renderHook<
   RenderedHookProps,
   RenderedHookResult,
   AdditionalEnvironmentProperties extends {} = {},
-  StoreState extends {} = {}
+  StoreState extends {} = {},
 >(
   callback: (props: RenderedHookProps) => RenderedHookResult,
   options: Partial<

--- a/packages/codemod/test/transforms.spec.ts
+++ b/packages/codemod/test/transforms.spec.ts
@@ -24,11 +24,9 @@ describe.each`
   ${'rename-mod-css-to-module-css'}        | ${'rename-mod-css-to-module-css.jsx'}
 `('testing transform "$transformName"', ({ transformName, fixtureName }) => {
   // Assumes transform is one level up from __tests__ directory
-  const module = require(path.join(
-    __dirname,
-    '../src/transforms',
-    transformName
-  ));
+  const module = require(
+    path.join(__dirname, '../src/transforms', transformName)
+  );
   const inputPath = path.join(fixturesPath, fixtureName);
 
   beforeEach(() => {

--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -101,10 +101,10 @@ export type TAppNotificationOfKind<T extends TAppNotificationOfDomain> =
     kind: 'global' extends T['domain']
       ? TAppNotificationKindGlobal
       : 'page' extends T['domain']
-      ? TAppNotificationKindPage
-      : 'side' extends T['domain']
-      ? TAppNotificationKindSide
-      : never;
+        ? TAppNotificationKindPage
+        : 'side' extends T['domain']
+          ? TAppNotificationKindSide
+          : never;
   };
 export type TAppNotificationApiError<ExtraFields extends {} = {}> = {
   message: string;
@@ -126,8 +126,8 @@ export type TAppNotification<T extends TAppNotificationOfKind<T>> =
     values?: 'api-error' extends T['kind']
       ? TAppNotificationValuesApiError
       : 'unexpected-error' extends T['kind']
-      ? TAppNotificationValuesUnexpectedError
-      : never;
+        ? TAppNotificationValuesUnexpectedError
+        : never;
   };
 export type TAppNotificationGlobal = TAppNotification<{
   domain: typeof NOTIFICATION_DOMAINS.GLOBAL;

--- a/packages/create-mc-app/src/tasks/update-application-config.ts
+++ b/packages/create-mc-app/src/tasks/update-application-config.ts
@@ -8,7 +8,7 @@ import { applicationTypes } from '../constants';
 import type { TCliTaskOptions } from '../types';
 import { wordify, resolveFilePathByExtension } from '../utils';
 
-function replaceApplicationInfoInApplicationConfig(
+async function replaceApplicationInfoInApplicationConfig(
   filePath: string,
   options: TCliTaskOptions
 ) {
@@ -69,10 +69,12 @@ function replaceApplicationInfoInApplicationConfig(
   });
 
   if (result?.code) {
-    const prettierConfig = prettier.resolveConfig.sync(
+    // Prettier v3's config resolution and formatting APIs are async-only
+    // (no more `.sync()` variants).
+    const prettierConfig = await prettier.resolveConfig(
       options.projectDirectoryPath
     );
-    const formattedData = prettier.format(
+    const formattedData = await prettier.format(
       result.code + os.EOL,
       prettierConfig ?? undefined
     );
@@ -96,14 +98,14 @@ function getApplicationConfigName(options: TCliTaskOptions) {
 function updateApplicationConfig(options: TCliTaskOptions): ListrTask {
   return {
     title: 'Updating application config file',
-    task: () => {
+    task: async () => {
       const configPath = resolveFilePathByExtension(
         path.join(
           options.projectDirectoryPath,
           getApplicationConfigName(options)
         )
       );
-      replaceApplicationInfoInApplicationConfig(configPath, options);
+      await replaceApplicationInfoInApplicationConfig(configPath, options);
     },
   };
 }

--- a/packages/create-mc-app/src/tasks/update-application-constants.ts
+++ b/packages/create-mc-app/src/tasks/update-application-constants.ts
@@ -8,7 +8,7 @@ import { applicationTypes } from '../constants';
 import type { TCliTaskOptions } from '../types';
 import { resolveFilePathByExtension } from '../utils';
 
-function replaceEntryPointUriPathInConstants(
+async function replaceEntryPointUriPathInConstants(
   filePath: string,
   options: TCliTaskOptions
 ) {
@@ -34,11 +34,13 @@ function replaceEntryPointUriPathInConstants(
     retainLines: true,
   });
   if (result?.code) {
-    const prettierConfig = prettier.resolveConfig.sync(
+    // Prettier v3's config resolution and formatting APIs are async-only
+    // (no more `.sync()` variants).
+    const prettierConfig = await prettier.resolveConfig(
       options.projectDirectoryPath
     );
 
-    const formattedData = prettier.format(
+    const formattedData = await prettier.format(
       result.code + os.EOL,
       prettierConfig ?? undefined
     );
@@ -52,11 +54,14 @@ function updateApplicationConstants(options: TCliTaskOptions): ListrTask {
   return {
     title: 'Updating application constants',
     enabled: options.applicationType === applicationTypes['custom-application'],
-    task: () => {
+    task: async () => {
       const applicationConstantsPath = resolveFilePathByExtension(
         path.join(options.projectDirectoryPath, 'src/constants')
       );
-      replaceEntryPointUriPathInConstants(applicationConstantsPath, options);
+      await replaceEntryPointUriPathInConstants(
+        applicationConstantsPath,
+        options
+      );
     },
   };
 }

--- a/packages/eslint-config-mc-app/index.js
+++ b/packages/eslint-config-mc-app/index.js
@@ -108,9 +108,7 @@ module.exports = [
         requireConfigFile: false,
         babelOptions: {
           presets: [
-            require.resolve(
-              '@commercetools-frontend/babel-preset-mc-app/production'
-            ),
+            require.resolve('@commercetools-frontend/babel-preset-mc-app/production'),
           ],
         },
       },

--- a/packages/i18n/src/async-locale-data/async-locale-data.tsx
+++ b/packages/i18n/src/async-locale-data/async-locale-data.tsx
@@ -20,8 +20,7 @@ export type Props = {
   // therefore causing flashing of translated content on subsequent re-renders.
   locale?: string;
   applicationMessages:
-    | { [locale: string]: TMessageTranslations }
-    | TMessageTranslationsAsync;
+    { [locale: string]: TMessageTranslations } | TMessageTranslationsAsync;
   children: (state: TRenderFunctionResult) => ReactNode;
 };
 

--- a/packages/i18n/src/export-types.ts
+++ b/packages/i18n/src/export-types.ts
@@ -9,12 +9,10 @@ export type TMessageStructuredJson = {
 };
 
 export type TMessageTranslations =
-  | Record<string, string>
-  | Record<string, MessageFormatElement[]>;
+  Record<string, string> | Record<string, MessageFormatElement[]>;
 
 export type TMergedMessages =
-  | TMessageTranslations
-  | Record<string, TMessageStructuredJson>;
+  TMessageTranslations | Record<string, TMessageStructuredJson>;
 
 export type TI18NImportData = {
   default: TMergedMessages;

--- a/packages/l10n/scripts/generate-l10n-data.js
+++ b/packages/l10n/scripts/generate-l10n-data.js
@@ -15,7 +15,16 @@ const prettier = require('prettier');
 const supportedLocales = require('../supported-locales');
 const parseUnhandledTimeZones = require('./parse-unhandled-time-zones');
 
-const prettierConfig = prettier.resolveConfig.sync();
+// Prettier v3's config resolution and formatting APIs are async-only
+// (no more `.sync()` variants), so the config is memoized as a promise
+// and awaited wherever formatting happens.
+let prettierConfigPromise;
+const getPrettierConfig = () => {
+  if (!prettierConfigPromise) {
+    prettierConfigPromise = prettier.resolveConfig();
+  }
+  return prettierConfigPromise;
+};
 
 const doesFileExist = (filePath) => {
   try {
@@ -353,9 +362,13 @@ function readTimeZoneTranslationFiles(sourceFilePath) {
   return JSON.parse(fs.readFileSync(sourceFilePath, { encoding: 'utf8' }));
 }
 
-function writeTimeZoneTranslationFiles(sourceFilePath, updatedTranslations) {
+async function writeTimeZoneTranslationFiles(
+  sourceFilePath,
+  updatedTranslations
+) {
   const json = JSON.stringify(updatedTranslations, null, 2);
-  const formatted = prettier.format(json, {
+  const prettierConfig = await getPrettierConfig();
+  const formatted = await prettier.format(json, {
     ...prettierConfig,
     parser: 'json',
   });
@@ -424,7 +437,7 @@ function throwIfIncludedTimeZoneIsNotTranslated(
   }
 }
 
-function writeTranslatedTimeZonesForLocale(
+async function writeTranslatedTimeZonesForLocale(
   sourceFilePath,
   newTranslations,
   key
@@ -443,7 +456,7 @@ function writeTranslatedTimeZonesForLocale(
           : newTranslations[timeZoneId],
       };
     }, {});
-  writeTimeZoneTranslationFiles(sourceFilePath, updatedTranslations);
+  await writeTimeZoneTranslationFiles(sourceFilePath, updatedTranslations);
   console.log(
     `[${key}]: writing ${
       Object.keys(newTranslations).length
@@ -508,10 +521,12 @@ async function updateTimeZoneData(key) {
           path.join(dataFolderPath, `${locale}.json`)
         ),
       ];
-      translationFilePaths.map((sourceFilePath) =>
-        writeTranslatedTimeZonesForLocale(sourceFilePath, TRANSLATE, key)
+      await Promise.all(
+        translationFilePaths.map((sourceFilePath) =>
+          writeTranslatedTimeZonesForLocale(sourceFilePath, TRANSLATE, key)
+        )
       );
-      writeTimeZoneTranslationFiles(
+      await writeTimeZoneTranslationFiles(
         translationsMapFilePath,
         sortTranslationsMap(translationsMap)
       );
@@ -524,7 +539,7 @@ async function updateTimeZoneData(key) {
     // Given timezones were excluded the file with the exclusion list needs to be written to disk.
     if (EXCLUDE.length) {
       // Write timezones to be excluded to translation map
-      writeTimeZoneTranslationFiles(
+      await writeTimeZoneTranslationFiles(
         translationsMapFilePath,
         sortTranslationsMap(translationsMap)
       );

--- a/packages/l10n/src/localize.ts
+++ b/packages/l10n/src/localize.ts
@@ -65,7 +65,7 @@ export const transformLocalizedStringToLocalizedField = (
  */
 export const applyTransformedLocalizedFields = <
   Input extends Record<string, unknown>,
-  Output extends Record<string, unknown>
+  Output extends Record<string, unknown>,
 >(
   objectWithLocalizedFields: Input,
   fieldNames: FieldNameTranformationMapping[]
@@ -75,8 +75,7 @@ export const applyTransformedLocalizedFields = <
       ...nextTransformed,
       [fieldName.to]: transformLocalizedFieldToLocalizedString(
         objectWithLocalizedFields[fieldName.from] as
-          | LocalizedField[]
-          | undefined
+          LocalizedField[] | undefined
       ),
     }),
     {}
@@ -107,7 +106,7 @@ export const applyTransformedLocalizedFields = <
  */
 export const applyTransformedLocalizedStrings = <
   Input extends Record<string, unknown>,
-  Output extends Record<string, unknown>
+  Output extends Record<string, unknown>,
 >(
   objectWithLocalizedStrings: Input,
   fieldNames: FieldNameTranformationMapping[]

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -314,9 +314,8 @@ async function run() {
       // Do this as the first thing so that any code reading it knows the right env.
       process.env.NODE_ENV = 'production';
 
-      const deploymentsSetCommand = await import(
-        './commands/deployment-previews-set'
-      );
+      const deploymentsSetCommand =
+        await import('./commands/deployment-previews-set');
       await deploymentsSetCommand.default(options);
     });
 

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
@@ -33,12 +33,10 @@ const defaultOptions: TWebpackConfigOptions<'development'> = {
 // Whether or not `react-refresh` is enabled, `react-refresh` is not 100% stable at this time,
 // which is why it's disabled by default.
 const hasReactRefresh = process.env.FAST_REFRESH === 'true';
-const webpackDevClientEntry = require.resolve(
-  'react-dev-utils/webpackHotDevClient'
-);
-const reactRefreshOverlayEntry = require.resolve(
-  'react-dev-utils/refreshOverlayInterop'
-);
+const webpackDevClientEntry =
+  require.resolve('react-dev-utils/webpackHotDevClient');
+const reactRefreshOverlayEntry =
+  require.resolve('react-dev-utils/refreshOverlayInterop');
 
 /**
  * This is a factory function to create the default webpack config
@@ -113,9 +111,7 @@ function createWebpackConfigForDevelopment(
 
     entry: {
       app: [
-        require.resolve(
-          '@commercetools-frontend/mc-scripts/application-runtime'
-        ),
+        require.resolve('@commercetools-frontend/mc-scripts/application-runtime'),
         !mergedOptions.toggleFlags.disableCoreJs &&
           require.resolve('core-js/stable'),
         // When using the experimental `react-refresh` integration,
@@ -186,9 +182,8 @@ function createWebpackConfigForDevelopment(
         new HtmlWebpackPlugin({
           inject: false,
           filename: paths.appIndexHtml,
-          template: require.resolve(
-            '@commercetools-frontend/mc-html-template/webpack'
-          ),
+          template:
+            require.resolve('@commercetools-frontend/mc-html-template/webpack'),
         }),
       mergedOptions.toggleFlags.generateIndexHtml &&
         new LocalHtmlWebpackPlugin(),
@@ -230,9 +225,7 @@ function createWebpackConfigForDevelopment(
                 babelrc: false,
                 presets: [
                   [
-                    require.resolve(
-                      '@commercetools-frontend/babel-preset-mc-app'
-                    ),
+                    require.resolve('@commercetools-frontend/babel-preset-mc-app'),
                     {
                       runtime: hasJsxRuntime() ? 'automatic' : 'classic',
                       disableCoreJs: mergedOptions.toggleFlags.disableCoreJs,
@@ -444,9 +437,7 @@ function createWebpackConfigForDevelopment(
                 compact: false,
                 presets: [
                   [
-                    require.resolve(
-                      '@commercetools-frontend/babel-preset-mc-app'
-                    ),
+                    require.resolve('@commercetools-frontend/babel-preset-mc-app'),
                     {
                       runtime: hasJsxRuntime() ? 'automatic' : 'classic',
                     },

--- a/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-production.ts
@@ -165,9 +165,7 @@ function createWebpackConfigForProduction(
     // In production, we only want to load the polyfills and the app code.
     entry: {
       app: [
-        require.resolve(
-          '@commercetools-frontend/mc-scripts/application-runtime'
-        ),
+        require.resolve('@commercetools-frontend/mc-scripts/application-runtime'),
         !mergedOptions.toggleFlags.disableCoreJs &&
           require.resolve('core-js/stable'),
         mergedOptions.entryPoint,
@@ -221,9 +219,8 @@ function createWebpackConfigForProduction(
         new HtmlWebpackPlugin({
           inject: false,
           filename: 'index.html.template',
-          template: require.resolve(
-            '@commercetools-frontend/mc-html-template/webpack'
-          ),
+          template:
+            require.resolve('@commercetools-frontend/mc-html-template/webpack'),
         }),
       mergedOptions.toggleFlags.enableExtractCss && // Extracts CSS into one CSS file to mimic CSS order in dev
         new MiniCssExtractPlugin({
@@ -252,9 +249,7 @@ function createWebpackConfigForProduction(
                 babelrc: false,
                 presets: [
                   [
-                    require.resolve(
-                      '@commercetools-frontend/babel-preset-mc-app'
-                    ),
+                    require.resolve('@commercetools-frontend/babel-preset-mc-app'),
                     {
                       runtime: hasJsxRuntime() ? 'automatic' : 'classic',
                       disableCoreJs: mergedOptions.toggleFlags.disableCoreJs,
@@ -482,9 +477,7 @@ function createWebpackConfigForProduction(
                 compact: false,
                 presets: [
                   [
-                    require.resolve(
-                      '@commercetools-frontend/babel-preset-mc-app'
-                    ),
+                    require.resolve('@commercetools-frontend/babel-preset-mc-app'),
                     {
                       runtime: hasJsxRuntime() ? 'automatic' : 'classic',
                     },
@@ -512,9 +505,7 @@ function createWebpackConfigForProduction(
         !(process.env.DISABLE_I18N_MESSAGE_COMPILATION === 'true') && {
           test: /i18n\/data\/.*\.json$/,
           use: [
-            require.resolve(
-              '@commercetools-frontend/mc-scripts/webpack-loaders/i18n-message-compilation-loader'
-            ),
+            require.resolve('@commercetools-frontend/mc-scripts/webpack-loaders/i18n-message-compilation-loader'),
           ],
         },
       ].filter(Boolean),

--- a/packages/mc-scripts/src/generated/core.ts
+++ b/packages/mc-scripts/src/generated/core.ts
@@ -299,9 +299,7 @@ export type TLocalizedString = {
 };
 
 export type TMediaContainer =
-  | TAwsContainer
-  | TAzureBlobStorageContainer
-  | TPublicContainer;
+  TAwsContainer | TAzureBlobStorageContainer | TPublicContainer;
 
 export type TMessagesConfiguration = {
   __typename?: 'MessagesConfiguration';

--- a/packages/mc-scripts/src/types.ts
+++ b/packages/mc-scripts/src/types.ts
@@ -120,6 +120,6 @@ export type TWebpackConfigOptions<ConfigMode extends TWebpackConfigMode> = {
   toggleFlags?: ConfigMode extends 'development'
     ? TWebpackConfigToggleFlagsForDevelopment
     : ConfigMode extends 'production'
-    ? TWebpackConfigToggleFlagsForProduction
-    : never;
+      ? TWebpackConfigToggleFlagsForProduction
+      : never;
 };

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -13,22 +13,23 @@ export type TNotificationMetaOptions = {
   onDismiss?: TNotificationOnDismiss;
 };
 
-export interface TAddNotificationAction<Payload extends TNotification>
-  extends Action<typeof ADD_NOTIFICATION> {
+export interface TAddNotificationAction<
+  Payload extends TNotification,
+> extends Action<typeof ADD_NOTIFICATION> {
   payload: Payload;
   meta?: TNotificationMetaOptions;
   dismiss?: () => void;
   [key: string]: unknown;
 }
 
-export interface TRemoveNotificationAction
-  extends Action<typeof REMOVE_NOTIFICATION> {
+export interface TRemoveNotificationAction extends Action<
+  typeof REMOVE_NOTIFICATION
+> {
   payload: TNotification;
   [key: string]: unknown;
 }
 
 export type TNotificationAction<Payload extends TNotification> =
-  | TAddNotificationAction<Payload>
-  | TRemoveNotificationAction;
+  TAddNotificationAction<Payload> | TRemoveNotificationAction;
 
 export type TNotificationState<Payload extends TNotification> = Payload[];

--- a/packages/permissions/src/components/authorized/authorized.tsx
+++ b/packages/permissions/src/components/authorized/authorized.tsx
@@ -75,7 +75,7 @@ const injectAuthorized =
     OwnProps extends {
       isAuthorized?: boolean;
     },
-    InjectedProps extends OwnProps & { [key: string]: boolean }
+    InjectedProps extends OwnProps & { [key: string]: boolean },
   >(
     demandedPermissions: TPermissionName[],
     options: TInjectAuthorizedOptions<OwnProps> = {},

--- a/packages/react-notifications/src/components/map-notification-to-component/map-notification-to-component.tsx
+++ b/packages/react-notifications/src/components/map-notification-to-component/map-notification-to-component.tsx
@@ -8,9 +8,7 @@ import type {
 export type Props = {
   mapNotificationToComponent: (
     notification:
-      | TAppNotificationGlobal
-      | TAppNotificationPage
-      | TAppNotificationSide
+      TAppNotificationGlobal | TAppNotificationPage | TAppNotificationSide
   ) => ElementType | null;
   children: ReactNode;
 };
@@ -18,9 +16,7 @@ export type Props = {
 const Context = createContext<
   (
     notification:
-      | TAppNotificationGlobal
-      | TAppNotificationPage
-      | TAppNotificationSide
+      TAppNotificationGlobal | TAppNotificationPage | TAppNotificationSide
   ) => ElementType | null
 >(() => null);
 

--- a/packages/react-notifications/src/components/notification/notification.styles.ts
+++ b/packages/react-notifications/src/components/notification/notification.styles.ts
@@ -89,9 +89,11 @@ const getStylesForCloseIcon = (props: StyleProps): SerializedStyles => css`
     width: 16px;
     height: 16px;
   }
-  ${props.domain !== NOTIFICATION_DOMAINS.SIDE
-    ? '& svg { fill: ' + designTokens.colorSurface + '; }'
-    : ''}
+  ${
+    props.domain !== NOTIFICATION_DOMAINS.SIDE
+      ? '& svg { fill: ' + designTokens.colorSurface + '; }'
+      : ''
+  }
 `;
 
 const getStylesForContent = (props: StyleProps): SerializedStyles => {
@@ -104,9 +106,9 @@ const getStylesForContent = (props: StyleProps): SerializedStyles => {
     flex-grow: 1;
     padding: ${`0 ${designTokens.spacingM}`};
     margin: 0;
-    font-size: ${props.domain === NOTIFICATION_DOMAINS.SIDE
-      ? '1rem'
-      : 'inherit'};
+    font-size: ${
+      props.domain === NOTIFICATION_DOMAINS.SIDE ? '1rem' : 'inherit'
+    };
 
     color: ${fontColor};
     p {
@@ -132,9 +134,9 @@ const getStylesForNotification = (props: StyleProps): SerializedStyles => {
     ${baseStyles};
     animation: ${showNotificationAnimation} 0.3s forwards;
     text-align: center;
-    background-color: ${props.fixed
-      ? 'transparent'
-      : getColorByType(props.type)};
+    background-color: ${
+      props.fixed ? 'transparent' : getColorByType(props.type)
+    };
 
     > * + * {
       margin-left: ${designTokens.spacingS};

--- a/packages/react-notifications/src/components/notifications-list/types.ts
+++ b/packages/react-notifications/src/components/notifications-list/types.ts
@@ -6,8 +6,6 @@ import type {
 
 export type TAppState = {
   notifications: (
-    | TAppNotificationGlobal
-    | TAppNotificationPage
-    | TAppNotificationSide
+    TAppNotificationGlobal | TAppNotificationPage | TAppNotificationSide
   )[];
 };

--- a/packages/sdk/src/test-utils/test-utils.ts
+++ b/packages/sdk/src/test-utils/test-utils.ts
@@ -9,14 +9,7 @@ import type { TSdkAction, Json } from '../types';
  */
 export type Headers = { [key: string]: string };
 export type MethodType =
-  | 'GET'
-  | 'POST'
-  | 'DELETE'
-  | 'HEAD'
-  | 'OPTIONS'
-  | 'PUT'
-  | 'PATCH'
-  | 'TRACE';
+  'GET' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'PUT' | 'PATCH' | 'TRACE';
 export type ClientRequest = {
   uri: string;
   method: MethodType;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -5,8 +5,7 @@ export type Json = { [key: string]: unknown };
 export type THttpMethod = 'GET' | 'POST' | 'DELETE' | 'HEAD';
 
 export type TForwardToAudiencePolicy =
-  | 'forward-url-full-path'
-  | 'forward-url-origin';
+  'forward-url-full-path' | 'forward-url-origin';
 
 export type TForwardToExchangeTokenClaim = 'permissions';
 
@@ -31,8 +30,7 @@ export interface TSdkActionPayloadForService extends TSdkActionPayloadBase {
   options: Json;
 }
 export type TSdkActionPayload =
-  | TSdkActionPayloadForUri
-  | TSdkActionPayloadForService;
+  TSdkActionPayloadForUri | TSdkActionPayloadForService;
 
 export type TSdkActionGetForUri = {
   type: 'SDK';
@@ -73,8 +71,7 @@ export type TSdkActionDeleteForService = {
   [key: string]: unknown;
 };
 export type TSdkActionDelete =
-  | TSdkActionDeleteForUri
-  | TSdkActionDeleteForService;
+  TSdkActionDeleteForUri | TSdkActionDeleteForService;
 
 export type TSdkActionHeadForUri = {
   type: 'SDK';
@@ -89,7 +86,4 @@ export type TSdkActionHeadForService = {
 export type TSdkActionHead = TSdkActionHeadForUri | TSdkActionHeadForService;
 
 export type TSdkAction =
-  | TSdkActionGet
-  | TSdkActionPost
-  | TSdkActionDelete
-  | TSdkActionHead;
+  TSdkActionGet | TSdkActionPost | TSdkActionDelete | TSdkActionHead;

--- a/playground/src/components/custom-views/index.js
+++ b/playground/src/components/custom-views/index.js
@@ -1,5 +1,6 @@
 import { lazy } from 'react';
 
-export const CustomPanelDemo = lazy(() =>
-  import('./custom-panel-demo' /* webpackChunkName: "custom-panel-demo" */)
+export const CustomPanelDemo = lazy(
+  () =>
+    import('./custom-panel-demo' /* webpackChunkName: "custom-panel-demo" */)
 );

--- a/playground/src/components/echo-server/index.js
+++ b/playground/src/components/echo-server/index.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
-const EchoServer = lazy(() =>
-  import('./echo-server' /* webpackChunkName: "echo-server" */)
+const EchoServer = lazy(
+  () => import('./echo-server' /* webpackChunkName: "echo-server" */)
 );
 
 export default EchoServer;

--- a/playground/src/components/entry-point/entry-point.jsx
+++ b/playground/src/components/entry-point/entry-point.jsx
@@ -12,8 +12,8 @@ import DemoCustomView from '../custom-views/demo-custom-view';
 // Here we split up the main (app) bundle with the actual application business logic.
 // Splitting by route is usually recommended and you can potentially have a splitting
 // point for each route. More info at https://reactjs.org/docs/code-splitting.html
-const AsyncPlaygroundRoutes = lazy(() =>
-  import('../../routes' /* webpackChunkName: "app-kit-playground" */)
+const AsyncPlaygroundRoutes = lazy(
+  () => import('../../routes' /* webpackChunkName: "app-kit-playground" */)
 );
 
 // Ensure to setup the global error listener before any React component renders

--- a/playground/src/components/formatters-demo/index.js
+++ b/playground/src/components/formatters-demo/index.js
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
-const FormattersDemo = lazy(() =>
-  import('./formatters-demo' /* webpackChunkName: "formatters-demo" */)
+const FormattersDemo = lazy(
+  () => import('./formatters-demo' /* webpackChunkName: "formatters-demo" */)
 );
 
 export default FormattersDemo;

--- a/playground/src/components/notifications-playground/index.js
+++ b/playground/src/components/notifications-playground/index.js
@@ -1,9 +1,10 @@
 import { lazy } from 'react';
 
-const NotificationsPlayground = lazy(() =>
-  import(
-    './notifications-playground' /* webpackChunkName: "notifications-playground" */
-  )
+const NotificationsPlayground = lazy(
+  () =>
+    import(
+      './notifications-playground' /* webpackChunkName: "notifications-playground" */
+    )
 );
 
 export default NotificationsPlayground;

--- a/playground/src/components/state-machines-details/index.js
+++ b/playground/src/components/state-machines-details/index.js
@@ -1,9 +1,10 @@
 import { lazy } from 'react';
 
-const StateMachinesDetails = lazy(() =>
-  import(
-    './state-machines-details' /* webpackChunkName: "state-machines-details" */
-  )
+const StateMachinesDetails = lazy(
+  () =>
+    import(
+      './state-machines-details' /* webpackChunkName: "state-machines-details" */
+    )
 );
 
 export default StateMachinesDetails;

--- a/playground/src/components/state-machines-list/index.js
+++ b/playground/src/components/state-machines-list/index.js
@@ -1,7 +1,10 @@
 import { lazy } from 'react';
 
-const StateMachinesList = lazy(() =>
-  import('./state-machines-list' /* webpackChunkName: "state-machines-list" */)
+const StateMachinesList = lazy(
+  () =>
+    import(
+      './state-machines-list' /* webpackChunkName: "state-machines-list" */
+    )
 );
 
 export default StateMachinesList;

--- a/playground/src/routes.jsx
+++ b/playground/src/routes.jsx
@@ -7,8 +7,8 @@ import NotificationsPlayground from './components/notifications-playground';
 import StateMachinesDetails from './components/state-machines-details';
 import StateMachinesList from './components/state-machines-list';
 
-const SplitterDemo = lazy(() =>
-  import('./components/splitter-demo/splitter-demo')
+const SplitterDemo = lazy(
+  () => import('./components/splitter-demo/splitter-demo')
 );
 
 const ApplicationRoutes = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ catalogs:
       version: 7.28.3
     '@babel/runtime':
       specifier: ^7.22.15
-      version: 7.28.6
+      version: 7.29.7
     '@babel/runtime-corejs3':
       specifier: ^7.22.15
       version: 7.29.0
@@ -664,8 +664,8 @@ catalogs:
       specifier: ^17.1.0
       version: 17.23.1
     eslint-plugin-prettier:
-      specifier: ^4.2.1
-      version: 4.2.5
+      specifier: ^5.5.6
+      version: 5.5.6
     eslint-plugin-react:
       specifier: ^7.33.2
       version: 7.37.5
@@ -682,8 +682,8 @@ catalogs:
       specifier: 11.2.6
       version: 11.2.6
     prettier:
-      specifier: 2.8.8
-      version: 2.8.8
+      specifier: 3.9.6
+      version: 3.9.6
     stylelint:
       specifier: 14.16.1
       version: 14.16.1
@@ -708,7 +708,7 @@ catalogs:
       version: 3.4.0
     '@commercetools/nimbus-icons':
       specifier: ^3.2.0
-      version: 3.2.0
+      version: 3.4.0
   react:
     '@radix-ui/react-dialog':
       specifier: 1.1.23
@@ -1306,7 +1306,7 @@ importers:
         version: 3.1.4(postcss@8.5.26)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3))
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       publint:
         specifier: catalog:repo
         version: 0.3.21
@@ -1540,7 +1540,7 @@ importers:
         version: 1.2.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       prop-types:
         specifier: catalog:react
         version: 15.8.1
@@ -1748,7 +1748,7 @@ importers:
         version: 1.2.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1953,7 +1953,7 @@ importers:
         version: 1.2.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       prop-types:
         specifier: catalog:react
         version: 15.8.1
@@ -2161,7 +2161,7 @@ importers:
         version: 1.2.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2225,13 +2225,13 @@ importers:
         version: 17.23.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(typescript@5.9.3)
       eslint-plugin-prettier:
         specifier: catalog:lint
-        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@2.8.8)
+        version: 5.5.6(@types/eslint@8.56.12)(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@3.9.6)
       globals:
         specifier: catalog:lint
         version: 15.15.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       typescript:
         specifier: catalog:build
         version: 5.9.3
@@ -2247,7 +2247,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2278,7 +2278,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2324,7 +2324,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2373,7 +2373,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2548,7 +2548,7 @@ importers:
         version: 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2600,7 +2600,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -2823,7 +2823,7 @@ importers:
         version: 3.14.1(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.14.2)(ws@8.18.3))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
+        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
       '@testing-library/react':
         specifier: catalog:test
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2865,7 +2865,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3000,7 +3000,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3036,7 +3036,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3072,7 +3072,7 @@ importers:
         version: 17.4.0(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
     devDependencies:
       '@commercetools-frontend/application-components':
         specifier: workspace:^
@@ -3100,7 +3100,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3119,7 +3119,7 @@ importers:
         version: 7.29.6(supports-color@8.1.1)
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3143,7 +3143,7 @@ importers:
         version: 5.0.8(enquirer@2.4.1)
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       semver:
         specifier: 'catalog:'
         version: 7.8.5
@@ -3162,7 +3162,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3238,7 +3238,7 @@ importers:
         version: 6.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
       eslint-plugin-prettier:
         specifier: catalog:lint
-        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@2.8.8)
+        version: 5.5.6(@types/eslint@8.56.12)(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@3.9.6)
       eslint-plugin-react:
         specifier: catalog:lint
         version: 7.37.5(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
@@ -3253,7 +3253,7 @@ importers:
         version: 15.15.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       typescript:
         specifier: catalog:build
         version: 5.9.3
@@ -3266,7 +3266,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3419,7 +3419,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3474,7 +3474,7 @@ importers:
         version: 2.7.0
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       prompts:
         specifier: 'catalog:'
         version: 2.4.2
@@ -3489,7 +3489,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3511,7 +3511,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3554,7 +3554,7 @@ importers:
         version: 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3719,7 +3719,7 @@ importers:
         version: 7.1.0(postcss@8.5.26)
       prettier:
         specifier: catalog:lint
-        version: 2.8.8
+        version: 3.9.6
       prompts:
         specifier: 'catalog:'
         version: 2.4.2
@@ -3780,7 +3780,7 @@ importers:
         version: 13.13.1(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
+        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
       '@tsconfig/node24':
         specifier: 'catalog:'
         version: 24.0.4
@@ -3819,7 +3819,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3832,7 +3832,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -3887,7 +3887,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -4002,7 +4002,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -4084,7 +4084,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -4136,7 +4136,7 @@ importers:
     dependencies:
       '@babel/runtime':
         specifier: catalog:build
-        version: 7.28.6
+        version: 7.29.7
       '@babel/runtime-corejs3':
         specifier: catalog:build
         version: 7.29.0
@@ -4242,10 +4242,10 @@ importers:
         version: 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
+        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
       '@commercetools/nimbus-icons':
         specifier: catalog:nimbus
-        version: 3.2.0(supports-color@8.1.1)(typescript@5.9.3)
+        version: 3.4.0(supports-color@8.1.1)(typescript@5.9.3)
       '@emotion/react':
         specifier: catalog:build
         version: 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -4396,7 +4396,7 @@ importers:
         version: 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools/nimbus':
         specifier: catalog:nimbus
-        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
+        version: 3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
       '@emotion/react':
         specifier: catalog:build
         version: 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -4626,16 +4626,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.7':
@@ -4653,20 +4645,12 @@ packages:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.29.8':
     resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
@@ -4690,20 +4674,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.29.7':
@@ -4740,24 +4716,12 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.29.7':
@@ -4771,11 +4735,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
@@ -5358,32 +5317,16 @@ packages:
     resolution: {integrity: sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.29.8':
     resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.8':
@@ -5928,9 +5871,6 @@ packages:
   '@commercetools/http-user-agent@3.0.0':
     resolution: {integrity: sha512-kHlVST/Ax8GFpG9vpcUR5wKBGBoY2tZDA87kSC3nxhgk2+szZfv7MMMaAt0EIz2thpyO7oJv9NyPY/3XrrNIXQ==}
     engines: {node: '>=14'}
-
-  '@commercetools/nimbus-icons@3.2.0':
-    resolution: {integrity: sha512-PIKVEJW8hef3mSDT4wCHssaCLZEdtkgA3AhQL4vUZO98+dAlRFi7O2gKjg284stOQ7++bfZg2dKaxaF5weUtbA==}
 
   '@commercetools/nimbus-icons@3.4.0':
     resolution: {integrity: sha512-++S3tqPxZ4uZuiCoM6eUEBaEynbjwRgyHdzdmUFZEoXtbIJWJ6RfdndsVkKRRCymt/nvH7edzuJqobV0rRpKSA==}
@@ -8470,9 +8410,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@pkgr/core@0.2.9':
-    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+  '@pkgr/core@0.3.6':
+    resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   '@pmmmwh/react-refresh-webpack-plugin@0.6.2':
     resolution: {integrity: sha512-IhIAD5n4XvGHuL9nAgWfsBR0TdxtjrUWETYKCBHxauYXEv+b+ctEbs9neEgPC7Ecgzv4bpZTBwesAoGDeFymzA==}
@@ -8752,11 +8692,6 @@ packages:
     peerDependencies:
       react: 19.2.8
 
-  '@react-types/shared@3.35.0':
-    resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
-    peerDependencies:
-      react: 19.2.8
-
   '@react-types/shared@3.36.1':
     resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
     peerDependencies:
@@ -8847,15 +8782,6 @@ packages:
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
-
-  '@rollup/pluginutils@5.2.0':
-    resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^4.59.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
 
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
@@ -9082,9 +9008,6 @@ packages:
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -10415,11 +10338,6 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
@@ -10468,9 +10386,6 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -12305,10 +12220,6 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.19.0:
-    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
@@ -12550,14 +12461,17 @@ packages:
     peerDependencies:
       eslint: '>=8.23.0'
 
-  eslint-plugin-prettier@4.2.5:
-    resolution: {integrity: sha512-9Ni+xgemM2IWLq6aXEpP2+V/V30GeA/46Ar629vcMqVPodFFWC9skHu/D1phvuqtS8bJCFnNf01/qcmqYEwNfg==}
-    engines: {node: '>=12.0.0'}
+  eslint-plugin-prettier@5.5.6:
+    resolution: {integrity: sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
+      '@types/eslint': ^8.2.2
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
     peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
       eslint-config-prettier:
         optional: true
 
@@ -13150,9 +13064,6 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
-
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
   get-tsconfig@4.14.1:
     resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
@@ -15363,10 +15274,6 @@ packages:
       uglify-js:
         optional: true
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -16335,8 +16242,8 @@ packages:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
 
-  prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
   prettier@2.8.8:
@@ -16344,13 +16251,13 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -16559,12 +16466,6 @@ packages:
       react: 19.2.8
       react-dom: 19.2.8
 
-  react-aria@3.49.0:
-    resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
-    peerDependencies:
-      react: 19.2.8
-      react-dom: 19.2.8
-
   react-aria@3.50.0:
     resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
     peerDependencies:
@@ -16728,11 +16629,6 @@ packages:
     peerDependencies:
       react: 19.2.8
       react-dom: 19.2.8
-
-  react-stately@3.47.0:
-    resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
-    peerDependencies:
-      react: 19.2.8
 
   react-stately@3.48.0:
     resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
@@ -17830,8 +17726,8 @@ packages:
     resolution: {integrity: sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==}
     engines: {node: '>=18'}
 
-  synckit@0.11.11:
-    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+  synckit@0.11.13:
+    resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
   systeminformation@5.31.5:
@@ -17843,10 +17739,6 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
-
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
-    engines: {node: '>=6'}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -18255,11 +18147,6 @@ packages:
 
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -19086,7 +18973,7 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@8.1.1)
       '@babel/types': 7.29.8
       babel-preset-fbjs: 3.4.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
@@ -19226,19 +19113,11 @@ snapshots:
       '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
       chokidar: 3.6.0
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
-
-  '@babel/compat-data@7.29.0': {}
 
   '@babel/compat-data@7.29.7': {}
 
@@ -19270,14 +19149,6 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 7.8.5
 
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@7.29.8':
     dependencies:
       '@babel/parser': 7.29.8
@@ -19289,14 +19160,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.8
-
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.7
-      lru-cache: 5.1.1
-      semver: 7.8.5
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -19337,18 +19200,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-globals@7.28.0': {}
-
   '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5(supports-color@8.1.1)':
-    dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
-      '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.28.6(supports-color@8.1.1)':
     dependencies:
       '@babel/traverse': 7.29.8(supports-color@8.1.1)
       '@babel/types': 7.29.8
@@ -19402,15 +19256,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -19425,10 +19273,6 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-
-  '@babel/parser@7.29.2':
-    dependencies:
       '@babel/types': 7.29.8
 
   '@babel/parser@7.29.8':
@@ -19673,7 +19517,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19818,11 +19662,11 @@ snapshots:
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19937,7 +19781,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
@@ -20102,7 +19946,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
@@ -20114,7 +19958,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
@@ -20134,33 +19978,13 @@ snapshots:
     dependencies:
       core-js-pure: 3.48.0
 
-  '@babel/runtime@7.28.6': {}
-
   '@babel/runtime@7.29.7': {}
-
-  '@babel/template@7.28.6':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
 
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
-
-  '@babel/traverse@7.29.0(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.8
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.8(supports-color@8.1.1)':
     dependencies:
@@ -20173,11 +19997,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.8':
     dependencies:
@@ -20412,12 +20231,12 @@ snapshots:
 
   '@commercetools-community-kit/i18n@0.3.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
 
   '@commercetools-docs/ui-kit@24.11.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/card': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20473,7 +20292,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/register': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/constants': 24.11.0
       '@types/lodash': 4.17.20
@@ -20498,7 +20317,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/register': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/constants': 24.11.0
       '@types/lodash': 4.17.20
@@ -20521,12 +20340,12 @@ snapshots:
 
   '@commercetools-frontend/constants@24.11.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
 
   '@commercetools-uikit/accessible-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -20544,7 +20363,7 @@ snapshots:
 
   '@commercetools-uikit/accessible-button@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -20561,7 +20380,7 @@ snapshots:
 
   '@commercetools-uikit/accessible-hidden@20.6.7(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
       react: 19.2.8
@@ -20571,7 +20390,7 @@ snapshots:
 
   '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20595,7 +20414,7 @@ snapshots:
 
   '@commercetools-uikit/avatar@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -20610,7 +20429,7 @@ snapshots:
 
   '@commercetools-uikit/calendar-time-utils@20.6.7(moment-timezone@0.6.0)(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
       moment-timezone: 0.6.0
@@ -20619,7 +20438,7 @@ snapshots:
 
   '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.4)(moment@2.30.1)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20646,7 +20465,7 @@ snapshots:
 
   '@commercetools-uikit/card@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20664,7 +20483,7 @@ snapshots:
 
   '@commercetools-uikit/card@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20682,7 +20501,7 @@ snapshots:
 
   '@commercetools-uikit/checkbox-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20700,7 +20519,7 @@ snapshots:
 
   '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -20715,7 +20534,7 @@ snapshots:
 
   '@commercetools-uikit/constraints@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -20730,7 +20549,7 @@ snapshots:
 
   '@commercetools-uikit/constraints@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -20744,7 +20563,7 @@ snapshots:
 
   '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -20785,7 +20604,7 @@ snapshots:
 
   '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
@@ -20808,7 +20627,7 @@ snapshots:
 
   '@commercetools-uikit/date-time-input@20.6.7(@types/react@19.2.4)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.0)(react@19.2.8)
@@ -20840,7 +20659,7 @@ snapshots:
 
   '@commercetools-uikit/design-system@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 19.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -20854,7 +20673,7 @@ snapshots:
 
   '@commercetools-uikit/design-system@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -20867,7 +20686,7 @@ snapshots:
 
   '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20890,7 +20709,7 @@ snapshots:
 
   '@commercetools-uikit/field-errors@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -20905,7 +20724,7 @@ snapshots:
 
   '@commercetools-uikit/field-label@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20929,7 +20748,7 @@ snapshots:
 
   '@commercetools-uikit/field-warnings@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -20944,7 +20763,7 @@ snapshots:
 
   '@commercetools-uikit/flat-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -20965,7 +20784,7 @@ snapshots:
 
   '@commercetools-uikit/flat-button@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20985,7 +20804,7 @@ snapshots:
 
   '@commercetools-uikit/grid@20.6.7(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -20996,7 +20815,7 @@ snapshots:
 
   '@commercetools-uikit/hooks@19.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
       '@types/raf-schd': 4.0.3
@@ -21007,7 +20826,7 @@ snapshots:
 
   '@commercetools-uikit/hooks@20.6.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
       '@types/raf-schd': 4.0.3
@@ -21018,12 +20837,12 @@ snapshots:
 
   '@commercetools-uikit/i18n@20.6.7':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
 
   '@commercetools-uikit/icon-button@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21043,7 +20862,7 @@ snapshots:
 
   '@commercetools-uikit/icons@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21061,7 +20880,7 @@ snapshots:
 
   '@commercetools-uikit/icons@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21078,7 +20897,7 @@ snapshots:
 
   '@commercetools-uikit/input-utils@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
@@ -21096,7 +20915,7 @@ snapshots:
 
   '@commercetools-uikit/label@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/text': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)
@@ -21112,7 +20931,7 @@ snapshots:
 
   '@commercetools-uikit/link@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21133,7 +20952,7 @@ snapshots:
 
   '@commercetools-uikit/loading-spinner@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21151,7 +20970,7 @@ snapshots:
 
   '@commercetools-uikit/loading-spinner@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21168,7 +20987,7 @@ snapshots:
 
   '@commercetools-uikit/localized-text-field@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21190,7 +21009,7 @@ snapshots:
 
   '@commercetools-uikit/localized-text-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21216,7 +21035,7 @@ snapshots:
 
   '@commercetools-uikit/localized-utils@20.6.7(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
       lodash: 4.18.1
@@ -21225,7 +21044,7 @@ snapshots:
 
   '@commercetools-uikit/messages@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/text': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21241,7 +21060,7 @@ snapshots:
 
   '@commercetools-uikit/multiline-text-field@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21263,7 +21082,7 @@ snapshots:
 
   '@commercetools-uikit/multiline-text-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21290,7 +21109,7 @@ snapshots:
 
   '@commercetools-uikit/notifications@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21306,7 +21125,7 @@ snapshots:
 
   '@commercetools-uikit/number-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21324,7 +21143,7 @@ snapshots:
 
   '@commercetools-uikit/pagination@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21350,7 +21169,7 @@ snapshots:
 
   '@commercetools-uikit/primary-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21371,7 +21190,7 @@ snapshots:
 
   '@commercetools-uikit/primary-button@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21391,7 +21210,7 @@ snapshots:
 
   '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21414,7 +21233,7 @@ snapshots:
 
   '@commercetools-uikit/secondary-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@6.8.9(react@19.2.8)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21435,7 +21254,7 @@ snapshots:
 
   '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21455,7 +21274,7 @@ snapshots:
 
   '@commercetools-uikit/secondary-icon-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21476,7 +21295,7 @@ snapshots:
 
   '@commercetools-uikit/secondary-icon-button@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21496,7 +21315,7 @@ snapshots:
 
   '@commercetools-uikit/select-field@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21519,7 +21338,7 @@ snapshots:
 
   '@commercetools-uikit/select-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21541,7 +21360,7 @@ snapshots:
 
   '@commercetools-uikit/select-utils@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
@@ -21564,7 +21383,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inline@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21578,7 +21397,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inline@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21591,7 +21410,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inset-squish@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21605,7 +21424,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inset-squish@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21618,7 +21437,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inset@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21632,7 +21451,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inset@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21645,7 +21464,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-stack@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21659,7 +21478,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-stack@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21672,7 +21491,7 @@ snapshots:
 
   '@commercetools-uikit/spacings@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21686,7 +21505,7 @@ snapshots:
 
   '@commercetools-uikit/spacings@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21700,7 +21519,7 @@ snapshots:
 
   '@commercetools-uikit/stamp@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21716,7 +21535,7 @@ snapshots:
 
   '@commercetools-uikit/tag@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21739,7 +21558,7 @@ snapshots:
 
   '@commercetools-uikit/text-field@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21762,7 +21581,7 @@ snapshots:
 
   '@commercetools-uikit/text-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21780,7 +21599,7 @@ snapshots:
 
   '@commercetools-uikit/text@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@6.8.9(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21797,7 +21616,7 @@ snapshots:
 
   '@commercetools-uikit/text@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -21813,7 +21632,7 @@ snapshots:
 
   '@commercetools-uikit/tooltip@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21833,7 +21652,7 @@ snapshots:
 
   '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21853,14 +21672,14 @@ snapshots:
 
   '@commercetools-uikit/utils@19.9.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@emotion/is-prop-valid': 1.2.2
       react: 19.2.8
 
   '@commercetools-uikit/utils@20.6.7(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@emotion/is-prop-valid': 1.4.0
       react: 19.2.8
@@ -21869,7 +21688,7 @@ snapshots:
 
   '@commercetools/composable-commerce-test-data@13.13.1(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools-frontend/constants': 24.11.0
@@ -21888,7 +21707,7 @@ snapshots:
 
   '@commercetools/composable-commerce-test-data@13.13.1(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools-frontend/constants': 24.11.0
@@ -21922,14 +21741,6 @@ snapshots:
 
   '@commercetools/http-user-agent@3.0.0': {}
 
-  '@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.3)':
-    dependencies:
-      '@material-design-icons/svg': 0.14.15
-      '@svgr/cli': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@material-design-icons/svg': 0.14.15
@@ -21940,88 +21751,14 @@ snapshots:
 
   '@commercetools/nimbus-tokens@3.4.0': {}
 
-  '@commercetools/nimbus@3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.2.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)':
-    dependencies:
-      '@chakra-ui/cli': 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
-      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@commercetools/nimbus-icons': 3.2.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools/nimbus-tokens': 3.4.0
-      '@emotion/is-prop-valid': 1.4.0
-      '@github-ui/storybook-addon-performance-panel': 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@internationalized/string': 3.2.9
-      '@react-aria/interactions': 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@react-aria/utils': 3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      dequal: 2.0.3
-      escape-html: 1.0.3
-      is-hotkey: 0.2.0
-      next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-aria: 3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-aria-components: 1.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-hotkeys-hook: 5.3.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-markdown: 10.1.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
-      react-stately: 3.48.0(react@19.2.8)
-      react-use: 17.6.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      remark-gfm: 4.0.1(supports-color@8.1.1)
-      remend: 1.3.0
-      slate: 0.123.0
-      slate-history: 0.115.0(slate@0.123.0)
-      slate-hyperscript: 0.115.0(slate@0.123.0)
-      slate-react: 0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0)
-      use-debounce: 10.1.1(react@19.2.8)
-    transitivePeerDependencies:
-      - '@storybook/icons'
-      - '@storybook/react'
-      - '@types/react'
-      - react-dom
-      - storybook
-      - supports-color
-
-  '@commercetools/nimbus@3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)':
+  '@commercetools/nimbus@3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)':
     dependencies:
       '@chakra-ui/cli': 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
       '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@commercetools/nimbus-icons': 3.4.0(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools/nimbus-tokens': 3.4.0
       '@emotion/is-prop-valid': 1.4.0
-      '@github-ui/storybook-addon-performance-panel': 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@internationalized/string': 3.2.9
-      '@react-aria/interactions': 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@react-aria/utils': 3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      dequal: 2.0.3
-      escape-html: 1.0.3
-      is-hotkey: 0.2.0
-      next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-aria: 3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-aria-components: 1.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-hotkeys-hook: 5.3.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-markdown: 10.1.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
-      react-stately: 3.48.0(react@19.2.8)
-      react-use: 17.6.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      remark-gfm: 4.0.1(supports-color@8.1.1)
-      remend: 1.3.0
-      slate: 0.123.0
-      slate-history: 0.115.0(slate@0.123.0)
-      slate-hyperscript: 0.115.0(slate@0.123.0)
-      slate-react: 0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0)
-      use-debounce: 10.1.1(react@19.2.8)
-    transitivePeerDependencies:
-      - '@storybook/icons'
-      - '@storybook/react'
-      - '@types/react'
-      - react-dom
-      - storybook
-      - supports-color
-
-  '@commercetools/nimbus@3.4.0(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@commercetools/nimbus-icons@3.4.0(supports-color@8.1.1)(typescript@5.9.3))(@commercetools/nimbus-tokens@3.4.0)(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-history@0.115.0(slate@0.123.0))(slate-hyperscript@0.115.0(slate@0.123.0))(slate-react@0.123.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(slate-dom@0.124.1(slate@0.123.0))(slate@0.123.0))(slate@0.123.0)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)':
-    dependencies:
-      '@chakra-ui/cli': 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
-      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@commercetools/nimbus-icons': 3.4.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools/nimbus-tokens': 3.4.0
-      '@emotion/is-prop-valid': 1.4.0
-      '@github-ui/storybook-addon-performance-panel': 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@github-ui/storybook-addon-performance-panel': 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@internationalized/string': 3.2.9
       '@react-aria/interactions': 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/utils': 3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -22102,7 +21839,7 @@ snapshots:
   '@commitlint/config-validator@17.8.1':
     dependencies:
       '@commitlint/types': 17.8.1
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   '@commitlint/ensure@17.8.1':
     dependencies:
@@ -22342,8 +22079,8 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5(supports-color@8.1.1)':
     dependencies:
-      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
-      '@babel/runtime': 7.28.6
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -22360,7 +22097,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/babel-plugin-jsx-pragmatic': 0.3.0(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
@@ -22390,7 +22127,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -22416,7 +22153,7 @@ snapshots:
 
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1))(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/is-prop-valid': 1.4.0
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -22959,7 +22696,7 @@ snapshots:
       json-stable-stringify: 1.3.0
       loud-rejection: 2.2.0
       tslib: 2.8.1
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - ts-jest
 
@@ -23131,7 +22868,7 @@ snapshots:
       chalk: 4.1.2
       json-stable-stringify: 1.3.0
       tslib: 2.8.1
-      typescript: 5.9.2
+      typescript: 5.9.3
     optionalDependencies:
       ts-jest: 29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3)
 
@@ -23142,7 +22879,7 @@ snapshots:
       chalk: 4.1.2
       json-stable-stringify: 1.3.0
       tslib: 2.8.1
-      typescript: 5.9.2
+      typescript: 5.9.3
     optionalDependencies:
       ts-jest: 29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3)
 
@@ -23153,21 +22890,14 @@ snapshots:
       chalk: 4.1.2
       json-stable-stringify: 1.3.0
       tslib: 2.8.1
-      typescript: 5.9.2
+      typescript: 5.9.3
     optionalDependencies:
       ts-jest: 29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3)
 
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@storybook/icons': 2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      storybook: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-    optionalDependencies:
-      react: 19.2.8
-
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
-    dependencies:
-      '@storybook/icons': 2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      storybook: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      storybook: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     optionalDependencies:
       react: 19.2.8
 
@@ -23179,9 +22909,9 @@ snapshots:
 
   '@graphql-codegen/cli@2.16.5(@babel/core@7.29.6(supports-color@8.1.1))(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(enquirer@2.4.1)(graphql@16.14.2)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
       '@graphql-codegen/core': 2.6.8(graphql@16.14.2)
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.14.2)
       '@graphql-tools/apollo-engine-loader': 7.3.26(graphql@16.14.2)
@@ -23910,7 +23640,7 @@ snapshots:
 
   '@hello-pangea/dnd@18.0.1(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       css-box-model: 1.2.1
       raf-schd: 4.0.3
       react: 19.2.8
@@ -24445,7 +24175,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/node': 22.19.17
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -24456,7 +24186,7 @@ snapshots:
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -25053,7 +24783,7 @@ snapshots:
   '@percy/config@1.32.6(typescript@5.9.3)':
     dependencies:
       '@percy/logger': 1.32.6
-      ajv: 8.18.0
+      ajv: 8.20.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       yaml: 2.8.3
     transitivePeerDependencies:
@@ -25145,7 +24875,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pkgr/core@0.2.9': {}
+  '@pkgr/core@0.3.6': {}
 
   '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@4.41.0)(webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))':
     dependencies:
@@ -25180,7 +24910,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@preconstruct/hook': 0.4.0(supports-color@8.1.1)
       '@rollup/plugin-alias': 3.1.9(rollup@2.80.0)
       '@rollup/plugin-commonjs': 15.1.0(rollup@2.80.0)
@@ -25403,19 +25133,19 @@ snapshots:
 
   '@react-aria/interactions@3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@react-types/shared': 3.35.0(react@19.2.8)
+      '@react-types/shared': 3.36.1(react@19.2.8)
       '@swc/helpers': 0.5.23
       react: 19.2.8
-      react-aria: 3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria: 3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
 
   '@react-aria/utils@3.34.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.8
-      react-aria: 3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria: 3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
-      react-stately: 3.47.0(react@19.2.8)
+      react-stately: 3.48.0(react@19.2.8)
 
   '@react-hook/latest@1.0.3(react@19.2.8)':
     dependencies:
@@ -25432,17 +25162,13 @@ snapshots:
       '@react-hook/passive-layout-effect': 1.2.1(react@19.2.8)
       react: 19.2.8
 
-  '@react-types/shared@3.35.0(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-
   '@react-types/shared@3.36.1(react@19.2.8)':
     dependencies:
       react: 19.2.8
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.4)(react@19.2.8)(redux@5.0.1))(react@19.2.8)':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
       immer: 11.1.16
       redux: 5.0.1
@@ -25551,14 +25277,6 @@ snapshots:
       estree-walker: 1.0.1
       picomatch: 4.0.5
       rollup: 2.80.0
-
-  '@rollup/pluginutils@5.2.0(rollup@4.62.4)':
-    dependencies:
-      '@types/estree': 1.0.9
-      estree-walker: 2.0.2
-      picomatch: 4.0.5
-    optionalDependencies:
-      rollup: 4.62.4
 
   '@rollup/pluginutils@5.4.0(rollup@4.62.4)':
     dependencies:
@@ -25720,8 +25438,6 @@ snapshots:
     dependencies:
       color: 5.0.2
       text-hex: 1.0.0
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -25999,14 +25715,14 @@ snapshots:
 
   '@testing-library/cypress@10.1.3(cypress@14.5.4)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       cypress: 14.5.4
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -26017,7 +25733,7 @@ snapshots:
   '@testing-library/dom@8.20.1':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -26036,7 +25752,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -26090,8 +25806,8 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
@@ -26298,7 +26014,7 @@ snapshots:
   '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
-      tapable: 2.3.0
+      tapable: 2.3.3
       webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -26462,7 +26178,7 @@ snapshots:
   '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
-      tapable: 2.3.0
+      tapable: 2.3.3
       webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -26669,7 +26385,7 @@ snapshots:
   '@vercel/nft@0.19.1(supports-color@8.1.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11(supports-color@8.1.1)
-      acorn: 8.15.0
+      acorn: 8.18.0
       bindings: 1.5.0
       estree-walker: 2.0.2
       glob: 7.2.3
@@ -26686,9 +26402,9 @@ snapshots:
   '@vercel/nft@1.10.0(rollup@4.62.4)(supports-color@8.1.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0(supports-color@8.1.1)
-      '@rollup/pluginutils': 5.2.0(rollup@4.62.4)
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.4)
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -27601,22 +27317,20 @@ snapshots:
 
   acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-walk: 8.3.4
 
-  acorn-import-attributes@1.9.5(acorn@8.15.0):
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
-
-  acorn@8.15.0: {}
+      acorn: 8.18.0
 
   acorn@8.18.0: {}
 
@@ -27658,13 +27372,6 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -27924,8 +27631,8 @@ snapshots:
 
   autoprefixer@10.4.22(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.1
-      caniuse-lite: 1.0.30001764
+      browserslist: 4.28.7
+      caniuse-lite: 1.0.30001807
       fraction.js: 5.3.4
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -27999,8 +27706,8 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/types': 7.29.8
       '@formatjs/icu-messageformat-parser': 2.11.4
       '@formatjs/ts-transformer': 3.14.2(ts-jest@29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3))
       '@types/babel__core': 7.20.5
@@ -28016,8 +27723,8 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/types': 7.29.8
       '@formatjs/icu-messageformat-parser': 2.11.4
       '@formatjs/ts-transformer': 3.14.2(ts-jest@29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3))
       '@types/babel__core': 7.20.5
@@ -28098,14 +27805,14 @@ snapshots:
 
   babel-plugin-preval@5.1.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/babel__core': 7.20.5
       babel-plugin-macros: 3.1.0
       require-from-string: 2.0.2
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
 
@@ -28116,9 +27823,9 @@ snapshots:
   babel-plugin-typescript-to-proptypes@2.1.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -29527,7 +29234,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
   dom-serializer@1.4.1:
@@ -29605,7 +29312,7 @@ snapshots:
 
   downshift@9.3.3(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
       react: 19.2.8
@@ -29614,7 +29321,7 @@ snapshots:
 
   downshift@9.4.0(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
       react: 19.2.8
@@ -29684,11 +29391,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-
-  enhanced-resolve@5.19.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.0
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -30012,7 +29714,7 @@ snapshots:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.17
@@ -30076,7 +29778,7 @@ snapshots:
 
   eslint-plugin-jest-dom@4.0.3(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 8.20.1
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       requireindex: 1.2.0
@@ -30114,10 +29816,10 @@ snapshots:
   eslint-plugin-n@17.23.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.24.5
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-plugin-es-x: 7.8.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.1
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
@@ -30126,12 +29828,14 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-prettier@4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@2.8.8):
+  eslint-plugin-prettier@5.5.6(@types/eslint@8.56.12)(eslint-config-prettier@8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(prettier@3.9.6):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
-      prettier: 2.8.8
-      prettier-linter-helpers: 1.0.0
+      prettier: 3.9.6
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.13
     optionalDependencies:
+      '@types/eslint': 8.56.12
       eslint-config-prettier: 8.10.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1)):
@@ -30230,8 +29934,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -30689,7 +30393,7 @@ snapshots:
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.8.5
-      tapable: 2.3.0
+      tapable: 2.3.3
       typescript: 5.9.3
       webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
@@ -30872,10 +30576,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-
-  get-tsconfig@4.13.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.14.1:
     dependencies:
@@ -31293,7 +30993,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -31353,7 +31053,7 @@ snapshots:
       html-minifier-terser: 6.1.0
       lodash: 4.18.1
       pretty-error: 4.0.0
-      tapable: 2.3.0
+      tapable: 2.3.3
     optionalDependencies:
       webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
@@ -32506,7 +32206,7 @@ snapshots:
       jest-util: 30.2.0
       pretty-format: 30.2.0
       semver: 7.8.5
-      synckit: 0.11.11
+      synckit: 0.11.13
     transitivePeerDependencies:
       - supports-color
 
@@ -32702,7 +32402,7 @@ snapshots:
   jsdom@21.1.2(supports-color@8.1.1):
     dependencies:
       abab: 2.0.6
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-globals: 7.0.1
       cssstyle: 3.0.0
       data-urls: 4.0.0
@@ -32785,7 +32485,7 @@ snapshots:
       js-yaml: 3.15.1
       lodash: 4.18.1
       minimist: 1.2.8
-      prettier: 3.8.1
+      prettier: 3.9.6
       tinyglobby: 0.2.17
 
   json-schema-traverse@0.4.1: {}
@@ -33832,7 +33532,7 @@ snapshots:
   mini-css-extract-plugin@2.10.2(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.3
       webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   minimalistic-assert@1.0.1: {}
@@ -33881,8 +33581,6 @@ snapshots:
       html-minifier-terser: 6.1.0
       postcss: 8.5.26
       uglify-js: 3.19.3
-
-  minipass@7.1.2: {}
 
   minipass@7.1.3: {}
 
@@ -34270,7 +33968,7 @@ snapshots:
 
   omit-empty-es@1.2.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
 
   on-finished@2.3.0:
@@ -34623,7 +34321,7 @@ snapshots:
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.5
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -34957,15 +34655,15 @@ snapshots:
 
   prepend-http@2.0.0: {}
 
-  prettier-linter-helpers@1.0.0:
+  prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
 
   prettier@2.8.8: {}
 
-  prettier@3.8.1: {}
-
   prettier@3.8.3: {}
+
+  prettier@3.9.6: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -35211,20 +34909,6 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       react-stately: 3.48.0(react@19.2.8)
 
-  react-aria@3.49.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@19.2.8)
-      '@swc/helpers': 0.5.23
-      aria-hidden: 1.2.6
-      clsx: 2.1.1
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-stately: 3.47.0(react@19.2.8)
-      use-sync-external-store: 1.6.0(react@19.2.8)
-
   react-aria@3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@internationalized/date': 3.12.2
@@ -35241,9 +34925,9 @@ snapshots:
 
   react-dev-utils@12.0.1(supports-color@8.1.1)(typescript@5.9.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       address: 1.2.2
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       chalk: 4.1.2
       cross-spawn: 7.0.6
       detect-port-alt: 1.1.6(supports-color@8.1.1)
@@ -35398,7 +35082,7 @@ snapshots:
 
   react-router-dom@5.3.4(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -35416,7 +35100,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -35434,7 +35118,7 @@ snapshots:
 
   react-select@5.10.2(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
       '@floating-ui/dom': 1.7.6
@@ -35448,16 +35132,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
-
-  react-stately@3.47.0(react@19.2.8):
-    dependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@19.2.8)
-      '@swc/helpers': 0.5.23
-      react: 19.2.8
-      use-sync-external-store: 1.6.0(react@19.2.8)
 
   react-stately@3.48.0(react@19.2.8):
     dependencies:
@@ -35479,7 +35153,7 @@ snapshots:
 
   react-textarea-autosize@8.5.9(@types/react@19.2.4)(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       react: 19.2.8
       use-composed-ref: 1.4.0(@types/react@19.2.4)(react@19.2.8)
       use-latest: 1.3.0(@types/react@19.2.4)(react@19.2.8)
@@ -35488,7 +35162,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -35684,7 +35358,7 @@ snapshots:
 
   relay-runtime@12.0.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       fbjs: 3.0.5
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -35919,7 +35593,7 @@ snapshots:
 
   rtl-css-js@1.16.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   run-applescript@7.1.0: {}
 
@@ -36486,7 +36160,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@2.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -36505,34 +36179,7 @@ snapshots:
       ws: 8.18.3
     optionalDependencies:
       '@types/react': 19.2.4
-      prettier: 2.8.8
-    transitivePeerDependencies:
-      - '@testing-library/dom'
-      - bufferutil
-      - react
-      - react-dom
-      - utf-8-validate
-
-  storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.4)(prettier@3.8.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/expect': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@webcontainer/env': 1.1.1
-      esbuild: 0.27.7
-      open: 10.2.0
-      oxc-parser: 0.127.0
-      oxc-resolver: 11.20.0
-      recast: 0.23.11
-      semver: 7.8.5
-      use-sync-external-store: 1.6.0(react@19.2.8)
-      ws: 8.18.3
-    optionalDependencies:
-      '@types/react': 19.2.4
-      prettier: 3.8.3
+      prettier: 3.9.6
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -36870,21 +36517,19 @@ snapshots:
       timeout-signal: 2.0.0
       whatwg-mimetype: 4.0.0
 
-  synckit@0.11.11:
+  synckit@0.11.13:
     dependencies:
-      '@pkgr/core': 0.2.9
+      '@pkgr/core': 0.3.6
 
   systeminformation@5.31.5: {}
 
   table@6.9.0:
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  tapable@2.3.0: {}
 
   tapable@2.3.3: {}
 
@@ -36942,7 +36587,7 @@ snapshots:
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -37176,7 +36821,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.11
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -37196,7 +36841,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.17
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -37329,8 +36974,6 @@ snapshots:
   typescript@4.3.4: {}
 
   typescript@5.6.1-rc: {}
-
-  typescript@5.9.2: {}
 
   typescript@5.9.3: {}
 
@@ -37841,7 +37484,7 @@ snapshots:
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-walk: 8.3.4
       commander: 7.2.0
       debounce: 1.2.1
@@ -37926,7 +37569,7 @@ snapshots:
       minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.3
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -438,7 +438,7 @@ catalogs:
     eslint-plugin-jest-dom: ^4.0.3
     eslint-plugin-jsx-a11y: ^6.7.1
     eslint-plugin-n: ^17.1.0
-    eslint-plugin-prettier: ^4.2.1
+    eslint-plugin-prettier: ^5.5.6
     eslint-plugin-react: ^7.33.2
     eslint-plugin-react-hooks: ^5.0.0
     eslint-plugin-testing-library: ^7.15.4
@@ -452,7 +452,7 @@ catalogs:
     stylelint-value-no-unknown-custom-properties: 4.0.0
 
     # Formatter
-    prettier: 2.8.8
+    prettier: 3.9.6
 
     # Pre-commit / type-check orchestrator
     lint-staged: 11.2.6

--- a/visual-testing-app/src/application.tsx
+++ b/visual-testing-app/src/application.tsx
@@ -20,14 +20,17 @@ const visualRoutesModules = import.meta.glob<TVisualRouteSpec>(
 
 const allUniqueVisualRouteComponents = Object.values(
   visualRoutesModules
-).reduce<Record<string, TVisualRouteSpec>>((allComponents, RouteComponent) => {
-  const route = RouteComponent.routePath.substring(1);
-  if (allComponents[route]) {
-    console.error(`Duplicate route generated for: /${route}`);
-  }
-  allComponents[route] = RouteComponent;
-  return allComponents;
-}, {} as Record<string, TVisualRouteSpec>);
+).reduce<Record<string, TVisualRouteSpec>>(
+  (allComponents, RouteComponent) => {
+    const route = RouteComponent.routePath.substring(1);
+    if (allComponents[route]) {
+      console.error(`Duplicate route generated for: /${route}`);
+    }
+    allComponents[route] = RouteComponent;
+    return allComponents;
+  },
+  {} as Record<string, TVisualRouteSpec>
+);
 const allSortedComponents = Object.keys(allUniqueVisualRouteComponents)
   .sort()
   .map<TVisualRouteSpec>((key) => allUniqueVisualRouteComponents[key]);


### PR DESCRIPTION
## Summary

Pathfinder for the bundled ESLint v9->v10 + Prettier v2->v3 major migration. **Only the Prettier v3 half shipped.** ESLint v10 is blocked by a hard upstream incompatibility (see below) and was intentionally left untouched at its current version in this PR.

| | Before | After |
|---|---|---|
| `prettier` | 2.8.8 | 3.9.6 |
| `eslint-plugin-prettier` | ^4.2.1 | ^5.5.6 |
| `eslint` | ^9.0.0 | **unchanged** (blocked, see below) |

## ESLint v10: blocked, not attempted

`eslint-config-mc-app`'s base config parses **every** `.js/.jsx/.ts/.tsx/.cjs/.mjs` file with `@babel/eslint-parser` (to support the Babel presets/plugins the MC app ecosystem relies on beyond what `@typescript-eslint/parser`/espree understand). I verified empirically (not just via peer-dependency ranges, which can lag) that:

- ESLint v10 requires custom `ScopeManager` implementations to provide an `addGlobals(names)` method (this is a documented breaking change).
- `@babel/eslint-parser`'s scope analyzer does not implement it. Repro:
  ```
  TypeError: scopeManager.addGlobals is not a function
      at addDeclaredGlobals (eslint/lib/languages/js/source-code/source-code.js:221:15)
  ```
- This is fixed only in `@babel/eslint-parser@8.x`, which requires `@babel/core@8.x`.
- The **entire 7.x line** of `@babel/eslint-parser` (up to the current latest, `7.29.7`) caps its `eslint` peer range at `^9.0.0` and cannot be patched forward without the v8 jump.
- This repo's Babel v8 migration is separately blocked on an unrelated Emotion incompatibility (per the existing STOP report on that pathfinder).

So the dependency chain is: **ESLint v10 -> requires `@babel/eslint-parser` v8 -> requires `@babel/core` v8 -> blocked by the same Emotion issue that stopped the Babel v8 pathfinder.** Forcing ESLint v10 here would either crash linting outright or require dropping/replacing `@babel/eslint-parser` as the base parser for the shared config, which is a design change (not a mechanical fix) with fan-out risk across every consumer of `eslint-config-mc-app`. Per the pathfinder brief, I'm stopping here rather than forcing it.

Everything else in the ESLint dependency graph (`eslint-plugin-react`, `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-jest*`, `eslint-plugin-testing-library`, `eslint-plugin-cypress`, `@typescript-eslint/*`) was checked and is *not* a blocker — some declare peer ranges that lag behind v10 but work fine functionally when force-installed (verified with a throwaway smoke test), others are already open-ended. `@babel/eslint-parser` is the one hard, un-workaround-able wall.

## What shipped: Prettier v2 -> v3

### Dependency changes
- `prettier`: `2.8.8` -> `3.9.6` (catalog `lint`)
- `eslint-plugin-prettier`: `^4.2.1` -> `^5.5.6` (required — v4 only supports Prettier's pre-v3 synchronous API; v5 requires `prettier>=3.0.0`)
- `eslint-config-prettier` stays at `^8.10.0` — already satisfies `eslint-plugin-prettier@5`'s peer range (`>=7.0.0 <10.0.0 || >=10.1.0`), no bump needed.

### Async API fixes
Prettier v3's `format()`, `check()`, `resolveConfig()`, `resolveConfigFile()`, and `getFileInfo()` are now Promise-returning only; the `.sync()` variants are gone. Found and fixed every direct caller in the repo:

- `packages/l10n/scripts/generate-l10n-data.js` — memoized `resolveConfig()` as a promise, made `writeTimeZoneTranslationFiles`/`writeTranslatedTimeZonesForLocale` async, awaited them through `updateTimeZoneData`.
- `packages/create-mc-app/src/tasks/update-application-constants.ts` and `update-application-config.ts` — awaited `resolveConfig()`/`format()`, marked the enclosing Listr `task` functions `async`.
- `packages/codemod/src/transforms/react-default-props-migration.ts` and `redesign-cleanup.ts` — **no change needed**. They already `await prettier.resolveConfig(...)` and `return prettier.format(...)` from an `async function`; an async function returning a promise flattens correctly, and jscodeshift's `Runner` already awaits transform results.

### Default `trailingComma` change (v3 default is now `"all"`, was `"es5"`)
Not a concern here — this repo's root `.prettierrc`, both `application-templates/*/.prettierrc`, both `custom-views-templates/*/.prettierrc`, and `jest-runner-eslint.config.js`'s `prettier/prettier` rule override all pin `trailingComma: "es5"` explicitly. No formatting change from the default flip.

### One-time reformat
Prettier v3's formatting engine changed several output decisions independent of any config (e.g., nested-ternary/conditional-type indentation, and a new trailing comma after the last parameter in generic type parameter lists). Ran `prettier --write` across the repo; ~55 files changed, all whitespace/punctuation only (verified via `git diff` spot checks — no semantic changes). Committed separately from the dependency bump for a clean diff.

### Changeset
Added a **major** changeset for `@commercetools-frontend/eslint-config-mc-app` and `@commercetools-backend/eslint-config-node` (both bundle `prettier`+`eslint-plugin-prettier` and are affected identically), plus a **patch** changeset for `@commercetools-frontend/l10n` and `@commercetools-frontend/create-mc-app` (internal async fix, no public API change). Consumer migration notes are in `.changeset/prettier-v3-migration.md`, covering: upgrading their own `prettier` to `^3`, the async API change if they call `prettier` directly, ESM/plugin-loading changes, and the one-time reformat they should expect.

Note: this repo uses a `fixed` changeset group across `@commercetools-frontend/*`, `@commercetools-backend/*`, etc., so the major bump will propagate to the whole group's version number at release time — that's existing repo policy, not something introduced here.

## Verification

All green on the final commit:
- `pnpm lint` (ESLint half via `jest-runner-eslint`): 1063/1063 test suites passing
- `pnpm lint` (Stylelint half): 8/8 passing
- `pnpm typecheck` (both `tsc` invocations): clean
- `pnpm build`: clean
- `pnpm test`: 123/123 suites, 1018/1018 tests passing

One unrelated pre-existing issue was ruled out during verification: `packages/i18n/src/load-i18n.ts` fails lint/typecheck on a fresh clone before running `pnpm compile-intl` (generated `compiled-data/*.json` files don't exist yet) — reproduced identically on unmodified `main`, not caused by this change.

## Known test-coverage gap (pre-existing, not introduced here)

`packages/create-mc-app/src/tasks/update-application-constants.ts` and `update-application-config.ts` have no unit tests today (neither before nor after this change), so the async conversion there is verified via `tsc` (type-level parity with the already-tested pattern in `packages/codemod`) rather than a red/green test. Flagging this rather than silently skipping it — worth a follow-up if this package gets test coverage in the future.

## Not done
- ESLint version bump (blocked, see above).
- No packages were published or released.
- This PR is not merged.
