### PR TITLE
fix(renovate): add ct-changesets[bot] to gitIgnoredAuthors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,5 +27,8 @@
     }
   ],
   "rebaseWhen": "never",
-  "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com",
+    "145970804+ct-changesets[bot]@users.noreply.github.com"
+  ]
 }


### PR DESCRIPTION
After #4121 switched changeset commits to the CT Changesets GitHub App (`createCommitOnBranch`), the commit author changed from `github-actions[bot]` to `ct-changesets[bot]`. But `gitIgnoredAuthors` only listed `github-actions[bot]`, so Renovate still flagged those commits as external edits and blocked auto-rebase (e.g. #4123).

This adds the `ct-changesets[bot]` email to `gitIgnoredAuthors` so Renovate treats those commits as non-human and stops blocking.