### PR TITLE
fix: move preview publish logic to script file

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 jobs:
-  release:
+  publish-preview:
     runs-on: ubuntu-latest
 
     timeout-minutes: 15
@@ -22,14 +22,37 @@ jobs:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
-      - name: Get branch of PR
-        uses: xt0rted/pull-request-comment-branch@e8b8daa837e8ea7331c0003c9c316a64c6d8b0b1 # v3
-        id: comment-branch
+      - name: Get PR branch
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const branch = pr.data.head.ref;
+            const sanitized = branch.replace(/[^a-zA-Z0-9-]/g, '-').slice(0, 40);
+            core.setOutput('ref', branch);
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('tag', sanitized);
+
+      - name: React to comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
 
       - name: Checkout PR branch
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.pr.outputs.ref }}
           token: ${{ steps.generate_github_token.outputs.token }}
 
       # Ensure we are using valid node version for npm trusted publishing AFTER checkout
@@ -63,15 +86,44 @@ jobs:
       # resolves issue_comment-triggered workflow YAML from the default
       # branch, but scripts come from the checkout.
       - name: Publishing preview releases to npm registry
+        id: publish
         run: ./scripts/preview-publish.sh
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
-          BRANCH_NAME: ${{ steps.comment-branch.outputs.head_ref }}
+          BRANCH_NAME: ${{ steps.pr.outputs.ref }}
 
-      - name: Post workflow result on PR as a comment
-        if: always()
-        run: |
-          gh issue comment ${{ github.event.issue.number }} \
-            --body "Release workflow ${{ job.status == 'success' && 'succeeded ✅' || 'failed ❌' }}\nSee details: [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment with install instructions
+        if: success()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const version = '${{ steps.publish.outputs.version }}';
+            const sha = '${{ steps.pr.outputs.sha }}'.slice(0, 7);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                `### 🚀 Preview published`,
+                '',
+                `**Version:** \`${version}\``,
+                `**Commit:** \`${sha}\``,
+                '',
+                '```bash',
+                `pnpm add @commercetools-frontend/application-shell@${version}`,
+                `pnpm add @commercetools-frontend/mc-scripts@${version}`,
+                '```',
+              ].join('\n'),
+            });
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### ❌ Preview publish failed\n\nSee details: [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`,
+            });

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -58,12 +58,12 @@ jobs:
           node-version: "24.19.0"
           registry-url: "https://registry.npmjs.org"
 
+      # Publish logic lives in scripts/preview-publish.sh (not inline) so
+      # that changes are picked up from the checked-out PR branch.  GitHub
+      # resolves issue_comment-triggered workflow YAML from the default
+      # branch, but scripts come from the checkout.
       - name: Publishing preview releases to npm registry
-        run: |
-          PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/^preview\///' | sed -e 's/[^a-zA-Z0-9-]/-/g')
-          pnpm changeset version --snapshot ${PREVIEW_TAG}
-          pnpm changeset publish --tag ${PREVIEW_TAG}
-          node ./scripts/update-npm-tag.mjs ${PREVIEW_TAG}
+        run: ./scripts/preview-publish.sh
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           BRANCH_NAME: ${{ steps.comment-branch.outputs.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 # Entry workflow that coordinates release processes:
 # - Publishes official releases when code is pushed to main, adhering to the single workflow, npm trusted publishing/OIDC pattern
-# - Publishes preview releases when triggered via PR comment with [preview_deployment]
+# - Publishes preview releases when triggered via PR comment with [publish-preview]
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
     secrets: inherit
 
   publish-preview:
-    if: github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '[preview_deployment]')
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '[publish-preview]')
     uses: ./.github/workflows/preview-release-on-comment.yml
     permissions:
       id-token: write

--- a/scripts/preview-publish.sh
+++ b/scripts/preview-publish.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Publish preview/snapshot releases from a PR branch.
+#
+# This script lives in the repo (not inline in the workflow YAML) so that
+# changes are picked up from the checked-out PR branch.  GitHub Actions
+# resolves issue_comment-triggered workflow files from the default branch,
+# but composite actions and scripts are resolved from the checkout — so
+# keeping the logic here avoids the "fixes on the PR never run" trap.
+#
+# Required env vars:
+#   BRANCH_NAME  — the PR head ref (e.g. preview/save-toolbar-cqw-v2)
+#   GITHUB_TOKEN — used by publish-all-snapshot-packages.mjs and update-npm-tag.mjs
+#
+# This script sets SKIP_POSTINSTALL_DEV_SETUP=1 for its own duration so
+# that any pnpm install triggered by changeset version doesn't re-run
+# preconstruct dev (which would overwrite the real builds with dev proxies).
+
+set -euo pipefail
+
+# ── Guard: prevent preconstruct dev from clobbering builds ───────────
+export SKIP_POSTINSTALL_DEV_SETUP=1
+
+# ── Compute preview tag from branch name ─────────────────────────────
+PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/^preview\///' | sed -e 's/[^a-zA-Z0-9-]/-/g')
+echo "Preview tag: ${PREVIEW_TAG}"
+
+# ── Bump versions to snapshot ────────────────────────────────────────
+# changeset version may trigger pnpm install (to update the lockfile
+# after modifying package.json versions).  SKIP_POSTINSTALL_DEV_SETUP
+# prevents the postinstall hook from running preconstruct dev.
+pnpm changeset version --snapshot "${PREVIEW_TAG}"
+
+# ── Rebuild everything ───────────────────────────────────────────────
+# After changeset version, pnpm install may have re-run.  Even with
+# SKIP_POSTINSTALL_DEV_SETUP the safest approach is an explicit rebuild
+# so the published tarballs always contain real compiled output.
+pnpm build
+
+# ── Publish ──────────────────────────────────────────────────────────
+# changeset publish only covers packages with an explicit changeset.
+# publish-all-snapshot-packages.mjs force-publishes the remaining public
+# packages so fixed-group consumers can install the full matching set.
+pnpm changeset publish --tag "${PREVIEW_TAG}"
+node ./scripts/publish-all-snapshot-packages.mjs "${PREVIEW_TAG}"
+node ./scripts/update-npm-tag.mjs "${PREVIEW_TAG}"

