### PR TITLE
[FEC-1297(Part 2)] emit performance marks for mc loading

### DIFF
--- a/.changeset/brave-otters-measure.md
+++ b/.changeset/brave-otters-measure.md
@@ -1,0 +1,18 @@
+---
+'@commercetools-frontend/application-shell': minor
+---
+
+Emit canonical `mc:*` performance marks for the application loading sequence, and export
+`PERFORMANCE_MARKS` along with the `TPerformanceMark` type so consumers can read the mark names
+rather than hardcoding them.
+
+Five marks are emitted: `mc:shell-chrome-mounted`, `mc:intl-ready`, `mc:content-rendered`,
+`mc:hydration-user`, and `mc:hydration-project`. Each also produces a `<name>:from-nav` measure
+from the navigation origin. `mc:skeleton-visible` is listed in `PERFORMANCE_MARKS` as the canonical
+name but is emitted separately from `mc-html-template`, because that file is untranspiled ES5 with
+no module system.
+
+Marks are recorded only once per name, and the first write wins. This matters because the shell
+subtree mounts twice on a cold load: the Suspense fallback for the lazily loaded splitter renders
+the same children, so a naive mount effect would record chunk-load latency instead of when the
+chrome actually appeared.

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -28,7 +28,7 @@ import {
 } from '@commercetools-frontend/sentry';
 import { DIMENSIONS, NAVBAR } from '../../constants';
 import { TFetchLoggedInUserQuery } from '../../types/generated/mc';
-import { getPreviousProjectKey } from '../../utils';
+import { getPreviousProjectKey, PERFORMANCE_MARKS } from '../../utils';
 import AppBar from '../app-bar';
 import ApplicationLoader from '../application-loader';
 import { getBrowserLocale } from '../application-shell-provider/utils';
@@ -38,6 +38,7 @@ import ErrorApologizer from '../error-apologizer';
 import FetchProject from '../fetch-project';
 import FetchUser from '../fetch-user';
 import NavBar from '../navbar';
+import PerformanceMark from '../performance-mark';
 import ProjectContainer from '../project-container';
 import RedirectToLogout from '../redirect-to-logout';
 import RedirectToProjectCreate from '../redirect-to-project-create';
