### PR TITLE
[FEC-1297(Part 1)]: add 'ANALYZE_BUNDLE_OUTPUT' JSON output

### DIFF
--- a/.changeset/olive-shrimps-win.md
+++ b/.changeset/olive-shrimps-win.md
@@ -5,7 +5,3 @@
 Add `ANALYZE_BUNDLE_OUTPUT=<path>` to write the bundle analysis to a JSON file
 instead of opening the browser report. Setting it implies `ANALYZE_BUNDLE=true`,
 so it can be used on its own. Leaving it unset keeps the existing behaviour.
-
-Bundle sizes on the Vite build path are now reported as gzip rather than stat,
-matching the webpack path, so figures are comparable across both. Numbers from
-earlier `bundles:analyze` runs will not line up with new ones.

--- a/.changeset/olive-shrimps-win.md
+++ b/.changeset/olive-shrimps-win.md
@@ -1,0 +1,11 @@
+---
+'@commercetools-frontend/mc-scripts': minor
+---
+
+Add `ANALYZE_BUNDLE_OUTPUT=<path>` to write the bundle analysis to a JSON file
+instead of opening the browser report. Setting it implies `ANALYZE_BUNDLE=true`,
+so it can be used on its own. Leaving it unset keeps the existing behaviour.
+
+Bundle sizes on the Vite build path are now reported as gzip rather than stat,
+matching the webpack path, so figures are comparable across both. Numbers from
+earlier `bundles:analyze` runs will not line up with new ones.

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -143,10 +143,10 @@ async function run() {
           analyzeOutput
             ? {
                 analyzerMode: 'json',
-                defaultSizes: 'gzip',
+                defaultSizes: 'stat',
                 fileName: analyzeOutput,
               }
-            : { defaultSizes: 'gzip', openAnalyzer: true }
+            : { defaultSizes: 'stat', openAnalyzer: true }
         ),
       process.env.ANALYZE_BUNDLE_TREE === 'true' &&
         (visualizer({ open: true, template: 'network' }) as PluginOption),

--- a/packages/mc-scripts/src/commands/build-vite.ts
+++ b/packages/mc-scripts/src/commands/build-vite.ts
@@ -19,6 +19,10 @@ import pluginSvgr from '../vite-plugins/vite-plugin-svgr';
 async function run() {
   const DEFAULT_PORT = parseInt(String(process.env.HTTP_PORT), 10) || 3001;
 
+  const analyzeOutput = process.env.ANALYZE_BUNDLE_OUTPUT;
+  const shouldAnalyze =
+    process.env.ANALYZE_BUNDLE === 'true' || Boolean(analyzeOutput);
+
   // Ensure the `/public` folder exists.
   fs.mkdirSync(paths.appBuild, { recursive: true });
 
@@ -133,8 +137,17 @@ async function run() {
       // Chunk cycles are silent at build time but crash at runtime with TDZ
       // errors (historical "aM is undefined" from the icons/app-shell split).
       pluginChunkCycleCheck(),
-      process.env.ANALYZE_BUNDLE === 'true' &&
-        analyzer({ defaultSizes: 'stat', openAnalyzer: true }),
+
+      shouldAnalyze &&
+        analyzer(
+          analyzeOutput
+            ? {
+                analyzerMode: 'json',
+                defaultSizes: 'gzip',
+                fileName: analyzeOutput,
+              }
+            : { defaultSizes: 'gzip', openAnalyzer: true }
+        ),
       process.env.ANALYZE_BUNDLE_TREE === 'true' &&
         (visualizer({ open: true, template: 'network' }) as PluginOption),
     ],


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Adds `ANALYZE_BUNDLE_OUTPUT=<path>` to `mc-scripts build`, writing the bundle analysis to a JSON file instead of opening the browser report. Groundwork for [`FEC-1297`](https://commercetools.atlassian.net/browse/FEC-1297), which needs machine-readable bundle size baselines.

Purely additive. With the variable unset, behaviour is byte-identical to before.

<details>
<summary>Agent context</summary>

**Why**

FEC-1297 establishes loading-performance baselines before optimization work
begins. One acceptance criterion is a recorded bundle size baseline for
critical-path chunks. `bundles:analyze` only opens an interactive browser
report, so there was nothing to commit or diff in CI.

**Change**

`packages/mc-scripts/src/commands/build-vite.ts`. Two `const`s hoisted to the
top of `run()`, and the analyzer plugin entry branches on them.

| Env | Result |
| --- | --- |
| `ANALYZE_BUNDLE=true` | Browser report, unchanged |
| `ANALYZE_BUNDLE_OUTPUT=<path>` | JSON written to `<path>`, no browser |
| Both | JSON wins, no browser |
| Neither | Analyzer skipped |

`ANALYZE_BUNDLE_OUTPUT` implies `ANALYZE_BUNDLE=true` so callers need only one
variable. `ANALYZE_BUNDLE_TREE` / `visualizer` is untouched.

**API notes**

`vite-bundle-analyzer@0.23.0` types `AnalyzerPluginOptions` as a discriminated
union. The `'json'` variant accepts `fileName` and has **no `openAnalyzer`**, so
the two option objects are built inside their own branches rather than spread
from a shared base. Note `fileName` also accepts
`(outputDir: string) => string`.

**Size metric is deliberately unchanged**

`defaultSizes` stays `'stat'` on both branches, so nothing about existing
reports moves. It also does not need deciding: every `Module` in the JSON
carries `parsedSize`, `gzipSize`, and `brotliSize` simultaneously, and
`defaultSizes` only picks which one the report leads with. (This plugin has no
`statSize`; `'stat'` maps to `parsedSize`, i.e. minified but uncompressed.)

**Existing bundle-size monitoring is unaffected**

`merchant-center-frontend/scripts/bundle-size/measure-lib.js` walks each app's
`public/` folder, skips `.map` files, and sums raw `stat()` sizes. It never
reads analyzer output, and neither the `measure_bundle_sizes` nor
`bundle_size_report` CircleCI job sets `ANALYZE_BUNDLE`, so this change cannot
reach that number. What it adds is per-chunk granularity, which that script
cannot provide since it reports one total per app.

**Why Vite only**

Every Merchant Center application sets `ENABLE_EXPERIMENTAL_VITE_BUNDLER="true"`
in its committed `.env.local`, and `mc-scripts/src/cli.ts:99` dispatches to
`build-vite` on that flag, so the webpack config is never reached. Left
untouched deliberately, since we are moving off webpack.

**Local testing caveat**

The playground cannot verify this from source. Both dynamic command imports in
`cli.ts:99-100` fail to resolve (`Cannot find module './commands/build-vite'`).
This predates the branch and affects the webpack branch identically, so a
preview release against a real application is the only end-to-end path.

</details>

#### Manual testing

Requires a preview release of this branch, since `merchant-center-frontend` consumes `mc-scripts` from npm.

New behaviour, from an application directory:

```
ANALYZE_BUNDLE_OUTPUT=bundle-stats.json pnpm build
```

Expect JSON at that path and no browser. Each module in it should carry `parsedSize`, `gzipSize`, and `brotliSize`.

Regression check that the existing path still works:

```
ANALYZE_BUNDLE=true pnpm build
```

Expect the browser report to open exactly as before.