### PR TITLE
feat(mc-html-template): HTML skeleton, non-blocking resources, and view transitions

### DIFF
--- a/.changeset/lucky-skeletons-appear.md
+++ b/.changeset/lucky-skeletons-appear.md
@@ -1,0 +1,12 @@
+---
+'@commercetools-frontend/mc-html-template': minor
+'@commercetools-frontend/mc-scripts': minor
+---
+
+Show an application-chrome skeleton while the Merchant Center loads, instead of a bare spinner on a blank page.
+
+Authenticated users now see the real chrome layout — header bar, dark sidebar and content area — from first paint, with no 250ms delay. The skeleton is sized from the same constants the React chrome uses, and honours the persisted pinned-menu state, so nothing shifts when React mounts. Unauthenticated users keep the existing spinner unchanged.
+
+The Open Sans webfont is also no longer render-blocking, and on the Vite build the application CSS is not either. Both are loaded as preloads and upgraded once ready, from the loading-screen script rather than an inline `onload` attribute, which the Merchant Center's Content Security Policy does not allow. The application is never revealed before its own stylesheets have applied, and never held back by a stylesheet that fails or stalls.
+
+Cross-app navigation opts in to cross-document view transitions where the browser supports them, so it crossfades instead of flashing a blank page. Users who prefer reduced motion keep the benefit without the animation.

--- a/.changeset/lucky-skeletons-appear.md
+++ b/.changeset/lucky-skeletons-appear.md
@@ -10,3 +10,12 @@ Authenticated users now see the real chrome layout — header bar, dark sidebar 
 The Open Sans webfont is also no longer render-blocking, and on the Vite build the application CSS is not either. Both are loaded as preloads and upgraded once ready, from the loading-screen script rather than an inline `onload` attribute, which the Merchant Center's Content Security Policy does not allow. The application is never revealed before its own stylesheets have applied, and never held back by a stylesheet that fails or stalls.
 
 Cross-app navigation opts in to cross-document view transitions where the browser supports them, so it crossfades instead of flashing a blank page. Users who prefer reduced motion keep the benefit without the animation.
+
+Two notes for anyone upgrading. `window.onAppLoaded()` no longer removes the
+loading element synchronously in every case: when the application's own
+stylesheets are still loading it defers removal until they resolve, bounded by a
+two-second deadline after which the application is revealed regardless. Callers
+that assumed the element was gone the moment the call returned should check that
+assumption. And the two packages now share a build-time marker attribute, so they
+are expected to be upgraded together — the repository already versions them in
+lockstep, but a project pinning them independently should keep them aligned.

--- a/.changeset/lucky-skeletons-appear.md
+++ b/.changeset/lucky-skeletons-appear.md
@@ -7,7 +7,7 @@ Show an application-chrome skeleton while the Merchant Center loads, instead of 
 
 Authenticated users now see the real chrome layout — header bar, dark sidebar and content area — from first paint, with no 250ms delay. The skeleton is sized from the same constants the React chrome uses, and honours the persisted pinned-menu state, so nothing shifts when React mounts. Unauthenticated users keep the existing spinner unchanged.
 
-The Open Sans webfont is also no longer render-blocking, and on the Vite build the application CSS is not either. Both are loaded as preloads and upgraded once ready, from the loading-screen script rather than an inline `onload` attribute, which the Merchant Center's Content Security Policy does not allow. The application is never revealed before its own stylesheets have applied, and never held back by a stylesheet that fails or stalls.
+Neither webfont is render-blocking any more, and nor is the application's own CSS on either build. They are loaded as preloads and upgraded once ready, from the loading-screen script rather than an inline `onload` attribute, which the Merchant Center's Content Security Policy does not allow. Because the loading screen's own script no longer waits behind a blocking stylesheet, the skeleton appears considerably earlier on a cold cache. The application is never revealed before its own stylesheets have applied, and never held back by a stylesheet that fails or stalls.
 
 Cross-app navigation opts in to cross-document view transitions where the browser supports them, so it crossfades instead of flashing a blank page. Users who prefer reduced motion keep the benefit without the animation.
 
@@ -19,3 +19,5 @@ that assumed the element was gone the moment the call returned should check that
 assumption. And the two packages now share a build-time marker attribute, so they
 are expected to be upgraded together — the repository already versions them in
 lockstep, but a project pinning them independently should keep them aligned.
+
+If your application renders `NimbusProvider` itself, pass `loadFonts={false}` so it does not add a second Inter stylesheet — the document now owns font loading, and the `data-nimbus-fonts` marker is kept on the link for that purpose. Leaving it on the default is harmless: the URL is identical, so the extra link resolves from the already-warm request rather than blocking anything.

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -76,15 +76,118 @@
 
     __APPLICATION_CSS_IMPORTS__
 
+    <!--
+      Loading screen styles.
+      NOTE: these live in <head>, NOT inside #app-loader. `onAppLoaded()`
+      removes #app-loader entirely, and the `@view-transition` opt-in below
+      must still be in the document at navigation time (long after React
+      mounted) or cross-document view transitions silently never fire.
+    -->
+    __LOADING_SCREEN_CSS__
+
     <title>Merchant Center</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
 
     <div id="app-loader">
-      <!-- Loading screen styles -->
-      __LOADING_SCREEN_CSS__
+      <!--
+        Authenticated variant: static app-chrome skeleton, revealed
+        immediately (no 250ms delay) by loading-screen.js when a cached
+        session is present. Mirrors NavBarSkeleton + AppBar so there is no
+        layout shift when React chrome mounts.
+      -->
+      <div
+        class="loading-skeleton loading-skeleton--hidden"
+        role="status"
+        aria-busy="true"
+      >
+        <span class="loading-skeleton__sr-only">Loading Merchant Center</span>
 
+        <div class="loading-skeleton__sidebar" aria-hidden="true">
+          <div class="loading-skeleton__navbar-header">
+            <div class="loading-skeleton__item loading-skeleton__item--narrow">
+              <div class="loading-skeleton__icon"></div>
+              <div class="loading-skeleton__title"></div>
+            </div>
+          </div>
+          <div class="loading-skeleton__navbar-body">
+            <div class="loading-skeleton__group">
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+            </div>
+            <div class="loading-skeleton__group">
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+            </div>
+            <div class="loading-skeleton__group">
+              <div class="loading-skeleton__item loading-skeleton__item--wide">
+                <div class="loading-skeleton__icon"></div>
+                <div class="loading-skeleton__title"></div>
+              </div>
+            </div>
+          </div>
+          <div class="loading-skeleton__navbar-footer">
+            <div class="loading-skeleton__expander"></div>
+          </div>
+        </div>
+
+        <div class="loading-skeleton__header" aria-hidden="true">
+          <div class="loading-skeleton__header-placeholder"></div>
+        </div>
+
+        <div class="loading-skeleton__content">
+          <p class="long-loading-notice long-loading-notice--hidden">
+            Sorry, this is taking an unusually long time.
+          </p>
+        </div>
+      </div>
+
+      <!-- Unauthenticated variant: unchanged bare spinner. -->
       <div class="loading-screen loading-screen--hidden">
         <svg class="loading-spinner" viewBox="0 0 40 40">
           <path

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -64,27 +64,15 @@
 
     <!-- Fonts -->
     <!--
-      Open Sans is preloaded instead of linked as a stylesheet so it does not
-      block first paint. `loading-screen.js` upgrades it to rel="stylesheet"
-      once loaded. That upgrade lives in the (CSP-hashed) inline script rather
-      than an inline `onload` handler attribute, which the production CSP
-      blocks:
-      script hashes do not cover event-handler attributes.
+      Preloaded rather than linked as stylesheets so they don't block first
+      paint; loading-screen.js upgrades them once loaded (not via an inline
+      `onload` attribute, which the production CSP blocks).
 
-      Inter is converted too. NimbusProvider renders a byte-identical
-      stylesheet link of its own, and React 19 dedupes hoisted stylesheets by
-      matching link[rel="stylesheet"][href] - which a preload does not match.
-      Nimbus therefore has to be told to stand down, via its `loadFonts={false}`
-      prop; `data-nimbus-fonts` is kept on both tags as the marker it uses to
-      recognise a host-owned font link.
-
-      Where a host still mounts NimbusProvider with the default `loadFonts`,
-      Nimbus injects its own stylesheet at mount. That is not a regression: the
-      href is identical, so the request is already warm from this preload and
-      first paint is not blocked either way.
-
-      `precedence` is dropped: React only ever reads the `data-precedence`
-      attribute it sets itself, so on a static tag it was inert.
+      Inter also needs NimbusProvider's `loadFonts={false}`: React 19 dedupes
+      stylesheets by href, and a preload doesn't match. Left on the default is
+      harmless, since the identical href just resolves from this preload
+      instead of a second request. `data-nimbus-fonts` marks the tag for
+      Nimbus to recognise.
     -->
     <link
       rel="preload"
@@ -114,11 +102,9 @@
     __APPLICATION_CSS_IMPORTS__
 
     <!--
-      Loading screen styles.
-      NOTE: these live in <head>, NOT inside #app-loader. `onAppLoaded()`
-      removes #app-loader entirely, and the `@view-transition` opt-in below
-      must still be in the document at navigation time (long after React
-      mounted) or cross-document view transitions silently never fire.
+      Lives in <head>, not inside #app-loader: onAppLoaded() removes that
+      element, and the @view-transition rule here must still be in the
+      document when the user navigates away.
     -->
     __LOADING_SCREEN_CSS__
 
@@ -128,12 +114,7 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
 
     <div id="app-loader">
-      <!--
-        Authenticated variant: static app-chrome skeleton, revealed
-        immediately (no 250ms delay) by loading-screen.js when a cached
-        session is present. Mirrors NavBarSkeleton + AppBar so there is no
-        layout shift when React chrome mounts.
-      -->
+      <!-- Authenticated: revealed immediately, mirrors the real app chrome. -->
       <div
         class="loading-skeleton loading-skeleton--hidden"
         role="status"
@@ -224,7 +205,7 @@
         </div>
       </div>
 
-      <!-- Unauthenticated variant: unchanged bare spinner. -->
+      <!-- Unauthenticated: unchanged spinner. -->
       <div class="loading-screen loading-screen--hidden">
         <svg class="loading-spinner" viewBox="0 0 40 40">
           <path

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -63,10 +63,31 @@
     __APPLICATION_SCRIPT_IMPORTS__
 
     <!-- Fonts -->
+    <!--
+      Open Sans is preloaded instead of linked as a stylesheet so it does not
+      block first paint. `loading-screen.js` upgrades it to rel="stylesheet"
+      once loaded. That upgrade lives in the (CSP-hashed) inline script rather
+      than an inline `onload` handler attribute, which the production CSP
+      blocks:
+      script hashes do not cover event-handler attributes.
+
+      The Inter link below is deliberately NOT converted. NimbusProvider
+      renders a byte-identical stylesheet link itself, and React 19 dedupes
+      hoisted stylesheets by matching link[rel="stylesheet"][href]. Changing
+      the rel would miss that match and Nimbus would inject its own blocking
+      stylesheet at mount instead - later than today, not earlier.
+    -->
     <link
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
-      rel="stylesheet"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"

--- a/packages/mc-html-template/html-docs/application.html
+++ b/packages/mc-html-template/html-docs/application.html
@@ -71,11 +71,20 @@
       blocks:
       script hashes do not cover event-handler attributes.
 
-      The Inter link below is deliberately NOT converted. NimbusProvider
-      renders a byte-identical stylesheet link itself, and React 19 dedupes
-      hoisted stylesheets by matching link[rel="stylesheet"][href]. Changing
-      the rel would miss that match and Nimbus would inject its own blocking
-      stylesheet at mount instead - later than today, not earlier.
+      Inter is converted too. NimbusProvider renders a byte-identical
+      stylesheet link of its own, and React 19 dedupes hoisted stylesheets by
+      matching link[rel="stylesheet"][href] - which a preload does not match.
+      Nimbus therefore has to be told to stand down, via its `loadFonts={false}`
+      prop; `data-nimbus-fonts` is kept on both tags as the marker it uses to
+      recognise a host-owned font link.
+
+      Where a host still mounts NimbusProvider with the default `loadFonts`,
+      Nimbus injects its own stylesheet at mount. That is not a regression: the
+      href is identical, so the request is already warm from this preload and
+      first paint is not blocked either way.
+
+      `precedence` is dropped: React only ever reads the `data-precedence`
+      attribute it sets itself, so on a static tag it was inert.
     -->
     <link
       rel="preload"
@@ -89,11 +98,18 @@
       />
     </noscript>
     <link
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
-      rel="stylesheet"
       data-nimbus-fonts=""
-      precedence="default"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+        rel="stylesheet"
+        data-nimbus-fonts=""
+      />
+    </noscript>
 
     __APPLICATION_CSS_IMPORTS__
 

--- a/packages/mc-html-template/html-scripts/loading-screen.js
+++ b/packages/mc-html-template/html-scripts/loading-screen.js
@@ -200,9 +200,14 @@
       window.performance.mark('mc:skeleton-visible');
 
       if (window.performance.measure) {
-        // Omitting `end`/`duration` measures from the time origin
+        // Distinct name on purpose: sharing it with the mark would make
+        // `getEntriesByName('mc:skeleton-visible')` return two entries of
+        // different entryType, and a consumer indexing [0] would read whichever
+        // sorted first. Omitting `end`/`duration` measures from the time origin
         // (navigationStart) to now.
-        window.performance.measure('mc:skeleton-visible', { start: 0 });
+        window.performance.measure('mc:skeleton-visible:duration', {
+          start: 0,
+        });
       }
     } catch (error) {
       // Instrumentation is best-effort.
@@ -233,7 +238,20 @@
   // invisible: before this gate existed `onAppLoaded` removed the loader
   // unconditionally, so an unbounded wait would be a new availability
   // regression. Degrade to visible-but-unstyled instead.
+  //
+  // Upgrading the stragglers first matters: a link left as `rel="preload"` would
+  // never apply its CSS even if the response arrives later, so zeroing the
+  // counter alone would trade a temporarily unstyled app for a permanently
+  // unstyled one. `false` skips the decrement, since the counter is zeroed next.
   setTimeout(function releaseStylesheetGate() {
+    const pendingEls = document.querySelectorAll(
+      'link[rel="preload"][as="style"]'
+    );
+
+    for (let index = 0; index < pendingEls.length; index += 1) {
+      upgradeStylesheetPreload(pendingEls[index], false);
+    }
+
     window.__CSS_REMAINING__ = 0;
     removeAppLoaderWhenReady();
   }, LONG_LOADING_DELAY);

--- a/packages/mc-html-template/html-scripts/loading-screen.js
+++ b/packages/mc-html-template/html-scripts/loading-screen.js
@@ -1,18 +1,12 @@
-// Drives the loading screen shown before React mounts:
-// - reveals either the authenticated app-chrome skeleton or the bare spinner
-// - upgrades non-blocking stylesheet preloads once they have loaded
-// - exposes `window.onAppLoaded`, which ConfigureIntlProvider calls when React
-//   is ready, and which removes the loader
-//
 // Needs to be compatible with all browsers supported without transpilation:
 // this file is inlined into the HTML document verbatim (only minified).
 (function initLoadingScreen() {
   const SPINNER_SHOW_DELAY = 250;
   const LONG_LOADING_DELAY = 2000;
-  // Mirrors WINDOW_SIZES.WIDE in packages/application-shell/src/constants.ts.
+  // Mirrors WINDOW_SIZES.WIDE in application-shell/src/constants.ts.
   const WIDE_VIEWPORT = 1200;
-  // Mirrors `staticUrlPathsInPositionOfProjectKey` in
-  // packages/application-shell-connectors: the shell renders no NavBar here.
+  // Mirrors `staticUrlPathsInPositionOfProjectKey`: the shell renders no
+  // NavBar on these routes.
   const NAVBARLESS_ROUTES = ['login', 'logout', 'account'];
 
   function readStorage(key) {
@@ -25,13 +19,9 @@
     }
   }
 
-  /* ---------------------------------------------------------------- *
-   * Loader removal, gated on our own stylesheets                     *
-   * ---------------------------------------------------------------- */
-
-  // Count of app stylesheets (marked `data-mc-css` by the build) that have not
-  // finished loading. React must not be revealed while any is outstanding or
-  // the app flashes unstyled.
+  // Count of app stylesheets (marked `data-mc-css` by the build) still
+  // pending. The app must not be revealed while this is above zero, or it
+  // flashes unstyled.
   window.__CSS_REMAINING__ = 0;
 
   let isAppReady = false;
@@ -50,16 +40,11 @@
     }
   }
 
