### PR TITLE
ci: add changeset to Renovate dependency PRs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,10 +18,10 @@ jobs:
       # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
-          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+          client-id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -23,10 +23,10 @@ jobs:
       # re-triggers required status checks (the default GITHUB_TOKEN cannot).
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
-          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+          client-id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
       # This action talks entirely to the GitHub API (reads PR files/commits
       # and writes the changeset via the Contents API) - no checkout needed.

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -1,0 +1,81 @@
+name: Add changeset to Renovate PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, labeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  renovate-changeset:
+    if: >
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      contains(github.event.pull_request.labels.*.name, '🤖 Type: Dependencies')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Get GitHub token via the CT Changesets App so the resulting push
+      # re-triggers required status checks (the default GITHUB_TOKEN cannot).
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+
+      # This action talks entirely to the GitHub API (reads PR files/commits
+      # and writes the changeset via the Contents API) - no checkout needed.
+      - name: Add changeset for dependency update
+        id: add_changeset
+        uses: mscharley/dependency-changesets-action@874dac2372a085cb94f750e8bdf5b1173a838a75 # v1.2.5
+        with:
+          token: ${{ steps.generate_github_token.outputs.token }}
+          # Renovate's default commit prefix is "chore(deps): ...", which
+          # conventional-commit parsing treats as a non-releasable change
+          # (only fix/feat/breaking map to a bump type). Disable it so every
+          # dependency update gets a patch-level changeset instead of being
+          # silently skipped.
+          use-conventional-commits: false
+          commit-message: "chore(deps): add changeset for dependency update"
+          author-name: "github-actions[bot]"
+          author-email: "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # `created-changeset` only reflects whether *this run* wrote a new
+      # file - on a later `synchronize` (e.g. Renovate rebasing) the action
+      # may leave an already-present changeset alone and report `false`,
+      # which would otherwise flip the sticky comment back to a false
+      # "not added" warning. Check the PR's actual file list instead, so the
+      # message reflects current state rather than this run's action alone.
+      - name: Check whether the PR has a changeset
+        id: check_changeset
+        env:
+          GH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+        run: |
+          has_changeset=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '[.[] | select(.filename | test("^\\.changeset/.*\\.md$")) | select(.filename != ".changeset/README.md") | select(.status != "removed")] | length > 0')
+          echo "has_changeset=$has_changeset" >> "$GITHUB_OUTPUT"
+
+      # Sticky so repeated `synchronize` events (e.g. Renovate rebasing the
+      # PR) update the same comment instead of piling up new ones.
+      - name: Comment on PR (changeset added)
+        if: steps.check_changeset.outputs.has_changeset == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          header: renovate-changeset
+          message: |
+            ✅ A changeset was automatically added for this dependency update.
+
+      - name: Comment on PR (changeset not added)
+        if: steps.check_changeset.outputs.has_changeset == 'false'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          header: renovate-changeset
+          message: |
+            ⚠️ No changeset was automatically added for this dependency update. Please add one manually if this change should be released.


### PR DESCRIPTION
## Summary
- Mirrors commercetools/nimbus's renovate-changeset.yml workflow: auto-adds a changeset via `mscharley/dependency-changesets-action` for Renovate PRs labeled `🤖 Type: Dependencies`, and posts a sticky PR comment reflecting the PR's current changeset state.
- Checks changeset presence via the GitHub API (PR file list) rather than the action's per-run output, so a later `synchronize` run that doesn't need to recreate an existing changeset doesn't flip the comment to a false "not added" warning.
- Migrates both this new workflow and the existing `publish-release.yml` from the archived `tibdex/github-app-token` to the officially maintained `actions/create-github-app-token@v3.2.0`, using the non-deprecated `client-id` input (accepts the same numeric App ID already stored in `CT_CHANGESETS_APP_ID`).

## Security notes
- `pull_request_target` is used, but no PR code is checked out or executed — `dependency-changesets-action` operates entirely via the GitHub API (Contents API), matching GitHub's recommended safe pattern for this trigger.
- The job gate requires both `renovate[bot]` as the PR author (unspoofable by non-App accounts) and the `🤖 Type: Dependencies` label.
- All third-party actions are pinned to full commit SHAs with version comments.

## Test plan
- YAML validated (`yaml.safe_load`) for both modified workflow files.
- No app-level test suite applicable to CI workflow config; will validate behavior on the next Renovate PR once merged.