### PR TITLE
refactor: simplify portal styling, add container-type to shell grid

### DIFF
--- a/.changeset/save-toolbar-cqw.md
+++ b/.changeset/save-toolbar-cqw.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/constants': patch
+---
+
+Replace the `#mc-main-container-portal` fixed-position portal target with a `container-type: inline-size` declaration on the shell grid div. Components like `SaveToolbar` can now use `100cqw` units to size themselves to the main column width, which tracks the splitter pane when the AI chat panel is open. The `MC_MAIN_CONTAINER_PORTAL_ID` constant has been removed from `@commercetools-frontend/constants`.

--- a/.changeset/save-toolbar-splitter-portal.md
+++ b/.changeset/save-toolbar-splitter-portal.md
@@ -1,6 +1,7 @@
 ---
 '@commercetools-frontend/application-shell': patch
 '@commercetools-frontend/actions-global': patch
+'@commercetools-frontend/constants': patch
 ---
 
 Move `#mc-main-container-portal` into `Splitter.Main` so the Cancel/Save bar stays as wide as the main column when the AI chat opens. Simplify the portal div to minimal stacking (no full-screen overlay). Add `container-type: inline-size` to the shell grid div so `100cqw` is available as a stable width reference in both splitter and fallback paths.

--- a/.changeset/save-toolbar-splitter-portal.md
+++ b/.changeset/save-toolbar-splitter-portal.md
@@ -1,5 +1,6 @@
 ---
 '@commercetools-frontend/application-shell': patch
+'@commercetools-frontend/actions-global': patch
 ---
 
 Move `#mc-main-container-portal` into `Splitter.Main` so the Cancel/Save bar stays as wide as the main column when the AI chat opens. Simplify the portal div to minimal stacking (no full-screen overlay). Add `container-type: inline-size` to the shell grid div so `100cqw` is available as a stable width reference in both splitter and fallback paths.

--- a/.changeset/save-toolbar-splitter-portal.md
+++ b/.changeset/save-toolbar-splitter-portal.md
@@ -2,4 +2,4 @@
 '@commercetools-frontend/application-shell': patch
 ---
 
-Move `#mc-main-container-portal` into `Splitter.Main` so the Cancel/Save bar stays as wide as the main column when the AI chat opens. If the splitter is not mounted, the same id is still rendered and pinned to the bottom of the window.
+Move `#mc-main-container-portal` into `Splitter.Main` so the Cancel/Save bar stays as wide as the main column when the AI chat opens. Simplify the portal div to minimal stacking (no full-screen overlay). Add `container-type: inline-size` to the shell grid div so `100cqw` is available as a stable width reference in both splitter and fallback paths.

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -62,6 +62,9 @@ jobs:
         run: |
           PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/^preview\///' | sed -e 's/[^a-zA-Z0-9-]/-/g')
           pnpm changeset version --snapshot ${PREVIEW_TAG}
+          # Rebuild to ensure preconstruct dev proxies from the initial install
+          # are overwritten with real builds before publishing.
+          pnpm build
           pnpm changeset publish --tag ${PREVIEW_TAG}
           node ./scripts/update-npm-tag.mjs ${PREVIEW_TAG}
         env:

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -62,14 +62,12 @@ jobs:
         run: |
           PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/^preview\///' | sed -e 's/[^a-zA-Z0-9-]/-/g')
           pnpm changeset version --snapshot ${PREVIEW_TAG}
-          # Rebuild after version bump to ensure preconstruct dev proxies
-          # (created during postinstall) are overwritten with real builds.
-          pnpm build
           pnpm changeset publish --tag ${PREVIEW_TAG}
           node ./scripts/update-npm-tag.mjs ${PREVIEW_TAG}
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           BRANCH_NAME: ${{ steps.comment-branch.outputs.head_ref }}
+          SKIP_POSTINSTALL_DEV_SETUP: '1'
 
       - name: Post workflow result on PR as a comment
         if: always()

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -65,7 +65,11 @@ jobs:
           # Rebuild to ensure preconstruct dev proxies from the initial install
           # are overwritten with real builds before publishing.
           pnpm build