-  // Assigning global callback used by ConfigureIntlProvider to remove the
-  // loading screen.
+  // Called by ConfigureIntlProvider once React is ready.
   window.onAppLoaded = function onAppLoaded() {
     isAppReady = true;
     removeAppLoaderWhenReady();
   };
-
-  /* ---------------------------------------------------------------- *
-   * Non-blocking stylesheet preloads                                 *
-   * ---------------------------------------------------------------- */
 
   function upgradeStylesheetPreload(linkEl, isCounted) {
     if (linkEl.getAttribute('data-mc-upgraded') !== null) {
@@ -76,15 +61,10 @@
   }
 
   function hasAlreadyLoaded(linkEl) {
-    // `linkEl.sheet` is always null on a preload - a preload has no associated
-    // stylesheet - so completion is detected through Resource Timing, which is
-    // populated for cross-origin responses without Timing-Allow-Origin.
-    //
-    // This matters more than it looks: this script is a parser-inserted classic
-    // script, so it is deferred while a script-blocking stylesheet is
-    // outstanding (Inter still is). By the time it runs, same-origin preloads
-    // started at parse time have usually already fired `load`, so relying on
-    // the event alone would leave them unupgraded forever.
+    // `linkEl.sheet` is always null on a preload, so completion is detected via
+    // Resource Timing instead. This matters: this script can run late enough
+    // (deferred behind another blocking stylesheet) that the `load` event on a
+    // fast preload has already fired and would otherwise be missed forever.
     if (!window.performance || !window.performance.getEntriesByName) {
       return false;
     }
@@ -101,30 +81,27 @@
   }
 
   function upgradeStylesheetPreloads() {
-    // Scoped to `as="style"` on purpose: other preload types share this
-    // document. FEC-1301 adds `as="fetch"` prefetch hints and Vite already
-    // emits `rel="modulepreload"`; rewriting either would break them.
+    // Scoped to `as="style"`: other preload types (e.g. `as="fetch"` prefetch
+    // hints, `rel="modulepreload"`) share this document and must not be touched.
     const linkEls = document.querySelectorAll(
       'link[rel="preload"][as="style"]'
     );
 
     for (let index = 0; index < linkEls.length; index += 1) {
       const linkEl = linkEls[index];
-      // Only app CSS gates the reveal. Fonts use `display=swap`, so gating on a
-      // third-party font request would delay the app for no visual benefit.
+      // Only app CSS gates the reveal; fonts already use `display=swap`.
       const isCounted = linkEl.getAttribute('data-mc-css') !== null;
 
       if (isCounted) {
         window.__CSS_REMAINING__ += 1;
       }
 
-      // Listeners are attached before the already-loaded check so a response
-      // arriving mid-loop cannot be missed.
+      // Attached before the already-loaded check, so a response arriving
+      // mid-loop cannot be missed.
       linkEl.addEventListener('load', function onStylesheetLoad() {
         upgradeStylesheetPreload(linkEl, isCounted);
       });
       linkEl.addEventListener('error', function onStylesheetError() {
-        // A failed stylesheet must never hold the app hostage.
         upgradeStylesheetPreload(linkEl, isCounted);
       });
 
@@ -133,10 +110,6 @@
       }
     }
   }
