### PR TITLE
ci: allow Renovate to rebase after changeset bot commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,5 +26,6 @@
       "enabled": false
     }
   ],
-  "rebaseWhen": "never"
+  "rebaseWhen": "never",
+  "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]
 }


### PR DESCRIPTION
Adds `github-actions[bot]` to Renovate's `gitIgnoredAuthors` so it doesn't treat the automated changeset commit (from #4111) as a human edit that blocks rebasing.

Without this, every Renovate PR that gets a changeset commit shows:
> **Edited/Blocked Notification** — Renovate will not automatically rebase this PR, because it does not recognize the last commit author.

The email `41898282+github-actions[bot]@users.noreply.github.com` matches the `author-email` used in `.github/actions/renovate-changeset/add-changeset.js`.