### PR TITLE
fix(application-shell): move portal target outside Splitter.Main

### DIFF
--- a/.changeset/save-toolbar-portal-above-splitter.md
+++ b/.changeset/save-toolbar-portal-above-splitter.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Move the SaveToolbar portal target (`#mc-main-container-portal`) from the authenticated shell grid into the splitter async wrapper, outside `Suspense` and `Splitter.Main`. This ensures the portal target escapes `container-type: inline-size` on `Splitter.Main` so `position: fixed` content spans both splitter panes, and sits at `z-index: 10001` above the modal portals container (`z-index: 10000`).


### PR DESCRIPTION
## Problem

The SaveToolbar portal target (`#mc-main-container-portal`) was inside the grid, inside `Splitter.Main`. This caused two issues:

1. **z-index occlusion**: z-index 9999 is below the modal portals container's 10000, so the save toolbar is hidden behind any active modal page.
2. **container-type trapping**: `Splitter.Main` has `container-type: inline-size`, which creates a containing block for `position: fixed` descendants. The toolbar couldn't span both splitter panes.

## Fix

Move `#mc-main-container-portal` from `application-shell-authenticated.tsx` into the splitter async wrapper (`application-shell-splitter.async.tsx`), rendered outside `<Suspense>` as a sibling in a fragment. This ensures:

- The portal target exists in both Nimbus and Passthrough (no-Nimbus) paths
- It escapes `container-type: inline-size` on `Splitter.Main`
- `position: fixed` content spans both splitter panes
- z-index 10001 beats the modal portals container (10000)

## Sibling PR

- mc-fe: https://github.com/commercetools/merchant-center-frontend/pull/20986

Supersedes #4132.