-
-  /* ---------------------------------------------------------------- *
-   * Variant selection                                                *
-   * ---------------------------------------------------------------- */
 
   function getFirstPathSegment() {
     return (window.location.pathname.split('/')[1] || '').toLowerCase();
@@ -160,10 +133,9 @@
   }
 
   function isNavbarExpanded() {
-    // Two inputs, not one: `useNavbarStateManager` resets `isMenuOpen` to false
-    // at or below WINDOW_SIZES.WIDE regardless of the persisted flag, so
-    // mirroring only the flag would jump 176px when React restores a collapsed
-    // navbar.
+    // Both checks matter: React collapses the navbar below WIDE_VIEWPORT
+    // regardless of the persisted flag, so honouring the flag alone would
+    // cause a layout jump on mount.
     return (
       readStorage('isForcedMenuOpen') === 'true' &&
       window.innerWidth > WIDE_VIEWPORT
@@ -189,9 +161,7 @@
   }
 
   function markSkeletonVisible() {
-    // Part of FEC-1297's `mc:*` mark set, emitted here because the skeleton is
-    // the only thing that knows when it actually became visible. Kept in its own
-    // try/catch so instrumentation can never prevent the stylesheet upgrade.
+    // Own try/catch so instrumentation can never block the stylesheet upgrade.
     try {
       if (!window.performance || !window.performance.mark) {
         return;
@@ -200,11 +170,9 @@
       window.performance.mark('mc:skeleton-visible');
 
       if (window.performance.measure) {
-        // Distinct name on purpose: sharing it with the mark would make
-        // `getEntriesByName('mc:skeleton-visible')` return two entries of
-        // different entryType, and a consumer indexing [0] would read whichever
-        // sorted first. Omitting `end`/`duration` measures from the time origin
-        // (navigationStart) to now.
+        // Named separately from the mark, or getEntriesByName would return two
+        // entries of different entryType. Omitting end/duration measures from
+        // the time origin to now.
         window.performance.measure('mc:skeleton-visible:duration', {
           start: 0,
         });
@@ -216,9 +184,8 @@
 
   function scheduleLongLoadingNotice(containerEl) {
     setTimeout(function showLongLoadingNotice() {
-      // Both variants carry a notice, but only the revealed one may be
-      // unhidden - an unscoped lookup would hit the skeleton's copy first and
-      // leave unauthenticated users without theirs.
+      // Scoped to the revealed container: both variants carry a notice, and an
+      // unscoped lookup would always hit the skeleton's copy first.
       const noticeEl =
         containerEl && containerEl.querySelector('.long-loading-notice');
 
@@ -228,21 +195,13 @@
     }, LONG_LOADING_DELAY);
   }
 
-  /* ---------------------------------------------------------------- *
-   * Run                                                              *
-   * ---------------------------------------------------------------- */
-
   upgradeStylesheetPreloads();
 
-  // Hard deadline. A stylesheet that never resolves must not leave the app
-  // invisible: before this gate existed `onAppLoaded` removed the loader
-  // unconditionally, so an unbounded wait would be a new availability
-  // regression. Degrade to visible-but-unstyled instead.
-  //
-  // Upgrading the stragglers first matters: a link left as `rel="preload"` would
-  // never apply its CSS even if the response arrives later, so zeroing the
-  // counter alone would trade a temporarily unstyled app for a permanently
-  // unstyled one. `false` skips the decrement, since the counter is zeroed next.
+  // Hard deadline so a stylesheet that never resolves can't leave the app
+  // invisible; it degrades to visible-but-unstyled instead. Upgrades the
+  // stragglers before zeroing the counter, or their CSS would never apply even
+  // once the response does arrive. `false` skips the decrement, since the
+  // counter is zeroed right after.
   setTimeout(function releaseStylesheetGate() {
     const pendingEls = document.querySelectorAll(
       'link[rel="preload"][as="style"]'

--- a/packages/mc-html-template/html-scripts/loading-screen.js
+++ b/packages/mc-html-template/html-scripts/loading-screen.js
@@ -7,20 +7,134 @@ window.onAppLoaded = function onAppLoaded() {
     appLoaderEl.parentNode.removeChild(appLoaderEl);
   }
 };
-// Handles showing and hiding different loading screen elements
-// Needs to be compatible with all browsers supported without transpilation.
-(function removeLoaders() {
-  setTimeout(function removeLoadingScreen() {
+
+// Handles showing and hiding different loading screen elements.
+// Needs to be compatible with all browsers supported without transpilation:
+// this file is inlined into the HTML document verbatim (only minified).
+(function initLoadingScreen() {
+  // Authenticated loads paint the skeleton immediately: unlike the bare
+  // spinner, the skeleton *is* the intended layout, so there is nothing to
+  // avoid flashing.
+  const SPINNER_SHOW_DELAY = 250;
+  const LONG_LOADING_DELAY = 2000;
+  // Mirrors WINDOW_SIZES.WIDE in packages/application-shell/src/constants.ts.
+  const WIDE_VIEWPORT = 1200;
+  // Mirrors `staticUrlPathsInPositionOfProjectKey` in
+  // packages/application-shell-connectors: the shell renders no NavBar here.
+  const NAVBARLESS_ROUTES = ['login', 'logout', 'account'];
+
+  function readStorage(key) {
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      // Storage access throws in some privacy modes. Treat it as absent
+      // rather than letting the page end up with no loading state at all.
+      return null;
+    }
+  }
+
+  function getFirstPathSegment() {
+    return (window.location.pathname.split('/')[1] || '').toLowerCase();
+  }
+
+  // Returns null when the bare spinner should be used instead of the skeleton.
+  function selectSkeletonVariant() {
+    if (readStorage('isAuthenticated') !== 'true') {
+      return null;
+    }
+
+    const segment = getFirstPathSegment();
+
+    // Custom Views mount their own shell inside a host application and never
+    // render the app chrome, so the skeleton would be wrong there.
+    if (segment === 'custom-views') {
+      return null;
+    }
+
+    return { hasNavbar: NAVBARLESS_ROUTES.indexOf(segment) === -1 };
+  }
+
+  function isNavbarExpanded() {
+    // Two inputs, not one: `useNavbarStateManager` resets `isMenuOpen` to false
+    // at or below WINDOW_SIZES.WIDE regardless of the persisted flag, so
+    // mirroring only the flag would jump 176px when React restores a collapsed
+    // navbar.
+    return (
+      readStorage('isForcedMenuOpen') === 'true' &&
+      window.innerWidth > WIDE_VIEWPORT
+    );
+  }
+
+  function revealSkeleton(variant) {
+    const skeletonEl = document.querySelector('.loading-skeleton');
+
+    if (!skeletonEl) {
+      return null;
+    }
+
+    if (!variant.hasNavbar) {
+      skeletonEl.classList.add('loading-skeleton--no-navbar');
+    } else if (isNavbarExpanded()) {
+      skeletonEl.classList.add('loading-skeleton--menu-expanded');
+    }
+
+    skeletonEl.classList.remove('loading-skeleton--hidden');
+
+    return skeletonEl;
+  }
+
+  function markSkeletonVisible() {
+    // Part of FEC-1297's `mc:*` mark set, emitted here because the skeleton is
+    // the only thing that knows when it actually became visible.
+    // Kept in its own try/catch so instrumentation can never prevent the
+    // stylesheet upgrade below from running.
+    try {
+      if (!window.performance || !window.performance.mark) {
+        return;
+      }
+
+      window.performance.mark('mc:skeleton-visible');
+
+      if (window.performance.measure) {
+        // Omitting `end`/`duration` measures from the time origin
+        // (navigationStart) to now.
+        window.performance.measure('mc:skeleton-visible', { start: 0 });
+      }
+    } catch (error) {
+      // Instrumentation is best-effort.
+    }
+  }
+
+  function scheduleLongLoadingNotice(containerEl) {
+    setTimeout(function showLongLoadingNotice() {
+      // Both variants carry a notice, but only the revealed one may be
+      // unhidden — an unscoped lookup would hit the skeleton's copy first and
+      // leave unauthenticated users without theirs.
+      const noticeEl =
+        containerEl && containerEl.querySelector('.long-loading-notice');
+
+      if (noticeEl) {
+        noticeEl.classList.remove('long-loading-notice--hidden');
+      }
+    }, LONG_LOADING_DELAY);
+  }
+
+  const variant = selectSkeletonVariant();
+  const skeletonEl = variant ? revealSkeleton(variant) : null;
+
+  if (skeletonEl) {
+    markSkeletonVisible();
+    scheduleLongLoadingNotice(skeletonEl);
+    return;
+  }
+
+  setTimeout(function showLoadingScreen() {
     const loadingScreenEl = document.querySelector('.loading-screen');
+
     if (loadingScreenEl) {
       loadingScreenEl.classList.remove('loading-screen--hidden');
     }
-  }, 250);
+  }, SPINNER_SHOW_DELAY);
 
-  setTimeout(function removeLongLoadingNotice() {
-    const longLoadingNoticeEl = document.querySelector('.long-loading-notice');
-    if (longLoadingNoticeEl) {
-      longLoadingNoticeEl.classList.remove('long-loading-notice--hidden');
-    }
-  }, 2000);
+  scheduleLongLoadingNotice(document.querySelector('.loading-screen'));
 })();

--- a/packages/mc-html-template/html-scripts/loading-screen.js
+++ b/packages/mc-html-template/html-scripts/loading-screen.js
@@ -1,20 +1,12 @@
-// Assigning global callback used by ConfigureIntlProvider to remove
-// loading screen.
-window.onAppLoaded = function onAppLoaded() {
-  const appLoaderEl = document.querySelector('#app-loader');
-
-  if (appLoaderEl) {
-    appLoaderEl.parentNode.removeChild(appLoaderEl);
-  }
-};
-
-// Handles showing and hiding different loading screen elements.
+// Drives the loading screen shown before React mounts:
+// - reveals either the authenticated app-chrome skeleton or the bare spinner
+// - upgrades non-blocking stylesheet preloads once they have loaded
+// - exposes `window.onAppLoaded`, which ConfigureIntlProvider calls when React
+//   is ready, and which removes the loader
+//
 // Needs to be compatible with all browsers supported without transpilation:
 // this file is inlined into the HTML document verbatim (only minified).
 (function initLoadingScreen() {
-  // Authenticated loads paint the skeleton immediately: unlike the bare
-  // spinner, the skeleton *is* the intended layout, so there is nothing to
-  // avoid flashing.
   const SPINNER_SHOW_DELAY = 250;
   const LONG_LOADING_DELAY = 2000;
   // Mirrors WINDOW_SIZES.WIDE in packages/application-shell/src/constants.ts.
@@ -27,17 +19,130 @@ window.onAppLoaded = function onAppLoaded() {
     try {
       return window.localStorage.getItem(key);
     } catch (error) {
-      // Storage access throws in some privacy modes. Treat it as absent
-      // rather than letting the page end up with no loading state at all.
+      // Storage access throws in some privacy modes. Treat it as absent rather
+      // than letting the page end up with no loading state at all.
       return null;
     }
   }
+
+  /* ---------------------------------------------------------------- *
+   * Loader removal, gated on our own stylesheets                     *
+   * ---------------------------------------------------------------- */
+
+  // Count of app stylesheets (marked `data-mc-css` by the build) that have not
+  // finished loading. React must not be revealed while any is outstanding or
+  // the app flashes unstyled.
+  window.__CSS_REMAINING__ = 0;
+
+  let isAppReady = false;
+
+  function removeAppLoader() {
+    const appLoaderEl = document.querySelector('#app-loader');
+
+    if (appLoaderEl) {
+      appLoaderEl.parentNode.removeChild(appLoaderEl);
+    }
+  }
+
+  function removeAppLoaderWhenReady() {
+    if (isAppReady && window.__CSS_REMAINING__ <= 0) {
+      removeAppLoader();
+    }
+  }
+
+  // Assigning global callback used by ConfigureIntlProvider to remove the
+  // loading screen.
+  window.onAppLoaded = function onAppLoaded() {
+    isAppReady = true;
+    removeAppLoaderWhenReady();
+  };
+
+  /* ---------------------------------------------------------------- *
+   * Non-blocking stylesheet preloads                                 *
+   * ---------------------------------------------------------------- */
+
+  function upgradeStylesheetPreload(linkEl, isCounted) {
+    if (linkEl.getAttribute('data-mc-upgraded') !== null) {
+      return;
+    }
+
+    linkEl.setAttribute('data-mc-upgraded', '');
+    linkEl.rel = 'stylesheet';
+
+    if (isCounted) {
+      window.__CSS_REMAINING__ -= 1;
+      removeAppLoaderWhenReady();
+    }
+  }
+
+  function hasAlreadyLoaded(linkEl) {
+    // `linkEl.sheet` is always null on a preload - a preload has no associated
+    // stylesheet - so completion is detected through Resource Timing, which is
+    // populated for cross-origin responses without Timing-Allow-Origin.
+    //
+    // This matters more than it looks: this script is a parser-inserted classic
+    // script, so it is deferred while a script-blocking stylesheet is
+    // outstanding (Inter still is). By the time it runs, same-origin preloads
+    // started at parse time have usually already fired `load`, so relying on
+    // the event alone would leave them unupgraded forever.
+    if (!window.performance || !window.performance.getEntriesByName) {
+      return false;
+    }
+
+    const entries = window.performance.getEntriesByName(linkEl.href);
+
+    for (let index = 0; index < entries.length; index += 1) {
+      if (entries[index].responseEnd > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function upgradeStylesheetPreloads() {
+    // Scoped to `as="style"` on purpose: other preload types share this
+    // document. FEC-1301 adds `as="fetch"` prefetch hints and Vite already
+    // emits `rel="modulepreload"`; rewriting either would break them.
+    const linkEls = document.querySelectorAll(
+      'link[rel="preload"][as="style"]'
+    );
+
+    for (let index = 0; index < linkEls.length; index += 1) {
+      const linkEl = linkEls[index];
+      // Only app CSS gates the reveal. Fonts use `display=swap`, so gating on a
+      // third-party font request would delay the app for no visual benefit.
+      const isCounted = linkEl.getAttribute('data-mc-css') !== null;
+
+      if (isCounted) {
+        window.__CSS_REMAINING__ += 1;
+      }
+
+      // Listeners are attached before the already-loaded check so a response
+      // arriving mid-loop cannot be missed.
+      linkEl.addEventListener('load', function onStylesheetLoad() {
+        upgradeStylesheetPreload(linkEl, isCounted);
+      });
+      linkEl.addEventListener('error', function onStylesheetError() {
+        // A failed stylesheet must never hold the app hostage.
+        upgradeStylesheetPreload(linkEl, isCounted);
+      });
+
+      if (hasAlreadyLoaded(linkEl)) {
+        upgradeStylesheetPreload(linkEl, isCounted);
+      }
+    }
+  }
+
+  /* ---------------------------------------------------------------- *
+   * Variant selection                                                *
+   * ---------------------------------------------------------------- */
 
   function getFirstPathSegment() {
     return (window.location.pathname.split('/')[1] || '').toLowerCase();
   }
 
-  // Returns null when the bare spinner should be used instead of the skeleton.
+  // Returns null when the bare spinner should be shown instead of the skeleton.
   function selectSkeletonVariant() {
     if (readStorage('isAuthenticated') !== 'true') {
       return null;
@@ -85,9 +190,8 @@ window.onAppLoaded = function onAppLoaded() {
 
   function markSkeletonVisible() {
     // Part of FEC-1297's `mc:*` mark set, emitted here because the skeleton is
-    // the only thing that knows when it actually became visible.
-    // Kept in its own try/catch so instrumentation can never prevent the
-    // stylesheet upgrade below from running.
+    // the only thing that knows when it actually became visible. Kept in its own
+    // try/catch so instrumentation can never prevent the stylesheet upgrade.
     try {
       if (!window.performance || !window.performance.mark) {
         return;
@@ -108,7 +212,7 @@ window.onAppLoaded = function onAppLoaded() {
   function scheduleLongLoadingNotice(containerEl) {
     setTimeout(function showLongLoadingNotice() {
       // Both variants carry a notice, but only the revealed one may be
-      // unhidden — an unscoped lookup would hit the skeleton's copy first and
+      // unhidden - an unscoped lookup would hit the skeleton's copy first and
       // leave unauthenticated users without theirs.
       const noticeEl =
         containerEl && containerEl.querySelector('.long-loading-notice');
@@ -118,6 +222,21 @@ window.onAppLoaded = function onAppLoaded() {
       }
     }, LONG_LOADING_DELAY);
   }
+
+  /* ---------------------------------------------------------------- *
+   * Run                                                              *
+   * ---------------------------------------------------------------- */
+
+  upgradeStylesheetPreloads();
+
+  // Hard deadline. A stylesheet that never resolves must not leave the app
+  // invisible: before this gate existed `onAppLoaded` removed the loader
+  // unconditionally, so an unbounded wait would be a new availability
+  // regression. Degrade to visible-but-unstyled instead.
+  setTimeout(function releaseStylesheetGate() {
+    window.__CSS_REMAINING__ = 0;
+    removeAppLoaderWhenReady();
+  }, LONG_LOADING_DELAY);
 
   const variant = selectSkeletonVariant();
   const skeletonEl = variant ? revealSkeleton(variant) : null;

--- a/packages/mc-html-template/html-styles/loading-screen.css
+++ b/packages/mc-html-template/html-styles/loading-screen.css
@@ -50,22 +50,17 @@
 }
 
 /* ==========================================================================
-   Authenticated loading skeleton (FEC-1298)
+   Authenticated loading skeleton
 
    Mirrors the real app chrome so there is no layout shift when React mounts.
-   Values are duplicated from packages/application-shell/src/constants.ts
-   (DIMENSIONS.header, NAVBAR.widthLeftNavigation*) and from the UI Kit design
-   system (--color-primary-10, --color-surface). They are hardcoded rather than
-   referenced because this stylesheet is inlined into the HTML document and
-   applies before any design-system stylesheet has loaded.
+   Values are duplicated from application-shell/src/constants.ts (DIMENSIONS,
+   NAVBAR) and the UI Kit design system, hardcoded because this stylesheet is
+   inlined and applies before any design-system stylesheet has loaded.
    ========================================================================== */
 
-/*
-  The app's own resets.css used to supply this render-blocking. Now that app CSS
-  is a preload, this inlined stylesheet has to stand alone at first paint or the
-  100vw/100vh skeleton renders inside the UA's default body margin. Left
-  unlayered so it wins over resets.css's @layer copy of the identical value.
-*/
+/* App CSS is now a preload rather than render-blocking, so this stylesheet
+   needs its own reset or the skeleton renders inside the UA's default body
+   margin. Left unlayered so it wins over resets.css's @layer copy. */
 html,
 body {
   margin: 0;
@@ -93,9 +88,7 @@ body {
   white-space: nowrap;
 }
 
-/* --- Sidebar: spans the header and content rows, as `aside` does in
-       application-shell-authenticated.tsx (grid-column 1/2, grid-row 2/4). --- */
-
+/* Spans the header and content rows, matching the real `aside` element. */
 .loading-skeleton__sidebar {
   display: flex;
   flex-direction: column;
@@ -109,8 +102,8 @@ body {
   width: 256px;
 }
 
-/* Routes that render no navbar (/account, /login, /logout) collapse the first
-   grid column to zero, matching AppBar's offsetLeft of 0px. */
+/* Routes with no navbar collapse the first grid column, matching AppBar's
+   offsetLeft of 0px. */
 .loading-skeleton--no-navbar .loading-skeleton__sidebar {
   display: none;
 }
@@ -199,8 +192,7 @@ body {
   background: rgba(255, 255, 255, 0.2);
 }
 
-/* --- Header: mirrors AppBar (colorSurface + shadow + 40px inline padding). --- */
-
+/* Mirrors AppBar's surface colour, shadow and inline padding. */
 .loading-skeleton__header {
   display: flex;
   justify-content: flex-end;
@@ -219,9 +211,7 @@ body {
   background: rgba(0, 0, 0, 0.08);
 }
 
-/* --- Content: intentionally empty per the ticket. Centres the reused
-       long-loading notice where users see it today. --- */
-
+/* Intentionally empty; centres the reused long-loading notice. */
 .loading-skeleton__content {
   display: flex;
   justify-content: center;
@@ -231,29 +221,20 @@ body {
 }
 
 /* ==========================================================================
-   Cross-document view transitions (FEC-1298)
+   Cross-document view transitions
 
    Opts the document in so cross-app navigation crossfades instead of flashing
-   a blank page. This rule must remain in the document after `onAppLoaded()`
-   removes #app-loader, which is why __LOADING_SCREEN_CSS__ is injected into
-   <head> rather than inside the loader element.
-
-   No `view-transition-name` is set: a name must exist on both the outgoing and
-   incoming documents to morph an element, and on the outgoing page the skeleton
-   is already gone while the real NavBar/AppBar are unnamed. Naming skeleton
-   elements alone would imply behaviour it cannot produce.
+   a blank page. No `view-transition-name` here: a name must exist on both the
+   outgoing and incoming documents to morph an element, and the skeleton is
+   already gone by the time the outgoing page navigates away.
    ========================================================================== */
 
 @view-transition {
   navigation: auto;
 }
 
-/*
-  Reduced motion neutralises the animation, NOT the transition. Switching the
-  navigation off entirely would give these users the blank screen back: the
-  no-blank-screen benefit comes from the browser holding the old snapshot,
-  which survives a near-instant animation.
-*/
+/* Neutralises the animation, not the transition: switching navigation off
+   would bring back the blank screen these users are meant to avoid. */
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(root),
   ::view-transition-new(root) {

--- a/packages/mc-html-template/html-styles/loading-screen.css
+++ b/packages/mc-html-template/html-styles/loading-screen.css
@@ -60,6 +60,18 @@
    applies before any design-system stylesheet has loaded.
    ========================================================================== */
 
+/*
+  The app's own resets.css used to supply this render-blocking. Now that app CSS
+  is a preload, this inlined stylesheet has to stand alone at first paint or the
+  100vw/100vh skeleton renders inside the UA's default body margin. Left
+  unlayered so it wins over resets.css's @layer copy of the identical value.
+*/
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
 .loading-skeleton {
   display: grid;
   grid-template-rows: auto 56px 1fr;

--- a/packages/mc-html-template/html-styles/loading-screen.css
+++ b/packages/mc-html-template/html-styles/loading-screen.css
@@ -237,8 +237,8 @@
 }
 
 /*
-  Reduced motion neutralises the animation, NOT the transition. Setting
-  `navigation: none` would give these users the blank screen back — the
+  Reduced motion neutralises the animation, NOT the transition. Switching the
+  navigation off entirely would give these users the blank screen back: the
   no-blank-screen benefit comes from the browser holding the old snapshot,
   which survives a near-instant animation.
 */

--- a/packages/mc-html-template/html-styles/loading-screen.css
+++ b/packages/mc-html-template/html-styles/loading-screen.css
@@ -48,3 +48,203 @@
   transform-origin: 20px 20px 0;
   animation: loading-spinner-animation 0.5s infinite linear;
 }
+
+/* ==========================================================================
+   Authenticated loading skeleton (FEC-1298)
+
+   Mirrors the real app chrome so there is no layout shift when React mounts.
+   Values are duplicated from packages/application-shell/src/constants.ts
+   (DIMENSIONS.header, NAVBAR.widthLeftNavigation*) and from the UI Kit design
+   system (--color-primary-10, --color-surface). They are hardcoded rather than
+   referenced because this stylesheet is inlined into the HTML document and
+   applies before any design-system stylesheet has loaded.
+   ========================================================================== */
+
+.loading-skeleton {
+  display: grid;
+  grid-template-rows: auto 56px 1fr;
+  grid-template-columns: min-content 1fr;
+  height: 100vh;
+  width: 100vw;
+}
+
+.loading-skeleton--hidden {
+  display: none;
+}
+
+.loading-skeleton__sr-only {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  white-space: nowrap;
+}
+
+/* --- Sidebar: spans the header and content rows, as `aside` does in
+       application-shell-authenticated.tsx (grid-column 1/2, grid-row 2/4). --- */
+
+.loading-skeleton__sidebar {
+  display: flex;
+  flex-direction: column;
+  grid-row: 2 / 4;
+  grid-column: 1 / 2;
+  width: 80px;
+  background: hsl(240, 66%, 19%);
+}
+
+.loading-skeleton--menu-expanded .loading-skeleton__sidebar {
+  width: 256px;
+}
+
+/* Routes that render no navbar (/account, /login, /logout) collapse the first
+   grid column to zero, matching AppBar's offsetLeft of 0px. */
+.loading-skeleton--no-navbar .loading-skeleton__sidebar {
+  display: none;
+}
+
+.loading-skeleton__navbar-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  height: 56px;
+}
+
+.loading-skeleton__navbar-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  padding: 16px;
+}
+
+.loading-skeleton__navbar-footer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 16px 0;
+}
+
+.loading-skeleton--menu-expanded .loading-skeleton__navbar-footer {
+  padding: 16px 58px;
+}
+
+.loading-skeleton__navbar-footer::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  width: calc(100% - 2 * 16px);
+  height: 1px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.loading-skeleton__group {
+  width: 100%;
+}
+
+.loading-skeleton__item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  height: 48px;
+}
+
+.loading-skeleton--menu-expanded .loading-skeleton__item--narrow {
+  padding: 12px 28px;
+}
+
+.loading-skeleton__icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* The real NavBarSkeleton renders MenuItemTitle only when expanded. */
+.loading-skeleton__title {
+  display: none;
+  flex: 1;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.loading-skeleton--menu-expanded .loading-skeleton__title {
+  display: block;
+}
+
+.loading-skeleton__expander {
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* --- Header: mirrors AppBar (colorSurface + shadow + 40px inline padding). --- */
+
+.loading-skeleton__header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  grid-row: 2 / 3;
+  grid-column: 2 / 3;
+  padding: 0 40px;
+  background: #fff;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.15);
+}
+
+.loading-skeleton__header-placeholder {
+  width: 120px;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+/* --- Content: intentionally empty per the ticket. Centres the reused
+       long-loading notice where users see it today. --- */
+
+.loading-skeleton__content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  grid-row: 3 / 4;
+  grid-column: 2 / 3;
+}
+
+/* ==========================================================================
+   Cross-document view transitions (FEC-1298)
+
+   Opts the document in so cross-app navigation crossfades instead of flashing
+   a blank page. This rule must remain in the document after `onAppLoaded()`
+   removes #app-loader, which is why __LOADING_SCREEN_CSS__ is injected into
+   <head> rather than inside the loader element.
+
+   No `view-transition-name` is set: a name must exist on both the outgoing and
+   incoming documents to morph an element, and on the outgoing page the skeleton
+   is already gone while the real NavBar/AppBar are unnamed. Naming skeleton
+   elements alone would imply behaviour it cannot produce.
+   ========================================================================== */
+
+@view-transition {
+  navigation: auto;
+}
+
+/*
+  Reduced motion neutralises the animation, NOT the transition. Setting
+  `navigation: none` would give these users the blank screen back — the
+  no-blank-screen benefit comes from the browser holding the old snapshot,
+  which survives a near-instant animation.
+*/
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 1ms;
+  }
+}

--- a/packages/mc-html-template/src/loading-screen.spec.ts
+++ b/packages/mc-html-template/src/loading-screen.spec.ts
@@ -62,6 +62,11 @@ const loadingScreen = () =>
   document.querySelector('.loading-screen') as HTMLElement;
 const appLoader = () => document.querySelector('#app-loader');
 
+// `onAppLoaded` is assigned onto `window` by the script under test, so it is not
+// on the global Window type.
+const callOnAppLoaded = () =>
+  (window as unknown as { onAppLoaded: () => void }).onAppLoaded();
+
 const addPreload = (attrs: Record<string, string>) => {
   const linkEl = document.createElement('link');
   Object.keys(attrs).forEach((name) => linkEl.setAttribute(name, attrs[name]));
@@ -102,10 +107,15 @@ const removePerformanceShim = () =>
     delete (window.performance as unknown as Record<string, unknown>)[method];
   });
 
-/** Pretends the given hrefs already finished loading, per Resource Timing. */
+/**
+ * Pretends the given absolute hrefs already finished loading, per Resource
+ * Timing. Matched exactly, because the real `getEntriesByName` does exact
+ * string matching on the resolved absolute URL - a substring stub would let the
+ * fast path pass here while missing in a browser.
+ */
 const stubCompletedResources = (hrefs: string[]) =>
   perf.getEntriesByName.mockImplementation((name: string) =>
-    hrefs.some((href) => name.indexOf(href) !== -1) ? [{ responseEnd: 12 }] : []
+    hrefs.indexOf(name) !== -1 ? [{ responseEnd: 12 }] : []
   );
 
 beforeEach(() => {
@@ -279,8 +289,9 @@ describe('mc:skeleton-visible mark', () => {
     bootLoadingScreen();
 
     expect(perf.mark).toHaveBeenCalledWith('mc:skeleton-visible');
-    // Measured from the time origin, i.e. navigationStart.
-    expect(perf.measure).toHaveBeenCalledWith('mc:skeleton-visible', {
+    // Measured from the time origin, i.e. navigationStart, under a name of its
+    // own so getEntriesByName('mc:skeleton-visible') returns only the mark.
+    expect(perf.measure).toHaveBeenCalledWith('mc:skeleton-visible:duration', {
       start: 0,
     });
   });
@@ -303,7 +314,7 @@ describe('mc:skeleton-visible mark', () => {
       href: 'https://cdn.example.com/app-shell.css',
       'data-mc-css': '',
     });
-    stubCompletedResources(['app-shell.css']);
+    stubCompletedResources(['https://cdn.example.com/app-shell.css']);
 
     expect(() => bootLoadingScreen()).not.toThrow();
 
@@ -380,7 +391,7 @@ describe('stylesheet preload upgrade', () => {
       href: 'https://cdn.example.com/app-shell.css',
       'data-mc-css': '',
     });
-    stubCompletedResources(['app-shell.css']);
+    stubCompletedResources(['https://cdn.example.com/app-shell.css']);
 
     bootLoadingScreen();
 
@@ -449,7 +460,7 @@ describe('onAppLoaded reveal gate', () => {
   it('should remove the loader immediately when no app CSS is pending', () => {
     bootLoadingScreen();
 
-    window.onAppLoaded();
+    callOnAppLoaded();
 
     expect(appLoader()).toBeNull();
   });
@@ -469,7 +480,7 @@ describe('onAppLoaded reveal gate', () => {
     });
 
     bootLoadingScreen();
-    window.onAppLoaded();
+    callOnAppLoaded();
 
     expect(appLoader()).not.toBeNull();
 
@@ -488,9 +499,47 @@ describe('onAppLoaded reveal gate', () => {
     });
 
     bootLoadingScreen();
-    window.onAppLoaded();
+    callOnAppLoaded();
 
     expect(appLoader()).toBeNull();
+  });
+
+  it('should upgrade straggler preloads when the deadline fires', () => {
+    // Zeroing the counter alone would leave the link as rel="preload" forever,
+    // so its CSS could never apply even if the response arrived later.
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/slow.css',
+      'data-mc-css': '',
+    });
+
+    bootLoadingScreen();
+    expect(linkEl.rel).toBe('preload');
+
+    jest.advanceTimersByTime(2000);
+
+    expect(linkEl.rel).toBe('stylesheet');
+    expect(linkEl.getAttribute('data-mc-upgraded')).toBe('');
+  });
+
+  it('should not double-release when a stylesheet loads after the deadline', () => {
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/late.css',
+      'data-mc-css': '',
+    });
+
+    bootLoadingScreen();
+    jest.advanceTimersByTime(2000);
+    linkEl.dispatchEvent(new Event('load'));
+
+    // The data-mc-upgraded guard makes the late event a no-op, so the counter
+    // cannot be driven negative.
+    expect((window as { __CSS_REMAINING__?: number }).__CSS_REMAINING__).toBe(
+      0
+    );
   });
 
   it('should reveal the app anyway when a stylesheet never resolves', () => {
@@ -505,7 +554,7 @@ describe('onAppLoaded reveal gate', () => {
     });
 
     bootLoadingScreen();
-    window.onAppLoaded();
+    callOnAppLoaded();
 
     expect(appLoader()).not.toBeNull();
 

--- a/packages/mc-html-template/src/loading-screen.spec.ts
+++ b/packages/mc-html-template/src/loading-screen.spec.ts
@@ -1,0 +1,516 @@
+import fs from 'fs';
+import path from 'path';
+import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
+import generateTemplate from './generate-template';
+import replaceHtmlPlaceholders from './replace-html-placeholders';
+
+/**
+ * Runtime harness for `html-scripts/loading-screen.js`.
+ *
+ * That file ships to the browser untranspiled and is inlined into the HTML by
+ * `replaceHtmlPlaceholders`, so nothing imports it as a module. It is read from
+ * disk (rather than through the preval'd `./load-html-scripts`) so a warm jest
+ * transform cache can never serve a stale copy.
+ */
+const scriptSource = fs.readFileSync(
+  path.join(__dirname, '../html-scripts/loading-screen.js'),
+  'utf8'
+);
+
+const env = {
+  applicationId: '__local:avengers',
+  applicationName: 'avengers-app',
+  entryPointUriPath: 'avengers',
+  cdnUrl: 'http://localhost:3001/',
+  env: 'test',
+  frontendHost: 'localhost:3001',
+  location: 'gcp-eu',
+  mcApiUrl: 'https://mc-api.example.com',
+  revision: '',
+  servedByProxy: false,
+} as unknown as ApplicationRuntimeConfig['env'];
+
+const compiledHtml = replaceHtmlPlaceholders(generateTemplate({}), {
+  env,
+  headers: { 'Content-Security-Policy': "default-src 'none'" } as never,
+});
+
+// The real `#app-loader` subtree, so these tests exercise the shipped markup
+// rather than a hand-written fixture.
+const loaderMarkup = compiledHtml.slice(
+  compiledHtml.indexOf('<div id="app-loader">'),
+  compiledHtml.indexOf('<div id="app">')
+);
+
+const bootLoadingScreen = () => {
+  // eslint-disable-next-line no-new-func
+  new Function(scriptSource)();
+};
+
+const setUrl = (pathname: string) => window.history.pushState({}, '', pathname);
+
+const setViewportWidth = (width: number) =>
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    configurable: true,
+    writable: true,
+  });
+
+const skeleton = () =>
+  document.querySelector('.loading-skeleton') as HTMLElement;
+const loadingScreen = () =>
+  document.querySelector('.loading-screen') as HTMLElement;
+const appLoader = () => document.querySelector('#app-loader');
+
+const addPreload = (attrs: Record<string, string>) => {
+  const linkEl = document.createElement('link');
+  Object.keys(attrs).forEach((name) => linkEl.setAttribute(name, attrs[name]));
+  document.head.appendChild(linkEl);
+  return linkEl;
+};
+
+/**
+ * jsdom implements neither User Timing nor Resource Timing - `performance.mark`,
+ * `measure` and `getEntriesByName` are all undefined - so the surface the script
+ * feature-detects has to be provided here. Without this shim the mark
+ * assertions below would pass vacuously.
+ */
+const PERFORMANCE_METHODS = ['mark', 'measure', 'getEntriesByName'] as const;
+
+type PerformanceShim = Record<(typeof PERFORMANCE_METHODS)[number], jest.Mock>;
+
+let perf: PerformanceShim;
+
+const installPerformanceShim = () => {
+  perf = {
+    mark: jest.fn(),
+    measure: jest.fn(),
+    getEntriesByName: jest.fn(() => []),
+  };
+
+  PERFORMANCE_METHODS.forEach((method) => {
+    Object.defineProperty(window.performance, method, {
+      value: perf[method],
+      configurable: true,
+      writable: true,
+    });
+  });
+};
+
+const removePerformanceShim = () =>
+  PERFORMANCE_METHODS.forEach((method) => {
+    delete (window.performance as unknown as Record<string, unknown>)[method];
+  });
+
+/** Pretends the given hrefs already finished loading, per Resource Timing. */
+const stubCompletedResources = (hrefs: string[]) =>
+  perf.getEntriesByName.mockImplementation((name: string) =>
+    hrefs.some((href) => name.indexOf(href) !== -1) ? [{ responseEnd: 12 }] : []
+  );
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  installPerformanceShim();
+  document.head.innerHTML = '';
+  document.body.innerHTML = `${loaderMarkup}<div id="app"></div>`;
+  window.localStorage.clear();
+  setUrl('/my-project-key/orders');
+  setViewportWidth(1400);
+  delete (window as { onAppLoaded?: unknown }).onAppLoaded;
+  (window as { __CSS_REMAINING__?: number }).__CSS_REMAINING__ = 0;
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  removePerformanceShim();
+  jest.restoreAllMocks();
+});
+
+describe('session gate', () => {
+  it('should reveal the skeleton immediately when a session is cached', () => {
+    window.localStorage.setItem('isAuthenticated', 'true');
+
+    bootLoadingScreen();
+
+    // No timers advanced: the skeleton is the intended layout, so unlike the
+    // bare spinner there is nothing to avoid flashing.
+    expect(skeleton().classList).not.toContain('loading-skeleton--hidden');
+    expect(loadingScreen().classList).toContain('loading-screen--hidden');
+  });
+
+  it('should show the spinner after 250ms when no session is cached', () => {
+    bootLoadingScreen();
+
+    expect(skeleton().classList).toContain('loading-skeleton--hidden');
+    expect(loadingScreen().classList).toContain('loading-screen--hidden');
+
+    jest.advanceTimersByTime(250);
+
+    expect(loadingScreen().classList).not.toContain('loading-screen--hidden');
+    expect(skeleton().classList).toContain('loading-skeleton--hidden');
+  });
+
+  it.each(['false', 'TRUE', '1', ''])(
+    'should treat the non-canonical flag value %p as unauthenticated',
+    (value) => {
+      window.localStorage.setItem('isAuthenticated', value);
+
+      bootLoadingScreen();
+
+      expect(skeleton().classList).toContain('loading-skeleton--hidden');
+    }
+  );
+
+  it('should fall back to the spinner when storage access throws', () => {
+    // Set the flag first, so a pass cannot come from the key merely being absent.
+    window.localStorage.setItem('isAuthenticated', 'true');
+
+    // Replace the whole `localStorage` object rather than spying on `getItem`:
+    // jsdom defines `getItem` as an own property of a proxied Storage instance,
+    // so a prototype spy is shadowed and an instance spy cannot be restored -
+    // and an unrestored one silently makes every later authenticated test read
+    // as unauthenticated.
+    const original = window.localStorage;
+
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem() {
+          throw new Error('SecurityError: storage is disabled');
+        },
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(() => bootLoadingScreen()).not.toThrow();
+      expect(skeleton().classList).toContain('loading-skeleton--hidden');
+
+      jest.advanceTimersByTime(250);
+
+      expect(loadingScreen().classList).not.toContain('loading-screen--hidden');
+    } finally {
+      Object.defineProperty(window, 'localStorage', {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+});
+
+describe('route gate', () => {
+  beforeEach(() => window.localStorage.setItem('isAuthenticated', 'true'));
+
+  it.each(['/account/profile', '/login', '/logout'])(
+    'should suppress the sidebar on %s, where the shell renders no NavBar',
+    (pathname) => {
+      setUrl(pathname);
+
+      bootLoadingScreen();
+
+      expect(skeleton().classList).toContain('loading-skeleton--no-navbar');
+      expect(skeleton().classList).not.toContain('loading-skeleton--hidden');
+    }
+  );
+
+  it('should fall back to the spinner for Custom Views', () => {
+    // Custom Views mount their own shell and never render the app chrome.
+    setUrl('/custom-views/abc123/projects/my-project-key');
+
+    bootLoadingScreen();
+
+    expect(skeleton().classList).toContain('loading-skeleton--hidden');
+
+    jest.advanceTimersByTime(250);
+
+    expect(loadingScreen().classList).not.toContain('loading-screen--hidden');
+  });
+
+  it('should render the full skeleton inside a project route', () => {
+    setUrl('/my-project-key/orders');
+
+    bootLoadingScreen();
+
+    expect(skeleton().classList).not.toContain('loading-skeleton--no-navbar');
+    expect(skeleton().classList).not.toContain('loading-skeleton--hidden');
+  });
+});
+
+describe('viewport gate', () => {
+  beforeEach(() => window.localStorage.setItem('isAuthenticated', 'true'));
+
+  it('should expand the sidebar when the menu is pinned on a wide viewport', () => {
+    window.localStorage.setItem('isForcedMenuOpen', 'true');
+    setViewportWidth(1400);
+
+    bootLoadingScreen();
+
+    expect(skeleton().classList).toContain('loading-skeleton--menu-expanded');
+  });
+
+  it('should stay collapsed when the menu is pinned at or below 1200px', () => {
+    // useNavbarStateManager resets isMenuOpen to false below WINDOW_SIZES.WIDE
+    // regardless of the flag, so honouring the flag alone would jump 176px.
+    window.localStorage.setItem('isForcedMenuOpen', 'true');
+    setViewportWidth(1100);
+
+    bootLoadingScreen();
+
+    expect(skeleton().classList).not.toContain(
+      'loading-skeleton--menu-expanded'
+    );
+  });
+
+  it('should stay collapsed when the menu is not pinned', () => {
+    setViewportWidth(1400);
+
+    bootLoadingScreen();
+
+    expect(skeleton().classList).not.toContain(
+      'loading-skeleton--menu-expanded'
+    );
+  });
+});
+
+describe('mc:skeleton-visible mark', () => {
+  it('should emit the mark on the authenticated path', () => {
+    window.localStorage.setItem('isAuthenticated', 'true');
+
+    bootLoadingScreen();
+
+    expect(perf.mark).toHaveBeenCalledWith('mc:skeleton-visible');
+    // Measured from the time origin, i.e. navigationStart.
+    expect(perf.measure).toHaveBeenCalledWith('mc:skeleton-visible', {
+      start: 0,
+    });
+  });
+
+  it('should not emit the mark on the spinner path', () => {
+    bootLoadingScreen();
+    jest.advanceTimersByTime(250);
+
+    expect(perf.mark).not.toHaveBeenCalled();
+  });
+
+  it('should still upgrade stylesheets when instrumentation throws', () => {
+    window.localStorage.setItem('isAuthenticated', 'true');
+    perf.mark.mockImplementation(() => {
+      throw new Error('performance is unavailable');
+    });
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/app-shell.css',
+      'data-mc-css': '',
+    });
+    stubCompletedResources(['app-shell.css']);
+
+    expect(() => bootLoadingScreen()).not.toThrow();
+
+    expect(linkEl.rel).toBe('stylesheet');
+  });
+});
+
+describe('missing User Timing API', () => {
+  it('should still reveal the skeleton when performance is unavailable', () => {
+    // The actual jsdom default, and a real possibility in older browsers.
+    removePerformanceShim();
+    window.localStorage.setItem('isAuthenticated', 'true');
+
+    expect(() => bootLoadingScreen()).not.toThrow();
+
+    expect(skeleton().classList).not.toContain('loading-skeleton--hidden');
+  });
+});
+
+describe('long-loading notice', () => {
+  const noticeIn = (root: HTMLElement) =>
+    root.querySelector('.long-loading-notice') as HTMLElement;
+
+  it('should reveal only the skeleton notice on the authenticated path', () => {
+    window.localStorage.setItem('isAuthenticated', 'true');
+
+    bootLoadingScreen();
+    jest.advanceTimersByTime(2000);
+
+    expect(noticeIn(skeleton()).classList).not.toContain(
+      'long-loading-notice--hidden'
+    );
+    expect(noticeIn(loadingScreen()).classList).toContain(
+      'long-loading-notice--hidden'
+    );
+  });
+
+  it('should reveal only the spinner notice on the unauthenticated path', () => {
+    bootLoadingScreen();
+    jest.advanceTimersByTime(2000);
+
+    expect(noticeIn(loadingScreen()).classList).not.toContain(
+      'long-loading-notice--hidden'
+    );
+    expect(noticeIn(skeleton()).classList).toContain(
+      'long-loading-notice--hidden'
+    );
+  });
+});
+
+describe('stylesheet preload upgrade', () => {
+  it('should upgrade a preload once it loads', () => {
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://fonts.example.com/open-sans.css',
+    });
+
+    bootLoadingScreen();
+    expect(linkEl.rel).toBe('preload');
+
+    linkEl.dispatchEvent(new Event('load'));
+
+    expect(linkEl.rel).toBe('stylesheet');
+  });
+
+  it('should upgrade a preload that already completed before the script ran', () => {
+    // The common case, not an edge case: this script is parser-inserted and
+    // deferred behind the still-blocking Inter stylesheet, so same-origin
+    // preloads have usually already fired `load` by the time it runs.
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/app-shell.css',
+      'data-mc-css': '',
+    });
+    stubCompletedResources(['app-shell.css']);
+
+    bootLoadingScreen();
+
+    expect(linkEl.rel).toBe('stylesheet');
+    expect((window as { __CSS_REMAINING__?: number }).__CSS_REMAINING__).toBe(
+      0
+    );
+  });
+
+  it('should upgrade at most once, so the counter cannot double-decrement', () => {
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/app-shell.css',
+      'data-mc-css': '',
+    });
+
+    bootLoadingScreen();
+    linkEl.dispatchEvent(new Event('load'));
+    linkEl.dispatchEvent(new Event('load'));
+
+    expect(linkEl.getAttribute('data-mc-upgraded')).toBe('');
+    expect((window as { __CSS_REMAINING__?: number }).__CSS_REMAINING__).toBe(
+      0
+    );
+  });
+
+  it('should release the counter when a stylesheet errors', () => {
+    const linkEl = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/app-shell.css',
+      'data-mc-css': '',
+    });
+
+    bootLoadingScreen();
+    linkEl.dispatchEvent(new Event('error'));
+
+    expect((window as { __CSS_REMAINING__?: number }).__CSS_REMAINING__).toBe(
+      0
+    );
+  });
+
+  it.each([
+    [
+      'as="fetch" prefetch hints (FEC-1301)',
+      { as: 'fetch', href: '/__prefetch/user' },
+    ],
+    ['modulepreload tags', { as: '', href: '/assets/chunk.js' }],
+  ])('should not touch %s', (_label, attrs) => {
+    const linkEl = addPreload({
+      rel: attrs.as === 'fetch' ? 'preload' : 'modulepreload',
+      ...(attrs.as ? { as: attrs.as } : {}),
+      href: attrs.href,
+    });
+
+    bootLoadingScreen();
+    linkEl.dispatchEvent(new Event('load'));
+
+    expect(linkEl.rel).not.toBe('stylesheet');
+    expect(linkEl.getAttribute('data-mc-upgraded')).toBeNull();
+  });
+});
+
+describe('onAppLoaded reveal gate', () => {
+  it('should remove the loader immediately when no app CSS is pending', () => {
+    bootLoadingScreen();
+
+    window.onAppLoaded();
+
+    expect(appLoader()).toBeNull();
+  });
+
+  it('should wait for every pending app stylesheet, not just the first', () => {
+    const first = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/app-shell.css',
+      'data-mc-css': '',
+    });
+    const second = addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/index.css',
+      'data-mc-css': '',
+    });
+
+    bootLoadingScreen();
+    window.onAppLoaded();
+
+    expect(appLoader()).not.toBeNull();
+
+    first.dispatchEvent(new Event('load'));
+    expect(appLoader()).not.toBeNull();
+
+    second.dispatchEvent(new Event('load'));
+    expect(appLoader()).toBeNull();
+  });
+
+  it('should not wait on fonts, which use display=swap', () => {
+    addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://fonts.example.com/open-sans.css',
+    });
+
+    bootLoadingScreen();
+    window.onAppLoaded();
+
+    expect(appLoader()).toBeNull();
+  });
+
+  it('should reveal the app anyway when a stylesheet never resolves', () => {
+    // Before this gate existed onAppLoaded removed the loader unconditionally,
+    // so an unbounded wait would be a new availability regression: degrade to
+    // visible-but-unstyled, never invisible.
+    addPreload({
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.example.com/never-resolves.css',
+      'data-mc-css': '',
+    });
+
+    bootLoadingScreen();
+    window.onAppLoaded();
+
+    expect(appLoader()).not.toBeNull();
+
+    jest.advanceTimersByTime(2000);
+
+    expect(appLoader()).toBeNull();
+  });
+});

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -92,7 +92,7 @@ describe('csp', () => {
     expect(
       processedApplicationConfig['Content-Security-Policy']
     ).toMatchInlineSnapshot(
-      `"default-src 'none'; script-src 'self' 'sha256-Zds3SjuKhSdOLbCJjb81bLwtslWHUFbRUXdW5CJleCY=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
+      `"default-src 'none'; script-src 'self' 'sha256-/zs6m6Et2WdBitRaMsJQ3vy85DjicEyTX/t38vXCOL8=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
     );
   });
 });

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -92,7 +92,7 @@ describe('csp', () => {
     expect(
       processedApplicationConfig['Content-Security-Policy']
     ).toMatchInlineSnapshot(
-      `"default-src 'none'; script-src 'self' 'sha256-/zs6m6Et2WdBitRaMsJQ3vy85DjicEyTX/t38vXCOL8=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
+      `"default-src 'none'; script-src 'self' 'sha256-Q8L9yd1RhMA+ZctsyiziJhGu22ioSNvYGSLkjUZMI2I=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
     );
   });
 });

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -92,7 +92,7 @@ describe('csp', () => {
     expect(
       processedApplicationConfig['Content-Security-Policy']
     ).toMatchInlineSnapshot(
-      `"default-src 'none'; script-src 'self' 'sha256-RACUtlMzZqF+zLJFAGOjaIZxjIlawfiKwgX9HWbQ9yQ=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
+      `"default-src 'none'; script-src 'self' 'sha256-JSeJQ5CizqhYgv0LDw5h8RLpiNVwX00DMLDFgvfxvDg=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
     );
   });
 });

