### PR TITLE
FEC-1289: fix bottom save toolbar overlap with AI chat panel

### DIFF
--- a/.changeset/save-toolbar-splitter-portal.md
+++ b/.changeset/save-toolbar-splitter-portal.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/application-shell': patch
+---
+
+Move `#mc-main-container-portal` into `Splitter.Main` so the Cancel/Save bar stays as wide as the main column when the AI chat opens. If the splitter is not mounted, the same id is still rendered and pinned to the bottom of the window.

--- a/packages/application-shell/src/components/application-shell-splitter/README.md
+++ b/packages/application-shell/src/components/application-shell-splitter/README.md
@@ -21,7 +21,7 @@ ApplicationShellAuthenticated
         └─ Splitter.Root (collapsed by default)
            ├─ Splitter.Main (containerType: inline-size, position: relative)
            │  ├─ {children} (nav, header, and the page)
-           │  └─ #mc-main-container-portal (empty div the save bar draws into)
+           │  └─ #mc-main-container-portal (0-height Box, position: absolute)
            ├─ Splitter.Handle
            └─ Splitter.Aside
               └─ Region (name=REGIONS.MC_RIGHT_PANEL)
@@ -38,11 +38,20 @@ longer a sibling of the splitter.
 
 ### SaveToolbar portal
 
-The empty `#mc-main-container-portal` `div` is where Merchant Center draws
-the Cancel/Save bar. With the splitter, that `div` is inside `Splitter.Main`
-(see the tree), so the bar stays as wide as the main column when the AI
-chat opens. Without the splitter, the fallback path pins the same `div` to
-the window (see above).
+The empty `#mc-main-container-portal` `Box` is where Merchant Center draws
+the Cancel/Save bar (`SaveToolbar` / `SaveToolbarSteps`). It lives inside
+`Splitter.Main` as a 0-height strip (`position: absolute`, `left` / `right` /
+`bottom: 0`, `height: 0`). `position: relative` on Main is the containing
+block so that strip is as wide as the main column, not the window.
+`transform: translateZ(0)` traps the bar's `position: fixed` to that box.
+`overflow: hidden` on Main clips the bar's slide-in (`bottom: -57px`) so
+the window does not grow.
+
+`containerType: inline-size` is for `PortalsContainer` (`100cqw` modals and
+dropdowns), not the save bar.
+
+Without the splitter, the fallback path still renders the same id as a
+`div` pinned to the bottom of the window.
 
 ## Consumer API
 

--- a/packages/application-shell/src/components/application-shell-splitter/README.md
+++ b/packages/application-shell/src/components/application-shell-splitter/README.md
@@ -19,8 +19,9 @@ ApplicationShellAuthenticated
   └─ ApplicationShellSplitter (lazy-loaded)
      └─ NimbusProvider
         └─ Splitter.Root (collapsed by default)
-           ├─ Splitter.Main (containerType: inline-size)
-           │  └─ {children} (the entire shell grid)
+           ├─ Splitter.Main (containerType: inline-size, position: relative)
+           │  ├─ {children} (nav, header, and the page)
+           │  └─ #mc-main-container-portal (empty div the save bar draws into)
            ├─ Splitter.Handle
            └─ Splitter.Aside
               └─ Region (name=REGIONS.MC_RIGHT_PANEL)
@@ -31,7 +32,17 @@ ApplicationShellAuthenticated
 If `@commercetools/nimbus` is not installed, the dynamic `import()` fails and
 the `.catch()` returns a passthrough component that renders `{children}`
 directly. The `Suspense` fallback also renders `{children}`, so there is no
-visible flash during chunk loading.
+visible flash during chunk loading. Both of those paths now also render
+`#mc-main-container-portal` (fixed to the window), since the portal is no
+longer a sibling of the splitter.
+
+### SaveToolbar portal
+
+The empty `#mc-main-container-portal` `div` is where Merchant Center draws
+the Cancel/Save bar. With the splitter, that `div` is inside `Splitter.Main`
+(see the tree), so the bar stays as wide as the main column when the AI
+chat opens. Without the splitter, the fallback path pins the same `div` to
+the window (see above).
 
 ## Consumer API
 

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter-wrapper.spec.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter-wrapper.spec.tsx
@@ -25,6 +25,19 @@ describe('ApplicationShellSplitterWrapper', () => {
       expect(source).toContain('children');
     });
 
