### PR TITLE
fix(application-shell): move portal target above splitter

### DIFF
--- a/.changeset/save-toolbar-above-splitter.md
+++ b/.changeset/save-toolbar-above-splitter.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Move the SaveToolbar portal target (`#mc-main-container-portal`) outside `<ApplicationShellSplitter>` and switch to `position: fixed` so the toolbar spans both splitter panes. Bump its `z-index` from `9999` to `10001` so it renders above the modal portals container (`z-index: 10000`), preventing modals from occluding the save toolbar.

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -434,23 +434,24 @@ export const ApplicationShellAuthenticated = (
                             </div>
                           </MainContainer>
                         )}
-                        {/* Portal target for SaveToolbar. Placed outside
-                            <MainContainer> so overflow:hidden (applied when
-                            a modal opens) does not clip the sticky toolbar.
-                            Shares MainContainer's grid cell and sticks to
-                            the bottom via align-self: end. */}
-                        <div
-                          id={MC_MAIN_CONTAINER_PORTAL_ID}
-                          css={css`
-                            grid-column: 2/3;
-                            grid-row: 3/4;
-                            align-self: end;
-                            z-index: 9999;
-                            pointer-events: none;
-                          `}
-                        />
                       </div>
                     </ApplicationShellSplitter>
+                    {/* Portal target for SaveToolbar. Placed outside
+                        <ApplicationShellSplitter> so it is not trapped in
+                        the splitter's stacking context. Uses position:fixed
+                        to overlay the bottom of the viewport, above the
+                        modal portals container (z-index 10001 > 10000). */}
+                    <div
+                      id={MC_MAIN_CONTAINER_PORTAL_ID}
+                      css={css`
+                        position: fixed;
+                        bottom: 0;
+                        left: 0;
+                        right: 0;
+                        z-index: 10001;
+                        pointer-events: none;
+                      `}
+                    />
                   </SetupFlopFlipProvider>
                 </ConfigureIntlProvider>
               )}


### PR DESCRIPTION
## Problem

PR #4120 placed `#mc-main-container-portal` inside the grid (inside `<ApplicationShellSplitter>`). This causes two issues:

1. **z-index occlusion**: the portal target's `z-index: 9999` is below the modal portals container's `z-index: 10000`, so the save toolbar is hidden behind any active modal page.
2. **splitter clipping**: the portal target is inside the splitter's main pane, so `position: fixed` content portaled into it doesn't span across the agent panel aside.

## Fix

- Move `#mc-main-container-portal` outside `<ApplicationShellSplitter>` so it is not constrained by the splitter's layout or `overflow: hidden`.
- Switch from grid positioning to `position: fixed; bottom: 0; left: 0; right: 0` so the toolbar spans the full viewport width (across both splitter panes).
- Bump `z-index` from `9999` to `10001` so content portaled here renders above the modal portals container (`z-index: 10000`).

## Sibling PR

- mc-fe: https://github.com/commercetools/merchant-center-frontend/pull/20986 (portals SaveToolbar into this target via `createPortal`)