--- a/packages/mc-html-template/src/process-headers.spec.ts
+++ b/packages/mc-html-template/src/process-headers.spec.ts
@@ -92,7 +92,7 @@ describe('csp', () => {
     expect(
       processedApplicationConfig['Content-Security-Policy']
     ).toMatchInlineSnapshot(
-      `"default-src 'none'; script-src 'self' 'sha256-JSeJQ5CizqhYgv0LDw5h8RLpiNVwX00DMLDFgvfxvDg=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
+      `"default-src 'none'; script-src 'self' 'sha256-Zds3SjuKhSdOLbCJjb81bLwtslWHUFbRUXdW5CJleCY=' 'sha256-5kzN9QxmTvcO/1/aYsVEo7hnWU50vwMjy6wviGxCOA0=' 'sha256-K4tyBnwnqF68wrXckWx1ce5+E4534Hv/ZdQEZLf+Z7Y='; connect-src 'self' app.launchdarkly.com clientsdk.launchdarkly.com clientstream.launchdarkly.com events.launchdarkly.com app.getsentry.com *.sentry.io https://example.com; img-src * data:; style-src 'self' fonts.googleapis.com data: 'unsafe-inline'; font-src 'self' fonts.gstatic.com data:; frame-src 'self'; upgrade-insecure-requests "`
     );
   });
 });

--- a/packages/mc-html-template/src/replace-html-placeholders.spec.ts
+++ b/packages/mc-html-template/src/replace-html-placeholders.spec.ts
@@ -95,10 +95,17 @@ describe('replaceHtmlPlaceholders', () => {
 
       // Attribute order and line wrapping are prettier's, so assert on the
       // attributes present in the tag rather than an exact one-line shape.
-      const tag = html.slice(
-        html.indexOf('<link', html.indexOf('rel="preload"') - 200),
-        html.indexOf('<noscript>')
-      );
+      // Anchored on the family so the assertion keeps pointing at Open Sans
+      // once other rel="preload" links exist earlier in the document.
+      const tag = html
+        .split('<link')
+        .find(
+          (candidate) =>
+            candidate.includes('family=Open+Sans') &&
+            candidate.includes('rel="preload"')
+        ) as string;
+
+      expect(tag).toBeDefined();
 
       expect(tag).toContain('rel="preload"');
       expect(tag).toContain('as="style"');
@@ -140,6 +147,16 @@ describe('replaceHtmlPlaceholders', () => {
     });
   });
 
+  describe('first-paint self-sufficiency', () => {
+    it('should reset the body margin itself, since app CSS is now a preload', () => {
+      // resets.css used to supply this render-blocking; a 100vw/100vh skeleton
+      // inside the UA default margin would overflow and shift.
+      const html = compile();
+
+      expect(html).toMatch(/html,\s*body\s*\{[^}]*margin:\s*0/);
+    });
+  });
+
   describe('view transitions', () => {
     it('should inject the loading screen styles outside #app-loader', () => {
       // `onAppLoaded()` removes #app-loader, and the @view-transition opt-in must
@@ -165,8 +182,14 @@ describe('replaceHtmlPlaceholders', () => {
   });
 
   describe('layout constants (drift alarm)', () => {
-    // Duplicated from packages/application-shell/src/constants.ts. If those
-    // change, the skeleton shifts layout at handoff and this test should fail.
+    // These literals are duplicated from packages/application-shell/src/constants.ts
+    // (DIMENSIONS.header, NAVBAR.widthLeftNavigation*) and the UI Kit's
+    // --color-primary-10. This test pins the values currently baked into
+    // loading-screen.css against an accidental edit HERE; it canNOT detect a
+    // change to constants.ts, because mc-html-template has no import path to
+    // application-shell and this CSS is inlined before any JS module loads.
+    // Cross-package drift remains a manual three-way responsibility, shared with
+    // navbar-skeleton.styles.tsx which also hardcodes these widths.
     it.each([
       ['header height', '56px'],
       ['navbar collapsed width', '80px'],

--- a/packages/mc-html-template/src/replace-html-placeholders.spec.ts
+++ b/packages/mc-html-template/src/replace-html-placeholders.spec.ts
@@ -123,21 +123,57 @@ describe('replaceHtmlPlaceholders', () => {
       expect(noscript).toContain('rel="stylesheet"');
     });
 
-    it('should leave the Inter/Nimbus link blocking and fully attributed', () => {
-      // NimbusProvider renders a byte-identical link and React 19 dedupes by
-      // matching link[rel="stylesheet"][href]. Converting this would make Nimbus
-      // inject its own blocking stylesheet at mount instead.
+    it('should preload Inter too, keeping the Nimbus marker', () => {
+      // Nimbus is told to stand down via its `loadFonts={false}` prop; the
+      // marker is what lets it recognise a host-owned font link.
       const html = compile();
-      const interLink = html.slice(
-        html.indexOf(
-          '<link\n      href="https://fonts.googleapis.com/css2?family=Inter'
-        ),
-        html.indexOf('__APPLICATION_CSS_IMPORTS__')
-      );
+      const interTag = html
+        .split('<link')
+        .find(
+          (candidate) =>
+            candidate.includes('family=Inter') &&
+            candidate.includes('rel="preload"')
+        ) as string;
 
-      expect(interLink).toContain('rel="stylesheet"');
-      expect(interLink).toContain('data-nimbus-fonts=""');
-      expect(interLink).toContain('precedence="default"');
+      expect(interTag).toBeDefined();
+      expect(interTag).toContain('as="style"');
+      expect(interTag).toContain('data-nimbus-fonts=""');
+    });
+
+    it('should provide a noscript stylesheet fallback for Inter', () => {
+      const html = compile();
+      // Match the block bodies, not `split('<noscript>')` -- that would leave
+      // the Inter preload sitting in the chunk before its own noscript.
+      const noscripts = (
+        html.match(/<noscript>[\s\S]*?<\/noscript>/g) ?? []
+      ).filter((block) => block.includes('family=Inter'));
+
+      expect(noscripts).toHaveLength(1);
+      expect(noscripts[0]).toContain('rel="stylesheet"');
+    });
+
+    it('should leave no render-blocking font stylesheet outside noscript', () => {
+      // The whole point: neither font may block first paint.
+      const html = compile();
+      const outsideNoscript = html.replace(
+        /<noscript>[\s\S]*?<\/noscript>/g,
+        ''
+      );
+      const blocking = outsideNoscript
+        .split('<link')
+        .filter(
+          (tag) =>
+            tag.includes('fonts.googleapis.com/css2') &&
+            tag.includes('rel="stylesheet"')
+        );
+
+      expect(blocking).toHaveLength(0);
+    });
+
+    it('should drop the inert precedence attribute', () => {
+      // React only reads the `data-precedence` attribute it sets itself, so on
+      // a static tag `precedence` never did anything.
+      expect(compile()).not.toContain('precedence=');
     });
 
     it('should not use an inline onload handler anywhere', () => {

--- a/packages/mc-html-template/src/replace-html-placeholders.spec.ts
+++ b/packages/mc-html-template/src/replace-html-placeholders.spec.ts
@@ -1,0 +1,179 @@
+import type { ApplicationRuntimeConfig } from '@commercetools-frontend/application-config';
+import generateTemplate from './generate-template';
+import replaceHtmlPlaceholders from './replace-html-placeholders';
+
+const env = {
+  applicationId: '__local:avengers',
+  applicationIdentifier: '__local:avengers',
+  applicationName: 'avengers-app',
+  entryPointUriPath: 'avengers',
+  cdnUrl: 'http://localhost:3001/',
+  env: 'test',
+  frontendHost: 'localhost:3001',
+  location: 'gcp-eu',
+  mcApiUrl: 'https://mc-api.europe-west1.gcp.commercetools.com',
+  revision: '',
+  servedByProxy: false,
+} as unknown as ApplicationRuntimeConfig['env'];
+
+const compile = () =>
+  replaceHtmlPlaceholders(generateTemplate({}), {
+    env,
+    headers: { 'Content-Security-Policy': "default-src 'none'" } as never,
+  });
+
+// The skeleton lives between `#app-loader`'s opening tag and the untouched
+// `.loading-screen` sibling. Anchored on stable substrings rather than whole
+// tags, since prettier wraps multi-attribute tags across lines.
+const getSkeletonMarkup = (html: string) => {
+  const start = html.indexOf('id="app-loader"');
+  const end = html.indexOf('class="loading-screen loading-screen--hidden"');
+
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  return html.slice(start, end);
+};
+
+describe('replaceHtmlPlaceholders', () => {
+  describe('loading skeleton markup', () => {
+    it('should render the skeleton with sidebar, header and content regions', () => {
+      const skeleton = getSkeletonMarkup(compile());
+
+      expect(skeleton).toContain('loading-skeleton__sidebar');
+      expect(skeleton).toContain('loading-skeleton__header');
+      expect(skeleton).toContain('loading-skeleton__content');
+    });
+
+    it('should keep the skeleton hidden until the script reveals it', () => {
+      expect(compile()).toContain(
+        'class="loading-skeleton loading-skeleton--hidden"'
+      );
+    });
+
+    it('should mirror the real NavBarSkeleton item structure', () => {
+      const sidebar = getSkeletonMarkup(compile());
+      // One icon per item; counting the item class itself would double-count,
+      // since each item also carries a `--wide`/`--narrow` modifier.
+      const items = sidebar.match(/loading-skeleton__icon/g) ?? [];
+
+      // 1 narrow header item, then body groups of 2, 10 and 1.
+      expect(items).toHaveLength(14);
+      expect(sidebar.match(/loading-skeleton__group/g)).toHaveLength(3);
+      expect(sidebar).toContain('loading-skeleton__expander');
+    });
+
+    it('should carry accessible loading semantics', () => {
+      const skeleton = getSkeletonMarkup(compile());
+
+      expect(skeleton).toContain('aria-busy="true"');
+      expect(skeleton).toContain('role="status"');
+      expect(skeleton).toContain('Loading Merchant Center');
+      // Decorative chrome must not be announced.
+      expect(skeleton).toContain('aria-hidden="true"');
+    });
+
+    it('should render a long-loading notice in both variants', () => {
+      const html = compile();
+
+      expect(
+        html.match(/long-loading-notice long-loading-notice--hidden/g)
+      ).toHaveLength(2);
+    });
+
+    it('should preserve the unauthenticated spinner and wordmark', () => {
+      const html = compile();
+
+      expect(html).toContain('class="loading-screen loading-screen--hidden"');
+      expect(html).toContain('loading-spinner-pointer');
+    });
+  });
+
+  describe('render-blocking resources', () => {
+    it('should preload Open Sans instead of linking it as a stylesheet', () => {
+      const html = compile();
+
+      // Attribute order and line wrapping are prettier's, so assert on the
+      // attributes present in the tag rather than an exact one-line shape.
+      const tag = html.slice(
+        html.indexOf('<link', html.indexOf('rel="preload"') - 200),
+        html.indexOf('<noscript>')
+      );
+
+      expect(tag).toContain('rel="preload"');
+      expect(tag).toContain('as="style"');
+      expect(tag).toMatch(/family=Open\+Sans/);
+    });
+
+    it('should provide a noscript stylesheet fallback for Open Sans', () => {
+      const html = compile();
+      const noscript = html.slice(
+        html.indexOf('<noscript>'),
+        html.indexOf('</noscript>')
+      );
+
+      expect(noscript).toMatch(/family=Open\+Sans/);
+      expect(noscript).toContain('rel="stylesheet"');
+    });
+
+    it('should leave the Inter/Nimbus link blocking and fully attributed', () => {
+      // NimbusProvider renders a byte-identical link and React 19 dedupes by
+      // matching link[rel="stylesheet"][href]. Converting this would make Nimbus
+      // inject its own blocking stylesheet at mount instead.
+      const html = compile();
+      const interLink = html.slice(
+        html.indexOf(
+          '<link\n      href="https://fonts.googleapis.com/css2?family=Inter'
+        ),
+        html.indexOf('__APPLICATION_CSS_IMPORTS__')
+      );
+
+      expect(interLink).toContain('rel="stylesheet"');
+      expect(interLink).toContain('data-nimbus-fonts=""');
+      expect(interLink).toContain('precedence="default"');
+    });
+
+    it('should not use an inline onload handler anywhere', () => {
+      // The production CSP allows neither 'unsafe-inline' nor 'unsafe-hashes' in
+      // script-src, and script hashes do not cover event-handler attributes.
+      expect(compile()).not.toContain('onload=');
+    });
+  });
+
+  describe('view transitions', () => {
+    it('should inject the loading screen styles outside #app-loader', () => {
+      // `onAppLoaded()` removes #app-loader, and the @view-transition opt-in must
+      // still be in the document when the user navigates away.
+      const html = compile();
+
+      expect(html.indexOf('<style>')).toBeLessThan(
+        html.indexOf('<div id="app-loader">')
+      );
+    });
+
+    it('should opt the document in to cross-document view transitions', () => {
+      expect(compile()).toContain('@view-transition');
+    });
+
+    it('should neutralise the animation under reduced motion, not the transition', () => {
+      const html = compile();
+
+      expect(html).toContain('prefers-reduced-motion: reduce');
+      expect(html).toContain('animation-duration');
+      expect(html).not.toContain('navigation: none');
+    });
+  });
+
+  describe('layout constants (drift alarm)', () => {
+    // Duplicated from packages/application-shell/src/constants.ts. If those
+    // change, the skeleton shifts layout at handoff and this test should fail.
+    it.each([
+      ['header height', '56px'],
+      ['navbar collapsed width', '80px'],
+      ['navbar expanded width', '256px'],
+      ['navbar background', 'hsl(240, 66%, 19%)'],
+    ])('should pin the %s to %s', (_label, value) => {
+      expect(compile()).toContain(value);
+    });
+  });
+});

--- a/packages/mc-html-template/src/webpack-html-template.spec.ts
+++ b/packages/mc-html-template/src/webpack-html-template.spec.ts
@@ -51,7 +51,7 @@ describe('webpackHtmlTemplate', () => {
   });
 
   describe('links it must not affect', () => {
-    it('should leave the template font links exactly as authored', () => {
+    it('should not claim the template font links as app CSS', () => {
       // The Vite path needs a bundle check to avoid this; here the CSS list is
       // supplied directly, so template links are structurally untouchable.
       const html = webpackHtmlTemplate(buildTemplateParams(['/app.abc.css']));
@@ -60,7 +60,6 @@ describe('webpackHtmlTemplate', () => {
         .find((tag) => tag.includes('family=Inter')) as string;
 
       expect(interTag).toBeDefined();
-      expect(interTag).toContain('rel="stylesheet"');
       expect(interTag).toContain('data-nimbus-fonts=""');
       expect(interTag).not.toContain('data-mc-css');
     });

--- a/packages/mc-html-template/src/webpack-html-template.spec.ts
+++ b/packages/mc-html-template/src/webpack-html-template.spec.ts
@@ -1,0 +1,91 @@
+import type { TemplateParameter } from 'html-webpack-plugin';
+import webpackHtmlTemplate from './webpack-html-template';
+
+const buildTemplateParams = (css: string[], js: string[] = ['/app.123.js']) =>
+  ({
+    htmlWebpackPlugin: { files: { css, js } },
+  } as unknown as TemplateParameter);
+
+describe('webpackHtmlTemplate', () => {
+  describe('app CSS', () => {
+    it('should emit stylesheets as non-blocking preloads marked as app CSS', () => {
+      const html = webpackHtmlTemplate(buildTemplateParams(['/app.abc.css']));
+
+      expect(html).toContain(
+        '<link rel="preload" as="style" data-mc-css href="__CDN_URL__app.abc.css">'
+      );
+      // The blocking form must be gone, or first paint still waits on it.
+      expect(html).not.toContain("rel='stylesheet' type='text/css'");
+    });
+
+    it('should trim the leading slash so __CDN_URL__ concatenates correctly', () => {
+      const html = webpackHtmlTemplate(buildTemplateParams(['/app.abc.css']));
+
+      expect(html).toContain('href="__CDN_URL__app.abc.css"');
+      expect(html).not.toContain('href="__CDN_URL__/app.abc.css"');
+    });
+
+    it('should keep vendor CSS ahead of app CSS', () => {
+      const html = webpackHtmlTemplate(
+        buildTemplateParams(['/app.abc.css', '/vendor.def.css'])
+      );
+
+      expect(html.indexOf('vendor.def.css')).toBeLessThan(
+        html.indexOf('app.abc.css')
+      );
+    });
+
+    it('should mark every emitted stylesheet', () => {
+      const html = webpackHtmlTemplate(
+        buildTemplateParams(['/vendor.def.css', '/app.abc.css'])
+      );
+
+      expect(html.match(/data-mc-css/g)).toHaveLength(2);
+    });
+
+    it('should emit no css links when the build produced none', () => {
+      const html = webpackHtmlTemplate(buildTemplateParams([]));
+
+      expect(html).not.toContain('data-mc-css');
+    });
+  });
+
+  describe('links it must not affect', () => {
+    it('should leave the template font links exactly as authored', () => {
+      // The Vite path needs a bundle check to avoid this; here the CSS list is
+      // supplied directly, so template links are structurally untouchable.
+      const html = webpackHtmlTemplate(buildTemplateParams(['/app.abc.css']));
+      const interTag = html
+        .split('<link')
+        .find((tag) => tag.includes('family=Inter')) as string;
+
+      expect(interTag).toBeDefined();
+      expect(interTag).toContain('rel="stylesheet"');
+      expect(interTag).toContain('data-nimbus-fonts=""');
+      expect(interTag).not.toContain('data-mc-css');
+    });
+
+    it('should leave the noscript Open Sans fallback a real stylesheet', () => {
+      const html = webpackHtmlTemplate(buildTemplateParams(['/app.abc.css']));
+      const noscript = html.slice(
+        html.indexOf('<noscript>'),
+        html.indexOf('</noscript>')
+      );
+
+      expect(noscript).toContain('rel="stylesheet"');
+      expect(noscript).not.toContain('data-mc-css');
+    });
+  });
+
+  describe('scripts', () => {
+    it('should still emit deferred script tags', () => {
+      const html = webpackHtmlTemplate(
+        buildTemplateParams([], ['/app.123.js'])
+      );
+
+      expect(html).toContain(
+        '<script src="__CDN_URL__app.123.js" defer></script>'
+      );
+    });
+  });
+});

--- a/packages/mc-html-template/src/webpack-html-template.ts
+++ b/packages/mc-html-template/src/webpack-html-template.ts
@@ -25,9 +25,24 @@ function webpackHtmlTemplate(templateParams: TemplateParameter) {
       fileName.replace(/^\//, '')
   );
 
+  // Emitted as non-blocking preloads rather than stylesheets, so app CSS does
+  // not block first paint (and therefore does not block the loading skeleton).
+  // `html-scripts/loading-screen.js` upgrades each one to `rel="stylesheet"`
+  // once it has loaded, and gates `window.onAppLoaded()` on the `data-mc-css`
+  // ones so the application is never revealed unstyled.
+  //
+  // That upgrade lives in the inline loading-screen script rather than an
+  // `onload` handler attribute because the production CSP allows neither
+  // 'unsafe-inline' nor 'unsafe-hashes' in `script-src`, and CSP script hashes
+  // do not cover event-handler attributes.
+  //
+  // Unlike the Vite path -- which has to identify Vite's own injected tags
+  // inside already-assembled HTML -- this function knows exactly which chunks
+  // are CSS, so no matching is involved and no other link in the template can
+  // be affected.
   const cssImports = cssChunks.map(
     (chunkPath) =>
-      `<link href="__CDN_URL__${chunkPath}" rel='stylesheet' type='text/css'>`
+      `<link rel="preload" as="style" data-mc-css href="__CDN_URL__${chunkPath}">`
   );
   const scriptImports = scriptChunks.map(
     (chunkPath) => `<script src="__CDN_URL__${chunkPath}" defer></script>`

--- a/packages/mc-html-template/src/webpack-html-template.ts
+++ b/packages/mc-html-template/src/webpack-html-template.ts
@@ -25,21 +25,9 @@ function webpackHtmlTemplate(templateParams: TemplateParameter) {
       fileName.replace(/^\//, '')
   );
 
-  // Emitted as non-blocking preloads rather than stylesheets, so app CSS does
-  // not block first paint (and therefore does not block the loading skeleton).
-  // `html-scripts/loading-screen.js` upgrades each one to `rel="stylesheet"`
-  // once it has loaded, and gates `window.onAppLoaded()` on the `data-mc-css`
-  // ones so the application is never revealed unstyled.
-  //
-  // That upgrade lives in the inline loading-screen script rather than an
-  // `onload` handler attribute because the production CSP allows neither
-  // 'unsafe-inline' nor 'unsafe-hashes' in `script-src`, and CSP script hashes
-  // do not cover event-handler attributes.
-  //
-  // Unlike the Vite path -- which has to identify Vite's own injected tags
-  // inside already-assembled HTML -- this function knows exactly which chunks
-  // are CSS, so no matching is involved and no other link in the template can
-  // be affected.
+  // Non-blocking preloads rather than stylesheets, so app CSS doesn't block
+  // first paint. `loading-screen.js` upgrades each one to `rel="stylesheet"`
+  // once loaded and gates `window.onAppLoaded()` on the `data-mc-css` ones.
   const cssImports = cssChunks.map(
     (chunkPath) =>
       `<link rel="preload" as="style" data-mc-css href="__CDN_URL__${chunkPath}">`

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -13,6 +13,7 @@ import { loadNimbusVitePlugin } from '../utils/try-load-nimbus-plugins';
 import pluginChunkCycleCheck from '../vite-plugins/vite-plugin-chunk-cycle-check';
 import pluginDynamicBaseAssetsGlobals from '../vite-plugins/vite-plugin-dynamic-base-assets-globals';
 import pluginI18nMessageCompilation from '../vite-plugins/vite-plugin-i18n-message-compilation';
+import pluginNonBlockingCss from '../vite-plugins/vite-plugin-non-blocking-css';
 import pluginPostCleanup from '../vite-plugins/vite-plugin-post-cleanup';
 import pluginSvgr from '../vite-plugins/vite-plugin-svgr';
 
@@ -129,6 +130,10 @@ async function run() {
       }),
       pluginDynamicBaseAssetsGlobals(),
       pluginI18nMessageCompilation(),
+      // Rewrite Vite's render-blocking stylesheet links into preloads that
+      // `loading-screen.js` upgrades once loaded, so app CSS no longer blocks
+      // first paint. Must stay after Vite's own `vite:build-html`.
+      pluginNonBlockingCss(),
       // Fail the build if the emitted chunk graph contains circular imports.
       // Chunk cycles are silent at build time but crash at runtime with TDZ
       // errors (historical "aM is undefined" from the icons/app-shell split).

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.spec.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.spec.ts
@@ -166,7 +166,7 @@ describe('vite-plugin-non-blocking-css', () => {
         }
       );
 
-    it('should leave the Inter/Nimbus font link blocking and unmarked', () => {
+    it('should leave the Inter/Nimbus font link untouched and unmarked', () => {
       const result = transform(
         pluginNonBlockingCss(),
         buildRealTemplateHtml(),
@@ -180,7 +180,8 @@ describe('vite-plugin-non-blocking-css', () => {
         .find((tag) => tag.includes('family=Inter')) as string;
 
       expect(interTag).toBeDefined();
-      expect(interTag).toContain('rel="stylesheet"');
+      // Inter is a preload in the template now, but it is a FONT: the plugin
+      // must not claim it as app CSS or it would gate app reveal on Google.
       expect(interTag).toContain('data-nimbus-fonts=""');
       expect(interTag).not.toContain('data-mc-css');
     });

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.spec.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.spec.ts
@@ -1,20 +1,37 @@
 import type { Plugin } from 'vite';
+import {
+  generateTemplate,
+  replaceHtmlPlaceholders,
+} from '@commercetools-frontend/mc-html-template';
 import pluginNonBlockingCss from './vite-plugin-non-blocking-css';
 
 /**
  * Invokes the `transformIndexHtml` hook. The cast is needed because Vite types
  * the hook's `this` as PluginContext, which this implementation does not use,
  * and because only the two context fields below are relevant here.
+ *
+ * `emittedCss` stands in for the CSS assets Vite put in the output bundle; the
+ * plugin only rewrites links whose href matches one of them.
  */
-const transform = (plugin: Plugin, html: string, isBuild: boolean) => {
+const transform = (
+  plugin: Plugin,
+  html: string,
+  isBuild: boolean,
+  emittedCss: string[] = ['app-shell.css', 'index.css']
+) => {
   const hook = plugin.transformIndexHtml;
 
   if (typeof hook !== 'function') {
     throw new Error('transformIndexHtml is not a function');
   }
 
+  const bundle = emittedCss.reduce<Record<string, unknown>>(
+    (acc, fileName) => Object.assign(acc, { [fileName]: { fileName } }),
+    { 'index.js': { fileName: 'index.js' } }
+  );
+
   return (hook as (html: string, ctx: { bundle?: unknown }) => string)(html, {
-    bundle: isBuild ? {} : undefined,
+    bundle: isBuild ? bundle : undefined,
   });
 };
 
@@ -77,7 +94,8 @@ describe('vite-plugin-non-blocking-css', () => {
       const result = transform(
         pluginNonBlockingCss(),
         '<link rel="stylesheet" href="__CDN_URL__app-shell.a1b2c3.css">',
-        true
+        true,
+        ['app-shell.a1b2c3.css']
       );
 
       expect(result).toContain('href="__CDN_URL__app-shell.a1b2c3.css"');
@@ -119,6 +137,99 @@ describe('vite-plugin-non-blocking-css', () => {
         '<link rel="preconnect" href="https://fonts.googleapis.com">';
 
       expect(transform(pluginNonBlockingCss(), html, true)).toBe(html);
+    });
+  });
+
+  describe('links it must not touch: real template output', () => {
+    // The regression these tests exist for: the plugin used to rewrite every
+    // rel="stylesheet" tag in the document, which on a real build also hit the
+    // Inter/Nimbus font link and the <noscript> fallback. Both then wrongly
+    // gained data-mc-css and started gating app reveal on Google Fonts.
+    const buildRealTemplateHtml = () =>
+      replaceHtmlPlaceholders(
+        generateTemplate({
+          cssImports: ['<link rel="stylesheet" href="app-shell.css">'],
+        }),
+        {
+          env: {
+            applicationName: 'harness',
+            entryPointUriPath: 'harness',
+            cdnUrl: 'http://localhost:3001/',
+            env: 'test',
+            frontendHost: 'localhost:3001',
+            location: 'gcp-eu',
+            mcApiUrl: 'https://mc-api.example.com',
+            revision: '',
+            servedByProxy: false,
+          } as never,
+          headers: { 'Content-Security-Policy': "default-src 'none'" } as never,
+        }
+      );
+
+    it('should leave the Inter/Nimbus font link blocking and unmarked', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        buildRealTemplateHtml(),
+        true,
+        ['app-shell.css']
+      );
+      // Scoped to the Inter tag alone: a wider window would swallow the
+      // adjacent app stylesheet, which is legitimately marked.
+      const interTag = result
+        .split('<link')
+        .find((tag) => tag.includes('family=Inter')) as string;
+
+      expect(interTag).toBeDefined();
+      expect(interTag).toContain('rel="stylesheet"');
+      expect(interTag).toContain('data-nimbus-fonts=""');
+      expect(interTag).not.toContain('data-mc-css');
+    });
+
+    it('should leave the noscript Open Sans fallback a real stylesheet', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        buildRealTemplateHtml(),
+        true,
+        ['app-shell.css']
+      );
+      const noscript = result.slice(
+        result.indexOf('<noscript>'),
+        result.indexOf('</noscript>')
+      );
+
+      expect(noscript).toContain('rel="stylesheet"');
+      expect(noscript).not.toContain('data-mc-css');
+    });
+
+    it('should never mark a fonts.googleapis.com href as app CSS', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        buildRealTemplateHtml(),
+        true,
+        ['app-shell.css']
+      );
+
+      result
+        .split('<link')
+        .filter((tag) => tag.includes('data-mc-css'))
+        .forEach((tag) => expect(tag).not.toContain('fonts.googleapis.com'));
+    });
+
+    it('should still rewrite the emitted app stylesheet in the same document', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        buildRealTemplateHtml(),
+        true,
+        ['app-shell.css']
+      );
+
+      expect(result).toContain('as="style" data-mc-css');
+    });
+
+    it('should rewrite nothing when the bundle emitted no CSS', () => {
+      const html = '<link rel="stylesheet" href="app-shell.css">';
+
+      expect(transform(pluginNonBlockingCss(), html, true, [])).toBe(html);
     });
   });
 

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.spec.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.spec.ts
@@ -1,0 +1,132 @@
+import type { Plugin } from 'vite';
+import pluginNonBlockingCss from './vite-plugin-non-blocking-css';
+
+/**
+ * Invokes the `transformIndexHtml` hook. The cast is needed because Vite types
+ * the hook's `this` as PluginContext, which this implementation does not use,
+ * and because only the two context fields below are relevant here.
+ */
+const transform = (plugin: Plugin, html: string, isBuild: boolean) => {
+  const hook = plugin.transformIndexHtml;
+
+  if (typeof hook !== 'function') {
+    throw new Error('transformIndexHtml is not a function');
+  }
+
+  return (hook as (html: string, ctx: { bundle?: unknown }) => string)(html, {
+    bundle: isBuild ? {} : undefined,
+  });
+};
+
+describe('vite-plugin-non-blocking-css', () => {
+  describe('plugin structure', () => {
+    it('should be a build-only plugin with a transformIndexHtml hook', () => {
+      const plugin = pluginNonBlockingCss();
+
+      expect(plugin.name).toBe('vite-plugin-non-blocking-css');
+      expect(plugin.apply).toBe('build');
+      expect(plugin.transformIndexHtml).toBeDefined();
+    });
+
+    it('should not set `enforce`, so it runs after vite:build-html', () => {
+      // Vite injects the stylesheet tags during `generateBundle` and only then
+      // applies normal- and post-order hooks. `enforce: 'pre'` would run before
+      // the tags exist and this plugin would be a no-op.
+      expect(pluginNonBlockingCss().enforce).toBeUndefined();
+    });
+  });
+
+  describe('rewriting stylesheet links', () => {
+    it('should rewrite a stylesheet link into a marked preload', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        '<link rel="stylesheet" crossorigin href="app-shell.css">',
+        true
+      );
+
+      expect(result).toBe(
+        '<link rel="preload" as="style" data-mc-css crossorigin href="app-shell.css">'
+      );
+    });
+
+    it('should preserve the crossorigin attribute Vite emitted', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        '<link rel="stylesheet" crossorigin href="index.css">',
+        true
+      );
+
+      expect(result).toContain('crossorigin');
+    });
+
+    it('should rewrite every stylesheet link', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        '<link rel="stylesheet" href="app-shell.css">' +
+          '<link rel="stylesheet" href="index.css">',
+        true
+      );
+
+      expect(
+        result.match(/rel="preload" as="style" data-mc-css/g)
+      ).toHaveLength(2);
+      expect(result).not.toContain('rel="stylesheet"');
+    });
+
+    it('should preserve a __CDN_URL__-prefixed href', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        '<link rel="stylesheet" href="__CDN_URL__app-shell.a1b2c3.css">',
+        true
+      );
+
+      expect(result).toContain('href="__CDN_URL__app-shell.a1b2c3.css"');
+    });
+
+    it('should rewrite a link whose rel follows its href', () => {
+      const result = transform(
+        pluginNonBlockingCss(),
+        '<link href="app-shell.css" rel="stylesheet">',
+        true
+      );
+
+      expect(result).toBe(
+        '<link href="app-shell.css" rel="preload" as="style" data-mc-css>'
+      );
+    });
+  });
+
+  describe('links it must not touch', () => {
+    it('should leave rel="modulepreload" alone', () => {
+      // Vite emits these already, and FEC-1303 tunes them. Rewriting one into a
+      // stylesheet would break module loading.
+      const html = '<link rel="modulepreload" crossorigin href="chunk.js">';
+
+      expect(transform(pluginNonBlockingCss(), html, true)).toBe(html);
+    });
+
+    it('should leave rel="preload" as="fetch" alone', () => {
+      // FEC-1301's proxy prefetch hints share this document.
+      const html =
+        '<link rel="preload" href="/__prefetch/user" as="fetch" crossorigin>';
+
+      expect(transform(pluginNonBlockingCss(), html, true)).toBe(html);
+    });
+
+    it('should leave icon and preconnect links alone', () => {
+      const html =
+        '<link rel="shortcut icon" type="image/png" href="favicon.png">' +
+        '<link rel="preconnect" href="https://fonts.googleapis.com">';
+
+      expect(transform(pluginNonBlockingCss(), html, true)).toBe(html);
+    });
+  });
+
+  describe('dev server', () => {
+    it('should return the html unmodified when there is no bundle', () => {
+      const html = '<link rel="stylesheet" href="app-shell.css">';
+
+      expect(transform(pluginNonBlockingCss(), html, false)).toBe(html);
+    });
+  });
+});

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.ts
@@ -1,16 +1,22 @@
 import type { Plugin } from 'vite';
 
 /**
- * Matches the stylesheet `<link>` tags Vite injects into the built HTML.
+ * Matches any stylesheet `<link>` tag. This is only a candidate filter -- which
+ * candidates are actually rewritten is decided by matching the tag's `href`
+ * against the CSS assets Vite really emitted (see `transformIndexHtml`).
  *
- * Deliberately narrow:
- * - only `rel="stylesheet"`, so `rel="modulepreload"` (which Vite also emits)
- *   and `rel="icon"` / `rel="preconnect"` are left alone
- * - the `rel` may appear before or after `href`, since tag attribute order is
- *   not part of Vite's contract
+ * That second check is load-bearing, not defensive. The built HTML also carries
+ * stylesheet links this plugin must never touch:
+ * - the Inter/Nimbus font link, which NimbusProvider renders identically and
+ *   React 19 dedupes by matching `link[rel="stylesheet"][href]`; rewriting it
+ *   makes Nimbus inject its own blocking stylesheet at mount instead
+ * - the `<noscript>` Open Sans fallback, which is inert as a preload
+ * Both would also wrongly gain `data-mc-css` and start gating app reveal on a
+ * third-party request.
  */
 const STYLESHEET_LINK_RE = /<link\b[^>]*\brel="stylesheet"[^>]*>/g;
 const REL_STYLESHEET_RE = /\brel="stylesheet"/;
+const HREF_RE = /\bhref="([^"]*)"/;
 
 /**
  * Rewrites Vite's render-blocking stylesheet `<link>` tags into non-blocking
@@ -41,9 +47,33 @@ function pluginNonBlockingCss(): Plugin {
         return html;
       }
 
-      return html.replace(STYLESHEET_LINK_RE, (tag) =>
-        tag.replace(REL_STYLESHEET_RE, 'rel="preload" as="style" data-mc-css')
+      // Only rewrite links pointing at CSS this build actually emitted. Anything
+      // else in the template -- fonts, the noscript fallback, icons -- is left
+      // exactly as authored.
+      const emittedCssFileNames = Object.keys(ctx.bundle).filter((fileName) =>
+        fileName.endsWith('.css')
       );
+
+      if (emittedCssFileNames.length === 0) {
+        return html;
+      }
+
+      return html.replace(STYLESHEET_LINK_RE, (tag) => {
+        const href = HREF_RE.exec(tag)?.[1];
+
+        // `endsWith` rather than equality: hrefs may carry the `__CDN_URL__`
+        // placeholder prefix from `experimental.renderBuiltUrl`.
+        const isEmittedCss = href
+          ? emittedCssFileNames.some((fileName) => href.endsWith(fileName))
+          : false;
+
+        return isEmittedCss
+          ? tag.replace(
+              REL_STYLESHEET_RE,
+              'rel="preload" as="style" data-mc-css'
+            )
+          : tag;
+      });
     },
   };
 }

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.ts
@@ -1,0 +1,51 @@
+import type { Plugin } from 'vite';
+
+/**
+ * Matches the stylesheet `<link>` tags Vite injects into the built HTML.
+ *
+ * Deliberately narrow:
+ * - only `rel="stylesheet"`, so `rel="modulepreload"` (which Vite also emits)
+ *   and `rel="icon"` / `rel="preconnect"` are left alone
+ * - the `rel` may appear before or after `href`, since tag attribute order is
+ *   not part of Vite's contract
+ */
+const STYLESHEET_LINK_RE = /<link\b[^>]*\brel="stylesheet"[^>]*>/g;
+const REL_STYLESHEET_RE = /\brel="stylesheet"/;
+
+/**
+ * Rewrites Vite's render-blocking stylesheet `<link>` tags into non-blocking
+ * preloads, marked with `data-mc-css`.
+ *
+ * `html-scripts/loading-screen.js` in `@commercetools-frontend/mc-html-template`
+ * upgrades them back to `rel="stylesheet"` once they have loaded, and gates
+ * `window.onAppLoaded()` on the `data-mc-css` ones so the app is never revealed
+ * unstyled. The upgrade lives in that inline script rather than in an
+ * `onload` handler attribute because the production CSP allows neither
+ * `'unsafe-inline'` nor `'unsafe-hashes'` in `script-src`, and script hashes do
+ * not cover event-handler attributes.
+ *
+ * NOTE: this only affects the Vite build. The default webpack build emits its
+ * CSS links from `mc-html-template`'s `webpack-html-template.ts` and is
+ * unchanged (see FEC-1298's follow-up work).
+ */
+function pluginNonBlockingCss(): Plugin {
+  return {
+    name: 'vite-plugin-non-blocking-css',
+    apply: 'build',
+    // No `enforce`: this must run after Vite's own `vite:build-html`, which
+    // injects the stylesheet tags during `generateBundle` and only then applies
+    // the normal- and post-order `transformIndexHtml` hooks.
+    transformIndexHtml(html, ctx) {
+      // `ctx.bundle` is only set for the build, not the dev server.
+      if (!ctx.bundle) {
+        return html;
+      }
+
+      return html.replace(STYLESHEET_LINK_RE, (tag) =>
+        tag.replace(REL_STYLESHEET_RE, 'rel="preload" as="style" data-mc-css')
+      );
+    },
+  };
+}
+
+export default pluginNonBlockingCss;

