### PR TITLE
chore(deps): trivial major-version dependency migrations

### DIFF
--- a/.changeset/trivial-major-dependency-migrations.md
+++ b/.changeset/trivial-major-dependency-migrations.md
@@ -1,0 +1,29 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+'@commercetools-frontend/codemod': patch
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/sdk': patch
+'@commercetools-frontend/browser-history': patch
+'@commercetools-frontend/react-notifications': patch
+'@commercetools-frontend/jest-preset-mc-app': patch
+'@commercetools-frontend/cypress': patch
+---
+
+Trivial ecosystem-churn dependency migrations pass: bumped several major-version dependencies whose API surface is either unchanged for our usage or only needed a mechanical import fix, verified via the full test/typecheck/build suite (see PR description for the per-dependency breakdown and the ones that were dropped after turning out not to be mechanical).
+
+- `glob` 10.x → 13.x (`mc-scripts`, `codemod`)
+- `dotenv` 16.x → 17.x (`mc-scripts`)
+- `fs-extra` 10.x → 11.x (`mc-scripts`)
+- `jwt-decode` 3.x → 4.x (`mc-scripts`, `application-shell`) — named export migration
+- `open` 10.x → 11.x (`mc-scripts`)
+- `webpackbar` 5.x → 7.x (`mc-scripts`)
+- `thread-loader` 3.x → 4.x (`mc-scripts`)
+- `svg-url-loader` 7.x → 8.x (`mc-scripts`)
+- `jscodeshift` 0.16.x → 17.x (`codemod`) — versioning-scheme renumbering, not a real breaking jump
+- `downshift` 6.x → 9.x (`application-shell`)
+- `fuse.js` 6.x → 7.x (`application-shell`)
+- `memoize-one` 5.x → 6.x (`application-shell`)
+- `qss` 2.x → 3.x (`application-shell`, `sdk`, `browser-history`)
+- `unfetch` 4.x → 5.x (`application-shell`, `sdk`, `jest-preset-mc-app`)
+- `reselect` 4.x → 5.x (`react-notifications`)
+- `@manypkg/get-packages` 1.x → 3.x (`cypress`)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           RTL_ASYNC_UTIL_TIMEOUT: 5000
 
       - name: Upload Jest coverage to Codecov
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/jest/lcov.info
@@ -374,7 +374,7 @@ jobs:
           mv ./coverage/lcov-report ./coverage/cypress/lcov-report
 
       - name: Upload Cypress coverage to Codecov
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/cypress/lcov.info

--- a/packages/application-shell/src/components/authenticated/oidc-callback.spec.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback.spec.tsx
@@ -21,7 +21,7 @@ describe('failed OIDC authentication', () => {
         disableRoutePermissionCheck: true,
       });
       await screen.findByText('Authentication error');
-      screen.getByText('Invalid token specified');
+      screen.getByText('Invalid token specified: must be a string');
     });
   });
 });

--- a/packages/application-shell/src/components/authenticated/oidc-callback.tsx
+++ b/packages/application-shell/src/components/authenticated/oidc-callback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import { decode } from 'qss';
 import { useLocation } from 'react-router-dom';
 import { oidcStorage } from '@commercetools-frontend/application-shell-connectors';

--- a/packages/cypress/src/task/index.ts
+++ b/packages/cypress/src/task/index.ts
@@ -40,7 +40,7 @@ const loadEnvironmentVariables = (
       return mergedEnvs;
     }
 
-    const env = require('dotenv').config({ path: envPath });
+    const env = require('dotenv').config({ path: envPath, quiet: true });
     if (env.error) {
       console.error(`Failed to load environment variables from ${envPath}`);
       return mergedEnvs;

--- a/packages/mc-scripts/src/cli.ts
+++ b/packages/mc-scripts/src/cli.ts
@@ -362,7 +362,7 @@ function loadDotEnvFiles(globalOptions: TCliGlobalOptions) {
       path.join(applicationDirectory, dotenvFile)
     );
     if (doesFileExist(dotenvFilePath)) {
-      dotenvExpand.expand(dotenv.config({ path: dotenvFilePath }));
+      dotenvExpand.expand(dotenv.config({ path: dotenvFilePath, quiet: true }));
     }
   });
 }

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
@@ -5,7 +5,6 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MomentLocalesPlugin from 'moment-locales-webpack-plugin';
 import type { XastElement, PluginInfo } from 'svgo';
 import webpack, { type Configuration } from 'webpack';
