### PR TITLE
chore(deps): remove webpackbar in favor of webpack's built-in progress bar

### DIFF
--- a/.changeset/remove-webpackbar.md
+++ b/.changeset/remove-webpackbar.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/mc-scripts': patch
+---
+
+Replaced `webpackbar` with webpack's own built-in `ProgressPlugin` progress bar (`progressBar: 'auto'`) in the development webpack config. `webpackbar` is unmaintained and was the reason `webpack` had been held back at 5.105.1 (see the "Held back" note this changeset previously replaced): webpack 5.109.x defers `ProgressPlugin` option-schema validation from the constructor to a later `compiler.hooks.validate` tap, and `webpackbar@5.0.2` overwrites `this.options` with its own non-schema `name`/`color`/`reporters`/`reporter` keys after calling `super()`, which that deferred validation now rejects. Dropping `webpackbar` removes the incompatibility, so `webpack` is bumped back to 5.109.2.
+
+No default-path behavior change (`mc-scripts start`/`build` still show progress while compiling), but note for anyone who imports `createWebpackConfigForDevelopment` from `@commercetools-frontend/mc-scripts/webpack` directly and inspects/replaces the `WebpackBar` plugin instance in the returned `Configuration.plugins` array: that plugin is now a `webpack.ProgressPlugin` instance instead.

--- a/packages/mc-scripts/package.json
+++ b/packages/mc-scripts/package.json
@@ -121,8 +121,7 @@
     "vite-bundle-analyzer": "catalog:build",
     "webpack": "catalog:build",
     "webpack-bundle-analyzer": "catalog:build",