--- a/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.ts
+++ b/packages/mc-scripts/src/vite-plugins/vite-plugin-non-blocking-css.ts
@@ -1,38 +1,21 @@
 import type { Plugin } from 'vite';
 
 /**
- * Matches any stylesheet `<link>` tag. This is only a candidate filter -- which
- * candidates are actually rewritten is decided by matching the tag's `href`
- * against the CSS assets Vite really emitted (see `transformIndexHtml`).
- *
- * That second check is load-bearing, not defensive. The built HTML also carries
- * stylesheet links this plugin must never touch:
- * - the Inter/Nimbus font link, which NimbusProvider renders identically and
- *   React 19 dedupes by matching `link[rel="stylesheet"][href]`; rewriting it
- *   makes Nimbus inject its own blocking stylesheet at mount instead
- * - the `<noscript>` Open Sans fallback, which is inert as a preload
- * Both would also wrongly gain `data-mc-css` and start gating app reveal on a
- * third-party request.
+ * Only a candidate filter: which links are actually rewritten is decided by
+ * matching `href` against the CSS assets Vite really emitted (see
+ * `transformIndexHtml`). That check matters, because the built HTML also
+ * carries stylesheet links this plugin must never touch -- the Inter/Nimbus
+ * font link and the `<noscript>` Open Sans fallback -- which would otherwise
+ * gain `data-mc-css` and start gating app reveal on a third-party request.
  */
 const STYLESHEET_LINK_RE = /<link\b[^>]*\brel="stylesheet"[^>]*>/g;
 const REL_STYLESHEET_RE = /\brel="stylesheet"/;
 const HREF_RE = /\bhref="([^"]*)"/;
 
 /**
- * Rewrites Vite's render-blocking stylesheet `<link>` tags into non-blocking
- * preloads, marked with `data-mc-css`.
- *
- * `html-scripts/loading-screen.js` in `@commercetools-frontend/mc-html-template`
- * upgrades them back to `rel="stylesheet"` once they have loaded, and gates
- * `window.onAppLoaded()` on the `data-mc-css` ones so the app is never revealed
- * unstyled. The upgrade lives in that inline script rather than in an
- * `onload` handler attribute because the production CSP allows neither
- * `'unsafe-inline'` nor `'unsafe-hashes'` in `script-src`, and script hashes do
- * not cover event-handler attributes.
- *
- * NOTE: this only affects the Vite build. The default webpack build emits its
- * CSS links from `mc-html-template`'s `webpack-html-template.ts` and is
- * unchanged (see FEC-1298's follow-up work).
+ * Rewrites Vite's render-blocking stylesheet links into preloads marked
+ * `data-mc-css`. `loading-screen.js` upgrades them back once loaded and gates
+ * `window.onAppLoaded()` on them so the app is never revealed unstyled.
  */
 function pluginNonBlockingCss(): Plugin {
   return {

--- a/playground/src/components/custom-views/demo-custom-view.jsx
+++ b/playground/src/components/custom-views/demo-custom-view.jsx
@@ -100,7 +100,10 @@ function DemoCustomView() {
     window.app.customViewId = CUSTOM_VIEW_ID;
     window.app.__DEVELOPMENT__.customViewConfig = DEMO_CUSTOM_VIEW;
     window.app.__DEVELOPMENT__.customViewHostUrl = window.location.href;
-    document.querySelector('.loading-screen').remove();
+    // Remove the whole #app-loader, not just .loading-screen: since FEC-1298
+    // the loader also contains a 100vh authenticated skeleton sibling, so
+    // removing only .loading-screen would leave this view pushed below the fold.
+    window.onAppLoaded();
     setIsLoading(false);
   }, []);
 

--- a/playground/src/components/custom-views/demo-custom-view.jsx
+++ b/playground/src/components/custom-views/demo-custom-view.jsx
@@ -100,9 +100,9 @@ function DemoCustomView() {
     window.app.customViewId = CUSTOM_VIEW_ID;
     window.app.__DEVELOPMENT__.customViewConfig = DEMO_CUSTOM_VIEW;
     window.app.__DEVELOPMENT__.customViewHostUrl = window.location.href;
-    // Remove the whole #app-loader, not just .loading-screen: since FEC-1298
-    // the loader also contains a 100vh authenticated skeleton sibling, so
-    // removing only .loading-screen would leave this view pushed below the fold.
+    // Removes the whole #app-loader: it also contains a 100vh skeleton
+    // sibling now, so removing only .loading-screen would leave this view
+    // pushed below the fold.
     window.onAppLoaded();
     setIsLoading(false);
   }, []);

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -19,7 +19,20 @@ module.exports = {
       true,
       { ignoreProperties: ['composes'] },
     ],
