### PR TITLE
ci: scope renovate-changeset.yml to npm/pnpm manifest changes

### DIFF
--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -5,6 +5,15 @@ on:
     types: [opened, synchronize, labeled]
     branches:
       - main
+    # Renovate applies the same '🤖 Type: Dependencies' label to every
+    # manager (npm, github-actions, docker, ...), but the changeset action
+    # only ever reacts to npm/pnpm manifest changes. Restrict the trigger to
+    # those paths so non-npm dependency PRs don't get a spurious "no
+    # changeset added" comment for something that was never applicable.
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Renovate applies the same `🤖 Type: Dependencies` label to every manager (npm, github-actions, docker, ...), but `mscharley/dependency-changesets-action` only ever reacts to `package.json`/`pnpm-workspace.yaml` changes. This mismatch meant the workflow ran — and its "no changeset" check posted a false ⚠️ warning comment — on Renovate PRs that never needed a changeset in the first place.

Concrete case: [#4107](https://github.com/commercetools/merchant-center-application-kit/pull/4107) only bumps `actions/stale` v10→v11 inside a workflow file. No `package.json` in the diff, so the action correctly wrote no changeset — but the workflow still ran and posted "⚠️ No changeset was automatically added ... Please add one manually", which is misleading since a changeset was never applicable.

## Change
Add a `paths` filter to the `pull_request_target` trigger in `renovate-changeset.yml`, mirroring the action's own detection logic:
```yaml
paths:
  - '**/package.json'
  - 'pnpm-lock.yaml'
  - 'pnpm-workspace.yaml'
```
No other lines changed — gate condition, token generation, changeset action invocation, and both sticky-comment steps are untouched.

## Test plan
- YAML validated (`yaml.safe_load`).
- Next GitHub-Actions-only/Docker-only Renovate PR should show no `renovate-changeset` check run at all (vs. today's run-but-no-op-with-warning-comment behavior seen on #4107).