@@ -213,6 +214,9 @@ export const ApplicationShellAuthenticated = (
                   // is not loaded.
                   {...(isLoadingLocaleData ? {} : { locale, messages })}
                 >
+                  {/* Not inside `ConfigureIntlProvider`, which also renders on
+                  unauthenticated, Custom View and error surfaces. */}
+                  <PerformanceMark mark={PERFORMANCE_MARKS.INTL_READY} />
                   <SetupFlopFlipProvider
                     user={normalizedUser}
                     projectKey={projectKeyFromUrl}
@@ -221,6 +225,9 @@ export const ApplicationShellAuthenticated = (
                     defaultFlags={props.defaultFeatureFlags}
                   >
                     <ApplicationShellSplitter locale={locale ?? 'en'}>
+                      <PerformanceMark
+                        mark={PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED}
+                      />
                       <ThemeSwitcher />
                       {/* NOTE: the requests in flight loader will render a loading
                       spinner into the AppBar. */}
@@ -318,6 +325,9 @@ export const ApplicationShellAuthenticated = (
                           </MainContainer>
                         ) : (
                           <MainContainer role="main">
+                            <PerformanceMark
+                              mark={PERFORMANCE_MARKS.CONTENT_RENDERED}
+                            />
                             <div ref={notificationsPageRef}>
                               <NotificationsList domain={DOMAINS.PAGE} />
                             </div>

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -45,16 +45,6 @@ jest.mock('../application-shell-provider/utils', () => ({
   getBrowserHistory: jest.fn(),
 }));
 
-// The test environment's `performance` has no `mark`/`measure`, so `markOnce`
-// would bail on its availability guard and emit nothing. These are added rather
-// than replacing the global so `performance.now` (used by React's scheduler)
-// keeps working.
-//
-// Names accumulate in a plain array at module scope, deliberately never
-// cleared. `markOnce` dedupes on a module-scoped `Set` that lives for the whole
-// test file, so only the first shell render in this file emits anything. An
-// array that outlives `beforeEach` makes the assertion independent of which
-// test happens to render first.
 const emittedPerformanceMarks = [];
 Object.defineProperty(globalThis.performance, 'mark', {
   configurable: true,
@@ -147,9 +137,7 @@ const renderApp = (ui, options = {}) => {
   const getByLeftNavigation = () => screen.getByTestId('left-navigation');
   const waitForLeftNavigationToBeLoaded = async () => {
     await findByLeftNavigation();
-    // Wait for the loading navbar to disappear. Instead of using `waitForElementToBeRemoved`,
-    // which seems not stable enough, we wait to find the "navigation" role, which is present
-    // when the navbar is loaded.
+
     await screen.findByRole('navigation');
   };
 
@@ -1557,19 +1545,6 @@ describe('when user is not ct staff', () => {
 });
 
 describe('FEC-1297 loading performance marks', () => {
-  // Guards the wiring in `application-shell-authenticated.tsx`. The mark
-  // utility and the `<PerformanceMark />` component have their own unit specs,
-  // but nothing else asserts that the shell actually places them, so a refactor
-  // that dropped or relocated one would silently stop the metric.
-  //
-  // Asserted in one test on purpose. Split across two, the second would only
-  // read `emittedPerformanceMarks` and would pass on an empty array whenever
-  // this one was filtered out with `-t`, proving nothing.
-  //
-  // The duplicate-count check below is a thin guard: `markOnce` makes duplicate
-  // emission impossible from inside this package, and its own spec covers that
-  // directly. It exists to catch a future caller that bypasses `markOnce` and
-  // calls `performance.mark` in the shell itself.
   it('emits every shell-owned mc:* mark exactly once during an authenticated load', async () => {
     const { waitForLeftNavigationToBeLoaded } = renderApp();
     await waitForLeftNavigationToBeLoaded();

--- a/packages/application-shell/src/components/application-shell/application-shell.spec.js
+++ b/packages/application-shell/src/components/application-shell/application-shell.spec.js
@@ -45,6 +45,30 @@ jest.mock('../application-shell-provider/utils', () => ({
   getBrowserHistory: jest.fn(),
 }));
 
+// The test environment's `performance` has no `mark`/`measure`, so `markOnce`
+// would bail on its availability guard and emit nothing. These are added rather
+// than replacing the global so `performance.now` (used by React's scheduler)
+// keeps working.
+//
+// Names accumulate in a plain array at module scope, deliberately never
+// cleared. `markOnce` dedupes on a module-scoped `Set` that lives for the whole
+// test file, so only the first shell render in this file emits anything. An
+// array that outlives `beforeEach` makes the assertion independent of which
+// test happens to render first.
+const emittedPerformanceMarks = [];
+Object.defineProperty(globalThis.performance, 'mark', {
+  configurable: true,
+  writable: true,
+  value: (name) => {
+    emittedPerformanceMarks.push(name);
+  },
+});
+Object.defineProperty(globalThis.performance, 'measure', {
+  configurable: true,
+  writable: true,
+  value: () => {},
+});
+
 const createTestProps = (props) => ({
   environment: {
     applicationName: 'my-app',
@@ -1529,5 +1553,47 @@ describe('when user is not ct staff', () => {
         STORAGE_KEYS.ACTIVE_USER_LANGUAGE
       );
     });
+  });
+});
+
+describe('FEC-1297 loading performance marks', () => {
+  // Guards the wiring in `application-shell-authenticated.tsx`. The mark
+  // utility and the `<PerformanceMark />` component have their own unit specs,
+  // but nothing else asserts that the shell actually places them, so a refactor
+  // that dropped or relocated one would silently stop the metric.
+  //
+  // Asserted in one test on purpose. Split across two, the second would only
+  // read `emittedPerformanceMarks` and would pass on an empty array whenever
+  // this one was filtered out with `-t`, proving nothing.
+  //
+  // The duplicate-count check below is a thin guard: `markOnce` makes duplicate
+  // emission impossible from inside this package, and its own spec covers that
+  // directly. It exists to catch a future caller that bypasses `markOnce` and
+  // calls `performance.mark` in the shell itself.
+  it('emits every shell-owned mc:* mark exactly once during an authenticated load', async () => {
+    const { waitForLeftNavigationToBeLoaded } = renderApp();
+    await waitForLeftNavigationToBeLoaded();
+
+    // `mc:skeleton-visible` is deliberately absent: FEC-1298 emits it from
+    // `mc-html-template`'s inline loading-screen script, not from this package.
+    expect(emittedPerformanceMarks).toEqual(
+      expect.arrayContaining([
+        'mc:intl-ready',
+        'mc:shell-chrome-mounted',
+        'mc:hydration-user',
+        'mc:hydration-project',
+        'mc:content-rendered',
+      ])
+    );
+    expect(emittedPerformanceMarks).not.toContain('mc:skeleton-visible');
+
+    const counts = emittedPerformanceMarks.reduce(
+      (acc, name) => ({ ...acc, [name]: (acc[name] ?? 0) + 1 }),
+      {}
+    );
+    const duplicated = Object.entries(counts).filter(([, count]) => count > 1);
+
+    // Names the offenders on failure, rather than just reporting a count.
+    expect(duplicated).toEqual([]);
   });
 });

--- a/packages/application-shell/src/components/fetch-project/fetch-project.tsx
+++ b/packages/application-shell/src/components/fetch-project/fetch-project.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import type { ApolloError } from '@apollo/client/errors';
 import { useMcQuery } from '@commercetools-frontend/application-shell-connectors';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
@@ -6,6 +6,7 @@ import type {
   TFetchProjectQuery,
   TFetchProjectQueryVariables,
 } from '../../types/generated/mc';
+import { markOnce, PERFORMANCE_MARKS } from '../../utils';
 import ProjectQuery from './fetch-project.mc.graphql';
 
 type RenderFnArgs = {
@@ -33,6 +34,13 @@ const FetchProject = (props: TFetchProjectProps) => {
     },
     skip: props.skip === true,
   });
+
+  useEffect(() => {
+    if (!loading && data?.project) {
+      markOnce(PERFORMANCE_MARKS.HYDRATION_PROJECT);
+    }
+  }, [loading, data?.project]);
+
   return (
     <>
       {props.children({

--- a/packages/application-shell/src/components/fetch-user/fetch-user.tsx
+++ b/packages/application-shell/src/components/fetch-user/fetch-user.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import type { ApolloError } from '@apollo/client/errors';
 import { useMcQuery } from '@commercetools-frontend/application-shell-connectors';
 import { GRAPHQL_TARGETS } from '@commercetools-frontend/constants';
@@ -6,6 +6,7 @@ import type {
   TFetchLoggedInUserQuery,
   TFetchLoggedInUserQueryVariables,
 } from '../../types/generated/mc';
+import { markOnce, PERFORMANCE_MARKS } from '../../utils';
 import LoggedInUserQuery from './fetch-user.mc.graphql';
 
 type RenderFnArgs = {
@@ -27,6 +28,13 @@ const FetchUser = (props: TFetchUserProps) => {
       enableSentryErrorReporting: true,
     },
   });
+
+  useEffect(() => {
+    if (!loading && data?.user) {
+      markOnce(PERFORMANCE_MARKS.HYDRATION_USER);
+    }
+  }, [loading, data?.user]);
+
   return (
     <>
       {props.children({ isLoading: loading, user: data && data.user, error })}

--- a/packages/application-shell/src/components/performance-mark/index.ts
+++ b/packages/application-shell/src/components/performance-mark/index.ts
@@ -1,0 +1,1 @@
+export { default } from './performance-mark';

--- a/packages/application-shell/src/components/performance-mark/performance-mark.spec.tsx
+++ b/packages/application-shell/src/components/performance-mark/performance-mark.spec.tsx
@@ -2,11 +2,6 @@ import { render } from '@testing-library/react';
 import { markOnce, PERFORMANCE_MARKS } from '../../utils';
 import PerformanceMark from './performance-mark';
 
-// `markOnce` is mocked so each test is independent. The real `markOnce` keeps
-// its dedupe `Set` at module scope, and resetting that per test is not possible
-// from here without also resetting React. The dedupe behaviour is covered
-// directly in `utils/performance-marks/performance-marks.spec.ts`; this file
-// only checks that the component calls it correctly.
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
   markOnce: jest.fn(),
@@ -56,11 +51,6 @@ describe('PerformanceMark', () => {
     expect(markOnceMock).toHaveBeenNthCalledWith(2, 'mc:hydration-project');
   });
 
-  // The shell subtree this component lives in mounts twice on a cold load: the
-  // Suspense fallback in `application-shell-splitter.async.tsx` is
-  // `props.children`, the same subtree that later renders inside the resolved
-  // splitter. The component calls `markOnce` on each mount by design; keeping
-  // only the first write is `markOnce`'s job, verified in its own spec.
   it('calls markOnce on every mount and lets it deduplicate', () => {
     const mark = PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED;
 

--- a/packages/application-shell/src/components/performance-mark/performance-mark.spec.tsx
+++ b/packages/application-shell/src/components/performance-mark/performance-mark.spec.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react';
+import { markOnce, PERFORMANCE_MARKS } from '../../utils';
+import PerformanceMark from './performance-mark';
+
+// `markOnce` is mocked so each test is independent. The real `markOnce` keeps
+// its dedupe `Set` at module scope, and resetting that per test is not possible
+// from here without also resetting React. The dedupe behaviour is covered
+// directly in `utils/performance-marks/performance-marks.spec.ts`; this file
+// only checks that the component calls it correctly.
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  markOnce: jest.fn(),
+}));
+
+const markOnceMock = markOnce as jest.Mock;
+
+describe('PerformanceMark', () => {
+  beforeEach(() => {
+    markOnceMock.mockClear();
+  });
+
+  it('renders nothing', () => {
+    const { container } = render(
+      <PerformanceMark mark={PERFORMANCE_MARKS.INTL_READY} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('marks on mount using the given name', () => {
+    render(<PerformanceMark mark={PERFORMANCE_MARKS.HYDRATION_USER} />);
+
+    expect(markOnceMock).toHaveBeenCalledTimes(1);
+    expect(markOnceMock).toHaveBeenCalledWith('mc:hydration-user');
+  });
+
+  it('does not mark again on re-render', () => {
+    const { rerender } = render(
+      <PerformanceMark mark={PERFORMANCE_MARKS.CONTENT_RENDERED} />
+    );
+
+    rerender(<PerformanceMark mark={PERFORMANCE_MARKS.CONTENT_RENDERED} />);
+    rerender(<PerformanceMark mark={PERFORMANCE_MARKS.CONTENT_RENDERED} />);
+
+    expect(markOnceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks again when the name changes', () => {
+    const { rerender } = render(
+      <PerformanceMark mark={PERFORMANCE_MARKS.HYDRATION_USER} />
+    );
+
+    rerender(<PerformanceMark mark={PERFORMANCE_MARKS.HYDRATION_PROJECT} />);
+
+    expect(markOnceMock).toHaveBeenNthCalledWith(1, 'mc:hydration-user');
+    expect(markOnceMock).toHaveBeenNthCalledWith(2, 'mc:hydration-project');
+  });
+
+  // The shell subtree this component lives in mounts twice on a cold load: the
+  // Suspense fallback in `application-shell-splitter.async.tsx` is
+  // `props.children`, the same subtree that later renders inside the resolved
+  // splitter. The component calls `markOnce` on each mount by design; keeping
+  // only the first write is `markOnce`'s job, verified in its own spec.
+  it('calls markOnce on every mount and lets it deduplicate', () => {
+    const mark = PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED;
+
+    const first = render(<PerformanceMark mark={mark} />);
+    first.unmount();
+    render(<PerformanceMark mark={mark} />);
+
+    expect(markOnceMock).toHaveBeenCalledTimes(2);
+    expect(markOnceMock).toHaveBeenCalledWith('mc:shell-chrome-mounted');
+  });
+});

--- a/packages/application-shell/src/components/performance-mark/performance-mark.tsx
+++ b/packages/application-shell/src/components/performance-mark/performance-mark.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { markOnce, type TShellPerformanceMark } from '../../utils';
+
+const PerformanceMark = ({ mark }: { mark: TShellPerformanceMark }) => {
+  useEffect(() => {
+    markOnce(mark);
+  }, [mark]);
+  return null;
+};
+
+export default PerformanceMark;

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -23,7 +23,6 @@ export { REGIONS } from './constants';
 export type { TApplicationShellSplitterValue } from './components/application-shell-splitter/application-shell-splitter';
 export { default as getPreviousProjectKey } from './utils/get-previous-project-key';
 export { default as setupGlobalErrorListener } from './utils/setup-global-error-listener';
-// For the FEC-1297 performance harness. `markOnce` stays internal.
 export { PERFORMANCE_MARKS } from './utils/performance-marks';
 export type { TPerformanceMark } from './utils/performance-marks';
 export { default as useRoutesCreator } from './hooks/use-routes-creator';

--- a/packages/application-shell/src/index.ts
+++ b/packages/application-shell/src/index.ts
@@ -23,6 +23,9 @@ export { REGIONS } from './constants';
 export type { TApplicationShellSplitterValue } from './components/application-shell-splitter/application-shell-splitter';
 export { default as getPreviousProjectKey } from './utils/get-previous-project-key';
 export { default as setupGlobalErrorListener } from './utils/setup-global-error-listener';
+// For the FEC-1297 performance harness. `markOnce` stays internal.
+export { PERFORMANCE_MARKS } from './utils/performance-marks';
+export type { TPerformanceMark } from './utils/performance-marks';
 export { default as useRoutesCreator } from './hooks/use-routes-creator';
 
 export {

--- a/packages/application-shell/src/utils/index.ts
+++ b/packages/application-shell/src/utils/index.ts
@@ -1,3 +1,8 @@
 export { default as selectProjectKeyFromLocalStorage } from './select-project-key-from-local-storage';
 export { default as getMcApiUrl } from './get-mc-api-url';
 export { default as getPreviousProjectKey } from './get-previous-project-key';
+export { default as markOnce, PERFORMANCE_MARKS } from './performance-marks';
+export type {
+  TPerformanceMark,
+  TShellPerformanceMark,
+} from './performance-marks';

--- a/packages/application-shell/src/utils/performance-marks/index.ts
+++ b/packages/application-shell/src/utils/performance-marks/index.ts
@@ -1,0 +1,5 @@
+export type {
+  TPerformanceMark,
+  TShellPerformanceMark,
+} from './performance-marks';
+export { default, PERFORMANCE_MARKS } from './performance-marks';

--- a/packages/application-shell/src/utils/performance-marks/performance-marks.spec.ts
+++ b/packages/application-shell/src/utils/performance-marks/performance-marks.spec.ts
@@ -92,9 +92,6 @@ describe('markOnce', () => {
     expect(mark).not.toHaveBeenCalled();
   });
 
-  // Timing instrumentation is observational. Callers invoke `markOnce` from
-  // `useEffect`, where a throw surfaces as an uncaught React error and can
-  // break shell mount.
   it('swallows errors thrown by the Performance API', () => {
     const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
     const throwingMeasure = jest.fn(() => {
@@ -139,9 +136,6 @@ describe('PERFORMANCE_MARKS', () => {
   it('holds the six canonical names from FEC-1297', () => {
     const { PERFORMANCE_MARKS } = loadModule();
 
-    // `mc:skeleton-visible` has no emitter in this package. FEC-1298 emits it
-    // by hand in `mc-html-template/html-scripts/loading-screen.js`, because
-    // that file is untranspiled ES5 with no module system.
     expect(Object.values(PERFORMANCE_MARKS)).toEqual([
       'mc:skeleton-visible',
       'mc:shell-chrome-mounted',

--- a/packages/application-shell/src/utils/performance-marks/performance-marks.spec.ts
+++ b/packages/application-shell/src/utils/performance-marks/performance-marks.spec.ts
@@ -1,0 +1,162 @@
+// The test environment's `performance` global has no `mark`/`measure`, so they
+// are stubbed rather than spied on.
+const originalPerformance = globalThis.performance;
+
+const setPerformance = (value: unknown) => {
+  Object.defineProperty(globalThis, 'performance', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+};
+
+// `markOnce` dedupes on a module-level `Set`, so every test needs a fresh
+// module instance. Requiring after `resetModules` gives that.
+const loadModule = () => {
+  jest.resetModules();
+  return require('./performance-marks');
+};
+
+describe('markOnce', () => {
+  let mark: jest.Mock;
+  let measure: jest.Mock;
+
+  beforeEach(() => {
+    mark = jest.fn();
+    measure = jest.fn();
+    setPerformance({ mark, measure });
+  });
+
+  afterEach(() => {
+    setPerformance(originalPerformance);
+  });
+
+  it('marks and measures from the navigation origin', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+
+    markOnce(PERFORMANCE_MARKS.INTL_READY);
+
+    expect(mark).toHaveBeenCalledWith('mc:intl-ready');
+    expect(measure).toHaveBeenCalledWith('mc:intl-ready:from-nav', {
+      start: 0,
+      end: 'mc:intl-ready',
+    });
+  });
+
+  // This guard is what makes the marks correct despite the shell subtree
+  // mounting twice on a cold load (the Suspense fallback in
+  // application-shell-splitter.async.tsx renders the same children).
+  it('keeps the first write and ignores repeat calls for the same mark', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+
+    markOnce(PERFORMANCE_MARKS.CONTENT_RENDERED);
+    markOnce(PERFORMANCE_MARKS.CONTENT_RENDERED);
+    markOnce(PERFORMANCE_MARKS.CONTENT_RENDERED);
+
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(measure).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks each mark name independently', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+
+    markOnce(PERFORMANCE_MARKS.HYDRATION_USER);
+    markOnce(PERFORMANCE_MARKS.HYDRATION_PROJECT);
+
+    expect(mark).toHaveBeenCalledTimes(2);
+    expect(mark).toHaveBeenCalledWith('mc:hydration-user');
+    expect(mark).toHaveBeenCalledWith('mc:hydration-project');
+  });
+
+  it('does nothing when the Performance API is unavailable', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+    setPerformance({});
+
+    expect(() =>
+      markOnce(PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED)
+    ).not.toThrow();
+    expect(measure).not.toHaveBeenCalled();
+  });
+
+  // `performance.measure`'s options-object form is newer than `mark`
+  // (Safari 14.1+, Chrome 78+) and is a DOM API, so core-js does not polyfill
+  // it. Marking without being able to measure would leave a mark the harness
+  // cannot turn into a duration, so neither call should happen.
+  it('does not mark when `measure` is unavailable', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+    setPerformance({ mark });
+
+    expect(() =>
+      markOnce(PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED)
+    ).not.toThrow();
+    expect(mark).not.toHaveBeenCalled();
+  });
+
+  // Timing instrumentation is observational. Callers invoke `markOnce` from
+  // `useEffect`, where a throw surfaces as an uncaught React error and can
+  // break shell mount.
+  it('swallows errors thrown by the Performance API', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+    const throwingMeasure = jest.fn(() => {
+      throw new TypeError('measure is not supported in this form');
+    });
+    setPerformance({ mark, measure: throwingMeasure });
+
+    expect(() => markOnce(PERFORMANCE_MARKS.INTL_READY)).not.toThrow();
+    expect(throwingMeasure).toHaveBeenCalled();
+  });
+
+  it('does not retry a mark whose measure failed', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+    const throwingMeasure = jest.fn(() => {
+      throw new TypeError('measure is not supported in this form');
+    });
+    setPerformance({ mark, measure: throwingMeasure });
+
+    markOnce(PERFORMANCE_MARKS.INTL_READY);
+    markOnce(PERFORMANCE_MARKS.INTL_READY);
+
+    // `alreadyMarked.add` runs after a successful `mark` and before `measure`,
+    // so a failed measure must not leave the door open to a duplicate mark.
+    expect(mark).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not record a mark as seen when it could not be written', () => {
+    const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
+
+    setPerformance({});
+    markOnce(PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED);
+
+    // Once the API is available the mark must still be writable.
+    setPerformance({ mark, measure });
+    markOnce(PERFORMANCE_MARKS.SHELL_CHROME_MOUNTED);
+
+    expect(mark).toHaveBeenCalledWith('mc:shell-chrome-mounted');
+  });
+});
+
+describe('PERFORMANCE_MARKS', () => {
+  it('holds the six canonical names from FEC-1297', () => {
+    const { PERFORMANCE_MARKS } = loadModule();
+
+    // `mc:skeleton-visible` has no emitter in this package. FEC-1298 emits it
+    // by hand in `mc-html-template/html-scripts/loading-screen.js`, because
+    // that file is untranspiled ES5 with no module system.
+    expect(Object.values(PERFORMANCE_MARKS)).toEqual([
+      'mc:skeleton-visible',
+      'mc:shell-chrome-mounted',
+      'mc:intl-ready',
+      'mc:content-rendered',
+      'mc:hydration-user',
+      'mc:hydration-project',
+    ]);
+  });
+
+  it('prefixes every name with `mc:` so consumers can filter on it', () => {
+    const { PERFORMANCE_MARKS } = loadModule();
+
+    Object.values(PERFORMANCE_MARKS).forEach((name) => {
+      expect(name).toMatch(/^mc:/);
+    });
+  });
+});

--- a/packages/application-shell/src/utils/performance-marks/performance-marks.spec.ts
+++ b/packages/application-shell/src/utils/performance-marks/performance-marks.spec.ts
@@ -43,9 +43,6 @@ describe('markOnce', () => {
     });
   });
 
-  // This guard is what makes the marks correct despite the shell subtree
-  // mounting twice on a cold load (the Suspense fallback in
-  // application-shell-splitter.async.tsx renders the same children).
   it('keeps the first write and ignores repeat calls for the same mark', () => {
     const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
 
@@ -78,10 +75,6 @@ describe('markOnce', () => {
     expect(measure).not.toHaveBeenCalled();
   });
 
-  // `performance.measure`'s options-object form is newer than `mark`
-  // (Safari 14.1+, Chrome 78+) and is a DOM API, so core-js does not polyfill
-  // it. Marking without being able to measure would leave a mark the harness
-  // cannot turn into a duration, so neither call should happen.
   it('does not mark when `measure` is unavailable', () => {
     const { default: markOnce, PERFORMANCE_MARKS } = loadModule();
     setPerformance({ mark });

--- a/packages/application-shell/src/utils/performance-marks/performance-marks.ts
+++ b/packages/application-shell/src/utils/performance-marks/performance-marks.ts
@@ -1,0 +1,40 @@
+export const PERFORMANCE_MARKS = {
+  SKELETON_VISIBLE: 'mc:skeleton-visible',
+  SHELL_CHROME_MOUNTED: 'mc:shell-chrome-mounted',
+  INTL_READY: 'mc:intl-ready',
+  CONTENT_RENDERED: 'mc:content-rendered',
+  HYDRATION_USER: 'mc:hydration-user',
+  HYDRATION_PROJECT: 'mc:hydration-project',
+} as const;
+
+export type TPerformanceMark =
+  (typeof PERFORMANCE_MARKS)[keyof typeof PERFORMANCE_MARKS];
+
+// Excludes `mc:skeleton-visible`, which FEC-1298 emits from mc-html-template's
+// inline script. `alreadyMarked` cannot see marks made outside this module.
+export type TShellPerformanceMark = Exclude<
+  TPerformanceMark,
+  typeof PERFORMANCE_MARKS.SKELETON_VISIBLE
+>;
+
+const alreadyMarked = new Set<TShellPerformanceMark>();
+
+const markOnce = (performanceMark: TShellPerformanceMark) => {
+  if (alreadyMarked.has(performanceMark)) return;
+  if (!performance?.mark || !performance.measure) return;
+
+  try {
+    performance.mark(performanceMark);
+    // Between the two calls: a failed `mark` should retry, a failed `measure`
+    // must not emit a second entry.
+    alreadyMarked.add(performanceMark);
+    performance.measure(`${performanceMark}:from-nav`, {
+      start: 0,
+      end: performanceMark,
+    });
+  } catch {
+    // Observational only; never break rendering.
+  }
+};
+
+export default markOnce;

--- a/packages/application-shell/src/utils/performance-marks/performance-marks.ts
+++ b/packages/application-shell/src/utils/performance-marks/performance-marks.ts
@@ -10,8 +10,6 @@ export const PERFORMANCE_MARKS = {
 export type TPerformanceMark =
   (typeof PERFORMANCE_MARKS)[keyof typeof PERFORMANCE_MARKS];
 
-// Excludes `mc:skeleton-visible`, which FEC-1298 emits from mc-html-template's
-// inline script. `alreadyMarked` cannot see marks made outside this module.
 export type TShellPerformanceMark = Exclude<
   TPerformanceMark,
   typeof PERFORMANCE_MARKS.SKELETON_VISIBLE
@@ -25,8 +23,7 @@ const markOnce = (performanceMark: TShellPerformanceMark) => {
 
   try {
     performance.mark(performanceMark);
-    // Between the two calls: a failed `mark` should retry, a failed `measure`
-    // must not emit a second entry.
+
     alreadyMarked.add(performanceMark);
     performance.measure(`${performanceMark}:from-nav`, {
       start: 0,


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Emits the six canonical `mc:*` performance marks for the Merchant Center loading sequence, and exports `PERFORMANCE_MARKS` so the FEC-1297 harness can read the names rather than hardcoding them. Groundwork for [`FEC-1297`](https://commercetools.atlassian.net/browse/FEC-1297).

Five marks ship here. `mc:skeleton-visible` is emitted by FEC-1298 from `mc-html-template`, which is untranspiled ES5 with no module system.

<details>
<summary>Agent context</summary>

**Where each mark is emitted**

| Mark | Location |
| --- | --- |
| `mc:intl-ready` | `application-shell-authenticated.tsx`, first child of `ConfigureIntlProvider` |
| `mc:shell-chrome-mounted` | Inside `ApplicationShellSplitter` |
| `mc:content-rendered` | The else-branch `MainContainer` |
| `mc:hydration-user` | `fetch-user.tsx`, on the query resolving |
| `mc:hydration-project` | `fetch-project.tsx`, on the query resolving |

**Why the marks live at the composition site, not in the components**

`ConfigureIntlProvider` renders in six places and is public API: the
unauthenticated branch of `application-shell-provider`, the OIDC callback error
page, both Custom View shells, the user-fetch error path, and the intended path.
Emitting from inside it meant a Custom View load recorded `mc:intl-ready` while
none of the other marks fired, and any custom application rendering the exported
component did the same. The two hydration marks are acceptable in
`FetchUser`/`FetchProject` because those only ever fetch the MC user and project.

**The Suspense double-mount**

`application-shell-splitter.async.tsx` uses `props.children` as its Suspense
fallback, so the whole chrome subtree mounts once while the splitter chunk is in
flight and again when it resolves. `markOnce` keeps the first write, which is
when the user actually saw the chrome; the second mount only reflects chunk-load
latency. `mc:intl-ready` sits outside the splitter and mounts once.

**API surface**

`markOnce` is deliberately internal. `TShellPerformanceMark` excludes
`mc:skeleton-visible`, so the shell cannot emit a mark that FEC-1298 already
emits from a separate module scope where this module's dedupe cannot see it, and
`performance.mark` appends rather than overwrites.

**Defensive behaviour**

`performance.measure`'s options-object form is newer than `mark` (Safari 14.1+,
Chrome 78+) and is a DOM API, so core-js does not polyfill it. Both are guarded,
and the calls are wrapped in `try/catch` because callers invoke `markOnce` from
`useEffect`, where a throw surfaces as an uncaught React error. All three
behaviours are pinned by tests: reverting the guard, rethrowing from the catch,
or moving `alreadyMarked.add` each fails at least one.

**Tests**

`performance-marks.spec.ts` covers `markOnce` directly, re-requiring the module
per test since the dedupe `Set` is module-scoped. `performance-mark.spec.tsx`
mocks `markOnce` and asserts only the component's contract. A new case in
`application-shell.spec.js` renders the authenticated shell and asserts all five
marks fire exactly once, which is the only test that would catch a refactor
dropping one from the shell.

</details>

#### Manual testing

Not required; the shell integration test covers the wiring. If you want to see it live, start a playground app and run in the console:

```
performance.getEntriesByType('measure').filter((e) => e.name.startsWith('mc:'))
```

Expect five entries with monotonically increasing durations. Note `mc:intl-ready` and `mc:shell-chrome-mounted` land in the same commit, so they will be very close together.
