### PR TITLE
fix(application-shell): move portal target outside Splitter.Main

### DIFF
--- a/.changeset/save-toolbar-portal-above-splitter.md
+++ b/.changeset/save-toolbar-portal-above-splitter.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Move the SaveToolbar portal target (`#mc-main-container-portal`) from the authenticated shell grid into the splitter async wrapper, outside `Suspense` and `Splitter.Main`. This ensures the portal target escapes `container-type: inline-size` on `Splitter.Main` so `position: fixed` content spans both splitter panes, and sits at `z-index: 10001` above the modal portals container (`z-index: 10000`).

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -18,11 +18,7 @@ import {
   selectUserLanguageFromStorage,
   type TApplicationContext,
 } from '@commercetools-frontend/application-shell-connectors';
-import {
-  DOMAINS,
-  LOGOUT_REASONS,
-  MC_MAIN_CONTAINER_PORTAL_ID,
-} from '@commercetools-frontend/constants';
+import { DOMAINS, LOGOUT_REASONS } from '@commercetools-frontend/constants';
 import type { TAsyncLocaleDataProps } from '@commercetools-frontend/i18n';
 import { AsyncLocaleData } from '@commercetools-frontend/i18n';
 import { NotificationsList } from '@commercetools-frontend/react-notifications';

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -434,21 +434,6 @@ export const ApplicationShellAuthenticated = (
                             </div>
                           </MainContainer>
                         )}
-                        {/* Portal target for SaveToolbar. Placed outside
-                            <MainContainer> so overflow:hidden (applied when
-                            a modal opens) does not clip the sticky toolbar.
-                            Shares MainContainer's grid cell and sticks to
-                            the bottom via align-self: end. */}
-                        <div
-                          id={MC_MAIN_CONTAINER_PORTAL_ID}
-                          css={css`
-                            grid-column: 2/3;
-                            grid-row: 3/4;
-                            align-self: end;
-                            z-index: 9999;
-                            pointer-events: none;
-                          `}
-                        />
                       </div>
                     </ApplicationShellSplitter>
                   </SetupFlopFlipProvider>

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.async.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.async.tsx
@@ -1,5 +1,7 @@
 import { type ReactNode, lazy, Suspense } from 'react';
+import { css } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
+import { MC_MAIN_CONTAINER_PORTAL_ID } from '@commercetools-frontend/constants';
 
 const Passthrough = ({ children }: { children: ReactNode }) => <>{children}</>;
 
@@ -29,14 +31,31 @@ const ApplicationShellSplitterWrapper = (
   const history = useHistory();
 
   return (
-    <Suspense fallback={props.children}>
-      <LazyApplicationShellSplitter
-        locale={props.locale}
-        navigate={history.push}
-      >
-        {props.children}
-      </LazyApplicationShellSplitter>
-    </Suspense>
+    <>
+      <Suspense fallback={props.children}>
+        <LazyApplicationShellSplitter
+          locale={props.locale}
+          navigate={history.push}
+        >
+          {props.children}
+        </LazyApplicationShellSplitter>
+      </Suspense>
+      {/* Portal target for SaveToolbar. Rendered outside Suspense so it
+          exists in both the Nimbus and Passthrough paths, and outside
+          Splitter.Main so container-type:inline-size does not trap
+          position:fixed. z-index 10001 beats the modal portals
+          container (z-index 10000). */}
+      <div
+        id={MC_MAIN_CONTAINER_PORTAL_ID}
+        css={css`
+          position: fixed;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          z-index: 10001;
+        `}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Problem

The SaveToolbar portal target (`#mc-main-container-portal`) was inside the grid, inside `Splitter.Main`. This caused two issues:

1. **z-index occlusion**: z-index 9999 is below the modal portals container's 10000, so the save toolbar is hidden behind any active modal page.
2. **container-type trapping**: `Splitter.Main` has `container-type: inline-size`, which creates a containing block for `position: fixed` descendants. The toolbar couldn't span both splitter panes.

## Fix

Move `#mc-main-container-portal` from `application-shell-authenticated.tsx` into the splitter async wrapper (`application-shell-splitter.async.tsx`), rendered outside `<Suspense>` as a sibling in a fragment. This ensures:

- The portal target exists in both Nimbus and Passthrough (no-Nimbus) paths
- It escapes `container-type: inline-size` on `Splitter.Main`
- `position: fixed` content spans both splitter panes
- z-index 10001 beats the modal portals container (10000)

## Sibling PR

- mc-fe: https://github.com/commercetools/merchant-center-frontend/pull/20986

Supersedes #4132 and #4136.