### PR TITLE
ci: fix renovate changeset for pnpm catalog dependencies

### DIFF
--- a/.github/actions/renovate-changeset/add-changeset.js
+++ b/.github/actions/renovate-changeset/add-changeset.js
@@ -1,0 +1,237 @@
+// Inline replacement for mscharley/dependency-changesets-action, which has a
+// bug parsing single-quoted YAML keys in pnpm-workspace.yaml diffs
+// (https://github.com/mscharley/dependency-changesets-action/issues/691).
+// This repo's pnpm catalogs use single-quoted scoped package names (pnpm's
+// default), so the upstream action silently no-ops.
+//
+// This script talks entirely to the GitHub API (reads PR files/commits and
+// writes the changeset via the Contents API) — no checkout needed for the
+// data it operates on (only the script itself needs to be checked out by the
+// calling workflow).
+
+const DEFAULT_PACKAGE_DIRS = ['packages', 'packages-backend'];
+
+/**
+ * Parses PR file diffs (as returned by `pulls.listFiles`) to find changed
+ * dependency names/versions from `pnpm-workspace.yaml` catalog entries and
+ * `package.json` dependency entries.
+ *
+ * @param {Array<{filename: string, patch?: string}>} files
+ * @returns {Map<string, string>} dependency name -> version
+ */
+function parseDeps(files) {
+  const changedDeps = new Map(); // name → version
+
+  for (const file of files) {
+    if (!file.patch) continue;
+
+    // Parse pnpm-workspace.yaml catalog changes
+    if (
+      file.filename === 'pnpm-workspace.yaml' ||
+      file.filename.endsWith('/pnpm-workspace.yaml')
+    ) {
+      for (const line of file.patch.split('\n')) {
+        if (!line.startsWith('+') || line.startsWith('+++')) continue;
+        // Handle single-quoted, double-quoted, and unquoted YAML keys:
+        //   +    '@scope/pkg': 3.5.1
+        //   +    "@scope/pkg": "^3.5.1"
+        //   +    pkg-name: 1.2.3
+        const m = line.match(
+          /^\+\s*['"]?([^\s'"]+?)['"]?:\s+['"]?([^\s'"]+?)['"]?\s*$/
+        );
+        if (!m) continue;
+        const [, name, value] = m;
+        // Only match dependency specifiers (start with digit or range prefix),
+        // skip YAML structure keys like `catalogs:`, `nimbus:`, or `true`/`false`.
+        if (/^[\d^~>=<*]/.test(value)) {
+          changedDeps.set(name, value.replace(/^[\^~>=<]+/, ''));
+        }
+      }
+    }
+
+    // Parse package.json dependency changes
+    if (
+      file.filename === 'package.json' ||
+      file.filename.endsWith('/package.json')
+    ) {
+      for (const line of file.patch.split('\n')) {
+        if (!line.startsWith('+') || line.startsWith('+++')) continue;
+        const m = line.match(/^\+\s*"([^"]+)":\s*"([^"]+)"/);
+        if (!m) continue;
+        const [, name, value] = m;
+        if (/^[\d^~>=<*]/.test(value)) {
+          changedDeps.set(name, value.replace(/^[\^~>=<]+/, ''));
+        }
+      }
+    }
+  }
+
+  return changedDeps;
+}
+
+/**
+ * Generates changeset markdown content for the affected packages and the
+ * dependency updates that triggered them.
+ *
+ * @param {Set<string>} affectedPackages
+ * @param {Map<string, string>} changedDeps
+ * @returns {string}
+ */
+function generateChangesetContent(affectedPackages, changedDeps) {
+  const frontmatter = [...affectedPackages]
+    .sort()
+    .map((p) => `'${p}': patch`)
+    .join('\n');
+  const depList = [...changedDeps.entries()]
+    .map(([k, v]) => `\`${k}\` to \`${v}\``)
+    .join(', ');
+  return `---\n${frontmatter}\n---\n\nUpdate dependency ${depList}.\n`;
+}
+
+/**
+ * Main entry point invoked by `actions/github-script`. Checks whether a
+ * changeset already exists on the PR, and if not, detects changed
+ * dependencies and, for any affected published workspace packages, commits a
+ * generated changeset file to the PR branch.
+ *
+ * @param {{github: object, context: object, core: object}} octokit
+ * @param {{packageDirs?: string[]}} [opts]
+ */
+async function run({ github, context, core }, opts = {}) {
+  const packageDirs = opts.packageDirs || DEFAULT_PACKAGE_DIRS;
+
+  const prNumber = context.payload.pull_request.number;
+  const { owner, repo } = context.repo;
+  const ref = context.payload.pull_request.head.ref;
+
+  // 1. Check if changeset already exists in the PR
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  const hasExistingChangeset = files.some(
+    (f) =>
+      f.filename.startsWith('.changeset/') &&
+      f.filename.endsWith('.md') &&
+      f.filename !== '.changeset/README.md' &&
+      f.status !== 'removed'
+  );
+
+  if (hasExistingChangeset) {
+    core.info('Changeset already exists in the PR');
+    core.setOutput('has_changeset', 'true');
+    return;
+  }
+
+  // 2. Find changed dependencies from pnpm-workspace.yaml and package.json diffs
+  const changedDeps = parseDeps(files);
+
+  if (changedDeps.size === 0) {
+    core.info('No dependency version changes detected in PR diff');
+    core.setOutput('has_changeset', 'false');
+    return;
+  }
+
+  core.info(
+    `Changed deps: ${[...changedDeps.entries()]
+      .map(([k, v]) => `${k}@${v}`)
+      .join(', ')}`
+  );
+
+  // 3. Find published workspace packages that consume the changed dependencies
+  const affectedPackages = new Set();
+
+  for (const dir of packageDirs) {
+    let entries;
+    try {
+      const { data } = await github.rest.repos.getContent({
+        owner,
+        repo,
+        path: dir,
+        ref,
+      });
+      entries = Array.isArray(data) ? data : [];
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (entry.type !== 'dir') continue;
+      try {
+        const { data: pkgData } = await github.rest.repos.getContent({
+          owner,
+          repo,
+          path: `${dir}/${entry.name}/package.json`,
+          ref,
+        });
+        const pkg = JSON.parse(
+          Buffer.from(pkgData.content, 'base64').toString()
+        );
+        if (pkg.private) continue;
+
+        const allDeps = {
+          ...pkg.dependencies,
+          ...pkg.devDependencies,
+          ...pkg.peerDependencies,
+        };
+
+        for (const depName of changedDeps.keys()) {
+          if (allDeps[depName]) {
+            affectedPackages.add(pkg.name);
+            break;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  if (affectedPackages.size === 0) {
+    core.info('No published workspace packages are affected');
+    core.setOutput('has_changeset', 'false');
+    return;
+  }
+
+  core.info(`Affected packages: ${[...affectedPackages].join(', ')}`);
+
+  // 4. Generate changeset content
+  const content = generateChangesetContent(affectedPackages, changedDeps);
+
+  // 5. Commit changeset via Contents API
+  const changesetPath = `.changeset/dependencies-GH-${prNumber}.md`;
+  try {
+    await github.rest.repos.createOrUpdateFileContents({
+      owner,
+      repo,
+      path: changesetPath,
+      message: 'chore(deps): add changeset for dependency update',
+      content: Buffer.from(content).toString('base64'),
+      branch: ref,
+      committer: {
+        name: 'github-actions[bot]',
+        email: '41898282+github-actions[bot]@users.noreply.github.com',
+      },
+      author: {
+        name: 'github-actions[bot]',
+        email: '41898282+github-actions[bot]@users.noreply.github.com',
+      },
+    });
+    core.info(`Created changeset: ${changesetPath}`);
+    core.setOutput('has_changeset', 'true');
+  } catch (err) {
+    // 409/422 = race with a concurrent run that already created the file
+    if (err.status === 409 || err.status === 422) {
+      core.info(
+        `Changeset already created by a concurrent run (${err.status})`
+      );
+      core.setOutput('has_changeset', 'true');
+    } else {
+      throw err;
+    }
+  }
+}
+
+module.exports = { parseDeps, generateChangesetContent, run };

--- a/.github/actions/renovate-changeset/add-changeset.spec.js
+++ b/.github/actions/renovate-changeset/add-changeset.spec.js
@@ -1,0 +1,351 @@
+const { parseDeps, generateChangesetContent, run } = require('./add-changeset');
+
+describe('parseDeps', () => {
+  it('parses single-quoted pnpm-workspace.yaml catalog entries', () => {
+    const files = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n catalog:\n-    '@scope/pkg': 3.5.0\n+    '@scope/pkg': 3.5.1`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.get('@scope/pkg')).toBe('3.5.1');
+  });
+
+  it('parses double-quoted pnpm-workspace.yaml catalog entries', () => {
+    const files = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n catalog:\n-    "@scope/pkg": "^3.5.0"\n+    "@scope/pkg": "^3.5.1"`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.get('@scope/pkg')).toBe('3.5.1');
+  });
+
+  it('parses unquoted pnpm-workspace.yaml catalog entries', () => {
+    const files = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n catalog:\n-    pkg-name: 1.2.2\n+    pkg-name: 1.2.3`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.get('pkg-name')).toBe('1.2.3');
+  });
+
+  it('skips YAML structural keys like catalogs:, nimbus:, catalog:', () => {
+    const files = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n+catalogs:\n+  nimbus:\n+catalog:\n+    pkg-name: 1.2.3`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.has('catalogs')).toBe(false);
+    expect(result.has('nimbus')).toBe(false);
+    expect(result.has('catalog')).toBe(false);
+    expect(result.get('pkg-name')).toBe('1.2.3');
+  });
+
+  it('skips non-version values like true and false', () => {
+    const files = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n+some-flag: true\n+other-flag: false`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('parses package.json dependency changes', () => {
+    const files = [
+      {
+        filename: 'package.json',
+        patch: `@@ -1,3 +1,3 @@\n-    "@scope/pkg": "^3.5.0",\n+    "@scope/pkg": "^3.5.1",`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.get('@scope/pkg')).toBe('3.5.1');
+  });
+
+  it('strips range prefixes from captured versions', () => {
+    const files = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n+    pkg-a: ^1.0.0\n+    pkg-b: ~2.0.0\n+    pkg-c: >=3.0.0`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.get('pkg-a')).toBe('1.0.0');
+    expect(result.get('pkg-b')).toBe('2.0.0');
+    expect(result.get('pkg-c')).toBe('3.0.0');
+  });
+
+  it('returns an empty map when there are no dependency changes', () => {
+    const files = [
+      { filename: 'README.md', patch: '@@ -1,1 +1,1 @@\n-old text\n+new text' },
+      { filename: 'src/index.js' },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('ignores +++ diff header lines', () => {
+    const files = [
+      {
+        filename: 'package.json',
+        patch: `@@ -1,3 +1,3 @@\n+++ b/package.json\n+    "@scope/pkg": "^3.5.1",`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.get('@scope/pkg')).toBe('3.5.1');
+    expect(result.size).toBe(1);
+  });
+
+  it('ignores removal lines (lines starting with - but not ---)', () => {
+    const files = [
+      {
+        filename: 'package.json',
+        patch: `@@ -1,3 +1,3 @@\n-    "@scope/pkg": "^3.5.0",`,
+      },
+    ];
+
+    const result = parseDeps(files);
+
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('generateChangesetContent', () => {
+  it('produces valid changeset markdown with sorted package entries', () => {
+    const affectedPackages = new Set([
+      '@commercetools-frontend/pkg-b',
+      '@commercetools-frontend/pkg-a',
+    ]);
+    const changedDeps = new Map([['some-dep', '1.2.3']]);
+
+    const content = generateChangesetContent(affectedPackages, changedDeps);
+
+    const lines = content.split('\n');
+    expect(lines[0]).toBe('---');
+    expect(lines[1]).toBe("'@commercetools-frontend/pkg-a': patch");
+    expect(lines[2]).toBe("'@commercetools-frontend/pkg-b': patch");
+    expect(lines[3]).toBe('---');
+  });
+
+  it('produces a sensible description for a single dep update', () => {
+    const affectedPackages = new Set(['@commercetools-frontend/pkg-a']);
+    const changedDeps = new Map([['some-dep', '1.2.3']]);
+
+    const content = generateChangesetContent(affectedPackages, changedDeps);
+
+    expect(content).toContain('Update dependency');
+    expect(content).toContain('`some-dep` to `1.2.3`');
+  });
+
+  it('lists all dep updates in the description for multiple deps', () => {
+    const affectedPackages = new Set(['@commercetools-frontend/pkg-a']);
+    const changedDeps = new Map([
+      ['dep-one', '1.0.0'],
+      ['dep-two', '2.0.0'],
+    ]);
+
+    const content = generateChangesetContent(affectedPackages, changedDeps);
+
+    expect(content).toContain('`dep-one` to `1.0.0`');
+    expect(content).toContain('`dep-two` to `2.0.0`');
+  });
+});
+
+describe('run', () => {
+  const owner = 'commercetools';
+  const repo = 'merchant-center-application-kit';
+  const prNumber = 123;
+  const ref = 'renovate/some-dep-1.x';
+
+  function createGithub({ files, contents }) {
+    return {
+      paginate: jest.fn(async () => files),
+      rest: {
+        pulls: {
+          listFiles: jest.fn(),
+        },
+        repos: {
+          getContent: jest.fn(async ({ path }) => {
+            if (contents[path]) {
+              return { data: contents[path] };
+            }
+            const err = new Error('Not Found');
+            err.status = 404;
+            throw err;
+          }),
+          createOrUpdateFileContents: jest.fn(async () => ({})),
+        },
+      },
+    };
+  }
+
+  function createContext() {
+    return {
+      payload: {
+        pull_request: {
+          number: prNumber,
+          head: { ref },
+        },
+      },
+      repo: { owner, repo },
+    };
+  }
+
+  function createCore() {
+    return {
+      info: jest.fn(),
+      setOutput: jest.fn(),
+    };
+  }
+
+  it('returns early with has_changeset=true when a changeset already exists', async () => {
+    const github = createGithub({
+      files: [
+        { filename: '.changeset/dependencies-GH-123.md', status: 'added' },
+      ],
+      contents: {},
+    });
+    const context = createContext();
+    const core = createCore();
+
+    await run({ github, context, core });
+
+    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
+    expect(github.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled();
+  });
+
+  it('sets has_changeset=false when no dependency changes are detected', async () => {
+    const github = createGithub({
+      files: [{ filename: 'README.md', patch: '+hello' }],
+      contents: {},
+    });
+    const context = createContext();
+    const core = createCore();
+
+    await run({ github, context, core });
+
+    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'false');
+    expect(github.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled();
+  });
+
+  it('creates a changeset when a workspace package consumes the changed dep', async () => {
+    const pkgJson = {
+      name: '@commercetools-frontend/some-pkg',
+      dependencies: { 'some-dep': '^1.0.0' },
+    };
+    const github = createGithub({
+      files: [
+        {
+          filename: 'pnpm-workspace.yaml',
+          patch: `@@ -1,3 +1,3 @@\n+    'some-dep': 1.2.3`,
+        },
+      ],
+      contents: {
+        packages: [{ type: 'dir', name: 'some-pkg' }],
+        'packages/some-pkg/package.json': {
+          content: Buffer.from(JSON.stringify(pkgJson)).toString('base64'),
+        },
+      },
+    });
+    const context = createContext();
+    const core = createCore();
+
+    await run({ github, context, core });
+
+    expect(github.rest.repos.createOrUpdateFileContents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner,
+        repo,
+        path: `.changeset/dependencies-GH-${prNumber}.md`,
+        branch: ref,
+      })
+    );
+    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
+  });
+
+  it('handles a 409 race condition from createOrUpdateFileContents gracefully', async () => {
+    const pkgJson = {
+      name: '@commercetools-frontend/some-pkg',
+      dependencies: { 'some-dep': '^1.0.0' },
+    };
+    const github = createGithub({
+      files: [
+        {
+          filename: 'pnpm-workspace.yaml',
+          patch: `@@ -1,3 +1,3 @@\n+    'some-dep': 1.2.3`,
+        },
+      ],
+      contents: {
+        packages: [{ type: 'dir', name: 'some-pkg' }],
+        'packages/some-pkg/package.json': {
+          content: Buffer.from(JSON.stringify(pkgJson)).toString('base64'),
+        },
+      },
+    });
+    github.rest.repos.createOrUpdateFileContents = jest.fn(async () => {
+      const err = new Error('Conflict');
+      err.status = 409;
+      throw err;
+    });
+    const context = createContext();
+    const core = createCore();
+
+    await run({ github, context, core });
+
+    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
+  });
+
+  it('respects a custom packageDirs option', async () => {
+    const pkgJson = {
+      name: '@commercetools-frontend/backend-pkg',
+      dependencies: { 'some-dep': '^1.0.0' },
+    };
+    const github = createGithub({
+      files: [
+        {
+          filename: 'pnpm-workspace.yaml',
+          patch: `@@ -1,3 +1,3 @@\n+    'some-dep': 1.2.3`,
+        },
+      ],
+      contents: {
+        'custom-dir': [{ type: 'dir', name: 'backend-pkg' }],
+        'custom-dir/backend-pkg/package.json': {
+          content: Buffer.from(JSON.stringify(pkgJson)).toString('base64'),
+        },
+      },
+    });
+    const context = createContext();
+    const core = createCore();
+
+    await run({ github, context, core }, { packageDirs: ['custom-dir'] });
+
+    expect(github.rest.repos.createOrUpdateFileContents).toHaveBeenCalled();
+    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
+  });
+});

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -5,6 +5,14 @@ on:
     types: [opened, synchronize, labeled]
     branches:
       - main
+    # Only run when npm/pnpm manifest files change — the changeset action
+    # only reacts to these, so non-npm dependency PRs (GitHub Actions,
+    # Docker, etc.) don't need it and shouldn't get a false "no changeset"
+    # warning.
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 
 permissions:
   contents: read
@@ -28,42 +36,176 @@ jobs:
           client-id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private-key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
-      # This action talks entirely to the GitHub API (reads PR files/commits
-      # and writes the changeset via the Contents API) - no checkout needed.
+      # Inline replacement for mscharley/dependency-changesets-action, which
+      # has a bug parsing single-quoted YAML keys in pnpm-workspace.yaml
+      # diffs (https://github.com/mscharley/dependency-changesets-action/issues/691).
+      # This repo's pnpm catalogs use single-quoted scoped package names
+      # (pnpm's default), so the upstream action silently no-ops.
+      #
+      # This script talks entirely to the GitHub API (reads PR files/commits
+      # and writes the changeset via the Contents API) — no checkout needed.
       - name: Add changeset for dependency update
         id: add_changeset
-        uses: mscharley/dependency-changesets-action@874dac2372a085cb94f750e8bdf5b1173a838a75 # v1.2.5
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{ steps.generate_github_token.outputs.token }}
-          # Renovate's default commit prefix is "chore(deps): ...", which
-          # conventional-commit parsing treats as a non-releasable change
-          # (only fix/feat/breaking map to a bump type). Disable it so every
-          # dependency update gets a patch-level changeset instead of being
-          # silently skipped.
-          use-conventional-commits: false
-          commit-message: "chore(deps): add changeset for dependency update"
-          author-name: "github-actions[bot]"
-          author-email: "41898282+github-actions[bot]@users.noreply.github.com"
+          github-token: ${{ steps.generate_github_token.outputs.token }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const ref = context.payload.pull_request.head.ref;
 
-      # `created-changeset` only reflects whether *this run* wrote a new
-      # file - on a later `synchronize` (e.g. Renovate rebasing) the action
-      # may leave an already-present changeset alone and report `false`,
-      # which would otherwise flip the sticky comment back to a false
-      # "not added" warning. Check the PR's actual file list instead, so the
-      # message reflects current state rather than this run's action alone.
-      - name: Check whether the PR has a changeset
-        id: check_changeset
-        env:
-          GH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
-        run: |
-          has_changeset=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --paginate --jq '[.[] | select(.filename | test("^\\.changeset/.*\\.md$")) | select(.filename != ".changeset/README.md") | select(.status != "removed")] | length > 0')
-          echo "has_changeset=$has_changeset" >> "$GITHUB_OUTPUT"
+            // 1. Check if changeset already exists in the PR
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: prNumber,
+            });
+
+            const hasExistingChangeset = files.some(f =>
+              f.filename.startsWith('.changeset/') &&
+              f.filename.endsWith('.md') &&
+              f.filename !== '.changeset/README.md' &&
+              f.status !== 'removed'
+            );
+
+            if (hasExistingChangeset) {
+              core.info('Changeset already exists in the PR');
+              core.setOutput('has_changeset', 'true');
+              return;
+            }
+
+            // 2. Find changed dependencies from pnpm-workspace.yaml and package.json diffs
+            const changedDeps = new Map(); // name → version
+
+            for (const file of files) {
+              if (!file.patch) continue;
+
+              // Parse pnpm-workspace.yaml catalog changes
+              if (file.filename === 'pnpm-workspace.yaml' || file.filename.endsWith('/pnpm-workspace.yaml')) {
+                for (const line of file.patch.split('\n')) {
+                  if (!line.startsWith('+') || line.startsWith('+++')) continue;
+                  // Handle single-quoted, double-quoted, and unquoted YAML keys:
+                  //   +    '@scope/pkg': 3.5.1
+                  //   +    "@scope/pkg": "^3.5.1"
+                  //   +    pkg-name: 1.2.3
+                  const m = line.match(/^\+\s*['"]?([^\s'"]+?)['"]?:\s+['"]?([^\s'"]+?)['"]?\s*$/);
+                  if (!m) continue;
+                  const [, name, value] = m;
+                  // Only match dependency specifiers (start with digit or range prefix),
+                  // skip YAML structure keys like `catalogs:`, `nimbus:`, or `true`/`false`.
+                  if (/^[\d^~>=<*]/.test(value)) {
+                    changedDeps.set(name, value.replace(/^[\^~>=<]+/, ''));
+                  }
+                }
+              }
+
+              // Parse package.json dependency changes
+              if (file.filename === 'package.json' || file.filename.endsWith('/package.json')) {
+                for (const line of file.patch.split('\n')) {
+                  if (!line.startsWith('+') || line.startsWith('+++')) continue;
+                  const m = line.match(/^\+\s*"([^"]+)":\s*"([^"]+)"/);
+                  if (!m) continue;
+                  const [, name, value] = m;
+                  if (/^[\d^~>=<*]/.test(value)) {
+                    changedDeps.set(name, value.replace(/^[\^~>=<]+/, ''));
+                  }
+                }
+              }
+            }
+
+            if (changedDeps.size === 0) {
+              core.info('No dependency version changes detected in PR diff');
+              core.setOutput('has_changeset', 'false');
+              return;
+            }
+
+            core.info(`Changed deps: ${[...changedDeps.entries()].map(([k, v]) => `${k}@${v}`).join(', ')}`);
+
+            // 3. Find published workspace packages that consume the changed dependencies
+            const packageDirs = ['packages', 'packages-backend'];
+            const affectedPackages = new Set();
+
+            for (const dir of packageDirs) {
+              let entries;
+              try {
+                const { data } = await github.rest.repos.getContent({ owner, repo, path: dir, ref });
+                entries = Array.isArray(data) ? data : [];
+              } catch {
+                continue;
+              }
+
+              for (const entry of entries) {
+                if (entry.type !== 'dir') continue;
+                try {
+                  const { data: pkgData } = await github.rest.repos.getContent({
+                    owner, repo, path: `${dir}/${entry.name}/package.json`, ref,
+                  });
+                  const pkg = JSON.parse(Buffer.from(pkgData.content, 'base64').toString());
+                  if (pkg.private) continue;
+
+                  const allDeps = {
+                    ...pkg.dependencies,
+                    ...pkg.devDependencies,
+                    ...pkg.peerDependencies,
+                  };
+
+                  for (const depName of changedDeps.keys()) {
+                    if (allDeps[depName]) {
+                      affectedPackages.add(pkg.name);
+                      break;
+                    }
+                  }
+                } catch {
+                  continue;
+                }
+              }
+            }
+
+            if (affectedPackages.size === 0) {
+              core.info('No published workspace packages are affected');
+              core.setOutput('has_changeset', 'false');
+              return;
+            }
+
+            core.info(`Affected packages: ${[...affectedPackages].join(', ')}`);
+
+            // 4. Generate changeset content
+            const frontmatter = [...affectedPackages].sort().map(p => `'${p}': patch`).join('\n');
+            const depList = [...changedDeps.entries()].map(([k, v]) => `\`${k}\` to \`${v}\``).join(', ');
+            const content = `---\n${frontmatter}\n---\n\nUpdate dependency ${depList}.\n`;
+
+            // 5. Commit changeset via Contents API
+            const changesetPath = `.changeset/dependencies-GH-${prNumber}.md`;
+            try {
+              await github.rest.repos.createOrUpdateFileContents({
+                owner, repo,
+                path: changesetPath,
+                message: 'chore(deps): add changeset for dependency update',
+                content: Buffer.from(content).toString('base64'),
+                branch: ref,
+                committer: {
+                  name: 'github-actions[bot]',
+                  email: '41898282+github-actions[bot]@users.noreply.github.com',
+                },
+                author: {
+                  name: 'github-actions[bot]',
+                  email: '41898282+github-actions[bot]@users.noreply.github.com',
+                },
+              });
+              core.info(`Created changeset: ${changesetPath}`);
+              core.setOutput('has_changeset', 'true');
+            } catch (err) {
+              // 409/422 = race with a concurrent run that already created the file
+              if (err.status === 409 || err.status === 422) {
+                core.info(`Changeset already created by a concurrent run (${err.status})`);
+                core.setOutput('has_changeset', 'true');
+              } else {
+                throw err;
+              }
+            }
 
       # Sticky so repeated `synchronize` events (e.g. Renovate rebasing the
       # PR) update the same comment instead of piling up new ones.
       - name: Comment on PR (changeset added)
-        if: steps.check_changeset.outputs.has_changeset == 'true'
+        if: steps.add_changeset.outputs.has_changeset == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
@@ -72,7 +214,7 @@ jobs:
             ✅ A changeset was automatically added for this dependency update.
 
       - name: Comment on PR (changeset not added)
-        if: steps.check_changeset.outputs.has_changeset == 'false'
+        if: steps.add_changeset.outputs.has_changeset == 'false'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -5,14 +5,30 @@ on:
     types: [opened, synchronize, labeled]
     branches:
       - main
-    # Only run when npm/pnpm manifest files change — the changeset action
-    # only reacts to these, so non-npm dependency PRs (GitHub Actions,
-    # Docker, etc.) don't need it and shouldn't get a false "no changeset"
-    # warning.
+    # Only run when npm/pnpm manifest files change — non-npm dependency PRs
+    # (GitHub Actions, Docker, etc.) don't need a changeset and shouldn't
+    # get a false "no changeset" warning.
     paths:
       - '**/package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
+  # Other repos in the org can call this workflow via:
+  #   uses: commercetools/merchant-center-application-kit/.github/workflows/renovate-changeset.yml@main
+  #   secrets: inherit
+  # The calling repo defines its own pull_request_target trigger with
+  # appropriate paths/branches filters.
+  workflow_call:
+    inputs:
+      package-dirs:
+        description: 'Comma-separated workspace package directories to scan'
+        required: false
+        type: string
+        default: 'packages,packages-backend'
+    secrets:
+      CT_CHANGESETS_APP_ID:
+        required: true
+      CT_CHANGESETS_APP_PEM:
+        required: true
 
 permissions:
   contents: read
@@ -36,171 +52,33 @@ jobs:
           client-id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private-key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
-      # Inline replacement for mscharley/dependency-changesets-action, which
-      # has a bug parsing single-quoted YAML keys in pnpm-workspace.yaml
-      # diffs (https://github.com/mscharley/dependency-changesets-action/issues/691).
-      # This repo's pnpm catalogs use single-quoted scoped package names
-      # (pnpm's default), so the upstream action silently no-ops.
-      #
-      # This script talks entirely to the GitHub API (reads PR files/commits
-      # and writes the changeset via the Contents API) — no checkout needed.
+      # Checkout THIS repo to access the script. Under pull_request_target
+      # the default ref is the base branch (main) — safe, never the PR head.
+      # For workflow_call from other repos, `repository` ensures we checkout
+      # this repo (where the script lives), not the calling repo.
+      # SECURITY: Do NOT add ref: pointing to the PR head here.
+      - name: Checkout script
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: commercetools/merchant-center-application-kit
+          sparse-checkout: .github/actions/renovate-changeset
+          sparse-checkout-cone-mode: false
+
+      # Replacement for mscharley/dependency-changesets-action, which has a
+      # bug parsing single-quoted YAML keys in pnpm-workspace.yaml diffs
+      # (https://github.com/mscharley/dependency-changesets-action/issues/691).
+      # This script talks entirely to the GitHub API — no checkout of PR
+      # content is needed, only the script itself (checked out above).
       - name: Add changeset for dependency update
         id: add_changeset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.generate_github_token.outputs.token }}
           script: |
-            const prNumber = context.payload.pull_request.number;
-            const { owner, repo } = context.repo;
-            const ref = context.payload.pull_request.head.ref;
-
-            // 1. Check if changeset already exists in the PR
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number: prNumber,
-            });
-
-            const hasExistingChangeset = files.some(f =>
-              f.filename.startsWith('.changeset/') &&
-              f.filename.endsWith('.md') &&
-              f.filename !== '.changeset/README.md' &&
-              f.status !== 'removed'
-            );
-
-            if (hasExistingChangeset) {
-              core.info('Changeset already exists in the PR');
-              core.setOutput('has_changeset', 'true');
-              return;
-            }
-
-            // 2. Find changed dependencies from pnpm-workspace.yaml and package.json diffs
-            const changedDeps = new Map(); // name → version
-
-            for (const file of files) {
-              if (!file.patch) continue;
-
-              // Parse pnpm-workspace.yaml catalog changes
-              if (file.filename === 'pnpm-workspace.yaml' || file.filename.endsWith('/pnpm-workspace.yaml')) {
-                for (const line of file.patch.split('\n')) {
-                  if (!line.startsWith('+') || line.startsWith('+++')) continue;
-                  // Handle single-quoted, double-quoted, and unquoted YAML keys:
-                  //   +    '@scope/pkg': 3.5.1
-                  //   +    "@scope/pkg": "^3.5.1"
-                  //   +    pkg-name: 1.2.3
-                  const m = line.match(/^\+\s*['"]?([^\s'"]+?)['"]?:\s+['"]?([^\s'"]+?)['"]?\s*$/);
-                  if (!m) continue;
-                  const [, name, value] = m;
-                  // Only match dependency specifiers (start with digit or range prefix),
-                  // skip YAML structure keys like `catalogs:`, `nimbus:`, or `true`/`false`.
-                  if (/^[\d^~>=<*]/.test(value)) {
-                    changedDeps.set(name, value.replace(/^[\^~>=<]+/, ''));
-                  }
-                }
-              }
-
-              // Parse package.json dependency changes
-              if (file.filename === 'package.json' || file.filename.endsWith('/package.json')) {
-                for (const line of file.patch.split('\n')) {
-                  if (!line.startsWith('+') || line.startsWith('+++')) continue;
-                  const m = line.match(/^\+\s*"([^"]+)":\s*"([^"]+)"/);
-                  if (!m) continue;
-                  const [, name, value] = m;
-                  if (/^[\d^~>=<*]/.test(value)) {
-                    changedDeps.set(name, value.replace(/^[\^~>=<]+/, ''));
-                  }
-                }
-              }
-            }
-
-            if (changedDeps.size === 0) {
-              core.info('No dependency version changes detected in PR diff');
-              core.setOutput('has_changeset', 'false');
-              return;
-            }
-
-            core.info(`Changed deps: ${[...changedDeps.entries()].map(([k, v]) => `${k}@${v}`).join(', ')}`);
-
-            // 3. Find published workspace packages that consume the changed dependencies
-            const packageDirs = ['packages', 'packages-backend'];
-            const affectedPackages = new Set();
-
-            for (const dir of packageDirs) {
-              let entries;
-              try {
-                const { data } = await github.rest.repos.getContent({ owner, repo, path: dir, ref });
-                entries = Array.isArray(data) ? data : [];
-              } catch {
-                continue;
-              }
-
-              for (const entry of entries) {
-                if (entry.type !== 'dir') continue;
-                try {
-                  const { data: pkgData } = await github.rest.repos.getContent({
-                    owner, repo, path: `${dir}/${entry.name}/package.json`, ref,
-                  });
-                  const pkg = JSON.parse(Buffer.from(pkgData.content, 'base64').toString());
-                  if (pkg.private) continue;
-
-                  const allDeps = {
-                    ...pkg.dependencies,
-                    ...pkg.devDependencies,
-                    ...pkg.peerDependencies,
-                  };
-
-                  for (const depName of changedDeps.keys()) {
-                    if (allDeps[depName]) {
-                      affectedPackages.add(pkg.name);
-                      break;
-                    }
-                  }
-                } catch {
-                  continue;
-                }
-              }
-            }
-
-            if (affectedPackages.size === 0) {
-              core.info('No published workspace packages are affected');
-              core.setOutput('has_changeset', 'false');
-              return;
-            }
-
-            core.info(`Affected packages: ${[...affectedPackages].join(', ')}`);
-
-            // 4. Generate changeset content
-            const frontmatter = [...affectedPackages].sort().map(p => `'${p}': patch`).join('\n');
-            const depList = [...changedDeps.entries()].map(([k, v]) => `\`${k}\` to \`${v}\``).join(', ');
-            const content = `---\n${frontmatter}\n---\n\nUpdate dependency ${depList}.\n`;
-
-            // 5. Commit changeset via Contents API
-            const changesetPath = `.changeset/dependencies-GH-${prNumber}.md`;
-            try {
-              await github.rest.repos.createOrUpdateFileContents({
-                owner, repo,
-                path: changesetPath,
-                message: 'chore(deps): add changeset for dependency update',
-                content: Buffer.from(content).toString('base64'),
-                branch: ref,
-                committer: {
-                  name: 'github-actions[bot]',
-                  email: '41898282+github-actions[bot]@users.noreply.github.com',
-                },
-                author: {
-                  name: 'github-actions[bot]',
-                  email: '41898282+github-actions[bot]@users.noreply.github.com',
-                },
-              });
-              core.info(`Created changeset: ${changesetPath}`);
-              core.setOutput('has_changeset', 'true');
-            } catch (err) {
-              // 409/422 = race with a concurrent run that already created the file
-              if (err.status === 409 || err.status === 422) {
-                core.info(`Changeset already created by a concurrent run (${err.status})`);
-                core.setOutput('has_changeset', 'true');
-              } else {
-                throw err;
-              }
-            }
+            const { run } = require('./.github/actions/renovate-changeset/add-changeset.js');
+            const packageDirs = ('${{ inputs.package-dirs }}' || 'packages,packages-backend')
+              .split(',').map(s => s.trim());
+            await run({ github, context, core }, { packageDirs });
 
       # Sticky so repeated `synchronize` events (e.g. Renovate rebasing the
       # PR) update the same comment instead of piling up new ones.


### PR DESCRIPTION
## Problem

The `mscharley/dependency-changesets-action` has a [bug in its diff parser](https://github.com/mscharley/dependency-changesets-action/issues/691) that silently breaks on this repo's pnpm catalogs. Its `parsePatch.ts` regex only strips **double quotes** from YAML keys, but pnpm's default output (and this repo) uses **single quotes** for scoped package names:

```yaml
# What this repo has (single quotes — pnpm's default for scoped names):
'@commercetools/nimbus': 3.5.0

# What the action's regex handles:
"@commercetools/nimbus": 3.5.0
```

This caused **every** catalog-managed Renovate PR to silently produce no changeset — the action reported success but wrote nothing. Observed on #4109, #4108, and all recent Renovate PRs.

## Fix

Replace the third-party action with an inline `actions/github-script` that:

1. **Checks if a changeset already exists** in the PR (handles `synchronize` reruns correctly — same logic as the previous separate "check" step, now folded in)
2. **Parses `pnpm-workspace.yaml` and `package.json` diffs** with a regex that handles single-quoted, double-quoted, and unquoted YAML keys
3. **Resolves affected workspace packages** by reading each `packages/*/package.json` and `packages-backend/*/package.json` via the Contents API, checking if the changed dependency appears in their deps
4. **Generates and commits** a changeset file via the Contents API (no checkout needed — same security model as before)
5. **Handles race conditions** (concurrent `opened` + `labeled` events) via 409/422 error handling

Also includes the `paths` filter from #4110 so non-npm Renovate PRs (GitHub Actions, Docker) don't trigger the workflow at all.

### What stays the same
- `pull_request_target` trigger (API-only, no checkout — safe)
- CT Changesets App token via `actions/create-github-app-token`
- `renovate[bot]` + label gate
- Sticky PR comments via `marocchino/sticky-pull-request-comment`
- All actions SHA-pinned

### What changes
- `mscharley/dependency-changesets-action` → `actions/github-script` inline script
- Separate "Check whether PR has changeset" step folded into the main script
- `paths` filter added to trigger

## Upstream

Filed: https://github.com/mscharley/dependency-changesets-action/issues/691

If the upstream fix ships, we could switch back — but the inline script is simple, has zero external dependencies beyond GitHub's own first-party action, and correctly handles this repo's specific catalog layout, so there's no urgency to revert.

## Test plan

- YAML validated locally
- Will validate on the next Renovate PR that touches a pnpm catalog entry (e.g. #4109 if rebased, or the next dependency update)

Supersedes #4110 (paths-filter-only fix).