-// @ts-expect-error: we don't care about the missing types.
 import WebpackBar from 'webpackbar';
 import type {
   TWebpackConfigToggleFlagsForDevelopment,

--- a/packages/mc-scripts/src/utils/auth-callback.ts
+++ b/packages/mc-scripts/src/utils/auth-callback.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import { exit } from 'node:process';
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import type { TMcCliAuthToken } from '../types';
 
 type TAuthCallbackServerOptions = {

--- a/packages/mc-scripts/src/utils/headless-auth.ts
+++ b/packages/mc-scripts/src/utils/headless-auth.ts
@@ -1,4 +1,4 @@
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import type { TMcCliAuthToken } from '../types';
 import CredentialsStorage from './credentials-storage';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,14 +231,14 @@ catalogs:
       specifier: 3.3.4
       version: 3.3.4
     svg-url-loader:
-      specifier: 7.1.1
-      version: 7.1.1
+      specifier: 8.1.0
+      version: 8.1.0
     terser-webpack-plugin:
       specifier: ^5.5.0
       version: 5.5.0
     thread-loader:
-      specifier: 3.0.4
-      version: 3.0.4
+      specifier: 4.0.4
+      version: 4.0.4
     ts-node:
       specifier: 10.9.2
       version: 10.9.2
@@ -267,8 +267,8 @@ catalogs:
       specifier: 5.2.6
       version: 5.2.6
     webpackbar:
-      specifier: 5.0.2
-      version: 5.0.2
+      specifier: 7.0.0
+      version: 7.0.0
   default:
     '@commercetools-community-kit/i18n':
       specifier: ^0.3.0
@@ -427,8 +427,8 @@ catalogs:
       specifier: 1.0.0
       version: 1.0.0
     cross-env:
-      specifier: 7.0.3
-      version: 7.0.3
+      specifier: 10.1.0
+      version: 10.1.0
     cypress:
       specifier: 14.5.4
       version: 14.5.4
@@ -439,8 +439,8 @@ catalogs:
       specifier: 1.0.2
       version: 1.0.2
     dotenv:
-      specifier: 16.6.1
-      version: 16.6.1
+      specifier: 17.4.2
+      version: 17.4.2
     execa:
       specifier: 5.1.1
       version: 5.1.1
@@ -460,14 +460,14 @@ catalogs:
       specifier: 5.0.0
       version: 5.0.0
     fs-extra:
-      specifier: 10.1.0
-      version: 10.1.0
+      specifier: 11.4.0
+      version: 11.4.0
     fuse.js:
-      specifier: 6.6.2
-      version: 6.6.2
+      specifier: 7.5.0
+      version: 7.5.0
     glob:
-      specifier: ^10.5.0
-      version: 10.5.0
+      specifier: ^13.0.6
+      version: 13.0.6
     graphql-request:
       specifier: 5.2.0
       version: 5.2.0
@@ -481,8 +481,8 @@ catalogs:
       specifier: ^5.10.0
       version: 5.10.0
     jscodeshift:
-      specifier: 0.16.1
-      version: 0.16.1
+      specifier: 17.4.0
+      version: 17.4.0
     jsdom:
       specifier: ^21.1.2
       version: 21.1.2
@@ -490,8 +490,8 @@ catalogs:
       specifier: 15.0.4
       version: 15.0.4
     jwt-decode:
-      specifier: 3.1.2
-      version: 3.1.2
+      specifier: 4.0.0
+      version: 4.0.0
     listr2:
       specifier: 5.0.8
       version: 5.0.8
@@ -499,8 +499,8 @@ catalogs:
       specifier: 2.7.0
       version: 2.7.0
     memoize-one:
-      specifier: 5.2.1
-      version: 5.2.1
+      specifier: 6.0.0
+      version: 6.0.0
     moment:
       specifier: ^2.29.4
       version: 2.30.1
@@ -514,8 +514,8 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
     open:
-      specifier: ^10.1.0
-      version: 10.2.0
+      specifier: ^11.0.0
+      version: 11.0.0
     postcss-load-config:
       specifier: 3.1.4
       version: 3.1.4
@@ -526,8 +526,8 @@ catalogs:
       specifier: 20.9.0
       version: 20.9.0
     qss:
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: 3.0.0
+      version: 3.0.0
     querystring-es3:
       specifier: ^0.2.1
       version: 0.2.1
@@ -535,8 +535,8 @@ catalogs:
       specifier: 1.2.2
       version: 1.2.2
     reselect:
-      specifier: 4.1.8
-      version: 4.1.8
+      specifier: 5.2.0
+      version: 5.2.0
     rimraf:
       specifier: 6.1.3
       version: 6.1.3
@@ -565,8 +565,8 @@ catalogs:
       specifier: 1.4.1
       version: 1.4.1
     unfetch:
-      specifier: 4.2.0
-      version: 4.2.0
+      specifier: 5.0.0
+      version: 5.0.0
     url:
       specifier: ^0.11.0
       version: 0.11.4
@@ -738,8 +738,8 @@ catalogs:
       specifier: ^2.3.2
       version: 2.5.1
     downshift:
-      specifier: 6.1.12
-      version: 6.1.12
+      specifier: 9.4.0
+      version: 9.4.0
     formik:
       specifier: 2.4.9
       version: 2.4.9
@@ -904,11 +904,11 @@ catalogs:
       specifier: 0.25.1
       version: 0.25.1
     '@manypkg/find-root':
-      specifier: 2.2.3
-      version: 2.2.3
+      specifier: 3.1.0
+      version: 3.1.0
     '@manypkg/get-packages':
-      specifier: 1.1.3
-      version: 1.1.3
+      specifier: 3.1.0
+      version: 3.1.0
     husky:
       specifier: 7.0.4
       version: 7.0.4
@@ -1031,8 +1031,8 @@ catalogs:
       specifier: 2.1.5
       version: 2.1.5
     wait-for-expect:
-      specifier: 3.0.2
-      version: 3.0.2
+      specifier: 4.0.0
+      version: 4.0.0
 
 overrides:
   '@types/eslint': ^8.2.2
@@ -1050,12 +1050,12 @@ overrides:
   react: 19.2.8
   react-dom: 19.2.8
   tar: '>=7.5.11'
-  test-exclude: ^7.0.1
+  test-exclude: ^8.0.0
   flat-cache>rimraf: ^5.0.10
   webpack-dev-server>rimraf: ^5.0.10
   react-dev-utils>fork-ts-checker-webpack-plugin: ^9.1.0
   lodash: 4.18.1
-  picomatch@^2: ^2.3.2
+  picomatch@^2: ^4.0.5
   flatted: '>=3.4.2'
   serialize-javascript: '>=7.0.7'
   axios: '>=1.15.2'
@@ -1075,7 +1075,7 @@ overrides:
   path-to-regexp@^6: ^6.3.0
   picomatch@^4: ^4.0.4
   rollup@^4: ^4.59.0
-  semver@^6: ^6.3.1
+  semver@^6: ^7.8.5
   svgo: '>=2.8.1'
   systeminformation: '>=5.31.0'
   tar-fs: '>=3.1.1'
@@ -1141,7 +1141,7 @@ importers:
         version: 17.8.1
       '@cypress/code-coverage':
         specifier: catalog:test
-        version: 3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+        version: 3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       '@faker-js/faker':
         specifier: catalog:test
         version: 8.4.1
@@ -1174,10 +1174,10 @@ importers:
         version: 0.25.1
       '@manypkg/find-root':
         specifier: catalog:repo
-        version: 2.2.3
+        version: 3.1.0
       '@manypkg/get-packages':
         specifier: catalog:repo
-        version: 1.1.3
+        version: 3.1.0
       '@percy/cli':
         specifier: catalog:test
         version: 1.32.6(supports-color@8.1.1)(typescript@5.9.3)
@@ -1249,13 +1249,13 @@ importers:
         version: 2.1.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       cross-env:
         specifier: 'catalog:'
-        version: 7.0.3
+        version: 10.1.0
       cypress:
         specifier: 'catalog:'
         version: 14.5.4
       dotenv:
         specifier: 'catalog:'
-        version: 16.6.1
+        version: 17.4.2
       eslint:
         specifier: catalog:lint
         version: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
@@ -1318,7 +1318,7 @@ importers:
         version: 20.9.0(supports-color@8.1.1)(typescript@5.9.3)
       qss:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 3.0.0
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2222,7 +2222,7 @@ importers:
         version: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jest:
         specifier: catalog:lint
-        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)
       eslint-plugin-n:
         specifier: catalog:lint
         version: 17.23.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(typescript@5.9.3)
@@ -2762,10 +2762,10 @@ importers:
         version: 0.0.2
       downshift:
         specifier: catalog:react
-        version: 6.1.12(react@19.2.8)
+        version: 9.4.0(react@19.2.8)
       fuse.js:
         specifier: 'catalog:'
-        version: 6.6.2
+        version: 7.5.0
       graphql:
         specifier: catalog:apollo
         version: 16.14.2
@@ -2777,13 +2777,13 @@ importers:
         version: 1.0.3
       jwt-decode:
         specifier: 'catalog:'
-        version: 3.1.2
+        version: 4.0.0
       lodash:
         specifier: 4.18.1
         version: 4.18.1
       memoize-one:
         specifier: 'catalog:'
-        version: 5.2.1
+        version: 6.0.0
       moment:
         specifier: 'catalog:'
         version: 2.30.1
@@ -2798,7 +2798,7 @@ importers:
         version: 15.8.1
       qss:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 3.0.0
       react-required-if:
         specifier: catalog:react
         version: 1.0.3
@@ -2816,7 +2816,7 @@ importers:
         version: 1.3.3
       unfetch:
         specifier: 'catalog:'
-        version: 4.2.0
+        version: 5.0.0
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -3054,7 +3054,7 @@ importers:
         version: 1.0.4(history@4.10.1)
       qss:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 3.0.0
 
   packages/codemod:
     dependencies:
@@ -3069,10 +3069,10 @@ importers:
         version: 13.1.0
       glob:
         specifier: 'catalog:'
-        version: 10.5.0
+        version: 13.0.6
       jscodeshift:
         specifier: 'catalog:'
-        version: 0.16.1(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 17.4.0(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       prettier:
         specifier: catalog:lint
         version: 2.8.8
@@ -3180,7 +3180,7 @@ importers:
         version: link:../constants
       '@manypkg/get-packages':
         specifier: catalog:repo
-        version: 1.1.3
+        version: 3.1.0
       '@types/semver':
         specifier: 'catalog:'
         version: 7.7.1
@@ -3232,7 +3232,7 @@ importers:
         version: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jest:
         specifier: catalog:lint
-        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3)
       eslint-plugin-jest-dom:
         specifier: catalog:lint
         version: 4.0.3(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))
@@ -3393,7 +3393,7 @@ importers:
         version: 1.0.5
       unfetch:
         specifier: 'catalog:'
-        version: 4.2.0
+        version: 5.0.0
     devDependencies:
       '@testing-library/react':
         specifier: catalog:test
@@ -3406,7 +3406,7 @@ importers:
     dependencies:
       create-jest-runner:
         specifier: 'catalog:'
-        version: 1.0.0(@jest/test-result@30.2.0)(jest-runner@30.4.2(supports-color@8.1.1))
+        version: 1.0.0(@jest/test-result@30.2.0)(jest-runner@30.2.0(supports-color@8.1.1))
       postcss-load-config:
         specifier: 'catalog:'
         version: 3.1.4(postcss@8.5.26)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
@@ -3617,7 +3617,7 @@ importers:
         version: 2.6.4
       '@types/webpack-bundle-analyzer':
         specifier: 'catalog:'
-        version: 4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+        version: 4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
       '@vitejs/plugin-react':
         specifier: catalog:build
         version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -3656,16 +3656,16 @@ importers:
         version: 8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       dotenv:
         specifier: 'catalog:'
-        version: 16.6.1
+        version: 17.4.2
       dotenv-expand:
         specifier: catalog:build
         version: 8.0.3
       fs-extra:
         specifier: 'catalog:'
-        version: 10.1.0
+        version: 11.4.0
       glob:
         specifier: 'catalog:'
-        version: 10.5.0
+        version: 13.0.6
       graphql:
         specifier: catalog:apollo
         version: 16.14.2
@@ -3683,7 +3683,7 @@ importers:
         version: 0.5.7
       jwt-decode:
         specifier: 'catalog:'
-        version: 3.1.2
+        version: 4.0.0
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -3701,7 +3701,7 @@ importers:
         version: 2.7.0
       open:
         specifier: 'catalog:'
-        version: 10.2.0
+        version: 11.0.0
       postcss:
         specifier: catalog:build
         version: 8.5.26
@@ -3752,13 +3752,13 @@ importers:
         version: 3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       svg-url-loader:
         specifier: catalog:build
-        version: 7.1.1(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 8.1.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       terser-webpack-plugin:
         specifier: catalog:build
         version: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       thread-loader:
         specifier: catalog:build
-        version: 3.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 4.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       url:
         specifier: 'catalog:'
         version: 0.11.4
@@ -3779,7 +3779,7 @@ importers:
         version: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       webpackbar:
         specifier: catalog:build
-        version: 5.0.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 7.0.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
     devDependencies:
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
@@ -3798,7 +3798,7 @@ importers:
         version: 4.17.20
       '@types/moment-locales-webpack-plugin':
         specifier: 'catalog:'
-        version: 1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+        version: 1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
       '@types/node-fetch':
         specifier: 'catalog:'
         version: 2.6.13
@@ -3974,7 +3974,7 @@ importers:
         version: 15.8.1
       reselect:
         specifier: 'catalog:'
-        version: 4.1.8
+        version: 5.2.0
     devDependencies:
       '@types/jest':
         specifier: catalog:test
@@ -4053,10 +4053,10 @@ importers:
         version: 15.8.1
       qss:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 3.0.0
       unfetch:
         specifier: 'catalog:'
-        version: 4.2.0
+        version: 5.0.0
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -4136,7 +4136,7 @@ importers:
         version: 6.4.1(supports-color@8.1.1)
       wait-for-expect:
         specifier: catalog:test
-        version: 3.0.2
+        version: 4.0.0
 
   packages/url-utils:
     dependencies:
@@ -6238,6 +6238,9 @@ packages:
     resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
     engines: {node: '>=18.0.0'}
 
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -7738,10 +7741,6 @@ packages:
     resolution: {integrity: sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/console@30.4.1':
-    resolution: {integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/core@30.2.0':
     resolution: {integrity: sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -7751,21 +7750,8 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/core@30.4.2':
-    resolution: {integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
   '@jest/diff-sequences@30.0.1':
     resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/diff-sequences@30.4.0':
-    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/environment-jsdom-abstract@30.2.0':
@@ -7786,10 +7772,6 @@ packages:
     resolution: {integrity: sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/environment@30.4.1':
-    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7798,16 +7780,8 @@ packages:
     resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect-utils@30.4.1':
-    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/expect@30.2.0':
     resolution: {integrity: sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect@30.4.1':
-    resolution: {integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/fake-timers@29.7.0':
@@ -7818,10 +7792,6 @@ packages:
     resolution: {integrity: sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/fake-timers@30.4.1':
-    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/get-type@30.1.0':
     resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -7830,29 +7800,12 @@ packages:
     resolution: {integrity: sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/globals@30.4.1':
-    resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/pattern@30.0.1':
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/pattern@30.4.0':
-    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/reporters@30.2.0':
     resolution: {integrity: sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
-  '@jest/reporters@30.4.1':
-    resolution: {integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -7868,16 +7821,8 @@ packages:
     resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/schemas@30.4.1':
-    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/snapshot-utils@30.2.0':
     resolution: {integrity: sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/snapshot-utils@30.4.1':
-    resolution: {integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/source-map@30.0.1':
@@ -7888,16 +7833,8 @@ packages:
     resolution: {integrity: sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-result@30.4.1':
-    resolution: {integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/test-sequencer@30.2.0':
     resolution: {integrity: sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/test-sequencer@30.4.1':
-    resolution: {integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/transform@29.7.0':
@@ -7906,10 +7843,6 @@ packages:
 
   '@jest/transform@30.2.0':
     resolution: {integrity: sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/transform@30.4.1':
-    resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@26.6.2':
@@ -7922,10 +7855,6 @@ packages:
 
   '@jest/types@30.2.0':
     resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.4.1':
-    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -8018,10 +7947,6 @@ packages:
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
-  '@manypkg/find-root@2.2.3':
-    resolution: {integrity: sha512-jtEZKczWTueJYHjGpxU3KJQ08Gsrf4r6Q2GjmPp/RGk5leeYAA1eyDADSAF+KVCsQ6EwZd/FMcOFCoMhtqdCtQ==}
-    engines: {node: '>=14.18.0'}
-
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
     engines: {node: '>=20.0.0'}
@@ -8032,10 +7957,6 @@ packages:
   '@manypkg/get-packages@3.1.0':
     resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
     engines: {node: '>=20.0.0'}
-
-  '@manypkg/tools@1.1.2':
-    resolution: {integrity: sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==}
-    engines: {node: '>=14.18.0'}
 
   '@manypkg/tools@2.1.0':
     resolution: {integrity: sha512-0FOIepYR4ugPYaHwK7hDeHDkfPOBVvayt9QpvRbi2LT/h2b0GaE/gM9Gag7fsnyYyNaTZ2IGyOuVg07IYepvYQ==}
@@ -9164,9 +9085,6 @@ packages:
 
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
-
-  '@sinonjs/fake-timers@15.4.0':
-    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
@@ -10517,11 +10435,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.18.0:
-    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
@@ -10625,6 +10538,10 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  ansis@3.17.0:
+    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+    engines: {node: '>=14'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -10869,12 +10786,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-0
 
-  babel-jest@30.4.1:
-    resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      '@babel/core': ^7.11.0 || ^8.0.0-0
-
   babel-loader@8.4.1:
     resolution: {integrity: sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==}
     engines: {node: '>= 8.9'}
@@ -10911,10 +10822,6 @@ packages:
 
   babel-plugin-jest-hoist@30.2.0:
     resolution: {integrity: sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  babel-plugin-jest-hoist@30.4.0:
-    resolution: {integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   babel-plugin-macros@3.1.0:
@@ -10977,12 +10884,6 @@ packages:
 
   babel-preset-jest@30.2.0:
     resolution: {integrity: sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      '@babel/core': ^7.11.0 || ^8.0.0-beta.1
-
-  babel-preset-jest@30.4.0:
-    resolution: {integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
@@ -11578,9 +11479,6 @@ packages:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
-  compute-scroll-into-view@1.0.20:
-    resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
-
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
@@ -11608,9 +11506,6 @@ packages:
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
-
-  consola@2.15.3:
-    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -11790,9 +11685,9 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-env@7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   cross-fetch@3.2.0:
@@ -12118,8 +12013,8 @@ packages:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
 
-  default-browser@5.3.0:
-    resolution: {integrity: sha512-Qq68+VkJlc8tjnPV1i7HtbIn7ohmjZa88qUvHMIK0ZKUXMCuV45cT7cEXALPUmeXCe0q1DWQkQTemHVaLIFSrg==}
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
   default-require-extensions@3.0.1:
@@ -12341,13 +12236,13 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
-  downshift@6.1.12:
-    resolution: {integrity: sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==}
+  downshift@9.3.3:
+    resolution: {integrity: sha512-otjI/WtoFcIXwPOyIQYkbrAZJA2Gjz67F8ENOh1RvmJalOg6fk0KEx4ljJSFuJB54ryc6doymPkCM+GjAZ7zjA==}
     peerDependencies:
       react: 19.2.8
 
-  downshift@9.3.3:
-    resolution: {integrity: sha512-otjI/WtoFcIXwPOyIQYkbrAZJA2Gjz67F8ENOh1RvmJalOg6fk0KEx4ljJSFuJB54ryc6doymPkCM+GjAZ7zjA==}
+  downshift@9.4.0:
+    resolution: {integrity: sha512-yIwyzRYzycKwMZhvOahsn4BmRr4Ffi0JymdWOtTDhR+LGDEXCZHTcwgUbNBC/oZLT6YrR46iwJe/BrQUS5ClQQ==}
     peerDependencies:
       react: 19.2.8
 
@@ -12428,10 +12323,6 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.24.5:
-    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
-    engines: {node: '>=10.13.0'}
-
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -12486,8 +12377,8 @@ packages:
   es-module-lexer@1.5.0:
     resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -12839,10 +12730,6 @@ packages:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  expect@30.4.1:
-    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   express-winston@4.2.0:
     resolution: {integrity: sha512-EMD74g63nVHi7pFleQw7KHCxiA1pjF5uCwbCfzGqmFxs9KvlDPIVS3cMGpULm6MshExMT9TjC3SqmRGB9kb7yw==}
     engines: {node: '>= 6'}
@@ -13170,8 +13057,8 @@ packages:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -13210,8 +13097,8 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  fuse.js@6.6.2:
-    resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
+  fuse.js@7.5.0:
+    resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
     engines: {node: '>=10'}
 
   gauge@2.7.4:
@@ -14037,6 +13924,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -14321,16 +14212,8 @@ packages:
     resolution: {integrity: sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-changed-files@30.4.1:
-    resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-circus@30.2.0:
     resolution: {integrity: sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-circus@30.4.2:
-    resolution: {integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-cli@30.2.0:
@@ -14343,33 +14226,8 @@ packages:
       node-notifier:
         optional: true
 
-  jest-cli@30.4.2:
-    resolution: {integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
   jest-config@30.2.0:
     resolution: {integrity: sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      '@types/node': ^22.13.2
-      esbuild-register: '>=3.4.0'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      esbuild-register:
-        optional: true
-      ts-node:
-        optional: true
-
-  jest-config@30.4.2:
-    resolution: {integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@types/node': ^22.13.2
@@ -14395,24 +14253,12 @@ packages:
     resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-diff@30.4.1:
-    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-docblock@30.2.0:
     resolution: {integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-docblock@30.4.0:
-    resolution: {integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-each@30.2.0:
     resolution: {integrity: sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-each@30.4.1:
-    resolution: {integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-environment-jsdom@30.2.0:
@@ -14432,10 +14278,6 @@ packages:
     resolution: {integrity: sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-environment-node@30.4.1:
-    resolution: {integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-environment-puppeteer@8.0.6:
     resolution: {integrity: sha512-mhmpVMK9Mnzr4DVAGhGA5yQGmlLv7ty5JW/A8jSz0Dlpbk0sGoyOzwjzgd/4wUAuOx2B3o7BLHbKYpzmGS4UIA==}
     engines: {node: '>=14.0.0'}
@@ -14452,16 +14294,8 @@ packages:
     resolution: {integrity: sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-haste-map@30.4.1:
-    resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-leak-detector@30.2.0:
     resolution: {integrity: sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-leak-detector@30.4.1:
-    resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-localstorage-mock@2.4.26:
@@ -14476,10 +14310,6 @@ packages:
     resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.4.1:
-    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -14488,20 +14318,12 @@ packages:
     resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.4.1:
-    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-mock@30.2.0:
     resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.4.1:
-    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
@@ -14531,24 +14353,12 @@ packages:
     resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-regex-util@30.4.0:
-    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-resolve-dependencies@30.2.0:
     resolution: {integrity: sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve-dependencies@30.4.2:
-    resolution: {integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-resolve@30.2.0:
     resolution: {integrity: sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-resolve@30.4.1:
-    resolution: {integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-runner-eslint@2.3.0:
@@ -14565,16 +14375,8 @@ packages:
     resolution: {integrity: sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runner@30.4.2:
-    resolution: {integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-runtime@30.2.0:
     resolution: {integrity: sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-runtime@30.4.2:
-    resolution: {integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-silent-reporter@0.6.0:
@@ -14582,10 +14384,6 @@ packages:
 
   jest-snapshot@30.2.0:
     resolution: {integrity: sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-snapshot@30.4.1:
-    resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@26.6.2:
@@ -14600,16 +14398,8 @@ packages:
     resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-util@30.4.1:
-    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-validate@30.2.0:
     resolution: {integrity: sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-validate@30.4.1:
-    resolution: {integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-watch-typeahead@3.0.1:
@@ -14620,10 +14410,6 @@ packages:
 
   jest-watcher@30.2.0:
     resolution: {integrity: sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-watcher@30.4.1:
-    resolution: {integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-worker@24.9.0:
@@ -14650,22 +14436,8 @@ packages:
     resolution: {integrity: sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-worker@30.4.1:
-    resolution: {integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest@30.2.0:
     resolution: {integrity: sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
-  jest@30.4.2:
-    resolution: {integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -14715,8 +14487,9 @@ packages:
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
-  jscodeshift@0.16.1:
-    resolution: {integrity: sha512-oMQXySazy63awNBzMpXbbVv73u3irdxTeX2L5ueRyFRxi32qb9uzdZdOY5fTBYADBG19l5M/wnGknZSV1dzCdA==}
+  jscodeshift@17.4.0:
+    resolution: {integrity: sha512-i3ESKiiTsGynxzTg5BhsZViD0ai72/6SsI1efDZxG6/5KCoElsmquxtyhXK5lpEgoO7MTNpYkjFEdEL97SkBNg==}
+    engines: {node: '>=16'}
     hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
@@ -14831,8 +14604,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
-  jwt-decode@3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@3.1.0:
     resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
@@ -15293,9 +15067,6 @@ packages:
   memfs@4.51.0:
     resolution: {integrity: sha512-4zngfkVM/GpIhC8YazOsM6E8hoB33NP0BCESPOA6z7qaL6umPJNqkO8CNYaLV2FB2MV6H1O3x2luHHOSqppv+A==}
 
-  memoize-one@5.2.1:
-    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
-
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
@@ -15562,49 +15333,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minimizer-webpack-plugin@5.6.1:
-    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@minify-html/node': '*'
-      '@swc/core': '*'
-      '@swc/css': '*'
-      '@swc/html': '*'
-      clean-css: '*'
-      cssnano: '*'
-      csso: '*'
-      esbuild: '*'
-      html-minifier-terser: '*'
-      lightningcss: '*'
-      postcss: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@minify-html/node':
-        optional: true
-      '@swc/core':
-        optional: true
-      '@swc/css':
-        optional: true
-      '@swc/html':
-        optional: true
-      clean-css:
-        optional: true
-      cssnano:
-        optional: true
-      csso:
-        optional: true
-      esbuild:
-        optional: true
-      html-minifier-terser:
-        optional: true
-      lightningcss:
-        optional: true
-      postcss:
-        optional: true
-      uglify-js:
-        optional: true
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -15737,10 +15465,6 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
-
-  node-dir@0.1.17:
-    resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
-    engines: {node: '>= 0.10.5'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -15955,6 +15679,10 @@ packages:
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -16244,10 +15972,6 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -16569,6 +16293,10 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -16613,10 +16341,6 @@ packages:
 
   pretty-format@30.2.0:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  pretty-format@30.4.1:
-    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   pretty-ms@7.0.1:
@@ -16757,8 +16481,8 @@ packages:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
-  qss@2.0.3:
-    resolution: {integrity: sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ==}
+  qss@3.0.0:
+    resolution: {integrity: sha512-ZHoCB3M/3Voev64zhLLUOKDtaEdJ/lymsJJ7R3KBusVZ2ovNiIB7XOq3Xh6V1a8O+Vho+g2B5YElq9zW7D8aQw==}
     engines: {node: '>=4'}
 
   quansync@0.2.11:
@@ -17226,11 +16950,8 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
-  reselect@4.1.8:
-    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
-
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
@@ -17295,11 +17016,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@2.6.3:
-    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -17457,10 +17173,6 @@ packages:
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   semver@7.5.4:
@@ -18065,11 +17777,11 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
-  svg-url-loader@7.1.1:
-    resolution: {integrity: sha512-NlsMCePODm7FQhU9aEZyGLPx5Xe1QRI1cSEUE6vTq5LJc9l9pStagvXoEIyZ9O3r00w6G3+Wbkimb+SC3DI/Aw==}
-    engines: {node: '>=10'}
+  svg-url-loader@8.1.0:
+    resolution: {integrity: sha512-8Mf5g0R44VSiTQnSXT6qCSHwCO3VwZAOcm+o0FB80wGGeZNDzKBPKc8gtfIbSfNPmnE8SHv/+e49vO2NVHEmKA==}
+    engines: {node: '>=14'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: ^5.0.0
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -18113,10 +17825,6 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tapable@2.3.3:
-    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
-    engines: {node: '>=6'}
-
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
 
@@ -18129,10 +17837,6 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
-
-  temp@0.9.4:
-    resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
-    engines: {node: '>=6.0.0'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -18159,9 +17863,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
@@ -18192,11 +17896,11 @@ packages:
     peerDependencies:
       tslib: ^2
 
-  thread-loader@3.0.4:
-    resolution: {integrity: sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==}
-    engines: {node: '>= 10.13.0'}
+  thread-loader@4.0.4:
+    resolution: {integrity: sha512-tXagu6Hivd03wB2tiS1bqvw345sc7mKei32EgpYpq31ZLes9FN0mEK2nKzXLRFgwt3PsBB0E/MZDp159rDoqwg==}
+    engines: {node: '>= 16.10.0'}
     peerDependencies:
-      webpack: ^4.27.0 || ^5.0.0
+      webpack: ^5.0.0
 
   throat@4.1.0:
     resolution: {integrity: sha512-wCVxLDcFxw7ujDxaeJC6nfl2XfHJNYs8yUYJnvMgtPEFlttP9tHSfRUv2vBe6C4hkVFPWoP1P6ZccbYjmSEkKA==}
@@ -18569,8 +18273,8 @@ packages:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
-  unfetch@4.2.0:
-    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
+  unfetch@5.0.0:
+    resolution: {integrity: sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -18943,8 +18647,8 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  wait-for-expect@3.0.2:
-    resolution: {integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==}
+  wait-for-expect@4.0.0:
+    resolution: {integrity: sha512-mcH2HYUUHhdFGHVJkgwkBxRihZO4VSuPyh6xhYHz7LEnYkcaLbTAEEsTpYiFw4UY45XdTZYYIaquuMucw9wWMw==}
 
   wait-for-observables@1.0.3:
     resolution: {integrity: sha512-fUXfx0u7LcoQRTTpWv8ghCrbf0bsgB/T8mxYlOph3RV3/9dMQGFq8HN/9rgzfvaCNLWBQoaLI0+61NyUjYYMYQ==}
@@ -18965,8 +18669,8 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
-  watchpack@2.5.2:
-    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
   wbuf@1.7.3:
@@ -19022,8 +18726,8 @@ packages:
       webpack-cli:
         optional: true
 
-  webpack-sources@3.5.1:
-    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
+  webpack-sources@3.3.3:
+    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
 
   webpack@5.105.1:
@@ -19036,21 +18740,17 @@ packages:
       webpack-cli:
         optional: true
 
-  webpack@5.109.2:
-    resolution: {integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
+  webpackbar@7.0.0:
+    resolution: {integrity: sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==}
+    engines: {node: '>=14.21.3'}
     peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-
-  webpackbar@5.0.2:
-    resolution: {integrity: sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==}
-    engines: {node: '>=12'}
-    peerDependencies:
+      '@rspack/core': '*'
       webpack: 3 || 4 || 5
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -19217,6 +18917,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
@@ -19367,7 +19071,7 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/traverse': 7.29.8(supports-color@8.1.1)
       '@babel/types': 7.29.8
       babel-preset-fbjs: 3.4.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
@@ -19539,7 +19243,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -19549,7 +19253,7 @@ snapshots:
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
+      semver: 7.8.5
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -19575,9 +19279,9 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.7
+      browserslist: 4.28.1
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.8.5
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -19585,7 +19289,7 @@ snapshots:
       '@babel/helper-validator-option': 7.29.7
       browserslist: 4.28.7
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.8.5
 
   '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
@@ -19596,7 +19300,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
       '@babel/traverse': 7.29.8(supports-color@8.1.1)
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -19605,7 +19309,7 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
-      semver: 6.3.1
+      semver: 7.8.5
 
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
@@ -20223,7 +19927,7 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20361,7 +20065,7 @@ snapshots:
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.46.0
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20369,7 +20073,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))':
@@ -20754,7 +20458,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/register': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/constants': 24.11.0
       '@types/lodash': 4.17.20
@@ -20779,7 +20483,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/register': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/constants': 24.11.0
       '@types/lodash': 4.17.20
@@ -20802,12 +20506,12 @@ snapshots:
 
   '@commercetools-frontend/constants@24.11.0':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
 
   '@commercetools-uikit/accessible-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -20852,7 +20556,7 @@ snapshots:
 
   '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20891,7 +20595,7 @@ snapshots:
 
   '@commercetools-uikit/calendar-time-utils@20.6.7(moment-timezone@0.6.0)(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
       moment-timezone: 0.6.0
@@ -20900,7 +20604,7 @@ snapshots:
 
   '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.4)(moment@2.30.1)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20927,7 +20631,7 @@ snapshots:
 
   '@commercetools-uikit/card@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -20981,7 +20685,7 @@ snapshots:
 
   '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.8)
@@ -20996,7 +20700,7 @@ snapshots:
 
   '@commercetools-uikit/constraints@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21121,7 +20825,7 @@ snapshots:
 
   '@commercetools-uikit/design-system@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/hooks': 19.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@emotion/react': 11.14.0(@types/react@19.2.4)(react@19.2.8)(supports-color@8.1.1)
@@ -21148,7 +20852,7 @@ snapshots:
 
   '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21225,7 +20929,7 @@ snapshots:
 
   '@commercetools-uikit/flat-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21277,7 +20981,7 @@ snapshots:
 
   '@commercetools-uikit/hooks@19.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
       '@types/raf-schd': 4.0.3
@@ -21324,7 +21028,7 @@ snapshots:
 
   '@commercetools-uikit/icons@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21414,7 +21118,7 @@ snapshots:
 
   '@commercetools-uikit/loading-spinner@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21631,7 +21335,7 @@ snapshots:
 
   '@commercetools-uikit/primary-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21672,7 +21376,7 @@ snapshots:
 
   '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@7.1.14(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21695,7 +21399,7 @@ snapshots:
 
   '@commercetools-uikit/secondary-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@6.8.9(react@19.2.8)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21736,7 +21440,7 @@ snapshots:
 
   '@commercetools-uikit/secondary-icon-button@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -21845,7 +21549,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inline@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21872,7 +21576,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inset-squish@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21899,7 +21603,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-inset@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21926,7 +21630,7 @@ snapshots:
 
   '@commercetools-uikit/spacings-stack@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -21953,7 +21657,7 @@ snapshots:
 
   '@commercetools-uikit/spacings@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/spacings-inline': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/spacings-inset': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -21997,7 +21701,7 @@ snapshots:
 
   '@commercetools-uikit/tag@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -22061,7 +21765,7 @@ snapshots:
 
   '@commercetools-uikit/text@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react-intl@6.8.9(react@19.2.8)(typescript@5.9.3))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
       '@commercetools-uikit/utils': 19.9.0(react@19.2.8)
@@ -22094,7 +21798,7 @@ snapshots:
 
   '@commercetools-uikit/tooltip@19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 19.9.0(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(supports-color@8.1.1)
@@ -22114,7 +21818,7 @@ snapshots:
 
   '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -22134,7 +21838,7 @@ snapshots:
 
   '@commercetools-uikit/utils@19.9.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@emotion/is-prop-valid': 1.2.2
       react: 19.2.8
@@ -22150,7 +21854,7 @@ snapshots:
 
   '@commercetools/composable-commerce-test-data@13.13.1(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.11)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools-frontend/constants': 24.11.0
@@ -22169,7 +21873,7 @@ snapshots:
 
   '@commercetools/composable-commerce-test-data@13.13.1(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@babel/runtime-corejs3': 7.29.0
       '@commercetools-frontend/application-config': 24.11.0(@types/node@22.19.17)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools-frontend/constants': 24.11.0
@@ -22445,7 +22149,7 @@ snapshots:
     dependencies:
       '@commitlint/top-level': 17.8.1
       '@commitlint/types': 17.8.1
-      fs-extra: 11.3.2
+      fs-extra: 11.4.0
       git-raw-commits: 2.0.11
       minimist: 1.2.8
 
@@ -22504,12 +22208,12 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@cypress/code-coverage@3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))':
+  '@cypress/code-coverage@3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/preset-env': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
-      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       chalk: 4.1.2
       cypress: 14.5.4
       dayjs: 1.11.13
@@ -22519,7 +22223,7 @@ snapshots:
       js-yaml: 3.15.1
       nyc: 15.1.0(supports-color@8.1.1)
       tinyglobby: 0.2.17
-      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -22544,16 +22248,16 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/preset-env': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
       bluebird: 3.7.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       semver: 7.8.5
-      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -22736,6 +22440,8 @@ snapshots:
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
+
+  '@epic-web/invariant@1.0.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -23234,7 +22940,7 @@ snapshots:
       chalk: 4.1.2
       commander: 12.1.0
       fast-glob: 3.3.3
-      fs-extra: 11.3.2
+      fs-extra: 11.4.0
       json-stable-stringify: 1.3.0
       loud-rejection: 2.2.0
       tslib: 2.8.1
@@ -24189,7 +23895,7 @@ snapshots:
 
   '@hello-pangea/dnd@18.0.1(@types/react@19.2.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       css-box-model: 1.2.1
       raf-schd: 4.0.3
       react: 19.2.8
@@ -24357,7 +24063,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -24377,16 +24083,6 @@ snapshots:
       jest-message-util: 30.2.0
       jest-util: 30.2.0
       slash: 3.0.0
-
-  '@jest/console@30.4.1':
-    dependencies:
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      chalk: 4.1.2
-      jest-message-util: 30.4.1
-      jest-util: 30.4.1
-      slash: 3.0.0
-    optional: true
 
   '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3))':
     dependencies:
@@ -24424,47 +24120,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.4.2(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.4.1
-      '@jest/pattern': 30.4.0
-      '@jest/reporters': 30.4.1(supports-color@8.1.1)
-      '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      exit-x: 0.2.2
-      fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
-      jest-haste-map: 30.4.1
-      jest-message-util: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-resolve: 30.4.1
-      jest-resolve-dependencies: 30.4.2(supports-color@8.1.1)
-      jest-runner: 30.4.2(supports-color@8.1.1)
-      jest-runtime: 30.4.2(supports-color@8.1.1)
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      jest-watcher: 30.4.1
-      pretty-format: 30.4.1
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-    optional: true
-
   '@jest/diff-sequences@30.0.1': {}
-
-  '@jest/diff-sequences@30.4.0':
-    optional: true
 
   '@jest/environment-jsdom-abstract@30.2.0(jsdom@26.1.0(supports-color@8.1.1))':
     dependencies:
@@ -24491,14 +24147,6 @@ snapshots:
       '@types/node': 22.19.17
       jest-mock: 30.2.0
 
-  '@jest/environment@30.4.1':
-    dependencies:
-      '@jest/fake-timers': 30.4.1
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      jest-mock: 30.4.1
-    optional: true
-
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
@@ -24507,25 +24155,12 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect-utils@30.4.1':
-    dependencies:
-      '@jest/get-type': 30.1.0
-    optional: true
-
   '@jest/expect@30.2.0(supports-color@8.1.1)':
     dependencies:
       expect: 30.2.0
       jest-snapshot: 30.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/expect@30.4.1(supports-color@8.1.1)':
-    dependencies:
-      expect: 30.4.1
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@jest/fake-timers@29.7.0':
     dependencies:
@@ -24545,16 +24180,6 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
 
-  '@jest/fake-timers@30.4.1':
-    dependencies:
-      '@jest/types': 30.4.1
-      '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 22.19.17
-      jest-message-util: 30.4.1
-      jest-mock: 30.4.1
-      jest-util: 30.4.1
-    optional: true
-
   '@jest/get-type@30.1.0': {}
 
   '@jest/globals@30.2.0(supports-color@8.1.1)':
@@ -24566,26 +24191,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/globals@30.4.1(supports-color@8.1.1)':
-    dependencies:
-      '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      jest-mock: 30.4.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@jest/pattern@30.0.1':
     dependencies:
       '@types/node': 22.19.17
       jest-regex-util: 30.0.1
-
-  '@jest/pattern@30.4.0':
-    dependencies:
-      '@types/node': 22.19.17
-      jest-regex-util: 30.4.0
-    optional: true
 
   '@jest/reporters@30.2.0(supports-color@8.1.1)':
     dependencies:
@@ -24615,35 +24224,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/reporters@30.4.1(supports-color@8.1.1)':
-    dependencies:
-      '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 30.4.1
-      '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.17
-      chalk: 4.1.2
-      collect-v8-coverage: 1.0.3
-      exit-x: 0.2.2
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
-      istanbul-reports: 3.2.0
-      jest-message-util: 30.4.1
-      jest-util: 30.4.1
-      jest-worker: 30.4.1
-      slash: 3.0.0
-      string-length: 4.0.2
-      v8-to-istanbul: 9.3.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -24652,25 +24232,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.47
 
-  '@jest/schemas@30.4.1':
-    dependencies:
-      '@sinclair/typebox': 0.34.47
-    optional: true
-
   '@jest/snapshot-utils@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
       chalk: 4.1.2
       graceful-fs: 4.2.11
       natural-compare: 1.4.0
-
-  '@jest/snapshot-utils@30.4.1':
-    dependencies:
-      '@jest/types': 30.4.1
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      natural-compare: 1.4.0
-    optional: true
 
   '@jest/source-map@30.0.1':
     dependencies:
@@ -24685,28 +24252,12 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
-  '@jest/test-result@30.4.1':
-    dependencies:
-      '@jest/console': 30.4.1
-      '@jest/types': 30.4.1
-      '@types/istanbul-lib-coverage': 2.0.6
-      collect-v8-coverage: 1.0.3
-    optional: true
-
   '@jest/test-sequencer@30.2.0':
     dependencies:
       '@jest/test-result': 30.2.0
       graceful-fs: 4.2.11
       jest-haste-map: 30.2.0
       slash: 3.0.0
-
-  '@jest/test-sequencer@30.4.1':
-    dependencies:
-      '@jest/test-result': 30.4.1
-      graceful-fs: 4.2.11
-      jest-haste-map: 30.4.1
-      slash: 3.0.0
-    optional: true
 
   '@jest/transform@29.7.0(supports-color@8.1.1)':
     dependencies:
@@ -24749,26 +24300,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/transform@30.4.1(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
-      chalk: 4.1.2
-      convert-source-map: 2.0.0
-      fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.11
-      jest-haste-map: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-util: 30.4.1
-      pirates: 4.0.7
-      slash: 3.0.0
-      write-file-atomic: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@jest/types@26.6.2':
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
@@ -24795,17 +24326,6 @@ snapshots:
       '@types/node': 22.19.17
       '@types/yargs': 17.0.34
       chalk: 4.1.2
-
-  '@jest/types@30.4.1':
-    dependencies:
-      '@jest/pattern': 30.4.0
-      '@jest/schemas': 30.4.1
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.17
-      '@types/yargs': 17.0.34
-      chalk: 4.1.2
-    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -24915,10 +24435,6 @@ snapshots:
       find-up: 4.1.0
       fs-extra: 8.1.0
 
-  '@manypkg/find-root@2.2.3':
-    dependencies:
-      '@manypkg/tools': 1.1.2
-
   '@manypkg/find-root@3.1.0':
     dependencies:
       '@manypkg/tools': 2.1.0
@@ -24936,12 +24452,6 @@ snapshots:
     dependencies:
       '@manypkg/find-root': 3.1.0
       '@manypkg/tools': 2.1.0
-
-  '@manypkg/tools@1.1.2':
-    dependencies:
-      fast-glob: 3.3.3
-      jju: 1.4.0
-      js-yaml: 3.15.1
 
   '@manypkg/tools@2.1.0':
     dependencies:
@@ -25922,7 +25432,7 @@ snapshots:
       immer: 11.1.16
       redux: 5.0.1
       redux-thunk: 3.1.0(redux@5.0.1)
-      reselect: 5.1.1
+      reselect: 5.2.0
     optionalDependencies:
       react: 19.2.8
       react-redux: 9.3.0(@types/react@19.2.4)(react@19.2.8)(redux@5.0.1)
@@ -26024,7 +25534,7 @@ snapshots:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
-      picomatch: 2.3.2
+      picomatch: 4.0.5
       rollup: 2.80.0
 
   '@rollup/pluginutils@5.2.0(rollup@4.62.4)':
@@ -26190,11 +25700,6 @@ snapshots:
   '@sinonjs/fake-timers@13.0.5':
     dependencies:
       '@sinonjs/commons': 3.0.1
-
-  '@sinonjs/fake-timers@15.4.0':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-    optional: true
 
   '@so-ric/colorspace@1.1.6':
     dependencies:
@@ -26780,23 +26285,14 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)':
+  '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
       tapable: 2.3.0
-      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
     transitivePeerDependencies:
-      - '@minify-html/node'
       - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
       - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
       - uglify-js
       - webpack-cli
 
@@ -26944,23 +26440,14 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)':
+  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
       tapable: 2.3.0
-      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
     transitivePeerDependencies:
-      - '@minify-html/node'
       - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
       - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
       - uglify-js
       - webpack-cli
 
@@ -27154,7 +26641,7 @@ snapshots:
   '@vercel/nft@0.19.1(supports-color@8.1.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11(supports-color@8.1.1)
-      acorn: 8.18.0
+      acorn: 8.15.0
       bindings: 1.5.0
       estree-walker: 2.0.2
       glob: 7.2.3
@@ -27172,8 +26659,8 @@ snapshots:
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0(supports-color@8.1.1)
       '@rollup/pluginutils': 5.2.0(rollup@4.62.4)
-      acorn: 8.18.0
-      acorn-import-attributes: 1.9.5(acorn@8.18.0)
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -27241,7 +26728,7 @@ snapshots:
     dependencies:
       '@vercel/nft': 0.19.1(supports-color@8.1.1)
       '@vercel/routing-utils': 1.13.3
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -28086,28 +27573,26 @@ snapshots:
 
   acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.18.0
+      acorn: 8.15.0
       acorn-walk: 8.3.4
 
-  acorn-import-attributes@1.9.5(acorn@8.18.0):
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
-      acorn: 8.18.0
+      acorn: 8.15.0
 
-  acorn-import-phases@1.0.4(acorn@8.18.0):
+  acorn-import-phases@1.0.4(acorn@8.15.0):
     dependencies:
-      acorn: 8.18.0
+      acorn: 8.15.0
 
-  acorn-jsx@5.3.2(acorn@8.18.0):
+  acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
-      acorn: 8.18.0
+      acorn: 8.15.0
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.18.0
+      acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  acorn@8.18.0: {}
 
   address@1.2.2: {}
 
@@ -28126,17 +27611,17 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.20.0):
+  ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.20.0
+      ajv: 8.18.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.20.0):
+  ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
-      ajv: 8.20.0
+      ajv: 8.18.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -28210,12 +27695,14 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  ansis@3.17.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.2
+      picomatch: 4.0.5
 
   apollo-link-logger@2.0.1(@apollo/client@3.14.1(@types/react@19.2.4)(graphql-ws@6.0.6(graphql@16.14.2)(ws@8.18.3))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
@@ -28470,20 +27957,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@30.4.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
-      babel-preset-jest: 30.4.0(@babel/core@7.29.6(supports-color@8.1.1))
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
@@ -28492,15 +27965,6 @@ snapshots:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
-
-  babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      find-cache-dir: 3.3.2
-      loader-utils: 2.0.4
-      make-dir: 3.1.0
-      schema-utils: 2.7.1
-      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   babel-plugin-dev-expression@0.2.3(@babel/core@7.29.6(supports-color@8.1.1)):
     dependencies:
@@ -28551,7 +28015,7 @@ snapshots:
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
-      test-exclude: 7.0.2
+      test-exclude: 8.0.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -28562,7 +28026,7 @@ snapshots:
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
-      test-exclude: 7.0.2
+      test-exclude: 8.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -28578,14 +28042,9 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
 
-  babel-plugin-jest-hoist@30.4.0:
-    dependencies:
-      '@types/babel__core': 7.20.5
-    optional: true
-
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
@@ -28594,7 +28053,7 @@ snapshots:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -28704,13 +28163,6 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       babel-plugin-jest-hoist: 30.2.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6(supports-color@8.1.1))
-
-  babel-preset-jest@30.4.0(@babel/core@7.29.6(supports-color@8.1.1)):
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6(supports-color@8.1.1))
-    optional: true
 
   bail@2.0.2: {}
 
@@ -29333,8 +28785,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  compute-scroll-into-view@1.0.20: {}
-
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
@@ -29372,8 +28822,6 @@ snapshots:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
-
-  consola@2.15.3: {}
 
   consola@3.4.2: {}
 
@@ -29547,19 +28995,20 @@ snapshots:
       jest-worker: 24.9.0
       throat: 4.1.0
 
-  create-jest-runner@1.0.0(@jest/test-result@30.2.0)(jest-runner@30.4.2(supports-color@8.1.1)):
+  create-jest-runner@1.0.0(@jest/test-result@30.2.0)(jest-runner@30.2.0(supports-color@8.1.1)):
     dependencies:
       chalk: 4.1.2
       jest-worker: 30.2.0
       p-limit: 3.1.0
     optionalDependencies:
       '@jest/test-result': 30.2.0
-      jest-runner: 30.4.2(supports-color@8.1.1)
+      jest-runner: 30.2.0(supports-color@8.1.1)
 
   create-require@1.1.1: {}
 
-  cross-env@7.0.3:
+  cross-env@10.1.0:
     dependencies:
+      '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
 
   cross-fetch@3.2.0:
@@ -29674,7 +29123,7 @@ snapshots:
 
   cssnano-preset-default@7.0.15(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.7
+      browserslist: 4.28.1
       css-declaration-sorter: 7.4.0(postcss@8.5.26)
       cssnano-utils: 5.0.2(postcss@8.5.26)
       postcss: 8.5.26
@@ -29936,7 +29385,7 @@ snapshots:
 
   default-browser-id@5.0.0: {}
 
-  default-browser@5.3.0:
+  default-browser@5.5.0:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.0
@@ -30054,7 +29503,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
   dom-serializer@1.4.1:
@@ -30130,18 +29579,18 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  downshift@6.1.12(react@19.2.8):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      compute-scroll-into-view: 1.0.20
-      prop-types: 15.8.1
-      react: 19.2.8
-      react-is: 17.0.2
-      tslib: 2.8.1
-
   downshift@9.3.3(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
+      compute-scroll-into-view: 3.1.1
+      prop-types: 15.8.1
+      react: 19.2.8
+      react-is: 18.3.1
+      tslib: 2.8.1
+
+  downshift@9.4.0(react@19.2.8):
+    dependencies:
+      '@babel/runtime': 7.28.6
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
       react: 19.2.8
@@ -30215,12 +29664,7 @@ snapshots:
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.3
-
-  enhanced-resolve@5.24.5:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
+      tapable: 2.3.0
 
   enquirer@2.4.1:
     dependencies:
@@ -30341,7 +29785,7 @@ snapshots:
 
   es-module-lexer@1.5.0: {}
 
-  es-module-lexer@2.3.1: {}
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -30591,7 +30035,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
-      semver: 6.3.1
+      semver: 7.8.5
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
@@ -30608,13 +30052,13 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
       requireindex: 1.2.0
 
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      jest: 30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
+      jest: 30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -30683,7 +30127,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
-      semver: 6.3.1
+      semver: 7.8.5
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -30757,8 +30201,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.18.0
-      acorn-jsx: 5.3.2(acorn@8.18.0)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -30879,16 +30323,6 @@ snapshots:
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
-
-  expect@30.4.1:
-    dependencies:
-      '@jest/expect-utils': 30.4.1
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
-      jest-mock: 30.4.1
-      jest-util: 30.4.1
-    optional: true
 
   express-winston@4.2.0(winston@3.19.0):
     dependencies:
@@ -31226,7 +30660,7 @@ snapshots:
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.8.5
-      tapable: 2.3.3
+      tapable: 2.3.0
       typescript: 5.9.3
       webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
 
@@ -31290,7 +30724,7 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.2:
+  fs-extra@11.4.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -31337,7 +30771,7 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  fuse.js@6.6.2: {}
+  fuse.js@7.5.0: {}
 
   gauge@2.7.4:
     dependencies:
@@ -31472,7 +30906,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.9
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -32300,6 +31734,8 @@ snapshots:
 
   is-in-ci@1.0.0: {}
 
+  is-in-ssh@1.0.0: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -32494,7 +31930,7 @@ snapshots:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -32504,7 +31940,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -32583,13 +32019,6 @@ snapshots:
       jest-util: 30.2.0
       p-limit: 3.1.0
 
-  jest-changed-files@30.4.1:
-    dependencies:
-      execa: 5.1.1
-      jest-util: 30.4.1
-      p-limit: 3.1.0
-    optional: true
-
   jest-circus@30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.2.0
@@ -32615,33 +32044,6 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-
-  jest-circus@30.4.2(babel-plugin-macros@3.1.0)(supports-color@8.1.1):
-    dependencies:
-      '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1(supports-color@8.1.1)
-      '@jest/test-result': 30.4.1
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      chalk: 4.1.2
-      co: 4.6.0
-      dedent: 1.7.0(babel-plugin-macros@3.1.0)
-      is-generator-fn: 2.1.0
-      jest-each: 30.4.1
-      jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
-      jest-runtime: 30.4.2(supports-color@8.1.1)
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
-      jest-util: 30.4.1
-      p-limit: 3.1.0
-      pretty-format: 30.4.1
-      pure-rand: 7.0.1
-      slash: 3.0.0
-      stack-utils: 2.0.6
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    optional: true
 
   jest-cli@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)):
     dependencies:
@@ -32680,26 +32082,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jest-cli@30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
-      '@jest/test-result': 30.4.1
-      '@jest/types': 30.4.1
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-    optional: true
 
   jest-config@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)):
     dependencies:
@@ -32767,39 +32149,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.4.0
-      '@jest/test-sequencer': 30.4.1
-      '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.4.2(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
-      jest-docblock: 30.4.0
-      jest-environment-node: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-resolve: 30.4.1
-      jest-runner: 30.4.2(supports-color@8.1.1)
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      parse-json: 5.2.0
-      pretty-format: 30.4.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.17
-      ts-node: 10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    optional: true
-
   jest-dev-server@8.0.5(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       chalk: 4.1.2
@@ -32826,22 +32175,9 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.2.0
 
-  jest-diff@30.4.1:
-    dependencies:
-      '@jest/diff-sequences': 30.4.0
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.4.1
-    optional: true
-
   jest-docblock@30.2.0:
     dependencies:
       detect-newline: 3.1.0
-
-  jest-docblock@30.4.0:
-    dependencies:
-      detect-newline: 3.1.0
-    optional: true
 
   jest-each@30.2.0:
     dependencies:
@@ -32850,15 +32186,6 @@ snapshots:
       chalk: 4.1.2
       jest-util: 30.2.0
       pretty-format: 30.2.0
-
-  jest-each@30.4.1:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      '@jest/types': 30.4.1
-      chalk: 4.1.2
-      jest-util: 30.4.1
-      pretty-format: 30.4.1
-    optional: true
 
   jest-environment-jsdom@30.2.0(supports-color@8.1.1):
     dependencies:
@@ -32890,17 +32217,6 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
-
-  jest-environment-node@30.4.1:
-    dependencies:
-      '@jest/environment': 30.4.1
-      '@jest/fake-timers': 30.4.1
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      jest-mock: 30.4.1
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-    optional: true
 
   jest-environment-puppeteer@8.0.6(debug@4.4.3(supports-color@8.1.1))(typescript@5.9.3):
     dependencies:
@@ -32947,32 +32263,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-haste-map@30.4.1:
-    dependencies:
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      anymatch: 3.1.3
-      fb-watchman: 2.0.2
-      graceful-fs: 4.2.11
-      jest-regex-util: 30.4.0
-      jest-util: 30.4.1
-      jest-worker: 30.4.1
-      picomatch: 4.0.5
-      walker: 1.0.8
-    optionalDependencies:
-      fsevents: 2.3.3
-    optional: true
-
   jest-leak-detector@30.2.0:
     dependencies:
       '@jest/get-type': 30.1.0
       pretty-format: 30.2.0
-
-  jest-leak-detector@30.4.1:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      pretty-format: 30.4.1
-    optional: true
 
   jest-localstorage-mock@2.4.26: {}
 
@@ -32989,14 +32283,6 @@ snapshots:
       chalk: 4.1.2
       jest-diff: 30.2.0
       pretty-format: 30.2.0
-
-  jest-matcher-utils@30.4.1:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.4.1
-      pretty-format: 30.4.1
-    optional: true
 
   jest-message-util@29.7.0:
     dependencies:
@@ -33022,20 +32308,6 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-message-util@30.4.1:
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@jest/types': 30.4.1
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      jest-util: 30.4.1
-      picomatch: 4.0.5
-      pretty-format: 30.4.1
-      slash: 3.0.0
-      stack-utils: 2.0.6
-    optional: true
-
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -33048,21 +32320,9 @@ snapshots:
       '@types/node': 22.19.17
       jest-util: 30.2.0
 
-  jest-mock@30.4.1:
-    dependencies:
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      jest-util: 30.4.1
-    optional: true
-
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
     optionalDependencies:
       jest-resolve: 30.2.0
-
-  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
-    optionalDependencies:
-      jest-resolve: 30.4.1
-    optional: true
 
   jest-preview@0.3.2(postcss@8.5.26)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)):
     dependencies:
@@ -33102,23 +32362,12 @@ snapshots:
 
   jest-regex-util@30.0.1: {}
 
-  jest-regex-util@30.4.0:
-    optional: true
-
   jest-resolve-dependencies@30.2.0(supports-color@8.1.1):
     dependencies:
       jest-regex-util: 30.0.1
       jest-snapshot: 30.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  jest-resolve-dependencies@30.4.2(supports-color@8.1.1):
-    dependencies:
-      jest-regex-util: 30.4.0
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   jest-resolve@30.2.0:
     dependencies:
@@ -33130,18 +32379,6 @@ snapshots:
       jest-validate: 30.2.0
       slash: 3.0.0
       unrs-resolver: 1.11.1
-
-  jest-resolve@30.4.1:
-    dependencies:
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      jest-haste-map: 30.4.1
-      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      slash: 3.0.0
-      unrs-resolver: 1.11.1
-    optional: true
 
   jest-runner-eslint@2.3.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3))):
     dependencies:
@@ -33188,34 +32425,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runner@30.4.2(supports-color@8.1.1):
-    dependencies:
-      '@jest/console': 30.4.1
-      '@jest/environment': 30.4.1
-      '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      chalk: 4.1.2
-      emittery: 0.13.1
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-docblock: 30.4.0
-      jest-environment-node: 30.4.1
-      jest-haste-map: 30.4.1
-      jest-leak-detector: 30.4.1
-      jest-message-util: 30.4.1
-      jest-resolve: 30.4.1
-      jest-runtime: 30.4.2(supports-color@8.1.1)
-      jest-util: 30.4.1
-      jest-watcher: 30.4.1
-      jest-worker: 30.4.1
-      p-limit: 3.1.0
-      source-map-support: 0.5.13
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   jest-runtime@30.2.0(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.2.0
@@ -33242,34 +32451,6 @@ snapshots:
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
-
-  jest-runtime@30.4.2(supports-color@8.1.1):
-    dependencies:
-      '@jest/environment': 30.4.1
-      '@jest/fake-timers': 30.4.1
-      '@jest/globals': 30.4.1(supports-color@8.1.1)
-      '@jest/source-map': 30.0.1
-      '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      chalk: 4.1.2
-      cjs-module-lexer: 2.2.0
-      collect-v8-coverage: 1.0.3
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-haste-map: 30.4.1
-      jest-message-util: 30.4.1
-      jest-mock: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-resolve: 30.4.1
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
-      jest-util: 30.4.1
-      slash: 3.0.0
-      strip-bom: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   jest-silent-reporter@0.6.0:
     dependencies:
@@ -33302,33 +32483,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.4.1(supports-color@8.1.1):
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/generator': 7.29.8
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/types': 7.29.8
-      '@jest/expect-utils': 30.4.1
-      '@jest/get-type': 30.1.0
-      '@jest/snapshot-utils': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
-      '@jest/types': 30.4.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6(supports-color@8.1.1))
-      chalk: 4.1.2
-      expect: 30.4.1
-      graceful-fs: 4.2.11
-      jest-diff: 30.4.1
-      jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
-      jest-util: 30.4.1
-      pretty-format: 30.4.1
-      semver: 7.8.5
-      synckit: 0.11.11
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   jest-util@26.6.2:
     dependencies:
       '@jest/types': 26.6.2
@@ -33345,7 +32499,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.2
+      picomatch: 4.0.5
 
   jest-util@30.2.0:
     dependencies:
@@ -33356,16 +32510,6 @@ snapshots:
       graceful-fs: 4.2.11
       picomatch: 4.0.5
 
-  jest-util@30.4.1:
-    dependencies:
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      graceful-fs: 4.2.11
-      picomatch: 4.0.5
-    optional: true
-
   jest-validate@30.2.0:
     dependencies:
       '@jest/get-type': 30.1.0
@@ -33374,16 +32518,6 @@ snapshots:
       chalk: 4.1.2
       leven: 3.1.0
       pretty-format: 30.2.0
-
-  jest-validate@30.4.1:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      '@jest/types': 30.4.1
-      camelcase: 6.3.0
-      chalk: 4.1.2
-      leven: 3.1.0
-      pretty-format: 30.4.1
-    optional: true
 
   jest-watch-typeahead@3.0.1(jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3))):
     dependencies:
@@ -33406,18 +32540,6 @@ snapshots:
       emittery: 0.13.1
       jest-util: 30.2.0
       string-length: 4.0.2
-
-  jest-watcher@30.4.1:
-    dependencies:
-      '@jest/test-result': 30.4.1
-      '@jest/types': 30.4.1
-      '@types/node': 22.19.17
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      emittery: 0.13.1
-      jest-util: 30.4.1
-      string-length: 4.0.2
-    optional: true
 
   jest-worker@24.9.0:
     dependencies:
@@ -33458,15 +32580,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest-worker@30.4.1:
-    dependencies:
-      '@types/node': 22.19.17
-      '@ungap/structured-clone': 1.3.0
-      jest-util: 30.4.1
-      merge-stream: 2.0.0
-      supports-color: 8.1.1
-    optional: true
-
   jest@30.2.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3))
@@ -33492,20 +32605,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jest@30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
-      '@jest/types': 30.4.1
-      import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.17)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-    optional: true
 
   jiti@1.17.1: {}
 
@@ -33548,10 +32647,10 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jscodeshift@0.16.1(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
+  jscodeshift@17.4.0(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
@@ -33560,14 +32659,13 @@ snapshots:
       '@babel/preset-flow': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/register': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))
-      chalk: 4.1.2
       flow-parser: 0.291.0
       graceful-fs: 4.2.11
-      micromatch: 4.0.8
       neo-async: 2.6.2
-      node-dir: 0.1.17
+      picocolors: 1.1.1
+      picomatch: 4.0.5
       recast: 0.23.11
-      temp: 0.9.4
+      tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
       '@babel/preset-env': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
@@ -33727,7 +32825,7 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
-  jwt-decode@3.1.2: {}
+  jwt-decode@4.0.0: {}
 
   keyv@3.1.0:
     dependencies:
@@ -34019,7 +33117,7 @@ snapshots:
 
   make-dir@3.1.0:
     dependencies:
-      semver: 6.3.1
+      semver: 7.8.5
 
   make-dir@4.0.0:
     dependencies:
@@ -34291,8 +33389,6 @@ snapshots:
       thingies: 2.5.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
-
-  memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
 
@@ -34682,7 +33778,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.5
 
   mime-db@1.52.0: {}
 
@@ -34742,30 +33838,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
-    optionalDependencies:
-      '@swc/core': 1.15.1(@swc/helpers@0.5.23)
-      clean-css: 5.3.3
-      cssnano: 7.1.7(postcss@8.5.26)
-      csso: 5.0.5
-      esbuild: 0.28.2
-      html-minifier-terser: 6.1.0
-      postcss: 8.5.26
-      uglify-js: 3.19.3
-
   minipass@7.1.2: {}
 
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mitt@3.0.0: {}
 
@@ -34918,10 +33997,6 @@ snapshots:
       tslib: 2.8.1
 
   node-abort-controller@3.1.1: {}
-
-  node-dir@0.1.17:
-    dependencies:
-      minimatch: 3.1.5
 
   node-domexception@1.0.0: {}
 
@@ -35088,7 +34163,7 @@ snapshots:
       rimraf: 3.0.2
       signal-exit: 3.0.7
       spawn-wrap: 2.0.0
-      test-exclude: 7.0.2
+      test-exclude: 8.0.0
       yargs: 15.4.1
     transitivePeerDependencies:
       - supports-color
@@ -35178,10 +34253,19 @@ snapshots:
 
   open@10.2.0:
     dependencies:
-      default-browser: 5.3.0
+      default-browser: 5.5.0
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
 
   open@8.4.2:
     dependencies:
@@ -35381,7 +34465,7 @@ snapshots:
       got: 9.6.0
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 6.3.1
+      semver: 7.8.5
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -35490,7 +34574,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -35524,8 +34608,6 @@ snapshots:
   picocolors@1.0.0: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
 
@@ -35825,6 +34907,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  powershell-utils@0.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prepend-http@2.0.0: {}
@@ -35863,14 +34947,6 @@ snapshots:
       '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
-
-  pretty-format@30.4.1:
-    dependencies:
-      '@jest/schemas': 30.4.1
-      ansi-styles: 5.2.0
-      react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.7
-    optional: true
 
   pretty-ms@7.0.1:
     dependencies:
@@ -36042,7 +35118,7 @@ snapshots:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
-  qss@2.0.3: {}
+  qss@3.0.0: {}
 
   quansync@0.2.11: {}
 
@@ -36361,7 +35437,7 @@ snapshots:
 
   react-textarea-autosize@8.5.9(@types/react@19.2.4)(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       react: 19.2.8
       use-composed-ref: 1.4.0(@types/react@19.2.4)(react@19.2.8)
       use-latest: 1.3.0(@types/react@19.2.4)(react@19.2.8)
@@ -36445,7 +35521,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.2
+      picomatch: 4.0.5
 
   readdirp@4.1.2: {}
 
@@ -36566,7 +35642,7 @@ snapshots:
 
   relay-runtime@12.0.0:
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       fbjs: 3.0.5
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -36668,9 +35744,7 @@ snapshots:
 
   requires-port@1.0.0: {}
 
-  reselect@4.1.8: {}
-
-  reselect@5.1.1: {}
+  reselect@5.2.0: {}
 
   resize-observer-polyfill@1.5.1: {}
 
@@ -36728,10 +35802,6 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@2.6.3:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@2.7.1:
     dependencies:
@@ -36807,7 +35877,7 @@ snapshots:
 
   rtl-css-js@1.16.1:
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
 
   run-applescript@7.1.0: {}
 
@@ -36875,9 +35945,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.20.0
-      ajv-formats: 2.1.1(ajv@8.20.0)
-      ajv-keywords: 5.1.0(ajv@8.20.0)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
 
   screenfull@5.2.0: {}
 
@@ -36904,11 +35974,9 @@ snapshots:
 
   semver-diff@3.1.1:
     dependencies:
-      semver: 6.3.1
+      semver: 7.8.5
 
   semver@5.7.2: {}
-
-  semver@6.3.1: {}
 
   semver@7.5.4:
     dependencies:
@@ -37727,10 +36795,9 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svg-url-loader@7.1.1(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  svg-url-loader@8.1.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
     dependencies:
       file-loader: 6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
-      loader-utils: 2.0.4
       webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
 
   svgo@4.0.1:
@@ -37779,8 +36846,6 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tapable@2.3.3: {}
-
   tar-fs@3.1.2:
     dependencies:
       pump: 3.0.3
@@ -37806,7 +36871,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -37817,11 +36882,6 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
     optional: true
-
-  temp@0.9.4:
-    dependencies:
-      mkdirp: 0.5.6
-      rimraf: 2.6.3
 
   term-size@2.2.1: {}
 
@@ -37840,14 +36900,14 @@ snapshots:
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.18.0
+      acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  test-exclude@7.0.2:
+  test-exclude@8.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.6
-      glob: 10.5.0
+      glob: 13.0.6
       minimatch: 10.2.5
 
   text-decoder@1.2.3:
@@ -37876,13 +36936,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  thread-loader@3.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  thread-loader@4.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.1
-      loader-utils: 2.0.4
       neo-async: 2.6.2
-      schema-utils: 3.3.0
+      schema-utils: 4.3.3
       webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
 
   throat@4.1.0: {}
@@ -38138,7 +37197,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
-      get-tsconfig: 4.14.1
+      get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -38257,7 +37316,7 @@ snapshots:
 
   undici@8.10.0: {}
 
-  unfetch@4.2.0: {}
+  unfetch@5.0.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -38669,7 +37728,7 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wait-for-expect@3.0.2: {}
+  wait-for-expect@4.0.0: {}
 
   wait-for-observables@1.0.3:
     dependencies:
@@ -38703,8 +37762,9 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  watchpack@2.5.2:
+  watchpack@2.5.1:
     dependencies:
+      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   wbuf@1.7.3:
@@ -38804,7 +37864,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-sources@3.5.1: {}
+  webpack-sources@3.3.3: {}
 
   webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3):
     dependencies:
@@ -38814,12 +37874,12 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.18.0
-      acorn-import-phases: 1.0.4(acorn@8.18.0)
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
       browserslist: 4.28.7
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.5
-      es-module-lexer: 2.3.1
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -38829,57 +37889,22 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.3
+      tapable: 2.3.0
       terser-webpack-plugin: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
 
-  webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3):
+  webpackbar@7.0.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
     dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.18.0
-      browserslist: 4.28.7
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.5
-      es-module-lexer: 2.3.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpackbar@5.0.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
-    dependencies:
-      chalk: 4.1.2
-      consola: 2.15.3
+      ansis: 3.17.0
+      consola: 3.4.2
       pretty-time: 1.1.0
       std-env: 3.10.0
+    optionalDependencies:
       webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
 
   websocket-driver@0.7.4:
@@ -39060,6 +38085,11 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.0
+      powershell-utils: 0.1.0
 
   xdg-basedir@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,8 +50,6 @@ minimumReleaseAgeExclude:
   - webpack-dev-server@5.2.6
   # Renovate security update: @babel/core@7.29.6
   - "@babel/core@7.29.6"
-  # Renovate security update: js-yaml@3.15.0 || 3.15.1
-  - js-yaml@3.15.0 || 3.15.1
 
 # Explicit block — same v11-default-pinning rationale as minimumReleaseAge.
 blockExoticSubdeps: true
@@ -93,7 +91,7 @@ overrides:
   '@typescript-eslint/parser': ^8.0.0
   browserslist: ^4.28.1
   diff: 4.0.4
-  js-yaml: 3.15.1
+  js-yaml: 5.2.3
   node-forge: 1.4.0
   react: 19.2.8
   react-dom: 19.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,7 +96,7 @@ overrides:
   react: 19.2.8
   react-dom: 19.2.8
   tar: '>=7.5.11'
-  test-exclude: ^7.0.1
+  test-exclude: ^8.0.0
   flat-cache>rimraf: ^5.0.10
   webpack-dev-server>rimraf: ^5.0.10
   react-dev-utils>fork-ts-checker-webpack-plugin: ^9.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -121,7 +121,7 @@ overrides:
   'path-to-regexp@^6': ^8.4.2
   'picomatch@^4': ^4.0.4
   'rollup@^4': ^4.59.0
-  'semver@^6': ^6.3.1
+  'semver@^6': ^7.8.5
   svgo: '>=2.8.1'
   systeminformation: '>=5.31.0'
   tar-fs: '>=3.1.1'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -252,7 +252,7 @@ catalog:
   moment-timezone: ^0.6.0
   node-fetch: 2.7.0
   omit-empty-es: 1.2.0
-  open: ^10.1.0
+  open: ^11.0.0
   postcss-load-config: 3.1.4
   prompts: ^2.4.2
   puppeteer: 20.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -384,7 +384,7 @@ catalogs:
     react-refresh: 0.18.0
     serialize-javascript: 7.0.7
     style-loader: 3.3.4
-    svg-url-loader: 7.1.1
+    svg-url-loader: 8.1.0
     '@svgr/babel-preset': ^6.5.1
     '@svgr/cli': 6.5.1
     '@svgr/core': ^6.5.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -509,7 +509,7 @@ catalogs:
     '@react-hook/latest': 1.0.3
     '@react-hook/resize-observer': 1.2.6
     classnames: ^2.3.2
-    downshift: 6.1.12
+    downshift: 9.4.0
     formik: 2.4.9
     prop-types: 15.8.1
     raf-schd: ^4.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,8 @@ minimumReleaseAgeExclude:
   - webpack-dev-server@5.2.6
   # Renovate security update: @babel/core@7.29.6
   - "@babel/core@7.29.6"
+  # Renovate security update: js-yaml@3.15.0 || 3.15.1
+  - js-yaml@3.15.0 || 3.15.1
 
 # Explicit block — same v11-default-pinning rationale as minimumReleaseAge.
 blockExoticSubdeps: true
@@ -91,7 +93,7 @@ overrides:
   '@typescript-eslint/parser': ^8.0.0
   browserslist: ^4.28.1
   diff: 4.0.4
-  js-yaml: 5.2.3
+  js-yaml: 3.15.1
   node-forge: 1.4.0
   react: 19.2.8
   react-dom: 19.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -120,7 +120,7 @@ overrides:
   'minimatch@^4': ^4.2.5
   'minimatch@^9': ^9.0.7
   'minimatch@^10': ^10.2.3
-  'path-to-regexp@^6': ^8.4.2
+  'path-to-regexp@^6': ^6.3.0
   'picomatch@^4': ^4.0.4
   'rollup@^4': ^4.59.0
   'semver@^6': ^7.8.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,9 +116,9 @@ overrides:
   fflate: 0.8.3
   immutable: '>=3.8.3'
   lodash-es: '>=4.17.21'
-  'minimatch@^3': ^3.1.4
-  'minimatch@^4': ^4.2.5
-  'minimatch@^9': ^9.0.7
+  'minimatch@^3': ^10.2.6
+  'minimatch@^4': ^10.2.6
+  'minimatch@^9': ^10.2.6
   'minimatch@^10': ^10.2.3
   'path-to-regexp@^6': ^6.3.0
   'picomatch@^4': ^4.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,9 +114,9 @@ overrides:
   fflate: 0.8.3
   immutable: '>=3.8.3'
   lodash-es: '>=4.17.21'
-  'minimatch@^3': ^10.2.6
-  'minimatch@^4': ^10.2.6
-  'minimatch@^9': ^10.2.6
+  'minimatch@^3': ^3.1.4
+  'minimatch@^4': ^4.2.5
+  'minimatch@^9': ^9.0.7
   'minimatch@^10': ^10.2.3
   'path-to-regexp@^6': ^8.4.2
   'picomatch@^4': ^4.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -228,7 +228,7 @@ catalog:
   debounce-async: 0.0.2
   deep-diff: 1.0.2
   dompurify: ^3.0.0
-  dotenv: 16.6.1
+  dotenv: 17.4.2
   execa: 5.1.1
   express: ^4.21.2
   express-winston: 4.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -370,7 +370,7 @@ catalogs:
     webpack: 5.105.1
     webpack-bundle-analyzer: 4.10.2
     webpack-dev-server: 5.2.6
-    webpackbar: 5.0.2
+    webpackbar: 7.0.0
     browserslist: ^4.28.1
     css-loader: 6.11.0
     css-minimizer-webpack-plugin: ^8.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -392,7 +392,7 @@ catalogs:
     '@svgr/plugin-svgo': 6.5.1
     '@svgr/webpack': ^6.5.1
     terser-webpack-plugin: ^5.5.0
-    thread-loader: 3.0.4
+    thread-loader: 4.0.4
     uglify-js: 3.19.3
     uglifycss: 0.0.29
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -522,7 +522,7 @@ catalogs:
     # Monorepo tooling
     '@manypkg/cli': 0.25.1
     '@manypkg/find-root': 3.1.0
-    '@manypkg/get-packages': 1.1.3
+    '@manypkg/get-packages': 3.1.0
 
     # Changesets / release tooling
     '@changesets/changelog-github': 0.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -256,7 +256,7 @@ catalog:
   postcss-load-config: 3.1.4
   prompts: ^2.4.2
   puppeteer: 20.9.0
-  qss: 2.0.3
+  qss: 3.0.0
   querystring-es3: ^0.2.1
   replace: 1.2.2
   reselect: 4.1.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,7 +101,7 @@ overrides:
   webpack-dev-server>rimraf: ^5.0.10
   react-dev-utils>fork-ts-checker-webpack-plugin: ^9.1.0
   lodash: 4.18.1
-  'picomatch@^2': ^2.3.2
+  'picomatch@^2': ^4.0.5
   flatted: '>=3.4.2'
   serialize-javascript: '>=7.0.7'
   axios: '>=1.15.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -221,7 +221,7 @@ catalog:
   cosmiconfig: 9.0.2
   cosmiconfig-typescript-loader: 6.3.0
   create-jest-runner: 1.0.0
-  cross-env: 7.0.3
+  cross-env: 10.1.0
   cypress: 14.5.4
   debounce-async: 0.0.2
   deep-diff: 1.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -240,7 +240,7 @@ catalog:
   history-query-enhancer: 1.0.4
   is-retina: 1.0.3
   jose: ^5.10.0
-  jscodeshift: 0.16.1
+  jscodeshift: 17.4.0
   jsdom: ^21.1.2
   json-schema-to-typescript: 15.0.4
   jwt-decode: 4.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -235,7 +235,7 @@ catalog:
   find-up: 5.0.0
   fs-extra: 11.4.0
   fuse.js: 7.5.0
-  glob: ^10.5.0
+  glob: ^13.0.6
   graphql-request: 5.2.0
   history-query-enhancer: 1.0.4
   is-retina: 1.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,7 +118,7 @@ overrides:
   'minimatch@^4': ^10.2.6
   'minimatch@^9': ^10.2.6
   'minimatch@^10': ^10.2.3
-  'path-to-regexp@^6': ^6.3.0
+  'path-to-regexp@^6': ^8.4.2
   'picomatch@^4': ^4.0.4
   'rollup@^4': ^4.59.0
   'semver@^6': ^6.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -234,7 +234,7 @@ catalog:
   fast-safe-stringify: 2.1.1
   find-up: 5.0.0
   fs-extra: 11.4.0
-  fuse.js: 6.6.2
+  fuse.js: 7.5.0
   glob: ^10.5.0
   graphql-request: 5.2.0
   history-query-enhancer: 1.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -509,7 +509,7 @@ catalogs:
     # React-bound utilities
     '@radix-ui/react-dialog': 1.1.23
     '@react-hook/latest': 1.0.3
-    '@react-hook/resize-observer': 1.2.6
+    '@react-hook/resize-observer': 2.0.2
     classnames: ^2.3.2
     downshift: 9.4.0
     formik: 2.4.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -521,7 +521,7 @@ catalogs:
   repo:
     # Monorepo tooling
     '@manypkg/cli': 0.25.1
-    '@manypkg/find-root': 2.2.3
+    '@manypkg/find-root': 3.1.0
     '@manypkg/get-packages': 1.1.3
 
     # Changesets / release tooling

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -243,7 +243,7 @@ catalog:
   jscodeshift: 0.16.1
   jsdom: ^21.1.2
   json-schema-to-typescript: 15.0.4
-  jwt-decode: 3.1.2
+  jwt-decode: 4.0.0
   listr2: 5.0.8
   lodash: 4.18.1
   logform: 2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -233,7 +233,7 @@ catalog:
   fast-equals: 2.0.4
   fast-safe-stringify: 2.1.1
   find-up: 5.0.0
-  fs-extra: 10.1.0
+  fs-extra: 11.4.0
   fuse.js: 6.6.2
   glob: ^10.5.0
   graphql-request: 5.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -509,7 +509,7 @@ catalogs:
     # React-bound utilities
     '@radix-ui/react-dialog': 1.1.23
     '@react-hook/latest': 1.0.3
-    '@react-hook/resize-observer': 2.0.2
+    '@react-hook/resize-observer': 1.2.6
     classnames: ^2.3.2
     downshift: 9.4.0
     formik: 2.4.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -621,7 +621,7 @@ catalogs:
 
     # Sentry test harness
     sentry-testkit: 6.4.1
-    wait-for-expect: 3.0.2
+    wait-for-expect: 4.0.0
 
     # E2E / visual regression (Cypress + Puppeteer + Percy)
     '@cypress/code-coverage': ^3.14.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -247,7 +247,7 @@ catalog:
   listr2: 5.0.8
   lodash: 4.18.1
   logform: 2.7.0
-  memoize-one: 5.2.1
+  memoize-one: 6.0.0
   moment: ^2.29.4
   moment-timezone: ^0.6.0
   node-fetch: 2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -269,7 +269,7 @@ catalog:
   tiny-invariant: 1.3.3
   tiny-warning: 1.0.3
   triple-beam: 1.4.1
-  unfetch: 4.2.0
+  unfetch: 5.0.0
   url: ^0.11.0
   uuid: 14.0.1
   wait-for-observables: 1.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -259,7 +259,7 @@ catalog:
   qss: 3.0.0
   querystring-es3: ^0.2.1
   replace: 1.2.2
-  reselect: 4.1.8
+  reselect: 5.2.0
   rimraf: 6.1.3
   rosie: 2.1.1
   semver: 7.8.5

--- a/scripts/mock-translate-i18n-messages.mjs
+++ b/scripts/mock-translate-i18n-messages.mjs
@@ -23,7 +23,7 @@ if (
   process.exit(0);
 }
 
-const { packages } = getPackagesSync();
+const { packages } = getPackagesSync(process.cwd());
 const templateFolderByApplicationType =
   applicationType === 'custom-application'
     ? 'application-templates'


### PR DESCRIPTION
Migrates the "trivial ecosystem churn" subset of the ~93 major-version dependencies excluded from #4077, one commit per dependency. This is a batch-migration PR only — it does not merge or close #4077 or any other PR, and it does not touch `chore/renovate-batch-consolidation` or any other in-flight branch.

## Included (16 dependencies/overrides, verified mechanical)

| Dependency | Change | Fix required |
| --- | --- | --- |
| `cross-env` | 7.0.3 → 10.1.0 | none (declared dep, unused in any current script) |
| `dotenv` | 16.6.1 → 17.4.2 | added `{ quiet: true }` at both call sites (`mc-scripts/src/cli.ts`, `cypress/src/task/index.ts`) to preserve v16's silent behavior — v17 logs a decorative line by default |
| `downshift` | 6.1.12 → 9.4.0 | none — classic render-prop `Downshift` component is explicitly unaffected by the v7/v8/v9 hook-only breaking changes per upstream migration guides |
| `fs-extra` | 10.1.0 → 11.4.0 | none — only uses stable `copySync`/`emptyDirSync`/`mkdirSync`/`renameSync`/`rmdirSync` |
| `fuse.js` | 6.6.2 → 7.5.0 | none — dead dependency, not imported anywhere in this repo's source |
| `glob` | ^10.5.0 → ^13.0.6 | none — dual CJS/ESM, only uses the stable `globSync` named export |
| `jscodeshift` | 0.16.1 → 17.4.0 | none — the 0.x→17.x jump is a versioning-scheme renumbering (like React 0.14→15), not 17 majors of real breaking changes |
| `jwt-decode` | 3.1.2 → 4.0.0 | changed `import jwtDecode from 'jwt-decode'` to `import { jwtDecode } from 'jwt-decode'` at 3 call sites (default export removed); updated one test's expected error message text (v4's `InvalidTokenError` is more specific) |
| `memoize-one` | 5.2.1 → 6.0.0 | none |
| `open` | ^10.1.0 → ^11.0.0 | none — already consumed via dynamic `import()` since it went ESM-only at v7 |
| `qss` | 2.0.3 → 3.0.0 | none — `encode`/`decode` behavior verified identical for this repo's usage patterns |
| `reselect` | 4.1.8 → 5.2.0 | none — basic `createSelector(selector, resultFn)` usage unaffected by the v5 default-memoizer change |
| `svg-url-loader` | 7.1.1 → 8.1.0 | none — webpack loader path only (`require.resolve`); flagging the `stripdeclarations`/`esModule` default-flip for reviewer awareness |
| `thread-loader` | 3.0.4 → 4.0.4 | none — webpack loader path only |
| `unfetch` | 4.2.0 → 5.0.0 | none — `unfetch/polyfill` subpath export preserved in v5 |
| `wait-for-expect` | 3.0.2 → 4.0.0 | none |
| `webpackbar` | 5.0.2 → 7.0.0 | removed a now-stale `@ts-expect-error` (v7 ships its own types) |
| `@manypkg/find-root` | 2.2.3 → 3.1.0 | none — only used from a native-ESM `.mjs` script |
| `@manypkg/get-packages` | 1.1.3 → 3.1.0 | none — verified the CJS `require()` path (used by the published `@commercetools-frontend/cypress` package) works on this repo's Node 24 runtime |
| `codecov/codecov-action` | v5 → v7 | re-pinned SHA (`fb8b3582c8e4def4969c97caa2f19720cb33a72f`); `token`/`files`/`name` inputs unchanged |
| `semver@^6` override | → v7 | none — pure transitive pin |
| `test-exclude` override | → v8 | none — pure transitive pin |
| `picomatch@^2` override | → v4 | none — consolidates onto the same v4 already pinned for the `@^4` range |

## Excluded as not trivial (dropped after investigation, with reasons)

| Dependency | Reason |
| --- | --- |
| `dotenv-expand` | Latest npm version jumps straight from 8.0.3 to **1000.0.0** with no intervening releases — an anomalous, non-actionable signal per task instructions. Left untouched. |
| `chalk` | ESM-only since v5. `packages/mc-scripts` publishes a CJS bundle via preconstruct and has 9+ CJS-style `import chalk from 'chalk'` call sites; fixing this needs a broader dynamic-import refactor, not a version bump. |
| `execa` | ESM-only since v6, same CJS-bundle problem as chalk (4 call sites in `create-mc-app`, each using the default-export-as-callable-function pattern). |
| `commander` | v15 is `"type": "module"` with `engines.node: ">=22.12.0"`. `mc-scripts`, `create-mc-app`, and `codemod` all declare explicit support for Node 18.x/20.x (below the `require(esm)` threshold) in their own `engines` field — bumping would silently break those declared-supported runtimes. |
| `listr2` | v11's `require` export condition resolves to an `.mjs` file (ESM-only). Same Node-engines conflict as commander for `create-mc-app` (`engines: "18.x || 20.x || >=22.0.0"`). |
| `jose` | v6 dropped its CJS build entirely. Reproduced a real failure: `pnpm test:node -- packages-backend/express/src/auth.spec.ts` fails with `SyntaxError: Unexpected token 'export'` because Jest's default transform doesn't handle ESM syntax in `node_modules`. |
| `minimatch@^3`/`@^4`/`@^9` overrides → v10 | **Reverted after breaking the test suite.** `eslint-plugin-import`'s `import/order` rule does a CJS-style `require('minimatch')` and calls the result as a function; minimatch v10 dropped the callable-default export (named exports only), so every `lint:js` run started throwing `TypeError: (0 , _minimatch2.default) is not a function`. |
| `js-yaml` override → v5 | **Reverted.** This is a blanket override (no `@<range>` qualifier), so it forces *every* transitive consumer onto v5 — not just this repo's own (nonexistent) direct usage. `@manypkg/tools` (a dependency of `@manypkg/find-root`/`@manypkg/get-packages`) does `import yaml from 'js-yaml'` (default import), which v5 no longer provides. Reproduced via a standalone ESM smoke test. |
| `path-to-regexp@^6` override → v8 | **Reverted after breaking the test suite.** `msw@1.3.5` depends on `path-to-regexp@^6.3.0` internally for REST/GraphQL handler URL matching. Forcing v8 broke MSW's request interception — `application-shell.spec.js` went from 41/41 passing to 41/41 failing (`POST http://localhost:8080/graphql net::ERR_FAILED`). |
| `@react-hook/resize-observer` | **Reverted after breaking the test suite.** v2 removed the automatic `@juggle/resize-observer` polyfill fallback that v1 bundled. jsdom has no native `ResizeObserver` (verified), so `useResizeObserver()` throws during render of `PortalsContainer` (part of the app shell's layout), crashing 37/41 tests in `application-shell.spec.js`. A real fix means adding a new direct dependency + either a call-site `{ polyfill }` option or a shared jest-harness polyfill — out of scope for a version bump. |
| `@cypress/code-coverage` | v4 requires Cypress ≥15.10.0. This repo's Cypress major bump is explicitly out of scope for this PR (per task instructions), so this dependency can't be upgraded independently. |

## Changeset

Added `.changeset/trivial-major-dependency-migrations.md` (patch bump) for every published package where an included dependency is a real `dependencies` entry: `@commercetools-frontend/mc-scripts`, `@commercetools-frontend/codemod`, `@commercetools-frontend/application-shell`, `@commercetools-frontend/sdk`, `@commercetools-frontend/browser-history`, `@commercetools-frontend/react-notifications`, `@commercetools-frontend/jest-preset-mc-app`, `@commercetools-frontend/cypress`. `wait-for-expect` (packages/sentry, devDependencies only) and `cross-env` (root-only devDependency) don't need a version bump, matching the precedent in `.changeset/security-deps-phase1.md`.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 1018/1018 passed (also caught and fixed the pre-existing-looking `oidc-callback.spec.tsx` message-text assertion, which was actually masked by the path-to-regexp/resize-observer regressions until those were reverted)
- `pnpm test:node` — 66/66 passed
- `pnpm check:workspace-constraints` — passed
- `pnpm check:package-shape` — passed (report-only mode; pre-existing attw/publint findings unrelated to this PR)
- `pnpm build` — succeeds
- Final commit regenerates `pnpm-lock.yaml` in one pass

Note on process: several of the "excluded" entries above were only discovered to be non-mechanical *after* an initial bump + full-suite test run surfaced real breakage (not from changelog review alone) — each such case is committed as an explicit revert with the reproduction details in the commit message, rather than silently omitted.