-    'property-no-unknown': [true, { ignoreProperties: ['composes'] }],
+    // stylelint 14.16.1 predates the View Transitions API, so `@view-transition`,
+    // its `navigation` descriptor and the `::view-transition-*` pseudo-elements
+    // are all unknown to it. See packages/mc-html-template/html-styles/loading-screen.css.
+    'at-rule-no-unknown': [true, { ignoreAtRules: ['view-transition'] }],
+    'property-no-unknown': [
+      true,
+      { ignoreProperties: ['composes', 'navigation'] },
+    ],
+    'selector-pseudo-element-no-unknown': [
+      true,
+      {
+        ignorePseudoElements: ['view-transition-old', 'view-transition-new'],
+      },
+    ],
     'declaration-colon-newline-after': null,
     'rule-empty-line-before': null,
     'value-list-comma-newline-after': null,


### PR DESCRIPTION
#### Summary

Merchant Center apps show a spinner on a blank page while React boots — around 900ms warm, a few seconds cold. This replaces that with a skeleton of the real app chrome (header, dark sidebar, content area) drawn straight from the HTML document, so something structural is on screen almost immediately.

It also makes both webfonts and the app's own CSS non-blocking, and opts the document in to cross-document view transitions so moving between MC apps crossfades instead of flashing white.