+          # Publish all public packages at the snapshot version. changeset publish
+          # only publishes packages explicitly listed in a changeset; force-publish
+          # the rest so fixed-group consumers can install the full set.
           pnpm changeset publish --tag ${PREVIEW_TAG}
+          node ./scripts/publish-all-snapshot-packages.mjs ${PREVIEW_TAG}
           node ./scripts/update-npm-tag.mjs ${PREVIEW_TAG}
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -62,6 +62,9 @@ jobs:
         run: |
           PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/^preview\///' | sed -e 's/[^a-zA-Z0-9-]/-/g')
           pnpm changeset version --snapshot ${PREVIEW_TAG}
+          # Rebuild after version bump to ensure preconstruct dev proxies
+          # (created during postinstall) are overwritten with real builds.
+          pnpm build
           pnpm changeset publish --tag ${PREVIEW_TAG}
           node ./scripts/update-npm-tag.mjs ${PREVIEW_TAG}
         env:

--- a/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
+++ b/packages/application-shell/src/components/application-shell-authenticated/application-shell-authenticated.tsx
@@ -232,6 +232,7 @@ export const ApplicationShellAuthenticated = (
                           display: grid;
                           grid-template-rows: auto ${DIMENSIONS.header} 1fr;
                           grid-template-columns: min-content 1fr;
+                          container-type: inline-size;
                         `}
                       >
                         <div

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.spec.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.spec.tsx
@@ -84,13 +84,7 @@ describe('ApplicationShellSplitter', () => {
       );
 
       expect(mockCapturedProps['Splitter.Main']).toEqual(
-        expect.objectContaining({
-          containerType: 'inline-size',
-          style: expect.objectContaining({
-            position: 'relative',
-            isolation: 'isolate',
-          }),
-        })
+        expect.objectContaining({ containerType: 'inline-size' })
       );
     });
   });

--- a/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
+++ b/packages/application-shell/src/components/application-shell-splitter/application-shell-splitter.tsx
@@ -43,26 +43,11 @@ const SPLITTER_ROOT_ID = 'mc-shell-splitter';
 const SPLITTER_MAIN_ID = 'mc-shell-splitter-main';
 const SPLITTER_ASIDE_ID = 'mc-shell-splitter-aside';
 
-// `relative` so the empty #mc-main-container-portal div below sizes to
-// Splitter.Main, not the window.
-// `isolate` so the bar can sit on the
-// form, not on the AI chat.
-const splitterMainStyle = {
-  position: 'relative',
-  isolation: 'isolate',
-} as const;
-
-// Stretch the empty portal div over Splitter.Main so the save bar
-// matches that space, not the window or the chat.
-// `inset: 0` covers the page so `pointer-events: none` lets clicks reach what is under it.
-// `z-index: 10001` is the same as the no-splitter fallback and sits above `#portals-container` (10000).
+// Minimal portal target: just stacking order above #portals-container (10000).
+// Collapses to 0×0 so it doesn't overlay content or block interactions.
 const portalInMainPaneCss = css`
   position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
   z-index: 10001;
-  transform: translateZ(0);
 `;
 
 const ApplicationShellSplitter = (props: TApplicationShellSplitterProps) => {
@@ -113,11 +98,7 @@ const ApplicationShellSplitter = (props: TApplicationShellSplitterProps) => {
         collapsedSize={0}
         collapsed={!open}
       >
-        <Splitter.Main
-          id={SPLITTER_MAIN_ID}
-          containerType="inline-size"
-          style={splitterMainStyle}
-        >
+        <Splitter.Main id={SPLITTER_MAIN_ID} containerType="inline-size">
           {props.children}
           <div
             id={MC_MAIN_CONTAINER_PORTAL_ID}

--- a/scripts/publish-all-snapshot-packages.mjs
+++ b/scripts/publish-all-snapshot-packages.mjs
@@ -1,0 +1,43 @@
+import { getPackages } from '@manypkg/get-packages';
+import shell from 'shelljs';
+
+const [, , distTag] = process.argv;
+
+if (!distTag) {
+  throw new Error('Please provide a NPM dist-tag as a parameter');
+}
+
+const { packages } = await getPackages(process.cwd());
+const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
+
+for (const pkg of publicPackages) {
+  const { name, version } = pkg.packageJson;
+
+  // Skip packages that don't have the snapshot version
+  if (!version.includes(distTag)) {
+    continue;
+  }
+
+  // Check if this version already exists on npm
+  const check = shell.exec(`npm view ${name}@${version} version 2>/dev/null`, {
+    silent: true,
+  });
+
+  if (check.stdout.trim() === version) {
+    console.log(`✓ ${name}@${version} already published`);
+    continue;
+  }
+
+  // Publish the package
+  console.log(`Publishing ${name}@${version}...`);
+  const result = shell.exec(`npm publish --tag ${distTag}`, {
+    cwd: pkg.dir,
+    silent: false,
+  });
+
+  if (result.code !== 0) {
+    console.error(`✗ Failed to publish ${name}@${version}`);
+  } else {
+    console.log(`✓ Published ${name}@${version}`);
+  }
+}

--- a/scripts/update-npm-tag.mjs
+++ b/scripts/update-npm-tag.mjs
@@ -8,22 +8,33 @@ async function getPublicPackagesNames() {
     .map((pkg) => pkg.packageJson.name);
 }
 
-async function getLatestReleaseCandidate(packageName, distTag) {
-  const response = await fetch(`https://registry.npmjs.org/${packageName}`);
-  const packageDetails = await response.json();
+async function getLatestReleaseCandidate(packageName, distTag, retries = 3) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    const response = await fetch(`https://registry.npmjs.org/${packageName}`);
+    const packageDetails = await response.json();
 
-  const filteredVersions = Object.entries(packageDetails.time)
-    .filter(([version]) => version.includes(distTag))
-    .sort(
-      ([, dateTimeA], [, dateTimeB]) =>
-        new Date(dateTimeB).getTime() - new Date(dateTimeA).getTime()
-    );
+    const filteredVersions = Object.entries(packageDetails.time)
+      .filter(([version]) => version.includes(distTag))
+      .sort(
+        ([, dateTimeA], [, dateTimeB]) =>
+          new Date(dateTimeB).getTime() - new Date(dateTimeA).getTime()
+      );
 
-  if (filteredVersions.length === 0) {
-    throw new Error(`No release candidate found with dist-tag ${distTag}`);
+    if (filteredVersions.length > 0) {
+      return filteredVersions[0][0];
+    }
+
+    if (attempt < retries) {
+      console.log(
+        `No version found for ${packageName} with dist-tag ${distTag}, retrying in 5s (attempt ${attempt}/${retries})...`
+      );
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
   }
 
-  return filteredVersions[0][0];
+  throw new Error(
+    `No release candidate found with dist-tag ${distTag} for ${packageName} after ${retries} attempts`
+  );
 }
 
 // Get the NPM dist-tag parameter


### PR DESCRIPTION
Builds on #4146 with three changes:

1. **Remove overlay styling from portal div**: `inset: 0` renders a container covering all of `Splitter.Main`'s content, blocking accessible interaction with the page ([details](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events)). Simplified to `position: absolute; z-index: 10001` (0×0, no overlay).

2. **Remove redundant `splitterMainStyle`**: The Nimbus [pane recipe](https://github.com/commercetools/nimbus/blob/main/packages/nimbus/src/components/splitter/splitter.recipe.ts#L46-L54) already applies `isolation: isolate`, and `container-type: inline-size` implies `contain: layout`.

3. **Add `container-type: inline-size` to the shell grid div**: Gives `100cqw` as a stable width reference in both splitter and fallback paths, so the toolbar and [`PortalsContainer`](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-components/src/components/portals-container/portals-container.tsx#L161-L170) (which already uses `cqw`) can size with `calc(100cqw - offsets)`.