+    it('source keeps a SaveToolbar portal in the passthrough and Suspense fallback', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const source = fs.readFileSync(
+        path.join(__dirname, 'application-shell-splitter.async.tsx'),
+        'utf8'
+      );
+
+      expect(source).toContain('FallbackSaveToolbarPortal');
+      expect(source).toContain('MC_MAIN_CONTAINER_PORTAL_ID');
+      expect(source).toContain('position: fixed');
+    });
+
     it('source gates the splitter on `hasNimbus`, falling back to passthrough', () => {
       const fs = require('fs');
       const path = require('path');

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.async.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.async.tsx
@@ -3,7 +3,30 @@ import { css } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
 import { MC_MAIN_CONTAINER_PORTAL_ID } from '@commercetools-frontend/constants';
 
-const Passthrough = ({ children }: { children: ReactNode }) => <>{children}</>;
+// Styles for the empty portal div when the splitter is not mounted:
+// There is no Splitter.Main to size to, so pin the div to the bottom
+// of the window (the old full-width bar).
+const fallbackPortalCss = css`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10001;
+`;
+
+// Renders the empty #mc-main-container-portal div so the save bar has
+// a place to draw into. Used when the splitter is not mounted
+// (Nimbus missing, or the chunk failed / is still loading).
+const FallbackSaveToolbarPortal = () => (
+  <div id={MC_MAIN_CONTAINER_PORTAL_ID} css={fallbackPortalCss} />
+);
+
+const Passthrough = ({ children }: { children: ReactNode }) => (
+  <>
+    {children}
+    <FallbackSaveToolbarPortal />
+  </>
+);
 
 const LazyApplicationShellSplitter = lazy(() =>
   import(
@@ -31,31 +54,24 @@ const ApplicationShellSplitterWrapper = (
   const history = useHistory();
 
   return (
-    <>
-      <Suspense fallback={props.children}>
-        <LazyApplicationShellSplitter
-          locale={props.locale}
-          navigate={history.push}
-        >
+    // Do not leave the old "outside the splitter" box next to Suspense.
+    // The splitter already puts one in the main pane; two same ids clash.
+    // Only the no-splitter paths (fallback + Passthrough) need this one.
+    <Suspense
+      fallback={
+        <>
           {props.children}
-        </LazyApplicationShellSplitter>
-      </Suspense>
-      {/* Portal target for SaveToolbar. Rendered outside Suspense so it
-          exists in both the Nimbus and Passthrough paths, and outside
-          Splitter.Main so container-type:inline-size does not trap
-          position:fixed. z-index 10001 beats the modal portals
-          container (z-index 10000). */}
-      <div
-        id={MC_MAIN_CONTAINER_PORTAL_ID}
-        css={css`
-          position: fixed;
-          bottom: 0;
-          left: 0;
-          right: 0;
-          z-index: 10001;
-        `}
-      />
-    </>
+          <FallbackSaveToolbarPortal />
+        </>
+      }
+    >
+      <LazyApplicationShellSplitter
+        locale={props.locale}
+        navigate={history.push}
+      >
+        {props.children}
+      </LazyApplicationShellSplitter>
+    </Suspense>
   );
 };
 

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.spec.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.spec.tsx
@@ -1,4 +1,5 @@
 import { render, act } from '@testing-library/react';
+import { MC_MAIN_CONTAINER_PORTAL_ID } from '@commercetools-frontend/constants';
 import ApplicationShellSplitter from './application-shell-splitter';
 
 const mockCapturedProps: Record<string, Record<string, unknown>> = {};
@@ -83,8 +84,29 @@ describe('ApplicationShellSplitter', () => {
       );
 
       expect(mockCapturedProps['Splitter.Main']).toEqual(
-        expect.objectContaining({ containerType: 'inline-size' })
+        expect.objectContaining({
+          containerType: 'inline-size',
+          style: expect.objectContaining({
+            position: 'relative',
+            isolation: 'isolate',
+          }),
+        })
       );
+    });
+  });
+
+  describe('SaveToolbar portal target', () => {
+    it('renders #mc-main-container-portal inside Splitter.Main', () => {
+      const { getByTestId } = render(
+        <ApplicationShellSplitter {...defaultProps}>
+          <div>content</div>
+        </ApplicationShellSplitter>
+      );
+
+      const portal = getByTestId(MC_MAIN_CONTAINER_PORTAL_ID);
+      expect(getByTestId('splitter-main')).toContainElement(portal);
+      expect(getByTestId('splitter-root')).toContainElement(portal);
+      expect(getByTestId('splitter-aside')).not.toContainElement(portal);
     });
   });
 

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.spec.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.spec.tsx
@@ -9,6 +9,15 @@ let mockHookOptions: Record<string, unknown> = {};
 jest.mock('@commercetools/nimbus', () => {
   return {
     NimbusProvider: ({ children }: { children: unknown }) => <>{children}</>,
+    Box: (p: { children?: unknown }) => {
+      const { children, ...rest } = p as Record<string, unknown>;
+      mockCapturedProps['Box'] = rest;
+      return (
+        <div data-testid={rest['data-testid'] as string}>
+          {children as never}
+        </div>
+      );
+    },
     Splitter: {
       Root: (p: { children: unknown }) => {
         const { children, ...rest } = p as Record<string, unknown>;
@@ -86,11 +95,13 @@ describe('ApplicationShellSplitter', () => {
       expect(mockCapturedProps['Splitter.Main']).toEqual(
         expect.objectContaining({
           containerType: 'inline-size',
-          style: expect.objectContaining({
-            position: 'relative',
-            isolation: 'isolate',
-          }),
+          position: 'relative',
+          overflow: 'hidden',
         })
+      );
+      expect(mockCapturedProps['Splitter.Main']).not.toHaveProperty('style');
+      expect(mockCapturedProps['Splitter.Main']).not.toHaveProperty(
+        'isolation'
       );
     });
   });
@@ -107,6 +118,27 @@ describe('ApplicationShellSplitter', () => {
       expect(getByTestId('splitter-main')).toContainElement(portal);
       expect(getByTestId('splitter-root')).toContainElement(portal);
       expect(getByTestId('splitter-aside')).not.toContainElement(portal);
+    });
+
+    it('sizes the portal as a 0-height strip with a fixed containing block', () => {
+      render(
+        <ApplicationShellSplitter {...defaultProps}>
+          <div>content</div>
+        </ApplicationShellSplitter>
+      );
+
+      expect(mockCapturedProps['Box']).toEqual(
+        expect.objectContaining({
+          id: MC_MAIN_CONTAINER_PORTAL_ID,
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: 0,
+          zIndex: 10001,
+          transform: 'translateZ(0)',
+        })
+      );
     });
   });
 

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
-import { css } from '@emotion/react';
 import type { NimbusRouterConfig } from '@commercetools/nimbus';
 import {
+  Box,
   NimbusProvider,
   Splitter,
   Region,
@@ -42,28 +42,6 @@ const OVERLAY_THRESHOLD = 1408;
 const SPLITTER_ROOT_ID = 'mc-shell-splitter';
 const SPLITTER_MAIN_ID = 'mc-shell-splitter-main';
 const SPLITTER_ASIDE_ID = 'mc-shell-splitter-aside';
-
-// `relative` so the empty #mc-main-container-portal div below sizes to
-// Splitter.Main, not the window.
-// `isolate` so the bar can sit on the
-// form, not on the AI chat.
-const splitterMainStyle = {
-  position: 'relative',
-  isolation: 'isolate',
-} as const;
-
-// Stretch the empty portal div over Splitter.Main so the save bar
-// matches that space, not the window or the chat.
-// `inset: 0` covers the page so `pointer-events: none` lets clicks reach what is under it.
-// `z-index: 10001` is the same as the no-splitter fallback and sits above `#portals-container` (10000).
-const portalInMainPaneCss = css`
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-  z-index: 10001;
-  transform: translateZ(0);
-`;
 
 const ApplicationShellSplitter = (props: TApplicationShellSplitterProps) => {
   const [open, setOpen] = useState(false);
@@ -116,13 +94,20 @@ const ApplicationShellSplitter = (props: TApplicationShellSplitterProps) => {
         <Splitter.Main
           id={SPLITTER_MAIN_ID}
           containerType="inline-size"
-          style={splitterMainStyle}
+          position="relative" // so #mc-main-container-portal (position: absolute) sizes to Splitter.Main
+          overflow="hidden" // fixes SaveToolbar to not grow the window when it slides in.
         >
           {props.children}
-          <div
+          <Box
             id={MC_MAIN_CONTAINER_PORTAL_ID}
             data-testid={MC_MAIN_CONTAINER_PORTAL_ID}
-            css={portalInMainPaneCss}
+            position="absolute"
+            left={0}
+            right={0}
+            bottom={0}
+            height={0}
+            zIndex={10001}
+            transform="translateZ(0)"
           />
         </Splitter.Main>
         <Splitter.Handle aria-label="Resize side panel" />

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { css } from '@emotion/react';
 import type { NimbusRouterConfig } from '@commercetools/nimbus';
 import {
   NimbusProvider,
@@ -6,6 +7,7 @@ import {
   Region,
   useResponsiveSplitterSizes,
 } from '@commercetools/nimbus';
+import { MC_MAIN_CONTAINER_PORTAL_ID } from '@commercetools-frontend/constants';
 import { REGIONS } from '../../constants';
 
 /**
@@ -40,6 +42,28 @@ const OVERLAY_THRESHOLD = 1408;
 const SPLITTER_ROOT_ID = 'mc-shell-splitter';
 const SPLITTER_MAIN_ID = 'mc-shell-splitter-main';
 const SPLITTER_ASIDE_ID = 'mc-shell-splitter-aside';
+
+// `relative` so the empty #mc-main-container-portal div below sizes to
+// Splitter.Main, not the window.
+// `isolate` so the bar can sit on the
+// form, not on the AI chat.
+const splitterMainStyle = {
+  position: 'relative',
+  isolation: 'isolate',
+} as const;
+
+// Stretch the empty portal div over Splitter.Main so the save bar
+// matches that space, not the window or the chat.
+// `inset: 0` covers the page so `pointer-events: none` lets clicks reach what is under it.
+// `z-index: 10001` is the same as the no-splitter fallback and sits above `#portals-container` (10000).
+const portalInMainPaneCss = css`
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 10001;
+  transform: translateZ(0);
+`;
 
 const ApplicationShellSplitter = (props: TApplicationShellSplitterProps) => {
   const [open, setOpen] = useState(false);
@@ -89,8 +113,17 @@ const ApplicationShellSplitter = (props: TApplicationShellSplitterProps) => {
         collapsedSize={0}
         collapsed={!open}
       >
-        <Splitter.Main id={SPLITTER_MAIN_ID} containerType="inline-size">
+        <Splitter.Main
+          id={SPLITTER_MAIN_ID}
+          containerType="inline-size"
+          style={splitterMainStyle}
+        >
           {props.children}
+          <div
+            id={MC_MAIN_CONTAINER_PORTAL_ID}
+            data-testid={MC_MAIN_CONTAINER_PORTAL_ID}
+            css={portalInMainPaneCss}
+          />
         </Splitter.Main>
         <Splitter.Handle aria-label="Resize side panel" />
         <Splitter.Aside id={SPLITTER_ASIDE_ID}>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This fixes the Cancel/Save bar (SaveToolbar / SaveToolbarSteps) staying window-wide and overlapping the AI chat in the MC.

#### Description
`#mc-main-container-portal` now lives inside `Splitter.Main`, so `SaveToolbar` and `SaveToolbarSteps` from `shared-ui` stay as wide as the main column (nav + page) and do not sit on the AI chat.

If the splitter is not mounted, the same id is still rendered and pinned to the bottom of the window.

Before:
https://github.com/user-attachments/assets/dab48c90-c544-481f-91bd-dac1b5532d03
<img width="3596" height="1610" alt="Screenshot 2026-09-08 at 14 47 36" src="https://github.com/user-attachments/assets/ad8d179e-4403-4e09-9bcb-526f68add2d1" />

Now
https://github.com/user-attachments/assets/c3659419-3e99-47ad-9efc-999de45f625f
<img width="3678" height="1864" alt="Screenshot 2026-09-08 at 14 51 41" src="https://github.com/user-attachments/assets/8b2ff29f-7e84-439c-b19e-32e2c85a441a" />

