### PR TITLE
ci: repin tj-actions/changed-files comment to exact patch tag

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,7 +39,12 @@ jobs:
       # dispatch bypasses it via the step `if:` conditions below).
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        # Comment tag is the exact patch (v46.0.5), NOT the floating `v46`.
+        # If upstream stops advancing the `v46` tag past this release the way it did for
+        # `v47` (see commercetools/nimbus#1928), a `# v46` comment would make Renovate
+        # resolve the stale ref and "update" the digest backwards. Pinning the comment to
+        # the exact tag keeps Renovate doing real semver comparison.
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           # push: diff newest commit. PR: diff whole PR (base...head).
           since_last_remote_commit: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -303,7 +303,12 @@ jobs:
       # Gate: upload to Chromatic only when files affecting rendered output change.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        # Comment tag is the exact patch (v46.0.5), NOT the floating `v46`.
+        # If upstream stops advancing the `v46` tag past this release the way it did for
+        # `v47` (see commercetools/nimbus#1928), a `# v46` comment would make Renovate
+        # resolve the stale ref and "update" the digest backwards. Pinning the comment to
+        # the exact tag keeps Renovate doing real semver comparison.
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           # push: diff newest commit. PR: diff whole PR (base...head).
           since_last_remote_commit: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Why

Both `.github/workflows/chromatic.yml` and `.github/workflows/main.yml` pin
`tj-actions/changed-files` to a commit SHA with a trailing comment naming only
the floating major tag (`# v46`), not the exact patch release.

This is the same class of bug fixed in commercetools/nimbus#1928: upstream
`tj-actions/changed-files` may stop advancing the floating `vNN` tag past its
first release (this happened with `v47` in nimbus, frozen at `v47.0.0` while
`v47.0.6` shipped six patches later). If that happens here too, Renovate
resolves the stale `v46` ref and proposes "updating" the digest backwards to
whatever `v46` last pointed to, silently reverting patches.

Retagging the trailing comment to the exact resolved release tag prevents this
because per-patch release tags don't move once published, so Renovate keeps
doing real semver comparison instead of trusting a floating ref.

## What changed

- Resolved the pinned SHA `ed68ef82c095e0d48ec87eccea555d944a631a4c` to its
  exact tag: **`v46.0.5`** (confirmed via the GitHub Tags API).
- Confirmed the floating `v46` tag currently **still points to the same SHA**
  — i.e. the risk here is latent (matches how nimbus's `v47` situation looked
  before it went stale), not yet triggered.
- Updated the trailing comment on both `uses: tj-actions/changed-files@...`
  lines from `# v46` to `# v46.0.5`, and added an explanatory comment above
  each line.
- **The pinned SHA itself was not changed** in either file — only the comment.

## Verification

- `git diff` confirms only the comment lines changed in both files; the SHA
  `ed68ef82c095e0d48ec87eccea555d944a631a4c` is untouched.