### PR TITLE
fix: update Content-Security-Policy to include clientsdk.launchdarkly

### DIFF
--- a/.changeset/bright-llamas-allow.md
+++ b/.changeset/bright-llamas-allow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/mc-html-template': patch
+---
+
+Allow LaunchDarkly SDK v4 clientsdk connections in the default CSP so feature flag initialization is not blocked.

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -19,6 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://app.launchdarkly.com" />
+    <link rel="preconnect" href="https://clientsdk.launchdarkly.com" />
     <link rel="preconnect" href="https://clientstream.launchdarkly.com" />
     <link rel="preconnect" href="https://events.launchdarkly.com" />
 

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -92,7 +92,7 @@ describe('csp', () => {
     expect(
       processedApplicationConfig['Content-Security-Policy']
     ).toMatchInlineSnapshot(
-      `"default-src 'none'; script-src 'self' 'sha256-RACUtlMzZqF+zLJFAGOjaIZxjIlawfiKwgX9HWbQ9yQ=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
+      `"default-src 'none'; script-src 'self' 'sha256-RACUtlMzZqF+zLJFAGOjaIZxjIlawfiKwgX9HWbQ9yQ=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
     );
   });
 });

--- a/packages/mc-html-template/src/process-headers.ts
+++ b/packages/mc-html-template/src/process-headers.ts
@@ -92,6 +92,7 @@ const processHeaders = (
       'connect-src': [
         "'self'",
         'app.launchdarkly.com',
+        'clientsdk.launchdarkly.com',
         'clientstream.launchdarkly.com',
         'events.launchdarkly.com',
         'app.getsentry.com',


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Application Kit 27.9.1 upgrades Flopflip to 15.1.11, which uses LaunchDarkly SDK v4. The new SDK connects to clientsdk.launchdarkly.com, but this domain is missing from the default CSP.


<!-- provide a short summary of your changes -->

#### Description

The browser blocks the request, causing the LaunchDarkly adapter to fail initialization and feature flags to fall back to their defaults. Spotted here initially https://github.com/commercetools/merchant-center-frontend/pull/21117
<img width="1458" height="574" alt="Screenshot 2026-08-13 at 11 59 55" src="https://github.com/user-attachments/assets/b4f840b9-8ee2-40fe-aecf-d6ac11c78650" />

This change adds clientsdk.launchdarkly.com to the default connect-src CSP and LaunchDarkly preconnect list, with updated tests.

<!-- provide some context -->