-    "webpack-dev-server": "catalog:build",
-    "webpackbar": "catalog:build"
+    "webpack-dev-server": "catalog:build"
   },
   "devDependencies": {
     "@commercetools/composable-commerce-test-data": "catalog:",

--- a/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
+++ b/packages/mc-scripts/src/config/create-webpack-config-for-development.ts
@@ -5,7 +5,6 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MomentLocalesPlugin from 'moment-locales-webpack-plugin';
 import type { XastElement, PluginInfo } from 'svgo';
 import webpack, { type Configuration } from 'webpack';
-import WebpackBar from 'webpackbar';
 import type {
   TWebpackConfigToggleFlagsForDevelopment,
   TWebpackConfigOptions,
@@ -162,7 +161,11 @@ function createWebpackConfigForDevelopment(
 
     plugins: [
       loadNimbusWebpackPlugin({ cwd: paths.appRoot }),
-      new WebpackBar(),
+      // Colored progress bar in interactive terminals, plain percentage
+      // lines otherwise (e.g. CI logs). Replaces `webpackbar`, which is
+      // unmaintained and broke on webpack's newer, deferred ProgressPlugin
+      // option validation.
+      new webpack.ProgressPlugin({ progressBar: 'auto' }),
       // Allows to "assign" custom options to the `webpack` object.
       // At the moment, this is used to share some props with `postcss.config`.
       new webpack.LoaderOptionsPlugin({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,17 +258,14 @@ catalogs:
       specifier: 0.23.0
       version: 0.23.0
     webpack:
-      specifier: 5.105.1
-      version: 5.105.1
+      specifier: 5.109.2
+      version: 5.109.2
     webpack-bundle-analyzer:
       specifier: 4.10.2
       version: 4.10.2
     webpack-dev-server:
       specifier: 5.2.6
       version: 5.2.6
-    webpackbar:
-      specifier: 7.0.0
-      version: 7.0.0
   default:
     '@commercetools-community-kit/i18n':
       specifier: ^0.3.0
@@ -1141,7 +1138,7 @@ importers:
         version: 17.8.1
       '@cypress/code-coverage':
         specifier: catalog:test
-        version: 3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       '@faker-js/faker':
         specifier: catalog:test
         version: 8.4.1
@@ -3542,10 +3539,10 @@ importers:
         version: 5.0.4
       html-webpack-plugin:
         specifier: catalog:build
-        version: 5.6.8(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 5.6.8(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       webpack:
         specifier: catalog:build
-        version: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+        version: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   packages/mc-scripts:
     dependencies:
@@ -3593,7 +3590,7 @@ importers:
         version: 6.6.6(ts-jest@29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3))
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: catalog:build
-        version: 0.6.2(react-refresh@0.18.0)(type-fest@4.41.0)(webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 0.6.2(react-refresh@0.18.0)(type-fest@4.41.0)(webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       '@rollup/plugin-graphql':
         specifier: catalog:build
         version: 2.0.5(graphql@16.14.2)(rollup@4.62.4)
@@ -3617,7 +3614,7 @@ importers:
         version: 2.6.4
       '@types/webpack-bundle-analyzer':
         specifier: 'catalog:'
-        version: 4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+        version: 4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
       '@vitejs/plugin-react':
         specifier: catalog:build
         version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -3629,7 +3626,7 @@ importers:
         version: 10.4.22(postcss@8.5.26)
       babel-loader:
         specifier: catalog:build
-        version: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       babel-plugin-formatjs:
         specifier: catalog:build
         version: 10.5.41(supports-color@8.1.1)(ts-jest@29.2.6(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.2)(jest@30.2.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)))(typescript@5.9.3))
@@ -3650,10 +3647,10 @@ importers:
         version: 3.46.0
       css-loader:
         specifier: catalog:build
-        version: 6.11.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 6.11.0(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       css-minimizer-webpack-plugin:
         specifier: catalog:build
-        version: 8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2
@@ -3677,7 +3674,7 @@ importers:
         version: 2.12.6(graphql@16.14.2)
       html-webpack-plugin:
         specifier: catalog:build
-        version: 5.6.8(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 5.6.8(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       json-loader:
         specifier: catalog:build
         version: 0.5.7
@@ -3689,13 +3686,13 @@ importers:
         version: 4.18.1
       mini-css-extract-plugin:
         specifier: catalog:build
-        version: 2.10.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 2.10.2(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       moment-locales-webpack-plugin:
         specifier: catalog:build
-        version: 1.2.0(moment@2.30.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 1.2.0(moment@2.30.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       node-fetch:
         specifier: 'catalog:'
         version: 2.7.0
@@ -3716,7 +3713,7 @@ importers:
         version: 14.1.0(postcss@8.5.26)
       postcss-loader:
         specifier: catalog:build
-        version: 6.2.1(postcss@8.5.26)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 6.2.1(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       postcss-reporter:
         specifier: catalog:build
         version: 7.1.0(postcss@8.5.26)
@@ -3731,7 +3728,7 @@ importers:
         version: 0.2.1
       react-dev-utils:
         specifier: catalog:build
-        version: 12.0.1(supports-color@8.1.1)(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 12.0.1(supports-color@8.1.1)(typescript@5.9.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       react-refresh:
         specifier: catalog:build
         version: 0.18.0
@@ -3749,16 +3746,16 @@ importers:
         version: 3.0.2
       style-loader:
         specifier: catalog:build
-        version: 3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 3.3.4(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       svg-url-loader:
         specifier: catalog:build
-        version: 8.1.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 8.1.0(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       terser-webpack-plugin:
         specifier: catalog:build
-        version: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       thread-loader:
         specifier: catalog:build
-        version: 4.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 4.0.4(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       url:
         specifier: 'catalog:'
         version: 0.11.4
@@ -3770,16 +3767,13 @@ importers:
         version: 0.23.0
       webpack:
         specifier: catalog:build
-        version: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+        version: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
       webpack-bundle-analyzer:
         specifier: catalog:build
         version: 4.10.2
       webpack-dev-server:
         specifier: catalog:build
-        version: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
-      webpackbar:
-        specifier: catalog:build
-        version: 7.0.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+        version: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
     devDependencies:
       '@commercetools/composable-commerce-test-data':
         specifier: 'catalog:'
@@ -3798,7 +3792,7 @@ importers:
         version: 4.17.20
       '@types/moment-locales-webpack-plugin':
         specifier: 'catalog:'
-        version: 1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+        version: 1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
       '@types/node-fetch':
         specifier: 'catalog:'
         version: 2.6.13
@@ -9491,9 +9485,6 @@ packages:
   '@types/dompurify@2.4.0':
     resolution: {integrity: sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==}
 
-  '@types/eslint-scope@3.7.7':
-    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
-
   '@types/eslint@8.56.12':
     resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
 
@@ -10415,12 +10406,6 @@ packages:
     peerDependencies:
       acorn: ^8
 
-  acorn-import-phases@1.0.4:
-    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      acorn: ^8.14.0
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -10432,6 +10417,11 @@ packages:
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -10538,10 +10528,6 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-
-  ansis@3.17.0:
-    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
-    engines: {node: '>=14'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -12323,6 +12309,10 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -12377,8 +12367,8 @@ packages:
   es-module-lexer@1.5.0:
     resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -13207,9 +13197,6 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
-
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -15333,6 +15320,49 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -16346,10 +16376,6 @@ packages:
   pretty-ms@7.0.1:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
-
-  pretty-time@1.1.0:
-    resolution: {integrity: sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==}
-    engines: {node: '>=4'}
 
   prism-react-renderer@2.4.0:
     resolution: {integrity: sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==}
@@ -17519,9 +17545,6 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -17823,6 +17846,10 @@ packages:
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-fs@3.1.2:
@@ -18669,8 +18696,8 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   wbuf@1.7.3:
@@ -18726,30 +18753,18 @@ packages:
       webpack-cli:
         optional: true
 
-  webpack-sources@3.3.3:
-    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
-  webpack@5.105.1:
-    resolution: {integrity: sha512-Gdj3X74CLJJ8zy4URmK42W7wTZUJrqL+z8nyGEr4dTN0kb3nVs+ZvjbTOqRYPD7qX4tUmwyHL9Q9K6T1seW6Yw==}
+  webpack@5.109.2:
+    resolution: {integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
-        optional: true
-
-  webpackbar@7.0.0:
-    resolution: {integrity: sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==}
-    engines: {node: '>=14.21.3'}
-    peerDependencies:
-      '@rspack/core': '*'
-      webpack: 3 || 4 || 5
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-      webpack:
         optional: true
 
   websocket-driver@0.7.4:
@@ -19279,7 +19294,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 7.8.5
 
@@ -22208,12 +22223,12 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@cypress/code-coverage@3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))':
+  '@cypress/code-coverage@3.14.7(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(cypress@14.5.4)(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/preset-env': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
-      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       chalk: 4.1.2
       cypress: 14.5.4
       dayjs: 1.11.13
@@ -22223,7 +22238,7 @@ snapshots:
       js-yaml: 3.15.1
       nyc: 15.1.0(supports-color@8.1.1)
       tinyglobby: 0.2.17
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -22248,16 +22263,16 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6(supports-color@8.1.1))(@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/preset-env': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+      babel-loader: 8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       bluebird: 3.7.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       semver: 7.8.5
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -25132,7 +25147,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@4.41.0)(webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@4.41.0)(webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))':
     dependencies:
       anser: 2.3.2
       core-js-pure: 3.48.0
@@ -25141,10 +25156,10 @@ snapshots:
       react-refresh: 0.18.0
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -26145,11 +26160,6 @@ snapshots:
     dependencies:
       '@types/trusted-types': 2.0.7
 
-  '@types/eslint-scope@3.7.7':
-    dependencies:
-      '@types/eslint': 8.56.12
-      '@types/estree': 1.0.9
-
   '@types/eslint@8.56.12':
     dependencies:
       '@types/estree': 1.0.8
@@ -26285,14 +26295,23 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)':
+  '@types/moment-locales-webpack-plugin@1.2.6(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
       tapable: 2.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
       - webpack-cli
 
@@ -26440,14 +26459,23 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)':
+  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)':
     dependencies:
       '@types/node': 22.19.17
       tapable: 2.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
       - webpack-cli
 
@@ -27580,10 +27608,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-import-phases@1.0.4(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -27593,6 +27617,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  acorn@8.18.0: {}
 
   address@1.2.2: {}
 
@@ -27611,17 +27637,17 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.18.0):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -27694,8 +27720,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
-
-  ansis@3.17.0: {}
 
   any-promise@1.3.0: {}
 
@@ -27957,14 +27981,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  babel-loader@8.4.1(@babel/core@7.29.6(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   babel-plugin-dev-expression@0.2.3(@babel/core@7.29.6(supports-color@8.1.1)):
     dependencies:
@@ -28044,7 +28068,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
@@ -29057,7 +29081,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@6.11.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  css-loader@6.11.0(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.26)
       postcss: 8.5.26
@@ -29068,9 +29092,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
-  css-minimizer-webpack-plugin@8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  css-minimizer-webpack-plugin@8.0.0(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.7(postcss@8.5.26)
@@ -29078,7 +29102,7 @@ snapshots:
       postcss: 8.5.26
       schema-utils: 4.3.3
       serialize-javascript: 7.1.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     optionalDependencies:
       clean-css: 5.3.3
       csso: 5.0.5
@@ -29123,7 +29147,7 @@ snapshots:
 
   cssnano-preset-default@7.0.15(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       css-declaration-sorter: 7.4.0(postcss@8.5.26)
       cssnano-utils: 5.0.2(postcss@8.5.26)
       postcss: 8.5.26
@@ -29666,6 +29690,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
@@ -29785,7 +29814,7 @@ snapshots:
 
   es-module-lexer@1.5.0: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -30503,11 +30532,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  file-loader@6.2.0(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   file-match@1.0.2:
     dependencies:
@@ -30647,7 +30676,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -30662,7 +30691,7 @@ snapshots:
       semver: 7.8.5
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   form-data@3.0.4:
     dependencies:
@@ -30898,8 +30927,6 @@ snapshots:
   glob-to-regex.js@1.2.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
-
-  glob-to-regexp@0.4.1: {}
 
   glob@10.5.0:
     dependencies:
@@ -31320,7 +31347,7 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
-  html-webpack-plugin@5.6.8(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  html-webpack-plugin@5.6.8(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -31328,7 +31355,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -33802,11 +33829,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  mini-css-extract-plugin@2.10.2(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   minimalistic-assert@1.0.1: {}
 
@@ -33838,6 +33865,23 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.0
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+    optionalDependencies:
+      '@swc/core': 1.15.1(@swc/helpers@0.5.23)
+      clean-css: 5.3.3
+      cssnano: 7.1.7(postcss@8.5.26)
+      csso: 5.0.5
+      esbuild: 0.28.2
+      html-minifier-terser: 6.1.0
+      postcss: 8.5.26
+      uglify-js: 3.19.3
+
   minipass@7.1.2: {}
 
   minipass@7.1.3: {}
@@ -33856,11 +33900,11 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  moment-locales-webpack-plugin@1.2.0(moment@2.30.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  moment-locales-webpack-plugin@1.2.0(moment@2.30.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       lodash.difference: 4.5.0
       moment: 2.30.1
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   moment-timezone@0.6.0:
     dependencies:
@@ -34728,13 +34772,13 @@ snapshots:
       postcss: 8.5.26
       ts-node: 10.9.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(@types/node@22.19.11)(typescript@5.9.3)
 
-  postcss-loader@6.2.1(postcss@8.5.26)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  postcss-loader@6.2.1(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.5.26
       semver: 7.8.5
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -34951,8 +34995,6 @@ snapshots:
   pretty-ms@7.0.1:
     dependencies:
       parse-ms: 2.1.0
-
-  pretty-time@1.1.0: {}
 
   prism-react-renderer@2.4.0(react@19.2.8):
     dependencies:
@@ -35197,7 +35239,7 @@ snapshots:
       react-stately: 3.48.0(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  react-dev-utils@12.0.1(supports-color@8.1.1)(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  react-dev-utils@12.0.1(supports-color@8.1.1)(typescript@5.9.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       address: 1.2.2
@@ -35208,7 +35250,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -35223,7 +35265,7 @@ snapshots:
       shell-quote: 1.10.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -35945,9 +35987,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
-      ajv-keywords: 5.1.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   screenfull@5.2.0: {}
 
@@ -36439,8 +36481,6 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
-
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -36667,9 +36707,9 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  style-loader@3.3.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  style-loader@3.3.4(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   style-search@0.1.0: {}
 
@@ -36795,10 +36835,10 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svg-url-loader@8.1.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  svg-url-loader@8.1.0(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   svgo@4.0.1:
     dependencies:
@@ -36846,6 +36886,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tapable@2.3.3: {}
+
   tar-fs@3.1.2:
     dependencies:
       pump: 3.0.3
@@ -36885,13 +36927,13 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  terser-webpack-plugin@5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     optionalDependencies:
       '@swc/core': 1.15.1(@swc/helpers@0.5.23)
       esbuild: 0.28.2
@@ -36936,13 +36978,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  thread-loader@4.0.4(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  thread-loader@4.0.4(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.1
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
   throat@4.1.0: {}
 
@@ -37197,7 +37239,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -37762,9 +37804,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  watchpack@2.5.1:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   wbuf@1.7.3:
@@ -37815,7 +37856,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  webpack-dev-middleware@7.4.5(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.51.0
@@ -37824,9 +37865,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
-  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
+  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -37854,58 +37895,53 @@ snapshots:
       serve-index: 1.9.1(supports-color@8.1.1)
       sockjs: 0.3.24
       spdy: 4.0.2(supports-color@8.1.1)
-      webpack-dev-middleware: 7.4.5(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
+      webpack-dev-middleware: 7.4.5(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
+      webpack: 5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  webpack-sources@3.3.3: {}
+  webpack-sources@3.5.1: {}
 
-  webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3):
+  webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3):
     dependencies:
-      '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn: 8.18.0
       browserslist: 4.28.7
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
+      enhanced-resolve: 5.24.5
+      es-module-lexer: 2.3.1
       eslint-scope: 5.1.1
       events: 3.3.0
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)(webpack@5.109.2(@swc/core@1.15.1(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@7.1.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.5.0(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
-
-  webpackbar@7.0.0(webpack@5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)):
-    dependencies:
-      ansis: 3.17.0
-      consola: 3.4.2
-      pretty-time: 1.1.0
-      std-env: 3.10.0
-    optionalDependencies:
-      webpack: 5.105.1(@swc/core@1.15.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(uglify-js@3.19.3)
 
   websocket-driver@0.7.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -360,19 +360,13 @@ catalogs:
     vite-bundle-analyzer: 0.23.0
 
     # Webpack + loaders/plugins (mc-scripts / mc-html-template)
-    # Held back from 5.109.x: webpack's ProgressPlugin now defers option
-    # schema validation until compiler.hooks.validate instead of validating
-    # synchronously in the constructor. webpackbar@5.0.2 (unmaintained)
-    # overwrites `this.options` with its own name/color/reporters/reporter
-    # keys right after calling super() — those keys aren't in webpack's
-    # ProgressPlugin schema, so the deferred validation now fails with
-    # "Invalid options object" and breaks every mc-scripts dev build.
-    # Revisit once webpackbar is fixed/replaced or dropped in favor of
-    # webpack's built-in progress bar.
-    webpack: 5.105.1
+    # `webpackbar` was dropped in favor of webpack's own built-in
+    # ProgressPlugin `progressBar` option (added in 5.109.x); that also
+    # means webpack no longer needs to be held back from 5.109.x for
+    # webpackbar's sake.
+    webpack: 5.109.2
     webpack-bundle-analyzer: 4.10.2
     webpack-dev-server: 5.2.6
-    webpackbar: 7.0.0
     browserslist: ^4.28.1
     css-loader: 6.11.0
     css-minimizer-webpack-plugin: ^8.0.0


### PR DESCRIPTION
## Why

`webpackbar@5.0.2` is unmaintained and is incompatible with webpack's newer `ProgressPlugin` option-validation timing:

- webpack 5.109.x moved `ProgressPlugin` option-schema validation out of the constructor and into a `compiler.hooks.validate` tap that fires later, reading `this.options` at that point.
- `WebpackBarPlugin` (from `webpackbar`) calls `super({ activeModules: true })` and then immediately overwrites `this.options` with its own `name`/`color`/`reporters`/`reporter` keys, none of which exist in `ProgressPlugin`'s schema.
- Old webpack validated synchronously in the constructor (before that overwrite), so it never saw the bad keys. New webpack validates lazily (after the overwrite), so it now hard-fails every `mc-scripts` dev build with `Invalid options object. Progress Plugin has been initialized using an options object that does not match the API schema.`

This is why `chore/renovate-batch-consolidation` (#4077) had to hold `webpack` back at 5.105.1 to unblock CI.

## What

- Removed `webpackbar` from `mc-scripts`'s dependencies and catalog entry.
- Replaced `new WebpackBar()` with webpack's own `new webpack.ProgressPlugin({ progressBar: 'auto' })` in `create-webpack-config-for-development.ts` — colored bar in interactive terminals, plain percentage lines in non-TTY output (CI logs).
- Bumped `webpack` back up to 5.109.2 in the catalog now that the incompatibility is gone.

## Verification

- `pnpm install` — clean, `webpackbar` fully removed from the lockfile.
- `pnpm run build` — mc-scripts builds/typechecks cleanly.
- `pnpm --filter @commercetools-frontend/mc-scripts run test` equivalent (root jest scoped to the package) — 100/100 tests pass.
- Ran the starter template dev server (`mc-scripts start`) — compiles successfully on webpack 5.109.2 with the new progress bar, no schema errors.
- Ran a production build (`mc-scripts build`) for the starter template — succeeds.
- `node scripts/check-workspace-constraints.js` — passes.

## Compat note

Not a breaking change for the default `mc-scripts start`/`build` path. One edge case: `createWebpackConfigForDevelopment` is exported from the public `@commercetools-frontend/mc-scripts/webpack` entrypoint — anyone who imports it directly and specifically looks for a `WebpackBar` plugin instance in the returned `Configuration.plugins` array would need to update, since that instance is now a `webpack.ProgressPlugin`. Called out in the changeset.