### PR TITLE
ci: use chromaui/action for e2e-playground Chromatic upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -394,15 +394,23 @@ jobs:
           CTP_INITIAL_PROJECT_KEY: ${{ secrets.CYPRESS_PROJECT_KEY }}
 
       # The archives are on disk, so this needs neither the server nor Cypress.
-      # `--exit-zero-on-changes` leaves the verdict to the required
-      # "UI Tests: app-kit-e2e-playground" check; failing here would skip coverage too.
+      # Use the official Action rather than the bare CLI: on a PR the checkout
+      # is a detached HEAD, so the bare CLI can't resolve the branch, warns
+      # "Pull request status updates likely won't work properly", and never
+      # posts the "UI Tests: app-kit-e2e-playground" status back — leaving that
+      # required check pending forever even though the Chromatic build passed.
+      # The Action forwards the workflow's PR/branch context so it reports back.
+      # `exitZeroOnChanges` leaves the verdict to that required check; failing
+      # here would skip coverage too.
       - name: Upload Cypress archives to Chromatic
         if:
           steps.changed-files.outputs.any_changed == 'true' && github.head_ref !=
           'changeset-release/main'
-        run: pnpm chromatic --cypress --exit-zero-on-changes
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_TOKEN_E2E_PLAYGROUND }}
+        uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_TOKEN_E2E_PLAYGROUND }}
+          cypress: true
+          exitZeroOnChanges: true
 
       # Chromatic didn't run, so post its required check ourselves or the PR waits forever.
       - name: No UI changes detected


### PR DESCRIPTION
## Why

`UI Tests: app-kit-e2e-playground` is a required branch-protection check, but it's stuck pending on essentially every PR that touches `packages/**`, `playground/**`, or `cypress/**` (verified on #4094, #4066, #4046, #4081, #4082) — even though the underlying Chromatic build for that project completes and passes.

Root cause: the `test_playground` job in `main.yml` uploads Cypress archives via the bare CLI:

```
run: pnpm chromatic --cypress --exit-zero-on-changes
```

On a PR, `actions/checkout` leaves the repo in a detached-HEAD state, so the bare CLI can't resolve the branch name from git history. It logs:

```
⚠ Branch 'nj-fix-ld-auth' does not exist
We tried to retrieve its latest commit but couldn't find it in your Git history.
Falling back to 26a91bc, but commit details (date, author) will be missing.
Pull request status updates likely won't work properly.
Please use our official GitHub Action or forward the pull_request event info to us.
```

...and never posts the `UI Tests: app-kit-e2e-playground` commit status back to GitHub, so the required check just sits pending forever, even after the Chromatic build itself finishes and passes on chromatic.com.

This only works on pushes to `main`, where the checkout is on a real branch ref rather than a detached PR head — which is why it's gone unnoticed until now.

## Fix

Swap the bare CLI call for the official `chromaui/action` (already used for the `app-kit-components` Storybook project in `chromatic.yml`), which forwards the workflow's GitHub Actions PR/branch context so Chromatic can report the result back correctly.

```diff
- run: pnpm chromatic --cypress --exit-zero-on-changes
- env:
-   CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_TOKEN_E2E_PLAYGROUND }}
+ uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+ with:
+   projectToken: ${{ secrets.CHROMATIC_TOKEN_E2E_PLAYGROUND }}
+   cypress: true
+   exitZeroOnChanges: true
```

## Verification

- Confirmed via `gh api .../status` that no recent PR (#4066, #4046, #4081, #4082) ever got a `UI Tests: app-kit-e2e-playground` status posted, while pushes to `main` (e.g. `2f5ed134d`, `1bfc25f44`) post it successfully.
- Validated the updated workflow YAML parses correctly.
- This PR itself will exercise the fixed path on a real PR — the `UI Tests: app-kit-e2e-playground` check on this PR should resolve to pass/fail instead of sitting pending.