--- a/scripts/preview-publish.sh
+++ b/scripts/preview-publish.sh
@@ -9,7 +9,7 @@
 # keeping the logic here avoids the "fixes on the PR never run" trap.
 #
 # Required env vars:
-#   BRANCH_NAME  — the PR head ref (e.g. preview/save-toolbar-cqw-v2)
+#   BRANCH_NAME  — the PR head ref (any branch with an open PR)
 #   GITHUB_TOKEN — used by publish-all-snapshot-packages.mjs and update-npm-tag.mjs
 #
 # This script sets SKIP_POSTINSTALL_DEV_SETUP=1 for its own duration so
@@ -41,6 +41,10 @@ pnpm build
 # changeset publish only covers packages with an explicit changeset.
 # publish-all-snapshot-packages.mjs force-publishes the remaining public
 # packages so fixed-group consumers can install the full matching set.
-pnpm changeset publish --tag "${PREVIEW_TAG}"
+pnpm changeset publish --tag "${PREVIEW_TAG}" 2>&1 | tee /tmp/publish-output.txt
 node ./scripts/publish-all-snapshot-packages.mjs "${PREVIEW_TAG}"
 node ./scripts/update-npm-tag.mjs "${PREVIEW_TAG}"
+
+# ── Extract published version for workflow output ────────────────────
+VERSION=$(grep -oP '@commercetools-frontend/application-shell@\K[^\s]+' /tmp/publish-output.txt | head -1)
+echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/scripts/publish-all-snapshot-packages.mjs
+++ b/scripts/publish-all-snapshot-packages.mjs
@@ -1,0 +1,43 @@
+import { getPackages } from '@manypkg/get-packages';
+import shell from 'shelljs';
+
+const [, , distTag] = process.argv;
+
+if (!distTag) {
+  throw new Error('Please provide a NPM dist-tag as a parameter');
+}
+
+const { packages } = await getPackages(process.cwd());
+const publicPackages = packages.filter((pkg) => !pkg.packageJson.private);
+
+for (const pkg of publicPackages) {
+  const { name, version } = pkg.packageJson;
+
+  // Skip packages that don't have the snapshot version
+  if (!version.includes(distTag)) {
+    continue;
+  }
+
+  // Check if this version already exists on npm
+  const check = shell.exec(`npm view ${name}@${version} version 2>/dev/null`, {
+    silent: true,
+  });
+
+  if (check.stdout.trim() === version) {
+    console.log(`✓ ${name}@${version} already published`);
+    continue;
+  }
+
+  // Publish the package
+  console.log(`Publishing ${name}@${version}...`);
+  const result = shell.exec(`npm publish --tag ${distTag}`, {
+    cwd: pkg.dir,
+    silent: false,
+  });
+
+  if (result.code !== 0) {
+    console.error(`✗ Failed to publish ${name}@${version}`);
+  } else {
+    console.log(`✓ Published ${name}@${version}`);
+  }
+}


### PR DESCRIPTION
## Problem

The preview release workflow publishes preconstruct dev proxy stubs instead of real builds. Two issues combine:

1. **`changeset version --snapshot` triggers `pnpm install`** (to update the lockfile after modifying package.json versions), which runs `postinstall.sh` → `preconstruct dev` → overwrites all real builds with dev proxy stubs right before publish.

2. **Workflow fixes on PR branches never execute** — GitHub Actions resolves `issue_comment`-triggered workflow YAML from the default branch (`main`), not the PR checkout. So fixes added to the YAML on a feature branch are silently ignored.

## Fix

Move the publish logic from inline YAML into `scripts/preview-publish.sh`. The script is resolved from the checked-out PR branch (unlike workflow YAML), and includes all three guards:

- `SKIP_POSTINSTALL_DEV_SETUP=1` — prevents `preconstruct dev` from running during the `pnpm install` triggered by `changeset version`
- `pnpm build` after `changeset version` — ensures real compiled output before publish
- `publish-all-snapshot-packages.mjs` — force-publishes the full fixed-group package set

## Evidence from CI logs

The [latest preview run](https://github.com/commercetools/merchant-center-application-kit/actions/runs/34264376263) shows the exact failure sequence:

```
$ changeset version --snapshot save-toolbar-cqw-v2
🦋  All files have been updated.

. postinstall$ ./scripts/postinstall.sh
. postinstall: Preparing development setup.
. postinstall: 🎁 success created links!       ← preconstruct dev overwrites builds
$ changeset publish --tag save-toolbar-cqw-v2  ← publishes dev proxies
```

## After merge

Once this lands on `main`, preview releases from any PR branch will publish real builds. Future changes to the publish flow can be made in `scripts/preview-publish.sh` on any branch and take effect immediately.