Jira: [FEC-1298](https://commercetools.atlassian.net/browse/FEC-1298) · Plan: [`perceived-loading-performance/plan.md` §B](https://github.com/commercetools/mc-foundation-planning/blob/main/perceived-loading-performance/plan.md#b-html-skeleton--non-blocking-resources--view-transitions)

#### Description

**Why the CSS handling looks unusual.** The ticket suggested the usual `onload="this.rel='stylesheet'"` preload trick. That cannot work here: production `script-src` is `'self'` plus hashes of three known inline scripts, and CSP hashes do not cover inline event-handler attributes — the preloads would never upgrade and the app would render completely unstyled, which local dev would not show you because dev gets `'unsafe-inline'`. So the upgrade happens inside `loading-screen.js` instead, whose hash `process-headers.ts` derives from the file itself. No security header changes.

**The skeleton is gated on three things** so it does not fight what React renders a moment later: a cached session (`localStorage.isAuthenticated`), the route (`/login`, `/logout` and `/account` render no navbar; Custom Views get the old spinner), and viewport width (a pinned-open menu collapses at ≤1200px, matching `useNavbarStateManager`). Sizes and colours come from the same constants the real chrome uses.

**On the fonts.** Both Open Sans and Inter are now preloads with `<noscript>` fallbacks. Inter needed care because `NimbusProvider` renders a byte-identical stylesheet and React 19 dedupes by matching `link[rel="stylesheet"][href]`, which a preload does not match — so `data-nimbus-fonts` is kept on the link as the marker Nimbus uses to recognise a host-owned font, and hosts that mount the provider themselves should pass `loadFonts={false}`. Leaving it on the default turns out to be harmless: the URL is identical, so the extra link resolves from the already-warm preload (`transferSize` 0, no second request) and first paint is not blocked either way. `application-shell` needed no change — its only provider already passes `loadFonts={false}`.

The knock-on effect is the bigger win. `loading-screen.js` is a parser-inserted classic script, so it was deferred behind Inter's blocking stylesheet before the skeleton could even be revealed. With both fonts non-blocking that deferral is gone: with **both Google Fonts requests aborted outright**, the skeleton still paints and `mc:skeleton-visible` fires at **11ms**.

**One thing from the ticket is deliberately not implemented.** `view-transition-name` is omitted, because a name has to exist on both the outgoing and incoming document to morph an element, and the skeleton is long gone by the time anyone navigates. Naming the React chrome alongside the skeleton is scoped to ticket C.

Both bundler paths get non-blocking app CSS: MC's own applications through the Vite plugin, starter templates and customer-built Custom Applications through `webpack-html-template.ts`.

#### Two acceptance criteria this does not meet

Flagging these so the ticket is not closed as fully accepted:

- **AC3's timing budget** — the mechanism is there (the skeleton mark fires at 11ms locally, even with fonts blocked), but AC3 asks for a p50 across runs on the integration environment and there is no performance harness in the repo yet to produce that.
- **AC5** — `useFullRedirectsForLinks` is `true` in `merchant-center-frontend`, and `menu-items.tsx:305` implements it as `location.replace()`. Programmatic navigation does not trigger a view transition, so the rule is inert until that override is retired.

AC4 (both fonts and the app CSS non-render-blocking) is met on both bundler paths.

#### Worth knowing if you consume these packages

- **`window.onAppLoaded()` is no longer always synchronous.** While the app's own stylesheets are still loading it defers removing the loader, bounded by a 2s deadline after which the app is revealed regardless. It used to remove unconditionally.
- **`data-mc-css`** is a new build-time marker emitted by `mc-scripts` and read by `mc-html-template`. The repo versions them in lockstep; keep them aligned if you pin independently.
- **`__LOADING_SCREEN_CSS__` moved into `<head>`.** This is required, not tidying: `onAppLoaded()` removes `#app-loader`, and the `@view-transition` opt-in has to still be in the document when the user navigates or the transition silently never fires.
- **Performance marks.** Only `mc:skeleton-visible` is emitted here, since the skeleton is the only thing that knows when it became visible; the rest of the `mc:*` set belongs in `application-shell`. Its measure is named `mc:skeleton-visible:duration` so `getEntriesByName('mc:skeleton-visible')` returns one entry rather than two of different `entryType`. The mark fires on the reveal call, not a confirmed paint.

#### Follow-ups

- Retire `useFullRedirectsForLinks` so view transitions actually fire in production
- Optionally pass `loadFonts={false}` at the `NimbusProvider` mounts in the app repos, to drop the now-redundant second Inter link
- `view-transition-name` on the real `NavBar`/`AppBar` for genuine chrome persistence
- Re-measure once a performance harness exists; this ships unattributed otherwise
- Fix the upstream plan doc (wrong dimensions, the CSP-invalid snippet, font URLs that do not exist, and a first-ever-visitor savings row the auth gate makes impossible)

#### Notes for reviewers

- **Expect a Chromatic diff.** `demo-custom-view.jsx` is one of the snapshot-gated playground views. Its `.loading-screen` removal stopped collapsing the loader once a 100vh skeleton sibling existed, hence the one-line change to `window.onAppLoaded()`.
- **The content area is intentionally empty**, per the ticket. On warm cache that means a motionless screen from ~100ms until React chrome arrives. Worth a look at whether it reads as loading or as broken.
- `stylelint.config.js` is relaxed for `@view-transition` and friends because stylelint is pinned at 14.16.1, which predates the API.
- This is the loading screen's first test coverage — there was none before.


[FEC-1298]: https://commercetools.atlassian.net/browse/FEC-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