### PR TITLE
fix(renovate-changeset): sign changeset commits via createCommitOnBranch

### DIFF
--- a/.github/actions/renovate-changeset/add-changeset.js
+++ b/.github/actions/renovate-changeset/add-changeset.js
@@ -5,9 +5,15 @@
 // default), so the upstream action silently no-ops.
 //
 // This script talks entirely to the GitHub API (reads PR files/commits and
-// writes the changeset via the Contents API) — no checkout needed for the
-// data it operates on (only the script itself needs to be checked out by the
-// calling workflow).
+// writes the changeset via the GraphQL createCommitOnBranch mutation) — no
+// checkout needed for the data it operates on (only the script itself needs to
+// be checked out by the calling workflow).
+//
+// The changeset is committed with createCommitOnBranch (not the REST Contents
+// API) because GitHub signs commits made this way, marking them "verified".
+// The org-wide "Require signed commits" ruleset rejects unsigned commits, and
+// REST Contents API commits are unsigned — which was blocking every Renovate
+// PR that received an auto-generated changeset (FEC-1316).
 
 const DEFAULT_PACKAGE_DIRS = ['packages', 'packages-backend'];
 
@@ -89,6 +95,23 @@ function generateChangesetContent(affectedPackages, changedDeps) {
 }
 
 /**
+ * Returns true if a PR file list already contains a changeset entry (any
+ * `.changeset/*.md` other than the README that hasn't been removed).
+ *
+ * @param {Array<{filename: string, status?: string}>} files
+ * @returns {boolean}
+ */
+function hasChangesetFile(files) {
+  return files.some(
+    (f) =>
+      f.filename.startsWith('.changeset/') &&
+      f.filename.endsWith('.md') &&
+      f.filename !== '.changeset/README.md' &&
+      f.status !== 'removed'
+  );
+}
+
+/**
  * Main entry point invoked by `actions/github-script`. Checks whether a
  * changeset already exists on the PR, and if not, detects changed
  * dependencies and, for any affected published workspace packages, commits a
@@ -111,15 +134,7 @@ async function run({ github, context, core }, opts = {}) {
     pull_number: prNumber,
   });
 
-  const hasExistingChangeset = files.some(
-    (f) =>
-      f.filename.startsWith('.changeset/') &&
-      f.filename.endsWith('.md') &&
-      f.filename !== '.changeset/README.md' &&
-      f.status !== 'removed'
-  );
-
-  if (hasExistingChangeset) {
+  if (hasChangesetFile(files)) {
     core.info('Changeset already exists in the PR');
     core.setOutput('has_changeset', 'true');
     return;
@@ -200,33 +215,55 @@ async function run({ github, context, core }, opts = {}) {
   // 4. Generate changeset content
   const content = generateChangesetContent(affectedPackages, changedDeps);
 
-  // 5. Commit changeset via Contents API
+  // 5. Commit the changeset via the GraphQL createCommitOnBranch mutation.
+  // Commits created this way are signed/verified by GitHub, which the
+  // "Require signed commits" ruleset requires; the REST Contents API produces
+  // unsigned commits and would block the PR (FEC-1316).
   const changesetPath = `.changeset/dependencies-GH-${prNumber}.md`;
   try {
-    await github.rest.repos.createOrUpdateFileContents({
-      owner,
-      repo,
-      path: changesetPath,
-      message: 'chore(deps): add changeset for dependency update',
-      content: Buffer.from(content).toString('base64'),
-      branch: ref,
-      committer: {
-        name: 'github-actions[bot]',
-        email: '41898282+github-actions[bot]@users.noreply.github.com',
-      },
-      author: {
-        name: 'github-actions[bot]',
-        email: '41898282+github-actions[bot]@users.noreply.github.com',
-      },
-    });
+    await github.graphql(
+      `mutation ($input: CreateCommitOnBranchInput!) {
+        createCommitOnBranch(input: $input) {
+          commit {
+            oid
+          }
+        }
+      }`,
+      {
+        input: {
+          branch: {
+            repositoryNameWithOwner: `${owner}/${repo}`,
+            branchName: ref,
+          },
+          expectedHeadOid: context.payload.pull_request.head.sha,
+          message: {
+            headline: 'chore(deps): add changeset for dependency update',
+          },
+          fileChanges: {
+            additions: [
+              {
+                path: changesetPath,
+                contents: Buffer.from(content).toString('base64'),
+              },
+            ],
+          },
+        },
+      }
+    );
     core.info(`Created changeset: ${changesetPath}`);
     core.setOutput('has_changeset', 'true');
   } catch (err) {
-    // 409/422 = race with a concurrent run that already created the file
-    if (err.status === 409 || err.status === 422) {
-      core.info(
-        `Changeset already created by a concurrent run (${err.status})`
-      );
+    // A concurrent run (e.g. an overlapping synchronize event) may have added
+    // the changeset and moved the branch head, making createCommitOnBranch
+    // reject our now-stale expectedHeadOid. If a changeset is present after the
+    // failure, that race already did the work; otherwise re-throw.
+    const currentFiles = await github.paginate(github.rest.pulls.listFiles, {
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+    if (hasChangesetFile(currentFiles)) {
+      core.info('Changeset already created by a concurrent run');
       core.setOutput('has_changeset', 'true');
     } else {
       throw err;

--- a/.github/actions/renovate-changeset/add-changeset.js
+++ b/.github/actions/renovate-changeset/add-changeset.js
@@ -112,6 +112,20 @@ function hasChangesetFile(files) {
 }
 
 /**
+ * Lists every file on a PR, paginating through all pages.
+ *
+ * @param {{github: object, owner: string, repo: string, prNumber: number}} params
+ * @returns {Promise<Array<{filename: string, status?: string, patch?: string}>>}
+ */
+function listPrFiles({ github, owner, repo, prNumber }) {
+  return github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+}
+
+/**
  * Main entry point invoked by `actions/github-script`. Checks whether a
  * changeset already exists on the PR, and if not, detects changed
  * dependencies and, for any affected published workspace packages, commits a
@@ -128,11 +142,7 @@ async function run({ github, context, core }, opts = {}) {
   const ref = context.payload.pull_request.head.ref;
 
   // 1. Check if changeset already exists in the PR
-  const files = await github.paginate(github.rest.pulls.listFiles, {
-    owner,
-    repo,
-    pull_number: prNumber,
-  });
+  const files = await listPrFiles({ github, owner, repo, prNumber });
 
   if (hasChangesetFile(files)) {
     core.info('Changeset already exists in the PR');
@@ -257,11 +267,16 @@ async function run({ github, context, core }, opts = {}) {
     // the changeset and moved the branch head, making createCommitOnBranch
     // reject our now-stale expectedHeadOid. If a changeset is present after the
     // failure, that race already did the work; otherwise re-throw.
-    const currentFiles = await github.paginate(github.rest.pulls.listFiles, {
-      owner,
-      repo,
-      pull_number: prNumber,
-    });
+    //
+    // Guard the recovery re-list: if it throws too (transient API/rate-limit
+    // error), surface the original commit failure rather than the misleading
+    // secondary listFiles error.
+    let currentFiles;
+    try {
+      currentFiles = await listPrFiles({ github, owner, repo, prNumber });
+    } catch {
+      throw err;
+    }
     if (hasChangesetFile(currentFiles)) {
       core.info('Changeset already created by a concurrent run');
       core.setOutput('has_changeset', 'true');

--- a/.github/actions/renovate-changeset/add-changeset.spec.js
+++ b/.github/actions/renovate-changeset/add-changeset.spec.js
@@ -299,6 +299,22 @@ describe('run', () => {
         }),
       })
     );
+
+    // Assert what actually gets committed — the decoded file body and the
+    // commit message — not just the path. This is the surface the PR changes,
+    // so a dropped `contents` or `headline` must fail a test.
+    const { input } = github.graphql.mock.calls[0][1];
+    expect(input.message.headline).toBe(
+      'chore(deps): add changeset for dependency update'
+    );
+    const committedContent = Buffer.from(
+      input.fileChanges.additions[0].contents,
+      'base64'
+    ).toString();
+    expect(committedContent).toBe(
+      "---\n'@commercetools-frontend/some-pkg': patch\n---\n\nUpdate dependency `some-dep` to `1.2.3`.\n"
+    );
+
     expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
   });
 

--- a/.github/actions/renovate-changeset/add-changeset.spec.js
+++ b/.github/actions/renovate-changeset/add-changeset.spec.js
@@ -186,6 +186,9 @@ describe('run', () => {
   function createGithub({ files, contents }) {
     return {
       paginate: jest.fn(async () => files),
+      graphql: jest.fn(async () => ({
+        createCommitOnBranch: { commit: { oid: 'newsha' } },
+      })),
       rest: {
         pulls: {
           listFiles: jest.fn(),
@@ -199,7 +202,6 @@ describe('run', () => {
             err.status = 404;
             throw err;
           }),
-          createOrUpdateFileContents: jest.fn(async () => ({})),
         },
       },
     };
@@ -210,7 +212,7 @@ describe('run', () => {
       payload: {
         pull_request: {
           number: prNumber,
-          head: { ref },
+          head: { ref, sha: 'headsha123' },
         },
       },
       repo: { owner, repo },
@@ -237,7 +239,7 @@ describe('run', () => {
     await run({ github, context, core });
 
     expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
-    expect(github.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled();
+    expect(github.graphql).not.toHaveBeenCalled();
   });
 
   it('sets has_changeset=false when no dependency changes are detected', async () => {
@@ -251,7 +253,7 @@ describe('run', () => {
     await run({ github, context, core });
 
     expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'false');
-    expect(github.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled();
+    expect(github.graphql).not.toHaveBeenCalled();
   });
 
   it('creates a changeset when a workspace package consumes the changed dep', async () => {
@@ -278,18 +280,69 @@ describe('run', () => {
 
     await run({ github, context, core });
 
-    expect(github.rest.repos.createOrUpdateFileContents).toHaveBeenCalledWith(
+    expect(github.graphql).toHaveBeenCalledWith(
+      expect.stringContaining('createCommitOnBranch'),
       expect.objectContaining({
-        owner,
-        repo,
-        path: `.changeset/dependencies-GH-${prNumber}.md`,
-        branch: ref,
+        input: expect.objectContaining({
+          branch: {
+            repositoryNameWithOwner: `${owner}/${repo}`,
+            branchName: ref,
+          },
+          expectedHeadOid: 'headsha123',
+          fileChanges: {
+            additions: [
+              expect.objectContaining({
+                path: `.changeset/dependencies-GH-${prNumber}.md`,
+              }),
+            ],
+          },
+        }),
       })
     );
     expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
   });
 
-  it('handles a 409 race condition from createOrUpdateFileContents gracefully', async () => {
+  it('treats a concurrent run that already added the changeset as success', async () => {
+    const pkgJson = {
+      name: '@commercetools-frontend/some-pkg',
+      dependencies: { 'some-dep': '^1.0.0' },
+    };
+    const depFiles = [
+      {
+        filename: 'pnpm-workspace.yaml',
+        patch: `@@ -1,3 +1,3 @@\n+    'some-dep': 1.2.3`,
+      },
+    ];
+    const github = createGithub({
+      files: depFiles,
+      contents: {
+        packages: [{ type: 'dir', name: 'some-pkg' }],
+        'packages/some-pkg/package.json': {
+          content: Buffer.from(JSON.stringify(pkgJson)).toString('base64'),
+        },
+      },
+    });
+    // Step 1 sees no changeset; the post-failure re-check sees one that a
+    // concurrent run committed while our expectedHeadOid went stale.
+    github.paginate = jest
+      .fn()
+      .mockResolvedValueOnce(depFiles)
+      .mockResolvedValueOnce([
+        ...depFiles,
+        { filename: '.changeset/dependencies-GH-123.md', status: 'added' },
+      ]);
+    github.graphql = jest.fn(async () => {
+      throw new Error('expectedHeadOid mismatch: branch head moved');
+    });
+    const context = createContext();
+    const core = createCore();
+
+    await run({ github, context, core });
+
+    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
+  });
+
+  it('re-throws when the commit fails and no changeset is present', async () => {
     const pkgJson = {
       name: '@commercetools-frontend/some-pkg',
       dependencies: { 'some-dep': '^1.0.0' },
@@ -308,17 +361,15 @@ describe('run', () => {
         },
       },
     });
-    github.rest.repos.createOrUpdateFileContents = jest.fn(async () => {
-      const err = new Error('Conflict');
-      err.status = 409;
-      throw err;
+    github.graphql = jest.fn(async () => {
+      throw new Error('Resource not accessible by integration');
     });
     const context = createContext();
     const core = createCore();
 
-    await run({ github, context, core });
-
-    expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
+    await expect(run({ github, context, core })).rejects.toThrow(
+      'Resource not accessible by integration'
+    );
   });
 
   it('respects a custom packageDirs option', async () => {
@@ -345,7 +396,7 @@ describe('run', () => {
 
     await run({ github, context, core }, { packageDirs: ['custom-dir'] });
 
-    expect(github.rest.repos.createOrUpdateFileContents).toHaveBeenCalled();
+    expect(github.graphql).toHaveBeenCalled();
     expect(core.setOutput).toHaveBeenCalledWith('has_changeset', 'true');
   });
 });


### PR DESCRIPTION
## What & why

The shared `renovate-changeset` reusable workflow auto-adds a changeset to Renovate dependency PRs. Its script committed that changeset with the REST **Contents API** (`repos.createOrUpdateFileContents`), which produces an **unsigned** commit (`github-actions[bot]`, `verification.reason: unsigned`).

Since the org-wide **"Require signed commits"** ruleset was enabled (part of Supply Chain Hardening, FEC-964), that unsigned commit blocks the whole PR:

> Merging is blocked — Commits must have verified signatures.

Renovate's own commits are signed, so only PRs that received an auto-changeset are affected — currently across **app-kit, merchant-center-frontend, and nimbus**.

Jira: **FEC-1316**

## Fix

Commit the changeset via the GraphQL **`createCommitOnBranch`** mutation instead of the REST Contents API. GitHub signs commits created this way (they show as _verified_), satisfying the ruleset — the same mechanism Renovate itself uses. The commit is now attributed to the CT Changesets App identity rather than `github-actions[bot]`.

Also:
- extracted the shared changeset-detection predicate (`hasChangesetFile`) and PR file-listing helper (`listPrFiles`), each used by both the early-exit check and the post-failure re-check;
- replaced the REST status-code race handling (409/422) with a robust re-check: if a changeset is present after a failed commit, a concurrent run already did the work; otherwise re-throw — and if the re-check's own API call fails, the original commit error is surfaced rather than masked.

## Testing

- `add-changeset.spec.js` updated to the new mechanism; **19/19 pass** locally. Runs in CI via `test:node`.
- New/updated cases: asserts the `createCommitOnBranch` input shape, including the decoded changeset body and commit message (not just the file path); a concurrent-run race resolves to success; a genuine commit failure re-throws.

## Rollout after merge

- **app-kit** — fixed on merge.
- **nimbus** — calls the reusable workflow at `@main` → picks up the fix automatically.
- **merchant-center-frontend** — pins the workflow to a SHA (`6df1e48…`) → needs a one-line pin bump to a commit that includes this change.

## Clearing already-blocked PRs

This does not retroactively re-sign existing branches (the workflow skips when a changeset already exists). For each blocked PR, recreate the Renovate branch (Dependency Dashboard "recreate", or delete the branch) so the fixed workflow adds a signed changeset.
